### PR TITLE
Add module loading to adventure editor

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -29,9 +29,11 @@
     <div class="controls">
       <button class="btn" id="regen">Generate World</button>
       <button class="btn" id="save">Download Module</button>
+      <button class="btn" id="load">Load Module</button>
       <button class="btn" id="setStart">Set Start</button>
       <button class="btn" id="playtest">Playtest</button>
     </div>
+    <input type="file" id="loadFile" accept="application/json" style="display:none" />
   </div>
   <fieldset class="card" id="npcCard">
     <legend>Add NPC</legend>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -364,6 +364,29 @@ function deleteQuest(){
   document.getElementById('questId').value=nextId('quest',moduleData.quests);
 }
 
+function applyLoadedModule(data){
+  moduleData.seed = data.seed || Date.now();
+  moduleData.npcs = data.npcs || [];
+  moduleData.items = data.items || [];
+  moduleData.quests = data.quests || [];
+  moduleData.buildings = data.buildings || [];
+  moduleData.start = data.start || {map:'world',x:2,y:Math.floor(WORLD_H/2)};
+
+  world = data.world || world;
+  buildings = moduleData.buildings.map(b=>({
+    ...b,
+    under: Array.from({length:b.h},()=>Array.from({length:b.w},()=>TILE.SAND))
+  }));
+
+  drawWorld();
+  renderNPCList();
+  renderItemList();
+  renderBldgList();
+  renderQuestList();
+  updateQuestOptions();
+  loadMods({});
+}
+
 function saveModule(){
   const bldgs=buildings.map(({under,...rest})=>rest);
   const data={...moduleData, world, buildings:bldgs};
@@ -393,6 +416,18 @@ document.getElementById('delBldg').onclick=deleteBldg;
 document.getElementById('delQuest').onclick=deleteQuest;
 document.getElementById('addMod').onclick=()=>modRow();
 document.getElementById('save').onclick=saveModule;
+document.getElementById('load').onclick=()=>document.getElementById('loadFile').click();
+document.getElementById('loadFile').addEventListener('change',e=>{
+  const file=e.target.files[0];
+  if(!file) return;
+  const reader=new FileReader();
+  reader.onload=()=>{
+    try{ applyLoadedModule(JSON.parse(reader.result)); }
+    catch(err){ alert('Invalid module'); }
+  };
+  reader.readAsText(file);
+  e.target.value='';
+});
 document.getElementById('setStart').onclick=()=>{settingStart=true;};
 document.getElementById('playtest').onclick=playtestModule;
 document.getElementById('npcTree').addEventListener('input',renderDialogPreview);


### PR DESCRIPTION
## Summary
- Add Load Module button and file input to Adventure Construction Kit
- Implement `applyLoadedModule` and file reading logic to populate editor

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check adventure-kit.js`


------
https://chatgpt.com/codex/tasks/task_e_689c70cd6370832898ebf19311a83ab7