### PR TITLE
Add hall exit key quest and door pulse

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -62,7 +62,7 @@ function drawScene(ctx){
     for(let vx=0; vx<VIEW_W; vx++){
       const gx=camX+vx, gy=camY+vy; if(gx<0||gy<0||gx>=W||gy>=H) continue;
       const t=grid[gy][gx]; ctx.fillStyle=colors[t]; ctx.fillRect(vx*TS,vy*TS,TS,TS);
-      if(t===TILE.DOOR){ ctx.strokeStyle='#9ef7a0'; ctx.strokeRect(vx*TS+5,vy*TS+5,TS-10,TS-10); }
+      if(t===TILE.DOOR){ ctx.strokeStyle='#9ef7a0'; ctx.strokeRect(vx*TS+5,vy*TS+5,TS-10,TS-10); if(doorPulseUntil && Date.now()<doorPulseUntil){ const a=0.3+0.2*Math.sin(Date.now()/200); ctx.globalAlpha=a; ctx.strokeRect(vx*TS+3,vy*TS+3,TS-6,TS-6); ctx.globalAlpha=1; } }
     }
   }
   const activeMap = (state.map==='creator'?'hall':state.map);


### PR DESCRIPTION
## Summary
- Replace training NPCs with exit door quest in the hall
- Seed a crate with a Rusted Key and add a flavor drifter
- Subtly pulse door outlines for the first minute and add reusable quest gating logic

## Testing
- `node --check dustland-core.js`
- `node --check dustland-engine.js`
- `node -e "require('./dustland-engine.js'); runTests();"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6898b6576cfc8328ae2b4319f62b43c3