### PR TITLE
Toggle mods UI based on item slot selection

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -82,7 +82,7 @@
         <option value="armor">Armor</option>
         <option value="trinket">Trinket</option>
       </select></label>
-      <div id="modsWrap">
+      <div id="modsWrap" style="display:none">
         <label>Mods</label>
         <div id="modBuilder"></div>
         <button class="btn" type="button" id="addMod">Add Mod</button>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -401,6 +401,12 @@ function deleteNPC(){
 function showItemEditor(show){
   document.getElementById('itemEditor').style.display = show ? 'block' : 'none';
 }
+
+function updateModsWrap(){
+  const slot=document.getElementById('itemSlot').value;
+  document.getElementById('modsWrap').style.display=
+    ['weapon','armor','trinket'].includes(slot)?'block':'none';
+}
 function startNewItem(){
   editItemIdx=-1;
   document.getElementById('itemName').value='';
@@ -408,6 +414,7 @@ function startNewItem(){
   document.getElementById('itemX').value=0;
   document.getElementById('itemY').value=0;
   document.getElementById('itemSlot').value='';
+  updateModsWrap();
   loadMods({});
   document.getElementById('itemValue').value=0;
   document.getElementById('itemUse').value='';
@@ -449,6 +456,7 @@ function editItem(i){
   document.getElementById('itemX').value=it.x;
   document.getElementById('itemY').value=it.y;
   document.getElementById('itemSlot').value=it.slot||'';
+  updateModsWrap();
   loadMods(it.mods);
   document.getElementById('itemValue').value=it.value||0;
   document.getElementById('itemUse').value=it.use?JSON.stringify(it.use,null,2):'';
@@ -693,6 +701,7 @@ document.getElementById('delItem').onclick=deleteItem;
 document.getElementById('delBldg').onclick=deleteBldg;
 document.getElementById('delQuest').onclick=deleteQuest;
 document.getElementById('addMod').onclick=()=>modRow();
+document.getElementById('itemSlot').addEventListener('change',updateModsWrap);
 document.getElementById('save').onclick=saveModule;
 document.getElementById('load').onclick=()=>document.getElementById('loadFile').click();
 document.getElementById('loadFile').addEventListener('change',e=>{


### PR DESCRIPTION
## Summary
- Hide mods builder by default and reveal only for weapon, armor, or trinket slots.
- Added listener on item slot dropdown to toggle mods UI visibility.
- Ensure new or edited items update mods UI based on selected slot.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd65945108328a0c2d76e47f7e766