### PR TITLE
Enhance ACK editor with playtest and dialog tools

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -6,6 +6,19 @@ const loader = document.getElementById('moduleLoader');
 const fileInput = document.getElementById('modFile');
 const loadBtn = document.getElementById('modLoadBtn');
 
+const playData = localStorage.getItem('ack_playtest');
+if(playData){
+  try{
+    moduleData = JSON.parse(playData);
+    localStorage.removeItem('ack_playtest');
+    loader.style.display='none';
+    window.openCreator = window._realOpenCreator;
+    openCreator();
+  }catch(e){
+    localStorage.removeItem('ack_playtest');
+  }
+}
+
 function applyModule(data){
   setRNGSeed(data.seed || Date.now());
   world = data.world || world;
@@ -58,10 +71,11 @@ loadBtn.onclick = () => {
 // After party creation, start the loaded module
 window.startGame = function(){
   if(moduleData) applyModule(moduleData);
-  setMap('world', 'Module');
-  player.x = 2;
-  player.y = Math.floor(WORLD_H/2);
-  centerCamera(player.x, player.y, 'world');
+  const start=moduleData && moduleData.start ? moduleData.start : {map:'world',x:2,y:Math.floor(WORLD_H/2)};
+  setMap(start.map||'world', 'Module');
+  player.x = start.x;
+  player.y = start.y;
+  centerCamera(player.x, player.y, start.map||'world');
   renderInv(); renderQuests(); renderParty(); updateHUD();
   log('Adventure begins.');
 };

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -29,20 +29,26 @@
     <div class="controls">
       <button class="btn" id="regen">Generate World</button>
       <button class="btn" id="save">Download Module</button>
+      <button class="btn" id="setStart">Set Start</button>
+      <button class="btn" id="playtest">Playtest</button>
     </div>
   </div>
   <fieldset class="card" id="npcCard">
     <legend>Add NPC</legend>
     <label>ID<input id="npcId"/></label>
     <label>Name<input id="npcName"/></label>
-    <label>Color<input id="npcColor" value="#9ef7a0"/></label>
+    <label>Color<input id="npcColor" type="color" value="#9ef7a0"/></label>
     <label>Map<input id="npcMap" value="world"/></label>
     <label>X<input id="npcX" type="number" min="0"/></label>
     <label>Y<input id="npcY" type="number" min="0"/></label>
     <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
     <label>Quest<select id="npcQuest"><option value="">(none)</option></select></label>
+    <label>Accept Text<textarea id="npcAccept" rows="2">Good luck.</textarea></label>
+    <label>Turn-in Text<textarea id="npcTurnin" rows="2">Thanks for helping.</textarea></label>
     <label>Tree JSON<textarea id="npcTree" rows="4" placeholder='{"start":{"text":"hi","choices":[{"label":"(Leave)","to":"bye"}]}}'></textarea></label>
+    <div id="dialogPreview" style="margin-top:6px"></div>
     <button class="btn" id="addNPC">Add NPC</button>
+    <button class="btn" id="delNPC" style="display:none">Delete NPC</button>
     <div class="list" id="npcList"></div>
   </fieldset>
   <fieldset class="card" id="itemCard">
@@ -65,6 +71,7 @@
     <label>Value<input id="itemValue" type="number" min="0"/></label>
     <label>Use<textarea id="itemUse" rows="2"></textarea></label>
     <button class="btn" id="addItem">Add Item</button>
+    <button class="btn" id="delItem" style="display:none">Delete Item</button>
     <div class="list" id="itemList"></div>
   </fieldset>
   <fieldset class="card" id="bldgCard">
@@ -72,6 +79,7 @@
     <label>X<input id="bldgX" type="number" min="0"/></label>
     <label>Y<input id="bldgY" type="number" min="0"/></label>
     <button class="btn" id="addBldg">Place Hut</button>
+    <button class="btn" id="delBldg" style="display:none">Remove Hut</button>
     <div class="list" id="bldgList"></div>
   </fieldset>
   <fieldset class="card" id="questCard">
@@ -82,7 +90,9 @@
     <label>Required Item<input id="questItem"/></label>
     <label>Reward Item<input id="questReward"/></label>
     <label>XP Reward<input id="questXP" type="number" min="0"/></label>
+    <label>NPC<select id="questNPC"><option value="">(none)</option></select></label>
     <button class="btn" id="addQuest">Add Quest</button>
+    <button class="btn" id="delQuest" style="display:none">Delete Quest</button>
     <div class="list" id="questList"></div>
   </fieldset>
   <script src="dustland-core.js"></script>

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -499,11 +499,12 @@ function makeInteriorRoom(){
 }
 function placeHut(x,y){
   const w=6,h=5;
+  const under=Array.from({length:h},(_,yy)=>Array.from({length:w},(_,xx)=>getTile('world',x+xx,y+yy)));
   for(let yy=0; yy<h; yy++){ for(let xx=0; xx<w; xx++){ setTile('world',x+xx,y+yy,TILE.BUILDING); }}
   const doorX=x+Math.floor(w/2), doorY=y+h-1; setTile('world',doorX,doorY,TILE.DOOR);
   const interiorId=makeInteriorRoom();
   const boarded = rng() < 0.3;
-  const b={x,y,w,h,doorX,doorY,interiorId,boarded};
+  const b={x,y,w,h,doorX,doorY,interiorId,boarded,under};
   buildings.push(b);
   return b;
 }

--- a/dustland.css
+++ b/dustland.css
@@ -15,13 +15,13 @@
     .tabs{display:flex;gap:6px;margin:8px 0}
     .tab{padding:6px 8px;border:1px solid #273027;border-radius:6px;cursor:pointer;background:#0f120f}
     .tab.active{outline:1px solid #4f6b4f}
-    #inv{display:grid;grid-template-columns:1fr;gap:6px;margin-top:8px}
+    #inv{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:6px;margin-top:8px}
     .slot{padding:6px 8px;border:1px dashed #2b382b;border-radius:6px;background:#0c0f0c}
     .slot.clickable{cursor:pointer}
-    #party{display:grid;grid-template-columns:1fr;gap:8px}
+    #party{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:8px}
     .pcard{border:1px solid #273027;border-radius:8px;background:#0f120f;padding:8px}
     .row{display:flex;flex-wrap:wrap;gap:8px}
-    #quests{display:grid;grid-template-columns:1fr;gap:8px}
+    #quests{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:8px}
     .q{border:1px solid #273027;border-radius:8px;background:#0f120f;padding:8px}
     .q .status{color:#9ab09a}
     .overlay{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.6);z-index:20}


### PR DESCRIPTION
## Summary
- Add dialog preview panel with quest accept/turn-in helpers
- Support color picker, auto IDs, and quest-to-NPC linking
- Let users set player start and playtest modules instantly

## Testing
- `node --check dustland-core.js`
- `node --check adventure-kit.js`
- `node --check ack-player.js`


------
https://chatgpt.com/codex/tasks/task_e_689c6cd78d288328ae8187e9bfcbc5e5