### PR TITLE
Add floating card editor and interactive NPC quests

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -22,12 +22,18 @@ function applyModule(data){
   });
   Object.keys(quests).forEach(k=> delete quests[k]);
   (data.quests||[]).forEach(q=>{
-    quests[q.id] = new Quest(q.id, q.title, q.desc);
+    quests[q.id] = new Quest(q.id, q.title, q.desc, {item:q.item, reward:q.reward, xp:q.xp});
   });
   NPCS.length = 0;
   (data.npcs||[]).forEach(n=>{
-    const tree = { start:{ text:n.dialog||'', choices:[{label:'(Leave)', to:'bye'}] } };
-    const npc = makeNPC(n.id, n.map||'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, '', '', tree);
+    let tree=n.tree;
+    if(typeof tree==='string'){ try{ tree=JSON.parse(tree); }catch(e){ tree=null; } }
+    if(!tree){
+      tree = { start:{ text:n.dialog||'', choices:[{label:'(Leave)', to:'bye'}] } };
+    }
+    let quest=null;
+    if(n.questId && quests[n.questId]) quest=quests[n.questId];
+    const npc = makeNPC(n.id, n.map||'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, '', '', tree, quest);
     NPCS.push(npc);
   });
 }

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -6,67 +6,85 @@
   <title>Adventure Construction Kit</title>
   <link rel="stylesheet" href="dustland.css" />
   <style>
-    body{display:flex;gap:16px;margin:0;padding:16px;background:#000;color:#c8f7c9;font-family:ui-monospace;position:relative;}
+    body{margin:0;background:#000;color:#c8f7c9;font-family:ui-monospace;position:relative;min-height:100vh;}
     body:after{content:"";position:fixed;inset:0;pointer-events:none;background:repeating-linear-gradient(to bottom,rgba(255,255,255,.05)0,rgba(255,255,255,.05)1px,rgba(0,0,0,0)2px);mix-blend-mode:overlay;opacity:.15;}
     canvas{border:1px solid #2b3b2b;background:#000;image-rendering:pixelated;box-shadow:0 0 12px #000,0 0 8px #9ef7a0;}
-    .side{width:260px;display:flex;flex-direction:column;gap:12px;}
-    .side fieldset{border:1px solid #2b3b2b;padding:8px;background:#0f120f;border-radius:8px;box-shadow:0 0 10px rgba(0,0,0,.6);}
+    .card{position:absolute;padding:8px;background:#0f120f;border:2px solid #2b3b2b;border-radius:8px;box-shadow:0 0 12px #000,0 0 8px #9ef7a0;}
     .list{font-size:12px;}
+    .list div{cursor:pointer;}
     label{display:block;margin-top:4px;font-size:12px;}
-    input,textarea{width:100%;margin-top:2px;background:#101910;border:1px solid #2b3b2b;color:#c8f7c9;font-family:inherit;font-size:12px;border-radius:4px;}
+    input,textarea,select{width:100%;margin-top:2px;background:#101910;border:1px solid #2b3b2b;color:#c8f7c9;font-family:inherit;font-size:12px;border-radius:4px;}
     button.btn{margin-top:6px;}
+    #mapCard{left:16px;top:16px;width:640px;}
+    #mapCard .controls{text-align:center;margin-top:8px;}
+    #npcCard{right:16px;top:16px;width:260px;}
+    #itemCard{right:16px;top:320px;width:260px;}
+    #bldgCard{right:16px;top:560px;width:260px;}
+    #questCard{right:16px;top:800px;width:260px;}
   </style>
 </head>
 <body>
-  <div>
+  <div class="card" id="mapCard">
     <canvas id="map" width="640" height="480" aria-label="Map preview"></canvas>
-    <div style="margin-top:8px">
+    <div class="controls">
       <button class="btn" id="regen">Generate World</button>
       <button class="btn" id="save">Download Module</button>
     </div>
   </div>
-  <div class="side">
-    <fieldset>
-      <legend>Add NPC</legend>
-      <label>ID<input id="npcId"/></label>
-      <label>Name<input id="npcName"/></label>
-      <label>Color<input id="npcColor" value="#9ef7a0"/></label>
-      <label>Map<input id="npcMap" value="world"/></label>
-      <label>X<input id="npcX" type="number" min="0"/></label>
-      <label>Y<input id="npcY" type="number" min="0"/></label>
-      <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
-      <button class="btn" id="addNPC">Add NPC</button>
-      <div class="list" id="npcList"></div>
-    </fieldset>
-    <fieldset>
-      <legend>Add Item</legend>
-      <label>Name<input id="itemName"/></label>
-      <label>Map<input id="itemMap" value="world"/></label>
-      <label>X<input id="itemX" type="number" min="0"/></label>
-      <label>Y<input id="itemY" type="number" min="0"/></label>
-      <label>Slot<input id="itemSlot"/></label>
-      <label>Mods<textarea id="itemMods" rows="2"></textarea></label>
-      <label>Value<input id="itemValue" type="number" min="0"/></label>
-      <label>Use<textarea id="itemUse" rows="2"></textarea></label>
-      <button class="btn" id="addItem">Add Item</button>
-      <div class="list" id="itemList"></div>
-    </fieldset>
-    <fieldset>
-      <legend>Add Building</legend>
-      <label>X<input id="bldgX" type="number" min="0"/></label>
-      <label>Y<input id="bldgY" type="number" min="0"/></label>
-      <button class="btn" id="addBldg">Place Hut</button>
-      <div class="list" id="bldgList"></div>
-    </fieldset>
-    <fieldset>
-      <legend>Add Quest</legend>
-      <label>ID<input id="questId"/></label>
-      <label>Title<input id="questTitle"/></label>
-      <label>Description<textarea id="questDesc" rows="2"></textarea></label>
-      <button class="btn" id="addQuest">Add Quest</button>
-      <div class="list" id="questList"></div>
-    </fieldset>
-  </div>
+  <fieldset class="card" id="npcCard">
+    <legend>Add NPC</legend>
+    <label>ID<input id="npcId"/></label>
+    <label>Name<input id="npcName"/></label>
+    <label>Color<input id="npcColor" value="#9ef7a0"/></label>
+    <label>Map<input id="npcMap" value="world"/></label>
+    <label>X<input id="npcX" type="number" min="0"/></label>
+    <label>Y<input id="npcY" type="number" min="0"/></label>
+    <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
+    <label>Quest<select id="npcQuest"><option value="">(none)</option></select></label>
+    <label>Tree JSON<textarea id="npcTree" rows="4" placeholder='{"start":{"text":"hi","choices":[{"label":"(Leave)","to":"bye"}]}}'></textarea></label>
+    <button class="btn" id="addNPC">Add NPC</button>
+    <div class="list" id="npcList"></div>
+  </fieldset>
+  <fieldset class="card" id="itemCard">
+    <legend>Add Item</legend>
+    <label>Name<input id="itemName"/></label>
+    <label>Map<input id="itemMap" value="world"/></label>
+    <label>X<input id="itemX" type="number" min="0"/></label>
+    <label>Y<input id="itemY" type="number" min="0"/></label>
+    <label>Slot<select id="itemSlot">
+      <option value="">(none)</option>
+      <option value="weapon">Weapon</option>
+      <option value="armor">Armor</option>
+      <option value="trinket">Trinket</option>
+    </select></label>
+    <div id="modsWrap">
+      <label>Mods</label>
+      <div id="modBuilder"></div>
+      <button class="btn" type="button" id="addMod">Add Mod</button>
+    </div>
+    <label>Value<input id="itemValue" type="number" min="0"/></label>
+    <label>Use<textarea id="itemUse" rows="2"></textarea></label>
+    <button class="btn" id="addItem">Add Item</button>
+    <div class="list" id="itemList"></div>
+  </fieldset>
+  <fieldset class="card" id="bldgCard">
+    <legend>Add Building</legend>
+    <label>X<input id="bldgX" type="number" min="0"/></label>
+    <label>Y<input id="bldgY" type="number" min="0"/></label>
+    <button class="btn" id="addBldg">Place Hut</button>
+    <div class="list" id="bldgList"></div>
+  </fieldset>
+  <fieldset class="card" id="questCard">
+    <legend>Add Quest</legend>
+    <label>ID<input id="questId"/></label>
+    <label>Title<input id="questTitle"/></label>
+    <label>Description<textarea id="questDesc" rows="2"></textarea></label>
+    <label>Required Item<input id="questItem"/></label>
+    <label>Reward Item<input id="questReward"/></label>
+    <label>XP Reward<input id="questXP" type="number" min="0"/></label>
+    <button class="btn" id="addQuest">Add Quest</button>
+    <div class="list" id="questList"></div>
+  </fieldset>
   <script src="dustland-core.js"></script>
   <script src="adventure-kit.js"></script>
 </body>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -11,6 +11,8 @@ const ctx = canvas.getContext('2d');
 let dragTarget=null;
 
 const moduleData = { seed: Date.now(), npcs: [], items: [], quests: [], buildings: [] };
+const STAT_OPTS=['ATK','DEF','LCK','INT','PER','CHA'];
+let editNPCIdx=-1, editItemIdx=-1, editQuestIdx=-1;
 
 function drawWorld(){
   const W = WORLD_W, H = WORLD_H;
@@ -42,6 +44,31 @@ function regenWorld(){
   drawWorld();
 }
 
+function modRow(stat='ATK', val=1){
+  const div=document.createElement('div');
+  const sel=document.createElement('select');
+  sel.className='modStat';
+  sel.innerHTML=STAT_OPTS.map(s=>`<option value="${s}"${s===stat?' selected':''}>${s}</option>`).join('');
+  const inp=document.createElement('input');
+  inp.type='number'; inp.className='modVal'; inp.value=val;
+  div.appendChild(sel); div.appendChild(inp);
+  document.getElementById('modBuilder').appendChild(div);
+}
+function collectMods(){
+  const mods={};
+  document.querySelectorAll('#modBuilder > div').forEach(div=>{
+    const stat=div.querySelector('.modStat').value;
+    const val=parseInt(div.querySelector('.modVal').value,10);
+    if(stat && val) mods[stat]=val;
+  });
+  return mods;
+}
+function loadMods(mods){
+  const mb=document.getElementById('modBuilder');
+  mb.innerHTML='';
+  Object.entries(mods||{}).forEach(([s,v])=>modRow(s,v));
+}
+
 // --- NPCs ---
 function addNPC(){
   const id=document.getElementById('npcId').value.trim();
@@ -51,13 +78,50 @@ function addNPC(){
   const x=parseInt(document.getElementById('npcX').value,10)||0;
   const y=parseInt(document.getElementById('npcY').value,10)||0;
   const dialog=document.getElementById('npcDialog').value.trim();
-  moduleData.npcs.push({id,name,color,map,x,y,dialog});
+  const questId=document.getElementById('npcQuest').value.trim();
+  let tree=null;
+  const treeTxt=document.getElementById('npcTree').value.trim();
+  if(treeTxt){ try{ tree=JSON.parse(treeTxt); }catch(e){ tree=null; } }
+  if(!tree){
+    if(questId){
+      tree={
+        start:{text:dialog,choices:[{label:'Accept quest',to:'accept',q:'accept'},{label:'Turn in',to:'do_turnin',q:'turnin'},{label:'(Leave)',to:'bye'}]},
+        accept:{text:'Good luck.',choices:[{label:'(Leave)',to:'bye'}]},
+        do_turnin:{text:'Thanks for helping.',choices:[{label:'(Leave)',to:'bye'}]}
+      };
+    } else {
+      tree={start:{text:dialog,choices:[{label:'(Leave)',to:'bye'}]}};
+    }
+  }
+  const npc={id,name,color,map,x,y,tree,questId};
+  if(editNPCIdx>=0){
+    moduleData.npcs[editNPCIdx]=npc;
+  } else {
+    moduleData.npcs.push(npc);
+  }
+  editNPCIdx=-1;
+  document.getElementById('addNPC').textContent='Add NPC';
   renderNPCList();
   drawWorld();
 }
+function editNPC(i){
+  const n=moduleData.npcs[i];
+  editNPCIdx=i;
+  document.getElementById('npcId').value=n.id;
+  document.getElementById('npcName').value=n.name;
+  document.getElementById('npcColor').value=n.color;
+  document.getElementById('npcMap').value=n.map;
+  document.getElementById('npcX').value=n.x;
+  document.getElementById('npcY').value=n.y;
+  document.getElementById('npcDialog').value=n.tree?.start?.text||'';
+  document.getElementById('npcQuest').value=n.questId||'';
+  document.getElementById('npcTree').value=JSON.stringify(n.tree,null,2);
+  document.getElementById('addNPC').textContent='Update NPC';
+}
 function renderNPCList(){
   const list=document.getElementById('npcList');
-  list.innerHTML=moduleData.npcs.map(n=>`<div>${n.id} @${n.map} (${n.x},${n.y})</div>`).join('');
+  list.innerHTML=moduleData.npcs.map((n,i)=>`<div data-idx="${i}">${n.id} @${n.map} (${n.x},${n.y})${n.questId?` [${n.questId}]`:''}</div>`).join('');
+  Array.from(list.children).forEach(div=>div.onclick=()=>editNPC(parseInt(div.dataset.idx,10)));
 }
 
 // --- Items ---
@@ -66,27 +130,48 @@ function addItem(){
   const map=document.getElementById('itemMap').value.trim()||'world';
   const x=parseInt(document.getElementById('itemX').value,10)||0;
   const y=parseInt(document.getElementById('itemY').value,10)||0;
-  const slot=document.getElementById('itemSlot').value.trim()||null;
-  let mods={};
-  try{ mods=JSON.parse(document.getElementById('itemMods').value||'{}'); }catch(e){ mods={}; }
+  const slot=document.getElementById('itemSlot').value||null;
+  const mods=collectMods();
   const value=parseInt(document.getElementById('itemValue').value,10)||0;
   let use=null;
   try{ use=JSON.parse(document.getElementById('itemUse').value||'null'); }catch(e){ use=null; }
-  moduleData.items.push({name,map,x,y,slot,mods,value,use});
+  const item={name,map,x,y,slot,mods,value,use};
+  if(editItemIdx>=0){
+    moduleData.items[editItemIdx]=item;
+  } else {
+    moduleData.items.push(item);
+  }
+  editItemIdx=-1;
+  document.getElementById('addItem').textContent='Add Item';
+  loadMods({});
   renderItemList();
   drawWorld();
 }
+function editItem(i){
+  const it=moduleData.items[i];
+  editItemIdx=i;
+  document.getElementById('itemName').value=it.name;
+  document.getElementById('itemMap').value=it.map;
+  document.getElementById('itemX').value=it.x;
+  document.getElementById('itemY').value=it.y;
+  document.getElementById('itemSlot').value=it.slot||'';
+  loadMods(it.mods);
+  document.getElementById('itemValue').value=it.value||0;
+  document.getElementById('itemUse').value=it.use?JSON.stringify(it.use,null,2):'';
+  document.getElementById('addItem').textContent='Update Item';
+}
 function renderItemList(){
   const list=document.getElementById('itemList');
-  list.innerHTML=moduleData.items.map(it=>`<div>${it.name} @${it.map} (${it.x},${it.y})</div>`).join('');
+  list.innerHTML=moduleData.items.map((it,i)=>`<div data-idx="${i}">${it.name} @${it.map} (${it.x},${it.y})</div>`).join('');
+  Array.from(list.children).forEach(div=>div.onclick=()=>editItem(parseInt(div.dataset.idx,10)));
 }
 
 // --- Buildings ---
 function addBuilding(){
   const x=parseInt(document.getElementById('bldgX').value,10)||0;
   const y=parseInt(document.getElementById('bldgY').value,10)||0;
-  placeHut(x,y);
-  moduleData.buildings = [...buildings];
+  const b=placeHut(x,y);
+  moduleData.buildings.push(b);
   renderBldgList();
   drawWorld();
 }
@@ -95,17 +180,58 @@ function renderBldgList(){
   list.innerHTML=moduleData.buildings.map(b=>`<div>Hut @(${b.x},${b.y})</div>`).join('');
 }
 
+function removeBuilding(b){
+  for(let yy=0; yy<b.h; yy++){ for(let xx=0; xx<b.w; xx++){ setTile('world',b.x+xx,b.y+yy,TILE.SAND); }}
+  const idx=buildings.indexOf(b); if(idx>=0) buildings.splice(idx,1);
+}
+function moveBuilding(b,x,y){
+  removeBuilding(b);
+  const nb=placeHut(x,y);
+  const idx=moduleData.buildings.indexOf(b);
+  moduleData.buildings[idx]=nb;
+  return nb;
+}
+
 // --- Quests ---
 function addQuest(){
   const id=document.getElementById('questId').value.trim();
   const title=document.getElementById('questTitle').value.trim();
   const desc=document.getElementById('questDesc').value.trim();
-  moduleData.quests.push({id,title,desc});
+  const item=document.getElementById('questItem').value.trim();
+  const reward=document.getElementById('questReward').value.trim();
+  const xp=parseInt(document.getElementById('questXP').value,10)||0;
+  const quest={id,title,desc,item:item||undefined,reward:reward||undefined,xp};
+  if(editQuestIdx>=0){
+    moduleData.quests[editQuestIdx]=quest;
+  } else {
+    moduleData.quests.push(quest);
+  }
+  editQuestIdx=-1;
+  document.getElementById('addQuest').textContent='Add Quest';
   renderQuestList();
 }
 function renderQuestList(){
   const list=document.getElementById('questList');
-  list.innerHTML=moduleData.quests.map(q=>`<div>${q.id}: ${q.title}</div>`).join('');
+  list.innerHTML=moduleData.quests.map((q,i)=>`<div data-idx="${i}">${q.id}: ${q.title}</div>`).join('');
+  Array.from(list.children).forEach(div=>div.onclick=()=>editQuest(parseInt(div.dataset.idx,10)));
+  updateQuestOptions();
+}
+function editQuest(i){
+  const q=moduleData.quests[i];
+  editQuestIdx=i;
+  document.getElementById('questId').value=q.id;
+  document.getElementById('questTitle').value=q.title;
+  document.getElementById('questDesc').value=q.desc;
+  document.getElementById('questItem').value=q.item||'';
+  document.getElementById('questReward').value=q.reward||'';
+  document.getElementById('questXP').value=q.xp||0;
+  document.getElementById('addQuest').textContent='Update Quest';
+}
+function updateQuestOptions(){
+  const sel=document.getElementById('npcQuest');
+  const cur=sel.value;
+  sel.innerHTML='<option value="">(none)</option>'+moduleData.quests.map(q=>`<option value="${q.id}">${q.title}</option>`).join('');
+  sel.value=cur;
 }
 
 function saveModule(){
@@ -123,6 +249,7 @@ document.getElementById('addNPC').onclick=addNPC;
 document.getElementById('addItem').onclick=addItem;
 document.getElementById('addBldg').onclick=addBuilding;
 document.getElementById('addQuest').onclick=addQuest;
+document.getElementById('addMod').onclick=()=>modRow();
 document.getElementById('save').onclick=saveModule;
 
 // --- Map interactions ---
@@ -139,23 +266,38 @@ canvas.addEventListener('mousedown',ev=>{
   if(dragTarget){ dragTarget._type='npc'; return; }
   dragTarget = moduleData.items.find(it=>it.map==='world'&&it.x===x&&it.y===y);
   if(dragTarget){ dragTarget._type='item'; return; }
+  dragTarget = moduleData.buildings.find(b=> x>=b.x && x<b.x+b.w && y>=b.y && y<b.y+b.h);
+  if(dragTarget){
+    dragTarget._type='bldg';
+    document.getElementById('bldgX').value=dragTarget.x;
+    document.getElementById('bldgY').value=dragTarget.y;
+    return;
+  }
   document.getElementById('npcX').value=x; document.getElementById('npcY').value=y;
   document.getElementById('itemX').value=x; document.getElementById('itemY').value=y;
+  document.getElementById('bldgX').value=x; document.getElementById('bldgY').value=y;
   drawWorld();
 });
 canvas.addEventListener('mousemove',ev=>{
   if(!dragTarget) return;
   const {x,y}=canvasPos(ev);
-  dragTarget.x=x; dragTarget.y=y;
-  if(dragTarget._type==='npc'){
-    renderNPCList();
-    document.getElementById('npcX').value=x; document.getElementById('npcY').value=y;
+  if(dragTarget._type==='bldg'){
+    dragTarget=moveBuilding(dragTarget,x,y); dragTarget._type='bldg';
+    renderBldgList();
+    document.getElementById('bldgX').value=x; document.getElementById('bldgY').value=y;
   } else {
-    renderItemList();
-    document.getElementById('itemX').value=x; document.getElementById('itemY').value=y;
+    dragTarget.x=x; dragTarget.y=y;
+    if(dragTarget._type==='npc'){
+      renderNPCList();
+      document.getElementById('npcX').value=x; document.getElementById('npcY').value=y;
+    } else {
+      renderItemList();
+      document.getElementById('itemX').value=x; document.getElementById('itemY').value=y;
+    }
   }
   drawWorld();
 });
 ['mouseup','mouseleave'].forEach(ev=>canvas.addEventListener(ev,()=>{ if(dragTarget) delete dragTarget._type; dragTarget=null; }));
 
 regenWorld();
+loadMods({});

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -503,7 +503,9 @@ function placeHut(x,y){
   const doorX=x+Math.floor(w/2), doorY=y+h-1; setTile('world',doorX,doorY,TILE.DOOR);
   const interiorId=makeInteriorRoom();
   const boarded = rng() < 0.3;
-  buildings.push({x,y,w,h,doorX,doorY,interiorId,boarded});
+  const b={x,y,w,h,doorX,doorY,interiorId,boarded};
+  buildings.push(b);
+  return b;
 }
 
 // ===== HALL =====


### PR DESCRIPTION
## Summary
- Allow huts to be repositioned with drag-and-drop and return building data from `placeHut`
- Enable NPC, item, and quest forms to edit existing entries from clickable lists
- Replace freeform item fields with enum-based slot dropdown and mod builder rows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c683d7fe08328b82badcf9c0b9c78