### PR TITLE
Refine Nano-generated choices

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -527,25 +527,30 @@ addToInv = function(item){
     }
     const handleSpecial = (c)=>{
       if(c.nano){
-        const roll = skillRoll(c.stat);
-        textEl.textContent = `You rolled ${roll} vs DC ${c.dc}.`;
-        if(roll >= c.dc){
-          if(/^xp\s*\d+/i.test(c.reward)){
-            const amt=parseInt(c.reward.replace(/[^0-9]/g,''),10)||0;
-            awardXP(leader(), amt);
-            textEl.textContent += ` Reward: ${amt} XP.`;
-          } else if(c.reward && c.reward.toLowerCase()!=='none'){
-            addToInv({name:c.reward});
-            textEl.textContent += ` You receive ${c.reward}.`;
-          } else {
-            textEl.textContent += ' Success.';
+        if(c.stat){
+          const roll = skillRoll(c.stat);
+          const success = roll >= c.dc;
+          textEl.textContent = success ? c.success : c.failure;
+          textEl.textContent += ` (Roll ${roll} vs DC ${c.dc}.)`;
+          if(success){
+            if(/^xp\s*\d+/i.test(c.reward)){
+              const amt=parseInt(c.reward.replace(/[^0-9]/g,''),10)||0;
+              awardXP(leader(), amt);
+              textEl.textContent += ` Reward: ${amt} XP.`;
+            } else if(c.reward){
+              addToInv({name:c.reward});
+              textEl.textContent += ` You receive ${c.reward}.`;
+            }
           }
-        } else {
-          textEl.textContent += ' Failed.';
+          usedNanoChoices.add(c.key);
+          setContinueOnly();
+          return true;
+        } else if(c.response){
+          textEl.textContent = c.response;
+          usedNanoChoices.add(c.key);
+          setContinueOnly();
+          return true;
         }
-        usedNanoChoices.add(c.key);
-        setContinueOnly();
-        return true;
       }
       if(currentNPC && typeof currentNPC.processChoice==='function'){
         return currentNPC.processChoice(c)===true;

--- a/dustland-nano.js
+++ b/dustland-nano.js
@@ -284,11 +284,14 @@ Context:
 - Do not repeat lines previously used for this NPC/node.
 
 CHOICE SCHEMA:
-- Format: <label>|<STAT>|<DC>|<Reward>
+- Skill check format: <label>|<STAT>|<DC>|<Reward>|<Success>|<Failure>
+- Only create a skill check if the reward is XP or an item.
 - STAT in {STR, AGI, INT, PER, LCK, CHA}; DC 6–12.
-- Reward: "none", "xp N", or an item name.
-- Output 0–2 choices. If no useful test fits, output none.
-- If you add a choice, it must NOT duplicate any label above.
+- Reward must be "xp N" or an item name; otherwise, omit the skill check.
+- Simple dialog format (no roll): <label>|<Response>
+- Success/failure/response lines follow the same style rules as dialog lines.
+ - Output 0–2 choices total. If no useful option fits, leave the Choices section empty.
+- Do not duplicate any label already visible to the player.
 
 OUTPUT EXAMPLES (FOLLOW FORMAT EXACTLY; THESE ARE EXAMPLES, NOT TO BE REPEATED):
 Lines:
@@ -296,16 +299,16 @@ Pump coughs at dusk but still runs.
 Keep the gears oiled and it behaves.
 If it wheezes, kick the intake gently.
 Choices:
-Check the intake|INT|9|xp 10
-Trade a spare filter|CHA|8|none
+Check the intake|INT|9|xp 10|Mesh clears and hum steadies.|You drop a bolt, cursing softly.
+Ask about spare parts|Any for trade?|She shakes her head and turns away.
 
 Lines:
 Tolls keep the road quiet and safe.
 Pay the price or pay in blood.
 Your choice decides your luck today.
 Choices:
-Diplomatically negotiate toll|CHA|9|none
-Intimidate her guard|STR|10|xp 12
+Intimidate her guard|STR|10|xp 12|Guard backs off, eyes wide.|He laughs and calls your bluff.
+Ask for mercy|Can you cut the toll?|She snorts but lets you pass.
 
 Lines:
 Road’s quiet, but don’t trust quiet.
@@ -313,15 +316,15 @@ Keep your head low past the ruins.
 Trade if you must; run if you can’t.
 
 Choices:
-Check the intake|INT|9|xp 10
-Offer spare gasket|CHA|8|Valve
+Check the intake|INT|9|xp 10|You tweak the valves and it purrs.|Steam hisses and you flinch back.
+Offer spare gasket|CHA|8|Valve|She smiles and pockets the part.|She waves you off, unimpressed.
 
 EXACT OUTPUT FORMAT:
 Lines:
-<up to 3 short dialog lines choices, no name/quotes/bullets>
+<up to 3 short dialog lines, no name/quotes/bullets>
 Choices:
-<label>|<STAT>|<DC>|<Reward>
-<label>|<STAT>|<DC>|<Reward>
+<label>|<STAT>|<DC>|<Reward>|<Success>|<Failure>
+<label>|<Response>
 `;
     return prompt;
   }
@@ -347,6 +350,7 @@ Choices:
     const choices = choicePart.split(/\r?\n/)
       .map(_parseChoice)
       .filter(Boolean)
+      .filter(c => !(c.stat && (!c.reward || c.reward.toLowerCase() === 'none')))
       .slice(0, 2);
   
     console.log("Produced:", lines, choices);
@@ -355,9 +359,21 @@ Choices:
 
   function _parseChoice(s){
     const parts = s.split('|').map(p=>p.trim());
-    if(parts.length < 4) return null;
-    const dc = parseInt(parts[2],10);
-    return {label:parts[0], stat:parts[1].toUpperCase(), dc:isNaN(dc)?0:dc, reward:parts[3]};
+    if(parts.length === 2){
+      return {label: parts[0], response: parts[1]};
+    }
+    if(parts.length >= 6){
+      const dc = parseInt(parts[2],10);
+      return {
+        label: parts[0],
+        stat: parts[1].toUpperCase(),
+        dc: isNaN(dc)?0:dc,
+        reward: parts[3],
+        success: parts[4],
+        failure: parts[5]
+      };
+    }
+    return null;
   }
 
   function _dedupe(arr){


### PR DESCRIPTION
## Summary
- Ensure Nano leaves the Choices section empty instead of emitting `none`
- Ignore skill checks with rewards missing or set to `none`
- Clean up example format instructions

## Testing
- `node --check dustland-nano.js`
- `node --check dustland-core.js`


------
https://chatgpt.com/codex/tasks/task_e_689b30911620832891afd080625fc929