### PR TITLE
Remove defeated raiders from game world

### DIFF
--- a/dustland-content.js
+++ b/dustland-content.js
@@ -254,6 +254,7 @@ function npc_Raider(x,y){
                   res.result==='bruise' ? 'A sharp blow leaves a bruise.' :
                   'You back away from the raider.';
       textEl.textContent = `Roll: ${res.roll} vs DEF ${res.dc}. ${msg}`;
+      if(res.result==='loot') removeNPC(this);
     }
   };
   return makeNPC('raider','world',x,y,'#f88','Road Raider','Bandit','Scarred scav looking for trouble.',{

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -432,6 +432,10 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
 }
 function resolveNode(tree, nodeId){ const n = tree[nodeId]; const choices = n.choices||[]; return {...n, choices}; }
 const NPCS=[];
+function removeNPC(npc){
+  const idx = NPCS.indexOf(npc);
+  if(idx > -1) NPCS.splice(idx,1);
+}
 const usedNanoChoices = new Set();
 
 // ===== WORLD GEN =====
@@ -866,4 +870,4 @@ function startRealWorld(){
 
 // Content pack moved to dustland-content.js
 
-Object.assign(window, {Dice, Character, Party, Quest, NPC, questLog, quickCombat});
+Object.assign(window, {Dice, Character, Party, Quest, NPC, questLog, quickCombat, removeNPC});


### PR DESCRIPTION
## Summary
- Add helper to remove NPCs from the global list
- Remove raider NPC when the player wins the encounter

## Testing
- `node --check dustland-core.js`
- `node --check dustland-content.js`


------
https://chatgpt.com/codex/tasks/task_e_689b4b884e588328ab7a7dec2bfefb49