### PR TITLE
Refactor dialog editor into modal

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -27,6 +27,9 @@
       #treeEditor .nodeHeader{display:flex;align-items:center;}
       #treeEditor .toggle{margin-right:4px;}
       #treeEditor .node.collapsed .nodeBody{display:none;}
+      .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.6);z-index:100;}
+      .modal.shown{display:flex;}
+      #dialogModal .card{position:relative;width:600px;max-height:80vh;overflow:auto;}
   </style>
 </head>
 <body>
@@ -65,12 +68,10 @@
       <div id="combatOpts" style="display:none"><p class="muted">(no combat options)</p></div>
       <label><input type="checkbox" id="npcShop"> Shop NPC</label>
       <div id="shopOpts" style="display:none"><p class="muted">(no shop options)</p></div>
-      <div id="treeWrap">
-        <label>Dialog Tree</label>
-        <div id="treeEditor"></div>
-        <div id="treeWarning" style="color:#f66;font-size:12px;margin-top:4px"></div>
-        <button class="btn" type="button" id="addNode">Add Node</button>
-      </div>
+        <div id="treeWrap">
+          <label>Dialog Tree</label>
+          <button class="btn" type="button" id="editDialog">Edit Dialog</button>
+        </div>
       <textarea id="npcTree" style="display:none"></textarea>
       <div id="dialogPreview" style="margin-top:6px"></div>
       <button class="btn" id="addNPC">Add NPC</button>
@@ -131,6 +132,17 @@
       <button class="btn" id="delQuest" style="display:none">Delete Quest</button>
     </div>
   </fieldset>
+  <div id="dialogModal" class="modal">
+    <div class="card">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
+        <div><b>Dialog Tree Editor</b></div>
+        <button class="btn" type="button" id="closeDialogModal">Close</button>
+      </div>
+      <div id="treeEditor"></div>
+      <div id="treeWarning" style="color:#f66;font-size:12px;margin-top:4px"></div>
+      <button class="btn" type="button" id="addNode">Add Node</button>
+    </div>
+  </div>
   <script src="dustland-core.js"></script>
   <script src="adventure-kit.js"></script>
 </body>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -325,6 +325,15 @@ function loadTreeEditor(){
   updateTreeData();
 }
 
+function openDialogEditor(){
+  document.getElementById('dialogModal').classList.add('shown');
+  renderTreeEditor();
+}
+
+function closeDialogEditor(){
+  document.getElementById('dialogModal').classList.remove('shown');
+}
+
 function toggleQuestDialogBtn(){
   const btn=document.getElementById('genQuestDialog');
   btn.style.display=document.getElementById('npcQuest').value? 'block' : 'none';
@@ -859,6 +868,9 @@ document.getElementById('loadFile').addEventListener('change',e=>{
   document.getElementById('setStart').onclick=()=>{settingStart=true;};
   document.getElementById('playtest').onclick=playtestModule;
   document.getElementById('addNode').onclick=addNode;
+  document.getElementById('editDialog').onclick=openDialogEditor;
+  document.getElementById('closeDialogModal').onclick=closeDialogEditor;
+  document.getElementById('dialogModal').addEventListener('click',e=>{ if(e.target.id==='dialogModal') closeDialogEditor(); });
 // Live preview when dialog text changes
 ['npcDialog','npcAccept','npcTurnin'].forEach(id=>{
   document.getElementById(id).addEventListener('input', renderDialogPreview);


### PR DESCRIPTION
## Summary
- move dialog tree editor into a floating modal for wider editing space
- add JavaScript controls to open and close the new dialog modal

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check adventure-kit.js`


------
https://chatgpt.com/codex/tasks/task_e_689ced65ff648328bb507d4beeaf4d56