### PR TITLE
Align NPC and item editors horizontally

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -17,8 +17,8 @@
     button.btn{margin-top:6px;}
     #mapCard{left:16px;top:16px;width:640px;}
     #mapCard .controls{text-align:center;margin-top:8px;}
-    #npcCard{right:16px;top:16px;width:260px;}
-    #itemCard{right:16px;top:320px;width:260px;}
+    #npcCard{right:292px;top:16px;width:260px;}
+    #itemCard{right:16px;top:16px;width:260px;}
     #bldgCard{right:16px;top:560px;width:260px;}
     #questCard{right:16px;top:800px;width:260px;}
   </style>


### PR DESCRIPTION
## Summary
- position NPC and item editor cards side by side to prevent vertical overlap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c727d76788328b00f1783693a2b0f