### PR TITLE
feat: allow entering building interiors

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -37,8 +37,8 @@ _______________________________________________________________________________
   - Picking up: stand next to or on your tile and press E/Space or T.
   - The selected party member (radio in Party tab) makes skill rolls and
     receives XP for dialog checks and quest rewards.
-  - World buildings appear as black structures; they are not enterable
-    from the overworld. Interiors are entered via scripted hall/world flows.
+  - World buildings appear as black structures; their doors lead to
+    simple interiors you can enter directly from the overworld.
   - Water is bright blue and is not walkable; items won’t spawn in water.
 
 [ CHARACTER CREATION ]
@@ -63,7 +63,7 @@ _______________________________________________________________________________
   - Stable boot: hall always renders before any modal (no blank canvas).
   - Items/NPCs draw before player (no sprite pop-under).
   - Loot from chests spawns on a nearby free tile (never under the player).
-  - Doors in world are decorative; hall top door exits to world.
+  - World building doors lead to interiors; hall top door exits to world.
   - “Selected” party member determines rolls & takes XP.
 
 [ TROUBLESHOOTING ]

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -150,7 +150,21 @@
     const grid=currentGrid(); const t=grid[player.y][player.x];
     if(t===TILE.DOOR){
       if(state.map==='hall' && player.y===1 && player.x===15){ startRealWorld(); return true; }
-      if(state.map==='world'){ log('The doorway is boarded up from the outside.'); return true; } // not enterable from world
+      if(state.map==='world'){
+        const b=buildings.find(b=> b.doorX===player.x && b.doorY===player.y);
+        if(b){
+          state.map=b.interiorId;
+          const I=interiors[state.map];
+          if(I){ player.x=I.entryX; player.y=I.entryY; }
+          document.getElementById('mapname').textContent='Interior';
+          log('You step inside.');
+          centerCamera(player.x,player.y,state.map);
+          updateHUD();
+          return true;
+        }
+        log('The doorway is boarded up from the outside.');
+        return true;
+      }
       if(state.map!=='world' && state.map!=='hall'){ // coming from interior
         const b=buildings.find(b=> b.interiorId===state.map);
         if(b){ state.map='world'; player.x=b.doorX; player.y=b.doorY-1; document.getElementById('mapname').textContent='Wastes'; log('You step back outside.'); centerCamera(player.x,player.y,state.map); updateHUD(); return true; }


### PR DESCRIPTION
## Summary
- Allow entering world buildings via door interaction and transitioning to associated interior maps
- Document interior access and update known behavior for world doors

## Testing
- `node --check dustland-core.js`


------
https://chatgpt.com/codex/tasks/task_e_6897b207a7048328aa3d89e90ecefef6