### PR TITLE
Fix dialog editor choice input layout

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -22,8 +22,13 @@
     #bldgCard{right:16px;top:560px;width:260px;}
       #questCard{right:16px;top:800px;width:260px;}
       #treeEditor .node{border:1px solid #2b3b2b;padding:4px;margin-top:4px;}
-      #treeEditor .choices div{display:flex;gap:4px;margin-top:2px;}
-      #treeEditor .choices input{flex:1;}
+      #treeEditor .choices div{display:flex;flex-wrap:wrap;gap:4px;margin-top:2px;}
+      #treeEditor .choices input,
+      #treeEditor .choices select{flex:1 1 120px;width:auto;min-width:120px;}
+      #treeEditor .choices .choiceSuccess,
+      #treeEditor .choices .choiceFailure{flex-basis:100%;}
+      #treeEditor .choices label{display:flex;align-items:center;gap:4px;margin-top:0;flex:0 0 auto;}
+      #treeEditor .choices .delChoice{flex:0 0 auto;}
       #treeEditor .nodeHeader{display:flex;align-items:center;}
       #treeEditor .toggle{margin-right:4px;}
       #treeEditor .node.collapsed .nodeBody{display:none;}


### PR DESCRIPTION
## Summary
- Improve dialog editor layout so choice fields expand and wrap, preventing tiny inputs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d02b9fd5c8328810d99970370406b