### PR TITLE
Ensure new games start in hall tutorial

### DIFF
--- a/dustland-content.js
+++ b/dustland-content.js
@@ -261,7 +261,12 @@ function npc_ExitDoor(x,y){
       {label:'(Leave)',to:'bye'}]},
     accept:{text:'Maybe a key is hidden nearby.',choices:[{label:'(Okay)',to:'bye'}]},
     do_turnin:{text:'The door grinds open.',choices:[{label:'(Continue)',to:'bye'}]}
-  }, quest);
+  }, quest, function(node){
+    if(node==='do_turnin'){
+      startRealWorld();
+      closeDialog();
+    }
+  });
 }
 
 function npc_KeyCrate(x,y){

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -639,7 +639,7 @@ addToInv = function(item){
   let step=1; let building=null; let built=[];
 
   function openCreator(){
-    if(!hall.grid || hall.grid.length===0) genHall();
+    genHall();
     state.map='hall';
     creator.style.display='flex';
     step=1;
@@ -701,8 +701,15 @@ addToInv = function(item){
 
   ccBack.onclick=()=>{ if(step>1) { step--; renderStep(); } };
   ccNext.onclick=()=>{ if(step<5){ step++; renderStep(); } else { finalizeCurrentMember(); building={ id:'pc'+(built.length+1), name:'', role:'Wanderer', stats:baseStats(), quirk:null, spec:null, origin:null }; step=1; renderStep(); log('Member added. You can add up to 2 more, or press Start Now.'); } };
-  ccStart.onclick=()=>{ if(built.length===0){ finalizeCurrentMember(); } closeCreator(); startRealWorld(); };
+  ccStart.onclick=()=>{ if(built.length===0){ finalizeCurrentMember(); } closeCreator(); startHall(); };
   ccLoad.onclick=()=>{ load(); closeCreator(); };
+
+  function startHall(){
+    document.getElementById('mapname').textContent='Test Hall';
+    state.map='hall';
+    centerCamera(player.x,player.y,'hall');
+    renderInv(); renderQuests(); renderParty(); updateHUD();
+  }
 
   function startRealWorld(){
     const seed = Date.now();


### PR DESCRIPTION
## Summary
- Always regenerate the hall when opening the character creator
- Start players in the hall and generate the wastes only after the locked door quest
- Transition to the wastes once the Rusted Key is used on the hall exit

## Testing
- `node --check dustland-core.js`
- `node --check dustland-content.js`


------
https://chatgpt.com/codex/tasks/task_e_68993177ff4883288de249f41cd44833