### PR TITLE
feat: add core NPC combat and shop presets

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -46,7 +46,10 @@ function applyModule(data){
     }
     let quest=null;
     if(n.questId && quests[n.questId]) quest=quests[n.questId];
-    const npc = makeNPC(n.id, n.map||'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, '', '', tree, quest);
+    const opts = {};
+    if(n.combat) opts.combat = n.combat;
+    if(n.shop) opts.shop = n.shop;
+    const npc = makeNPC(n.id, n.map||'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, '', '', tree, quest, null, null, opts);
     NPCS.push(npc);
   });
 }

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -45,6 +45,8 @@
     <label>Quest<select id="npcQuest"><option value="">(none)</option></select></label>
     <label>Accept Text<textarea id="npcAccept" rows="2">Good luck.</textarea></label>
     <label>Turn-in Text<textarea id="npcTurnin" rows="2">Thanks for helping.</textarea></label>
+    <label><input type="checkbox" id="npcCombat"> Combat NPC</label>
+    <label><input type="checkbox" id="npcShop"> Shop NPC</label>
     <label>Tree JSON<textarea id="npcTree" rows="4" placeholder='{"start":{"text":"hi","choices":[{"label":"(Leave)","to":"bye"}]}}'></textarea></label>
     <div id="dialogPreview" style="margin-top:6px"></div>
     <button class="btn" id="addNPC">Add NPC</button>

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -273,58 +273,22 @@ function npc_Raider(x,y){
       const r = skillRoll('CHA'); const dc = DC.TALK;
       textEl.textContent = `Roll: ${r} vs DC ${dc}. ${r>=dc ? 'He grunts and lets you pass.' : 'He tightens his grip.'}`;
     }
-    if(node==='do_fight'){
-      const res = quickCombat({DEF:5, loot:{name:'Raider Knife', slot:'weapon', mods:{ATK:+1}}});
-      const msg = res.result==='loot' ? 'The raider collapses. You take his knife.' :
-                  res.result==='bruise' ? 'A sharp blow leaves a bruise.' :
-                  'You back away from the raider.';
-      textEl.textContent = `Roll: ${res.roll} vs DEF ${res.dc}. ${msg}`;
-      if(res.result==='loot') removeNPC(this);
-    }
   };
   return makeNPC('raider','world',x,y,'#f88','Road Raider','Bandit','Scarred scav looking for trouble.',{
     start:{text:'A raider blocks the path, eyeing your gear.', choices:[
-      {label:'(Fight)', to:'do_fight'},
       {label:'(Talk) Stand down', to:'rollcha'},
       {label:'(Leave)', to:'bye'}
     ]},
-    rollcha:{text:'', choices:[{label:'(Continue)', to:'bye'}]},
-    do_fight:{text:'', choices:[{label:'(Continue)', to:'bye'}]}
-  }, null, processNode);
+    rollcha:{text:'', choices:[{label:'(Continue)', to:'bye'}]}
+  }, null, processNode, null, {combat:{DEF:5, loot:{name:'Raider Knife', slot:'weapon', mods:{ATK:+1}}}});
 }
 
 function npc_Trader(x,y){
-  const processNode = function(node){
-    if(node==='sell'){
-      const items = player.inv.map((it,idx)=>({label:`Sell ${it.name} (${Math.max(1, it.value || 0)} ${CURRENCY})`, to:'sell', sellIndex:idx}));
-      if(items.length===0){
-        this.tree.sell.text = 'Nothing to sell.';
-      } else {
-        this.tree.sell.text = 'What are you selling?';
-      }
-      items.push({label:'(Back)', to:'start'});
-      this.tree.sell.choices = items;
-    }
-  };
-  const processChoice = function(c){
-    if(typeof c.sellIndex==='number'){
-      const it = player.inv.splice(c.sellIndex,1)[0];
-      const val = Math.max(1, it.value || 0);
-      player.scrap += val;
-      renderInv(); updateHUD();
-      textEl.textContent = `Sold ${it.name} for ${val} ${CURRENCY}.`;
-      currentNode='sell';
-      renderDialog();
-      return true;
-    }
-  };
   return makeNPC('trader','world',x,y,'#caffc6','Cass the Trader','Shopkeep','A roving merchant weighing your wares.',{
     start:{ text:'Got goods to sell? I pay in scrap.', choices:[
-      {label:'(Sell items)', to:'sell'},
       {label:'(Leave)', to:'bye'}
-    ]},
-    sell:{ text:'What are you selling?', choices:[] }
-  }, null, processNode, processChoice);
+    ]}
+  }, null, null, null, {shop:true});
 }
 
 function npc_ExitDoor(x,y){


### PR DESCRIPTION
## Summary
- move combat and shop behaviors to core NPC implementation
- add editor presets for combat and shop NPCs
- simplify module NPC definitions to use new presets

## Testing
- `node --check dustland-core.js`
- `node --check modules/dustland.module.js`
- `node --check ack-player.js`
- `node --check adventure-kit.js`

------
https://chatgpt.com/codex/tasks/task_e_689c7009802483289c135b627b188b2d