### PR TITLE
feat: show tabs side-by-side on wide screens

### DIFF
--- a/ack-player.html
+++ b/ack-player.html
@@ -33,9 +33,11 @@
           <div class="tab" id="tabParty">Party</div>
           <div class="tab" id="tabQuests">Quests</div>
         </div>
-        <div id="inv"></div>
-        <div id="party" style="display:none"></div>
-        <div id="quests" style="display:none"></div>
+        <div class="tabwrap" id="tabWrap">
+          <div id="inv"></div>
+          <div id="party" style="display:none"></div>
+          <div id="quests" style="display:none"></div>
+        </div>
         <div style="margin-top:8px">
           <button class="btn" id="saveBtn">Save</button>
           <button class="btn" id="loadBtn">Load</button>

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -122,12 +122,46 @@ function drawScene(ctx){
 }
 
 // ===== HUD & Tabs =====
+const TAB_BREAKPOINT = 1600;
+let activeTab = 'inv';
+
 function updateHUD(){
   hpEl.textContent=player.hp;
   apEl.textContent=player.ap;
   if(scrEl) scrEl.textContent = player.scrap;
 }
-function showTab(which){ const inv=document.getElementById('inv'), partyEl=document.getElementById('party'), q=document.getElementById('quests'); const tInv=document.getElementById('tabInv'), tP=document.getElementById('tabParty'), tQ=document.getElementById('tabQuests'); inv.style.display=(which==='inv'?'grid':'none'); partyEl.style.display=(which==='party'?'grid':'none'); q.style.display=(which==='quests'?'grid':'none'); for(const el of [tInv,tP,tQ]) el.classList.remove('active'); if(which==='inv') tInv.classList.add('active'); if(which==='party') tP.classList.add('active'); if(which==='quests') tQ.classList.add('active'); }
+
+function showTab(which){
+  activeTab = which;
+  if(window.innerWidth >= TAB_BREAKPOINT) return;
+  const inv=document.getElementById('inv'), partyEl=document.getElementById('party'), q=document.getElementById('quests');
+  const tInv=document.getElementById('tabInv'), tP=document.getElementById('tabParty'), tQ=document.getElementById('tabQuests');
+  inv.style.display=(which==='inv'?'grid':'none');
+  partyEl.style.display=(which==='party'?'grid':'none');
+  q.style.display=(which==='quests'?'grid':'none');
+  for(const el of [tInv,tP,tQ]) el.classList.remove('active');
+  if(which==='inv') tInv.classList.add('active');
+  if(which==='party') tP.classList.add('active');
+  if(which==='quests') tQ.classList.add('active');
+}
+
+function updateTabsLayout(){
+  const wide = window.innerWidth >= TAB_BREAKPOINT;
+  const tabs = document.querySelector('.tabs');
+  const inv=document.getElementById('inv'), partyEl=document.getElementById('party'), q=document.getElementById('quests');
+  if(wide){
+    if(tabs) tabs.style.display='none';
+    inv.style.display='grid';
+    partyEl.style.display='grid';
+    q.style.display='grid';
+  } else {
+    if(tabs) tabs.style.display='flex';
+    showTab(activeTab);
+  }
+}
+window.addEventListener('resize', updateTabsLayout);
+updateTabsLayout();
+
 document.getElementById('tabInv').onclick=()=>showTab('inv');
 document.getElementById('tabParty').onclick=()=>showTab('party');
 document.getElementById('tabQuests').onclick=()=>showTab('quests');

--- a/dustland.css
+++ b/dustland.css
@@ -133,7 +133,10 @@
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
         gap: 6px;
-        margin-top: 8px
+    }
+
+    .tabwrap {
+        margin-top: 8px;
     }
 
     .slot {
@@ -181,6 +184,28 @@
 
     .q .status {
         color: #9ab09a
+    }
+
+    @media (min-width: 1600px) {
+        .panel {
+            width: 840px;
+        }
+
+        .tabs {
+            display: none;
+        }
+
+        .tabwrap {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 12px;
+        }
+
+        .tabwrap > #inv,
+        .tabwrap > #party,
+        .tabwrap > #quests {
+            display: grid !important;
+        }
     }
 
     .overlay {

--- a/dustland.html
+++ b/dustland.html
@@ -33,15 +33,17 @@
           <div class="tab" id="tabParty">Party</div>
           <div class="tab" id="tabQuests">Quests</div>
         </div>
-        <div id="inv"></div>
-        <div id="party" style="display:none"></div>
+        <div class="tabwrap" id="tabWrap">
+          <div id="inv"></div>
+          <div id="party" style="display:none"></div>
           <div id="quests" style="display:none"></div>
-          <div style="margin-top:8px">
-            <button class="btn" id="saveBtn">Save</button>
-            <button class="btn" id="loadBtn">Load</button>
-            <button class="btn" id="resetBtn">Reset</button>
-            <button class="btn" id="nanoToggle">Nano Dialog</button>
-          </div>
+        </div>
+        <div style="margin-top:8px">
+          <button class="btn" id="saveBtn">Save</button>
+          <button class="btn" id="loadBtn">Load</button>
+          <button class="btn" id="resetBtn">Reset</button>
+          <button class="btn" id="nanoToggle">Nano Dialog</button>
+        </div>
         </div>
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- add wrapper around tab content and responsive CSS to show inventory, party, and quests in columns on very wide screens
- widen sidebar and hide tab headers at 1600px+, displaying all sections simultaneously
- adjust engine logic to handle responsive layout and window resizing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc732a9048328838d9b603b6481fe