### PR TITLE
Toggle quest text fields based on quest selection

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -52,8 +52,10 @@
       <label>Y<input id="npcY" type="number" min="0"/></label>
       <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
       <label>Quest<select id="npcQuest"><option value="">(none)</option></select></label>
-      <label>Accept Text<textarea id="npcAccept" rows="2">Good luck.</textarea></label>
-      <label>Turn-in Text<textarea id="npcTurnin" rows="2">Thanks for helping.</textarea></label>
+      <div id="questTextWrap" style="display:none">
+        <label>Accept Text<textarea id="npcAccept" rows="2">Good luck.</textarea></label>
+        <label>Turn-in Text<textarea id="npcTurnin" rows="2">Thanks for helping.</textarea></label>
+      </div>
       <label><input type="checkbox" id="npcCombat"> Combat NPC</label>
       <label><input type="checkbox" id="npcShop"> Shop NPC</label>
       <div id="treeWrap">

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -247,6 +247,11 @@ function generateQuestTree(){
   loadTreeEditor();
 }
 
+function toggleQuestTextWrap(){
+  const wrap=document.getElementById('questTextWrap');
+  wrap.style.display=document.getElementById('npcQuest').value? 'block':'none';
+}
+
 // --- NPCs ---
 function applyCombatTree(tree){
   tree.start = tree.start || {text:'', choices:[]};
@@ -286,6 +291,7 @@ function startNewNPC(){
   document.getElementById('npcQuest').value='';
   document.getElementById('npcAccept').value='Good luck.';
   document.getElementById('npcTurnin').value='Thanks for helping.';
+  toggleQuestTextWrap();
   document.getElementById('npcTree').value='';
   document.getElementById('npcCombat').checked=false;
   document.getElementById('npcShop').checked=false;
@@ -368,6 +374,7 @@ function editNPC(i){
   document.getElementById('npcQuest').value=n.questId||'';
   document.getElementById('npcAccept').value=n.tree?.accept?.text||'Good luck.';
   document.getElementById('npcTurnin').value=n.tree?.do_turnin?.text||'Thanks for helping.';
+  toggleQuestTextWrap();
   document.getElementById('npcTree').value=JSON.stringify(n.tree,null,2);
    document.getElementById('npcCombat').checked=!!n.combat;
    document.getElementById('npcShop').checked=!!n.shop;
@@ -711,6 +718,7 @@ document.getElementById('loadFile').addEventListener('change',e=>{
   document.getElementById('addNode').onclick=addNode;
 ['npcDialog','npcAccept','npcTurnin','npcQuest'].forEach(id=>{
   document.getElementById(id).addEventListener(id==='npcQuest'?'change':'input',()=>{
+    if(id==='npcQuest') toggleQuestTextWrap();
     if(document.getElementById('npcQuest').value) generateQuestTree(); else renderDialogPreview();
   });
 });


### PR DESCRIPTION
## Summary
- Wrap Accept/Turn-in text fields in hidden container `#questTextWrap`
- Show quest-specific text only when an NPC quest is selected
- Ensure quest text visibility resets when creating or editing NPCs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd65805388328927e2d1e6dd95c0f