### PR TITLE
Gate world behind demo completion

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -356,7 +356,32 @@
 
   // ===== Save/Load & Start =====
   function save(){ const data={world, player, state, NPCS, buildings, interiors, itemDrops, quests, party}; localStorage.setItem('dustland_crt', JSON.stringify(data)); log('Game saved.'); }
-  function load(){ const j=localStorage.getItem('dustland_crt'); if(!j){ log('No save.'); return; } const d=JSON.parse(j); world=d.world; Object.assign(player,d.player); Object.assign(state,d.state); NPCS.length=0; d.NPCS.forEach(n=> NPCS.push(n)); buildings.length=0; d.buildings.forEach(b=> buildings.push(b)); interiors={}; Object.keys(d.interiors).forEach(k=> interiors[k]=d.interiors[k]); itemDrops.length=0; d.itemDrops.forEach(i=> itemDrops.push(i)); Object.keys(quests).forEach(k=> delete quests[k]); Object.keys(d.quests||{}).forEach(k=> quests[k]=d.quests[k]); party.length=0; (d.party||[]).forEach(m=> party.push(m)); document.getElementById('mapname').textContent= state.map==='world'? 'Wastes' : (state.map==='hall'?'Test Hall':'Interior'); centerCamera(player.x,player.y,state.map); renderInv(); renderQuests(); renderParty(); updateHUD(); log('Game loaded.'); }
+  function load(){
+    const j=localStorage.getItem('dustland_crt');
+    if(!j){ log('No save.'); return; }
+    const d=JSON.parse(j);
+    world=d.world;
+    Object.assign(player,d.player);
+    Object.assign(state,d.state);
+    NPCS.length=0; d.NPCS.forEach(n=> NPCS.push(n));
+    buildings.length=0; d.buildings.forEach(b=> buildings.push(b));
+    interiors={}; Object.keys(d.interiors).forEach(k=> interiors[k]=d.interiors[k]);
+    itemDrops.length=0; d.itemDrops.forEach(i=> itemDrops.push(i));
+    Object.keys(quests).forEach(k=> delete quests[k]);
+    Object.keys(d.quests||{}).forEach(k=> quests[k]=d.quests[k]);
+    party.length=0; (d.party||[]).forEach(m=> party.push(m));
+    if(!player.flags || !player.flags.demoComplete){
+      state.map='hall';
+      if(!hall.grid || hall.grid.length===0) genHall();
+      player.x=hall.entryX; player.y=hall.entryY;
+      document.getElementById('mapname').textContent='Test Hall';
+    } else {
+      document.getElementById('mapname').textContent= state.map==='world'? 'Wastes' : (state.map==='hall'?'Test Hall':'Interior');
+    }
+    centerCamera(player.x,player.y,state.map);
+    renderInv(); renderQuests(); renderParty(); updateHUD();
+    log('Game loaded.');
+  }
 
   const startEl = document.getElementById('start');
   const startContinue = document.getElementById('startContinue');

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -20,6 +20,11 @@ function toast(msg) {
   toastHost.appendChild(t);
   requestAnimationFrame(()=>{ t.style.opacity = '1'; t.style.transform='translateY(0)'; });
   setTimeout(()=>{ t.style.opacity='0'; t.style.transform='translateY(-6px)'; setTimeout(()=> t.remove(), 180); }, 1600);
+  if(/end of demo/i.test(msg) || /demo complete/i.test(msg)){
+    player.flags = player.flags || {};
+    player.flags.demoComplete = true;
+    if(typeof save === 'function') save();
+  }
 }
 
 // Tile colors for rendering
@@ -202,7 +207,20 @@ if (window.NanoDialog) NanoDialog.init();
 
 if(location.hash.includes('test')){ runTests(); }
 else {
-  if(localStorage.getItem('dustland_crt')){ document.getElementById('start').style.display='flex'; }
-  else { openCreator(); }
+  const saveStr = localStorage.getItem('dustland_crt');
+  if(saveStr){
+    try{
+      const d = JSON.parse(saveStr);
+      if(d.player && d.player.flags && d.player.flags.demoComplete){
+        document.getElementById('start').style.display='flex';
+      } else {
+        load();
+      }
+    } catch(e){
+      openCreator();
+    }
+  } else {
+    openCreator();
+  }
 }
 

--- a/dustland.html
+++ b/dustland.html
@@ -50,7 +50,7 @@
     <div class="win">
       <header>Dustland — Start</header>
       <main>
-        <p class="muted">Save detected. Continue or start a new game?</p>
+        <p class="muted">Continue your journey or start a new game?</p>
         <div>
           <button class="btn" id="startContinue">Continue</button>
           <button class="btn" id="startNew">New Game</button>


### PR DESCRIPTION
## Summary
- Default loads to the hall until the demo is finished
- Offer Continue on the start screen only after the demo is done
- Mark demo completion after the end-of-demo toast and auto-save

## Testing
- `node --check dustland-core.js`
- `node --check dustland-engine.js`


------
https://chatgpt.com/codex/tasks/task_e_6898b57047d88328b963256e7bc9fa38