### PR TITLE
Add map and item detail support in module editor and player

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -18,7 +18,7 @@ function applyModule(data){
   });
   itemDrops.length = 0;
   (data.items||[]).forEach(it=>{
-    itemDrops.push({map:'world', x:it.x, y:it.y, name:it.name, slot:it.slot, mods:it.mods});
+    itemDrops.push({map:it.map||'world', x:it.x, y:it.y, name:it.name, slot:it.slot, mods:it.mods, value:it.value, use:it.use});
   });
   Object.keys(quests).forEach(k=> delete quests[k]);
   (data.quests||[]).forEach(q=>{
@@ -27,7 +27,7 @@ function applyModule(data){
   NPCS.length = 0;
   (data.npcs||[]).forEach(n=>{
     const tree = { start:{ text:n.dialog||'', choices:[{label:'(Leave)', to:'bye'}] } };
-    const npc = makeNPC(n.id, 'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, '', '', tree);
+    const npc = makeNPC(n.id, n.map||'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, '', '', tree);
     NPCS.push(npc);
   });
 }

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -30,6 +30,7 @@
       <label>ID<input id="npcId"/></label>
       <label>Name<input id="npcName"/></label>
       <label>Color<input id="npcColor" value="#9ef7a0"/></label>
+      <label>Map<input id="npcMap" value="world"/></label>
       <label>X<input id="npcX" type="number" min="0"/></label>
       <label>Y<input id="npcY" type="number" min="0"/></label>
       <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
@@ -39,8 +40,13 @@
     <fieldset>
       <legend>Add Item</legend>
       <label>Name<input id="itemName"/></label>
+      <label>Map<input id="itemMap" value="world"/></label>
       <label>X<input id="itemX" type="number" min="0"/></label>
       <label>Y<input id="itemY" type="number" min="0"/></label>
+      <label>Slot<input id="itemSlot"/></label>
+      <label>Mods<textarea id="itemMods" rows="2"></textarea></label>
+      <label>Value<input id="itemValue" type="number" min="0"/></label>
+      <label>Use<textarea id="itemUse" rows="2"></textarea></label>
       <button class="btn" id="addItem">Add Item</button>
       <div class="list" id="itemList"></div>
     </fieldset>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -22,7 +22,7 @@ function drawWorld(){
     }
   }
   // Draw NPC markers
-  moduleData.npcs.forEach(n=>{
+  moduleData.npcs.filter(n=> n.map==='world').forEach(n=>{
     ctx.fillStyle = n.color || '#fff';
     ctx.fillRect(n.x*sx, n.y*sy, sx, sy);
   });
@@ -40,29 +40,37 @@ function addNPC(){
   const id=document.getElementById('npcId').value.trim();
   const name=document.getElementById('npcName').value.trim();
   const color=document.getElementById('npcColor').value.trim()||'#fff';
+  const map=document.getElementById('npcMap').value.trim()||'world';
   const x=parseInt(document.getElementById('npcX').value,10)||0;
   const y=parseInt(document.getElementById('npcY').value,10)||0;
   const dialog=document.getElementById('npcDialog').value.trim();
-  moduleData.npcs.push({id,name,color,x,y,dialog});
+  moduleData.npcs.push({id,name,color,map,x,y,dialog});
   renderNPCList();
   drawWorld();
 }
 function renderNPCList(){
   const list=document.getElementById('npcList');
-  list.innerHTML=moduleData.npcs.map(n=>`<div>${n.id} @(${n.x},${n.y})</div>`).join('');
+  list.innerHTML=moduleData.npcs.map(n=>`<div>${n.id} @${n.map} (${n.x},${n.y})</div>`).join('');
 }
 
 // --- Items ---
 function addItem(){
   const name=document.getElementById('itemName').value.trim();
+  const map=document.getElementById('itemMap').value.trim()||'world';
   const x=parseInt(document.getElementById('itemX').value,10)||0;
   const y=parseInt(document.getElementById('itemY').value,10)||0;
-  moduleData.items.push({name,x,y});
+  const slot=document.getElementById('itemSlot').value.trim()||null;
+  let mods={};
+  try{ mods=JSON.parse(document.getElementById('itemMods').value||'{}'); }catch(e){ mods={}; }
+  const value=parseInt(document.getElementById('itemValue').value,10)||0;
+  let use=null;
+  try{ use=JSON.parse(document.getElementById('itemUse').value||'null'); }catch(e){ use=null; }
+  moduleData.items.push({name,map,x,y,slot,mods,value,use});
   renderItemList();
 }
 function renderItemList(){
   const list=document.getElementById('itemList');
-  list.innerHTML=moduleData.items.map(it=>`<div>${it.name} @(${it.x},${it.y})</div>`).join('');
+  list.innerHTML=moduleData.items.map(it=>`<div>${it.name} @${it.map} (${it.x},${it.y})</div>`).join('');
 }
 
 // --- Buildings ---


### PR DESCRIPTION
## Summary
- allow specifying map for NPCs/items in editor and player
- include item slot, mods, value, and use fields when saving/loading modules

## Testing
- `node --check adventure-kit.js`
- `node --check ack-player.js`


------
https://chatgpt.com/codex/tasks/task_e_689b943d797c832888d22bdc41aa28cc