### PR TITLE
Add NPC combat and shop option sections

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -55,7 +55,9 @@
       <label>Accept Text<textarea id="npcAccept" rows="2">Good luck.</textarea></label>
       <label>Turn-in Text<textarea id="npcTurnin" rows="2">Thanks for helping.</textarea></label>
       <label><input type="checkbox" id="npcCombat"> Combat NPC</label>
+      <div id="combatOpts" style="display:none"><p class="muted">(no combat options)</p></div>
       <label><input type="checkbox" id="npcShop"> Shop NPC</label>
+      <div id="shopOpts" style="display:none"><p class="muted">(no shop options)</p></div>
       <div id="treeWrap">
         <label>Dialog Tree</label>
         <div id="treeEditor"></div>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -270,6 +270,12 @@ function removeShopTree(tree){
     tree.start.choices = tree.start.choices.filter(c=>c.to!=='sell');
   delete tree.sell;
 }
+function updateNPCOptSections(){
+  document.getElementById('combatOpts').style.display =
+    document.getElementById('npcCombat').checked ? 'block' : 'none';
+  document.getElementById('shopOpts').style.display =
+    document.getElementById('npcShop').checked ? 'block' : 'none';
+}
 function showNPCEditor(show){
   document.getElementById('npcEditor').style.display = show ? 'block' : 'none';
 }
@@ -289,6 +295,7 @@ function startNewNPC(){
   document.getElementById('npcTree').value='';
   document.getElementById('npcCombat').checked=false;
   document.getElementById('npcShop').checked=false;
+  updateNPCOptSections();
   document.getElementById('addNPC').textContent='Add NPC';
   document.getElementById('delNPC').style.display='none';
   loadTreeEditor();
@@ -350,6 +357,7 @@ function addNPC(){
   document.getElementById('npcDesc').value='';
   document.getElementById('npcCombat').checked=false;
   document.getElementById('npcShop').checked=false;
+  updateNPCOptSections();
   drawWorld();
   loadTreeEditor();
   showNPCEditor(false);
@@ -371,6 +379,7 @@ function editNPC(i){
   document.getElementById('npcTree').value=JSON.stringify(n.tree,null,2);
    document.getElementById('npcCombat').checked=!!n.combat;
    document.getElementById('npcShop').checked=!!n.shop;
+  updateNPCOptSections();
   document.getElementById('addNPC').textContent='Update NPC';
   document.getElementById('delNPC').style.display='block';
   loadTreeEditor();
@@ -714,6 +723,8 @@ document.getElementById('loadFile').addEventListener('change',e=>{
     if(document.getElementById('npcQuest').value) generateQuestTree(); else renderDialogPreview();
   });
 });
+document.getElementById('npcCombat').addEventListener('change',updateNPCOptSections);
+document.getElementById('npcShop').addEventListener('change',updateNPCOptSections);
 
 // --- Map interactions ---
 function canvasPos(ev){


### PR DESCRIPTION
## Summary
- Add hidden `#combatOpts` and `#shopOpts` containers for NPC editor
- Toggle option sections via `#npcCombat` and `#npcShop` checkboxes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd65769408328bdf62ab9d8d83f1d