### PR TITLE
Allow editing NPC descriptions

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -49,7 +49,7 @@ function applyModule(data){
     const opts = {};
     if(n.combat) opts.combat = n.combat;
     if(n.shop) opts.shop = n.shop;
-    const npc = makeNPC(n.id, n.map||'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, '', '', tree, quest, null, null, opts);
+    const npc = makeNPC(n.id, n.map||'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, '', n.desc||'', tree, quest, null, null, opts);
     NPCS.push(npc);
   });
 }

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -39,6 +39,7 @@
     <legend>Add NPC</legend>
     <label>ID<input id="npcId"/></label>
     <label>Name<input id="npcName"/></label>
+    <label>Description<textarea id="npcDesc" rows="2"></textarea></label>
     <label>Color<input id="npcColor" type="color" value="#9ef7a0"/></label>
     <label>Map<input id="npcMap" value="world"/></label>
     <label>X<input id="npcX" type="number" min="0"/></label>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -132,6 +132,7 @@ function removeShopTree(tree){
 function addNPC(){
   const id=document.getElementById('npcId').value.trim();
   const name=document.getElementById('npcName').value.trim();
+  const desc=document.getElementById('npcDesc').value.trim();
   const color=document.getElementById('npcColor').value.trim()||'#fff';
   const map=document.getElementById('npcMap').value.trim()||'world';
   const x=parseInt(document.getElementById('npcX').value,10)||0;
@@ -161,7 +162,7 @@ function addNPC(){
   document.getElementById('npcTree').value=JSON.stringify(tree,null,2);
   renderDialogPreview();
 
-  const npc={id,name,color,map,x,y,tree,questId};
+  const npc={id,name,desc,color,map,x,y,tree,questId};
   if(combat) npc.combat = {DEF:5};
   if(shop) npc.shop = true;
   if(editNPCIdx>=0){
@@ -174,6 +175,7 @@ function addNPC(){
   document.getElementById('delNPC').style.display='none';
   renderNPCList();
   document.getElementById('npcId').value=nextId('npc',moduleData.npcs);
+  document.getElementById('npcDesc').value='';
   document.getElementById('npcCombat').checked=false;
   document.getElementById('npcShop').checked=false;
   drawWorld();
@@ -184,6 +186,7 @@ function editNPC(i){
   editNPCIdx=i;
   document.getElementById('npcId').value=n.id;
   document.getElementById('npcName').value=n.name;
+  document.getElementById('npcDesc').value=n.desc||'';
   document.getElementById('npcColor').value=n.color;
   document.getElementById('npcMap').value=n.map;
   document.getElementById('npcX').value=n.x;
@@ -215,6 +218,7 @@ function deleteNPC(){
   renderNPCList();
   drawWorld();
   document.getElementById('npcId').value=nextId('npc',moduleData.npcs);
+  document.getElementById('npcDesc').value='';
   renderDialogPreview();
 }
 


### PR DESCRIPTION
## Summary
- Support description text when adding or editing NPCs in Adventure Kit
- Pass saved NPC descriptions to `makeNPC` in module player

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check adventure-kit.js`
- `node --check ack-player.js`


------
https://chatgpt.com/codex/tasks/task_e_689c75502b488328b1b6b69fd84e9162