### PR TITLE
fix: handle missing start menu elements

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -814,8 +814,8 @@ const startContinue = document.getElementById('startContinue');
 const startNew = document.getElementById('startNew');
 function showStart(){ startEl.style.display='flex'; }
 function hideStart(){ startEl.style.display='none'; }
-startContinue.onclick=()=>{ load(); hideStart(); };
-startNew.onclick=()=>{ hideStart(); resetAll(); };
+if (startContinue) startContinue.onclick = () => { load(); hideStart(); };
+if (startNew) startNew.onclick = () => { hideStart(); resetAll(); };
 
 function resetAll(){
   party.length=0; player.inv=[]; player.flags={}; player.scrap=0;


### PR DESCRIPTION
## Summary
- avoid null errors when attaching start menu button handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cc5b3248883288d3eb005af5b4b1d