### PR TITLE
Remove Grin NPC icon after recruitment

### DIFF
--- a/dustland-content.js
+++ b/dustland-content.js
@@ -6,12 +6,6 @@ function dropItemSafe(map, x, y, item) {
   itemDrops.push({ map, x: spot.x, y: spot.y, ...item });
 }
 
-function removeItemByName(name) {
-  const i = player.inv.findIndex(it => it.name === name);
-  if (i > -1) return player.inv.splice(i, 1)[0];
-  return null;
-}
-
 function hasItem(name) { return player.inv.some(it => it.name === name); }
 function leader() { return party.leader(); }
 function skillRoll(stat, add = 0, sides = ROLL_SIDES) {
@@ -102,16 +96,17 @@ function npc_Grin(x,y){
         const m = makeMember('grin', 'Grin', 'Scavenger');
         m.stats.AGI += 1; m.stats.PER += 1;
         addPartyMember(m);
+        removeNPC(this);
         defaultQuestProcessor(this,'do_turnin');
       }
     }
     if(node==='dopay'){
       const tIndex = player.inv.findIndex(it=> it.slot==='trinket');
       if(tIndex>-1){
-        player.inv.splice(tIndex,1);
-        renderInv();
+        removeFromInv(tIndex);
         const m = makeMember('grin', 'Grin', 'Scavenger');
         addPartyMember(m);
+        removeNPC(this);
         log('Grin joins you.');
         defaultQuestProcessor(this,'do_turnin');
       } else {

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -206,6 +206,14 @@ function addToInv(item){
         .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'inventory change'));
   }
 }
+function removeFromInv(invIndex){
+  player.inv.splice(invIndex,1);
+  renderInv();
+  if (window.NanoDialog) {
+    NPCS.filter(n=> n.map === (state.map==='creator'?'hall':state.map))
+        .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'inventory change'));
+  }
+}
 let selectedMember = 0;
 
 function equipItem(memberIndex, invIndex){
@@ -387,12 +395,6 @@ function completeQuest(id){ questLog.complete(id); }
 
 // minimal core helpers so defaultQuestProcessor works even without content helpers loaded yet
 function hasItem(name){ return player.inv.some(it=> it.name===name); }
-function removeItemByName(name){
-  const i = player.inv.findIndex(it => it.name === name);
-  if(i>-1) return player.inv.splice(i,1)[0];
-  return null;
-}
-
 function defaultQuestProcessor(npc, nodeId){
   const meta = npc.quest;
   if(!meta) return;
@@ -401,7 +403,7 @@ function defaultQuestProcessor(npc, nodeId){
   }
   if(nodeId==='do_turnin' && meta.status==='active'){
     if(!meta.item || hasItem(meta.item)){
-      if(meta.item){ removeItemByName(meta.item); renderInv(); }
+      if(meta.item){ const i = player.inv.findIndex(it=> it.name===meta.item); if(i>-1) removeFromInv(i); }
       questLog.complete(meta.id);
       if(meta.reward){ addToInv(meta.reward); }
       if(meta.xp){ awardXP(leader(), meta.xp); }


### PR DESCRIPTION
## Summary
- Rename inventory helper to `removeFromInv` for parity with `addToInv`
- Drop unused `removeItemByName` and remove quest items through `removeFromInv`

## Testing
- `node --version`
- `node --check dustland-content.js`
- `node --check dustland-core.js`


------
https://chatgpt.com/codex/tasks/task_e_689b43e33fd48328b903c26294328ab4