### PR TITLE
Add manual quest dialog generation button

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -52,6 +52,7 @@
       <label>Y<input id="npcY" type="number" min="0"/></label>
       <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
       <label>Quest<select id="npcQuest"><option value="">(none)</option></select></label>
+      <button class="btn" type="button" id="genQuestDialog" style="display:none">Generate Quest Dialog</button>
       <label>Accept Text<textarea id="npcAccept" rows="2">Good luck.</textarea></label>
       <label>Turn-in Text<textarea id="npcTurnin" rows="2">Thanks for helping.</textarea></label>
       <label><input type="checkbox" id="npcCombat"> Combat NPC</label>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -225,6 +225,11 @@ function loadTreeEditor(){
   updateTreeData();
 }
 
+function toggleQuestDialogBtn(){
+  const btn=document.getElementById('genQuestDialog');
+  btn.style.display=document.getElementById('npcQuest').value? 'block' : 'none';
+}
+
 function addNode(){
   const id = Object.keys(treeData).length? 'node'+Object.keys(treeData).length : 'start';
   treeData[id]={text:'',choices:[{label:'(Leave)',to:'bye'}]};
@@ -292,6 +297,7 @@ function startNewNPC(){
   document.getElementById('addNPC').textContent='Add NPC';
   document.getElementById('delNPC').style.display='none';
   loadTreeEditor();
+  toggleQuestDialogBtn();
   placingType='npc';
   placingPos=null;
   showNPCEditor(true);
@@ -374,6 +380,7 @@ function editNPC(i){
   document.getElementById('addNPC').textContent='Update NPC';
   document.getElementById('delNPC').style.display='block';
   loadTreeEditor();
+  toggleQuestDialogBtn();
   showNPCEditor(true);
 }
 function renderNPCList(){
@@ -709,11 +716,14 @@ document.getElementById('loadFile').addEventListener('change',e=>{
   document.getElementById('setStart').onclick=()=>{settingStart=true;};
   document.getElementById('playtest').onclick=playtestModule;
   document.getElementById('addNode').onclick=addNode;
-['npcDialog','npcAccept','npcTurnin','npcQuest'].forEach(id=>{
-  document.getElementById(id).addEventListener(id==='npcQuest'?'change':'input',()=>{
-    if(document.getElementById('npcQuest').value) generateQuestTree(); else renderDialogPreview();
-  });
+['npcDialog','npcAccept','npcTurnin'].forEach(id=>{
+  document.getElementById(id).addEventListener('input',renderDialogPreview);
 });
+document.getElementById('npcQuest').addEventListener('change',()=>{
+  toggleQuestDialogBtn();
+  renderDialogPreview();
+});
+document.getElementById('genQuestDialog').onclick=generateQuestTree;
 
 // --- Map interactions ---
 function canvasPos(ev){


### PR DESCRIPTION
## Summary
- Add "Generate Quest Dialog" button to NPC editor and show only when a quest is selected
- Replace automatic quest dialog generation with manual button-triggered generation
- Keep dialog preview updating on field edits by calling `renderDialogPreview`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check adventure-kit.js` *(fails: SyntaxError: Unexpected token 'else')*

------
https://chatgpt.com/codex/tasks/task_e_689cd654a7708328833fea9267f73c93