### PR TITLE
Add Adventure Construction Kit

### DIFF
--- a/ack-player.html
+++ b/ack-player.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ACK Module Player</title>
+  <link rel="stylesheet" href="dustland.css" />
+</head>
+<body>
+  <div id="nanoStatus">
+    <div id="nanoProgress" class="nano-progress"></div>
+    <div id="nanoBadge" class="nano-badge off">✗</div>
+  </div>
+  <div class="wrap">
+    <div class="crt-wrap" style="flex:1;display:flex;align-items:center;justify-content:center">
+      <div class="tube">
+        <canvas id="game" width="640" height="480" class="glow" aria-label="Dustland CRT"></canvas>
+      </div>
+    </div>
+    <aside class="panel">
+      <h1>DUSTLAND // CRT v0.6.7</h1>
+      <div class="content" id="log"></div>
+      <div class="content">
+        <div class="hud">
+          <div class="badge">HP: <span id="hp">10</span></div>
+          <div class="badge">AP: <span id="ap">2</span></div>
+          <div class="badge">Scrap: <span id="scrap">0</span></div>
+          <div class="badge">Map: <span id="mapname">—</span></div>
+        </div>
+        <p class="muted" style="margin-top:10px">Controls: <b>WASD/Arrows</b> move • <b>E/Space</b> interact/door & take nearby item • <b>T</b> take item • <b>I</b> Inventory • <b>P</b> Party • <b>Q</b> Quests • <b>G/L</b> save/load • <b>M</b> minimap • <b>Esc</b> close</p>
+        <div class="tabs">
+          <div class="tab active" id="tabInv">Inventory</div>
+          <div class="tab" id="tabParty">Party</div>
+          <div class="tab" id="tabQuests">Quests</div>
+        </div>
+        <div id="inv"></div>
+        <div id="party" style="display:none"></div>
+        <div id="quests" style="display:none"></div>
+        <div style="margin-top:8px">
+          <button class="btn" id="saveBtn">Save</button>
+          <button class="btn" id="loadBtn">Load</button>
+          <button class="btn" id="resetBtn">Reset</button>
+          <button class="btn" id="nanoToggle">Nano Dialog</button>
+        </div>
+      </div>
+    </aside>
+  </div>
+
+  <!-- Start Menu (unused here, but kept for engine compatibility) -->
+  <div id="start">
+    <div class="win">
+      <header>Dustland — Start</header>
+      <main>
+        <p class="muted">Continue your journey or start a new game?</p>
+        <div>
+          <button class="btn" id="startContinue">Continue</button>
+          <button class="btn" id="startNew">New Game</button>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <!-- Dialog overlay -->
+  <div class="overlay" id="overlay" role="dialog" aria-modal="true">
+    <div class="dialog">
+      <header>
+        <div class="portrait" id="port"></div>
+        <div><div id="npcName" style="font-weight:700"></div><div class="small" id="npcTitle"></div></div>
+      </header>
+      <main id="dialogText"></main>
+      <div class="choices" id="choices"></div>
+    </div>
+  </div>
+
+  <!-- Character Creator -->
+  <div id="creator" style="display:none">
+    <div class="win">
+      <header>
+        <div><b>Dustland: Party Creation</b> — <span id="ccStep">1</span>/5</div>
+        <div class="small">Create up to 3 drifters (or start now)</div>
+      </header>
+      <main>
+        <div class="pbox">
+          <div class="p" id="ccPortrait">@</div>
+        </div>
+        <div id="ccRight"></div>
+      </main>
+      <div class="footer">
+        <div class="small" id="ccHint">Pick a name and portrait.</div>
+        <div class="right">
+          <button class="btn" id="ccLoad">Load Game</button>
+          <button class="btn" id="ccStart">Start Now</button>
+          <button class="btn" id="ccBack">Back</button>
+          <button class="btn" id="ccNext">Next</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Module Loader -->
+  <div id="moduleLoader" style="position:fixed;inset:0;background:rgba(0,0,0,.8);display:flex;align-items:center;justify-content:center;z-index:40">
+    <div class="win" style="width:min(420px,92vw);background:#0b0d0b;border:1px solid #2a382a;border-radius:12px;box-shadow:0 20px 80px rgba(0,0,0,.7);overflow:hidden">
+      <header style="padding:10px 12px;border-bottom:1px solid #223022;font-weight:700">Load Adventure Module</header>
+      <main style="padding:12px">
+        <p class="muted" style="margin-bottom:8px">Select an ACK module JSON file to begin.</p>
+        <input type="file" id="modFile" accept="application/json" />
+        <button class="btn" id="modLoadBtn" style="margin-top:8px">Load Module</button>
+      </main>
+    </div>
+  </div>
+
+  <script src="dustland-core.js"></script>
+  <script>
+    window._realOpenCreator = window.openCreator;
+    window.openCreator = function(){};
+    window.showStart = function(){};
+  </script>
+  <script src="dustland-content.js"></script>
+  <script src="dustland-nano.js"></script>
+  <script src="dustland-engine.js"></script>
+  <script src="ack-player.js"></script>
+</body>
+</html>

--- a/ack-player.js
+++ b/ack-player.js
@@ -1,0 +1,64 @@
+// ACK Module Player
+// Loads a module JSON and starts the game using its data.
+
+// Prevent default content seeding
+window.seedWorldContent = () => {};
+
+let moduleData = null;
+const loader = document.getElementById('moduleLoader');
+const fileInput = document.getElementById('modFile');
+const loadBtn = document.getElementById('modLoadBtn');
+
+function applyModule(data){
+  setRNGSeed(data.seed || Date.now());
+  world = data.world || world;
+  buildings = data.buildings || [];
+  buildings.forEach(b=>{
+    if(!interiors[b.interiorId]){
+      const id = makeInteriorRoom();
+      b.interiorId = id;
+    }
+  });
+  itemDrops.length = 0;
+  (data.items||[]).forEach(it=>{
+    itemDrops.push({map:'world', x:it.x, y:it.y, name:it.name, slot:it.slot, mods:it.mods});
+  });
+  Object.keys(quests).forEach(k=> delete quests[k]);
+  (data.quests||[]).forEach(q=>{
+    quests[q.id] = new Quest(q.id, q.title, q.desc);
+  });
+  NPCS.length = 0;
+  (data.npcs||[]).forEach(n=>{
+    const tree = { start:{ text:n.dialog||'', choices:[{label:'(Leave)', to:'bye'}] } };
+    const npc = makeNPC(n.id, 'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, '', '', tree);
+    NPCS.push(npc);
+  });
+}
+
+loadBtn.onclick = () => {
+  const file = fileInput.files[0];
+  if(!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      moduleData = JSON.parse(reader.result);
+      loader.style.display = 'none';
+      window.openCreator = window._realOpenCreator;
+      openCreator();
+    } catch(err){
+      alert('Invalid module');
+    }
+  };
+  reader.readAsText(file);
+};
+
+// After party creation, start the loaded module
+window.startHall = function(){
+  if(moduleData) applyModule(moduleData);
+  setMap('world', 'Module');
+  player.x = 2;
+  player.y = Math.floor(WORLD_H/2);
+  centerCamera(player.x, player.y, 'world');
+  renderInv(); renderQuests(); renderParty(); updateHUD();
+  log('Adventure begins.');
+};

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Adventure Construction Kit</title>
+  <link rel="stylesheet" href="dustland.css" />
+  <style>
+    body{display:flex;gap:16px;margin:0;padding:16px;background:#000;color:#c8f7c9;font-family:ui-monospace;}
+    canvas{border:1px solid #2b3b2b;background:#000;image-rendering:pixelated;}
+    .side{width:260px;display:flex;flex-direction:column;gap:12px;}
+    .side fieldset{border:1px solid #2b3b2b;padding:8px;}
+    .list{font-size:12px;}
+    label{display:block;margin-top:4px;font-size:12px;}
+    input,textarea{width:100%;margin-top:2px;background:#101910;border:1px solid #2b3b2b;color:#c8f7c9;font-family:inherit;font-size:12px;}
+    button.btn{margin-top:6px;}
+  </style>
+</head>
+<body>
+  <div>
+    <canvas id="map" width="640" height="480" aria-label="Map preview"></canvas>
+    <div style="margin-top:8px">
+      <button class="btn" id="regen">Generate World</button>
+      <button class="btn" id="save">Download Module</button>
+    </div>
+  </div>
+  <div class="side">
+    <fieldset>
+      <legend>Add NPC</legend>
+      <label>ID<input id="npcId"/></label>
+      <label>Name<input id="npcName"/></label>
+      <label>Color<input id="npcColor" value="#9ef7a0"/></label>
+      <label>X<input id="npcX" type="number" min="0"/></label>
+      <label>Y<input id="npcY" type="number" min="0"/></label>
+      <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
+      <button class="btn" id="addNPC">Add NPC</button>
+      <div class="list" id="npcList"></div>
+    </fieldset>
+    <fieldset>
+      <legend>Add Item</legend>
+      <label>Name<input id="itemName"/></label>
+      <label>X<input id="itemX" type="number" min="0"/></label>
+      <label>Y<input id="itemY" type="number" min="0"/></label>
+      <button class="btn" id="addItem">Add Item</button>
+      <div class="list" id="itemList"></div>
+    </fieldset>
+    <fieldset>
+      <legend>Add Building</legend>
+      <label>X<input id="bldgX" type="number" min="0"/></label>
+      <label>Y<input id="bldgY" type="number" min="0"/></label>
+      <button class="btn" id="addBldg">Place Hut</button>
+      <div class="list" id="bldgList"></div>
+    </fieldset>
+    <fieldset>
+      <legend>Add Quest</legend>
+      <label>ID<input id="questId"/></label>
+      <label>Title<input id="questTitle"/></label>
+      <label>Description<textarea id="questDesc" rows="2"></textarea></label>
+      <button class="btn" id="addQuest">Add Quest</button>
+      <div class="list" id="questList"></div>
+    </fieldset>
+  </div>
+  <script src="dustland-core.js"></script>
+  <script src="adventure-kit.js"></script>
+</body>
+</html>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1,0 +1,112 @@
+// Adventure Construction Kit
+// Provides basic tools to build Dustland modules.
+
+// Ensure world generation doesn't pull default content
+window.seedWorldContent = () => {};
+
+const colors = {0:'#1e271d',1:'#2c342c',2:'#1573ff',3:'#203320',4:'#394b39',5:'#304326',6:'#4d5f4d',7:'#233223',8:'#8bd98d',9:'#000'};
+const canvas = document.getElementById('map');
+const ctx = canvas.getContext('2d');
+
+const moduleData = { seed: Date.now(), npcs: [], items: [], quests: [], buildings: [] };
+
+function drawWorld(){
+  const W = WORLD_W, H = WORLD_H;
+  const sx = canvas.width / W;
+  const sy = canvas.height / H;
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const t = world[y][x];
+      ctx.fillStyle = colors[t] || '#000';
+      ctx.fillRect(x*sx, y*sy, sx, sy);
+    }
+  }
+  // Draw NPC markers
+  moduleData.npcs.forEach(n=>{
+    ctx.fillStyle = n.color || '#fff';
+    ctx.fillRect(n.x*sx, n.y*sy, sx, sy);
+  });
+}
+
+function regenWorld(){
+  moduleData.seed = Date.now();
+  genWorld(moduleData.seed);
+  moduleData.buildings = [...buildings];
+  drawWorld();
+}
+
+// --- NPCs ---
+function addNPC(){
+  const id=document.getElementById('npcId').value.trim();
+  const name=document.getElementById('npcName').value.trim();
+  const color=document.getElementById('npcColor').value.trim()||'#fff';
+  const x=parseInt(document.getElementById('npcX').value,10)||0;
+  const y=parseInt(document.getElementById('npcY').value,10)||0;
+  const dialog=document.getElementById('npcDialog').value.trim();
+  moduleData.npcs.push({id,name,color,x,y,dialog});
+  renderNPCList();
+  drawWorld();
+}
+function renderNPCList(){
+  const list=document.getElementById('npcList');
+  list.innerHTML=moduleData.npcs.map(n=>`<div>${n.id} @(${n.x},${n.y})</div>`).join('');
+}
+
+// --- Items ---
+function addItem(){
+  const name=document.getElementById('itemName').value.trim();
+  const x=parseInt(document.getElementById('itemX').value,10)||0;
+  const y=parseInt(document.getElementById('itemY').value,10)||0;
+  moduleData.items.push({name,x,y});
+  renderItemList();
+}
+function renderItemList(){
+  const list=document.getElementById('itemList');
+  list.innerHTML=moduleData.items.map(it=>`<div>${it.name} @(${it.x},${it.y})</div>`).join('');
+}
+
+// --- Buildings ---
+function addBuilding(){
+  const x=parseInt(document.getElementById('bldgX').value,10)||0;
+  const y=parseInt(document.getElementById('bldgY').value,10)||0;
+  placeHut(x,y);
+  moduleData.buildings = [...buildings];
+  renderBldgList();
+  drawWorld();
+}
+function renderBldgList(){
+  const list=document.getElementById('bldgList');
+  list.innerHTML=moduleData.buildings.map(b=>`<div>Hut @(${b.x},${b.y})</div>`).join('');
+}
+
+// --- Quests ---
+function addQuest(){
+  const id=document.getElementById('questId').value.trim();
+  const title=document.getElementById('questTitle').value.trim();
+  const desc=document.getElementById('questDesc').value.trim();
+  moduleData.quests.push({id,title,desc});
+  renderQuestList();
+}
+function renderQuestList(){
+  const list=document.getElementById('questList');
+  list.innerHTML=moduleData.quests.map(q=>`<div>${q.id}: ${q.title}</div>`).join('');
+}
+
+function saveModule(){
+  const data={...moduleData, world, buildings};
+  const blob=new Blob([JSON.stringify(data,null,2)],{type:'application/json'});
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download='adventure-module.json';
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+document.getElementById('regen').onclick=regenWorld;
+document.getElementById('addNPC').onclick=addNPC;
+document.getElementById('addItem').onclick=addItem;
+document.getElementById('addBldg').onclick=addBuilding;
+document.getElementById('addQuest').onclick=addQuest;
+document.getElementById('save').onclick=saveModule;
+
+regenWorld();


### PR DESCRIPTION
## Summary
- Add new `adventure-kit.html` page for building custom adventures
- Provide `adventure-kit.js` tooling to generate maps, place NPCs, items, buildings, and quests
- Enable downloading constructed module as JSON
- Add `ack-player.html` and `ack-player.js` to load modules, create a party, and play custom adventures

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b61672e408328a8485e3bf2db5571