### PR TITLE
feat: add collapsible nodes to tree editor

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -24,6 +24,9 @@
       #treeEditor .node{border:1px solid #2b3b2b;padding:4px;margin-top:4px;}
       #treeEditor .choices div{display:flex;gap:4px;margin-top:2px;}
       #treeEditor .choices input{flex:1;}
+      #treeEditor .nodeHeader{display:flex;align-items:center;}
+      #treeEditor .toggle{margin-right:4px;}
+      #treeEditor .node.collapsed .nodeBody{display:none;}
   </style>
 </head>
 <body>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -173,10 +173,16 @@ function renderTreeEditor(){
   Object.entries(treeData).forEach(([id,node])=>{
     const div=document.createElement('div');
     div.className='node';
-    div.innerHTML=`<label>Node ID<input class="nodeId" value="${id}"></label><label>Text<textarea class="nodeText" rows="2">${node.text||''}</textarea></label><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button>`;
+    div.innerHTML=`<div class="nodeHeader"><button class="toggle" type="button">[-]</button><label>Node ID<input class="nodeId" value="${id}"></label></div><div class="nodeBody"><label>Text<textarea class="nodeText" rows="2">${node.text||''}</textarea></label><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button></div>`;
     const choicesDiv=div.querySelector('.choices');
     (node.choices||[]).forEach(ch=>addChoiceRow(choicesDiv,ch));
     div.querySelector('.addChoice').onclick=()=>addChoiceRow(choicesDiv);
+    const toggleBtn=div.querySelector('.toggle');
+    toggleBtn.addEventListener('click',()=>{
+      div.classList.toggle('collapsed');
+      toggleBtn.textContent=div.classList.contains('collapsed')?'[+]':'[-]';
+      updateTreeData();
+    });
     wrap.appendChild(div);
   });
   wrap.querySelectorAll('input,textarea').forEach(el=> el.addEventListener('input',updateTreeData));
@@ -185,10 +191,14 @@ function renderTreeEditor(){
 
 function updateTreeData(){
   const wrap=document.getElementById('treeEditor');
-  treeData={};
+  const newTree={};
   wrap.querySelectorAll('.node').forEach(nodeEl=>{
     const id=nodeEl.querySelector('.nodeId').value.trim();
     if(!id) return;
+    if(nodeEl.classList.contains('collapsed')){
+      if(treeData[id]) newTree[id]=treeData[id];
+      return;
+    }
     const text=nodeEl.querySelector('.nodeText').value;
     const choices=[];
     nodeEl.querySelectorAll('.choices > div').forEach(chEl=>{
@@ -212,8 +222,9 @@ function updateTreeData(){
         choices.push(c);
       }
     });
-    treeData[id]={text,choices};
+    newTree[id]={text,choices};
   });
+  treeData=newTree;
   document.getElementById('npcTree').value=JSON.stringify(treeData,null,2);
   renderDialogPreview();
 }


### PR DESCRIPTION
## Summary
- Add collapse toggle to each tree node header
- Hide node body with CSS when collapsed
- Skip collapsed nodes when serializing tree data

## Testing
- `node --check adventure-kit.js` *(fails: SyntaxError: Unexpected token 'else')*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd653fcb4832886a359752d6c828f