### PR TITLE
Refactor adventure kit layout

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -34,7 +34,6 @@
     }
 
     .card {
-      position: absolute;
       padding: 8px;
       background: #0f120f;
       border: 2px solid #2b3b2b;
@@ -73,39 +72,9 @@
       margin-top: 6px;
     }
 
-    #mapCard {
-      left: 16px;
-      top: 16px;
-      width: 640px;
-    }
-
     #mapCard .controls {
       text-align: center;
       margin-top: 8px;
-    }
-
-    #npcCard {
-      right: 292px;
-      top: 16px;
-      width: 260px;
-    }
-
-    #itemCard {
-      right: 16px;
-      top: 16px;
-      width: 260px;
-    }
-
-    #bldgCard {
-      right: 16px;
-      top: 560px;
-      width: 260px;
-    }
-
-    #questCard {
-      right: 16px;
-      top: 800px;
-      width: 260px;
     }
 
     #treeEditor .node {
@@ -182,30 +151,31 @@
 </head>
 
 <body>
-  <div class="card" id="mapCard">
-    <canvas id="map" width="640" height="480" aria-label="Map preview"></canvas>
-    <div class="controls">
-      <button class="btn" id="regen">Generate World</button>
-      <button class="btn btn--primary" id="save">Download Module</button>
-      <button class="btn" id="load">Load Module</button>
-      <button class="btn" id="setStart">Set Start</button>
-      <button class="btn btn--primary" id="playtest">Playtest</button>
-    </div>
-    <input type="file" id="loadFile" accept="application/json" style="display:none" />
-  </div>
-  <aside class="panel-right" id="editorPanel">
-    <div class="tabs2" role="tablist" aria-label="Editors">
-      <button class="tab2 active" data-tab="npc" role="tab" aria-selected="true">NPCs</button>
-      <button class="tab2" data-tab="items" role="tab" aria-selected="false">Items</button>
-      <button class="tab2" data-tab="buildings" role="tab" aria-selected="false">Buildings</button>
-      <button class="tab2" data-tab="quests" role="tab" aria-selected="false">Quests</button>
-    </div>
-    <div class="tabpanes">
-      <fieldset class="card" id="npcCard" data-pane="npc">
-        <legend>NPCs</legend>
-        <div class="list" id="npcList"></div>
-        <button class="btn" type="button" id="newNPC">+ NPC</button>
-        <div id="npcEditor" style="display:none">
+  <div class="ak-layout">
+    <section class="card map-card" id="mapCard">
+      <canvas id="map" width="640" height="480" aria-label="Map preview"></canvas>
+      <div class="controls">
+        <button class="btn" id="regen">Generate World</button>
+        <button class="btn btn--primary" id="save">Download Module</button>
+        <button class="btn" id="load">Load Module</button>
+        <button class="btn" id="setStart">Set Start</button>
+        <button class="btn btn--primary" id="playtest">Playtest</button>
+      </div>
+      <input type="file" id="loadFile" accept="application/json" style="display:none" />
+    </section>
+    <aside class="editor-panel" id="editorPanel">
+      <div class="tabs2" role="tablist" aria-label="Editors">
+        <button class="tab2 active" data-tab="npc" role="tab" aria-selected="true">NPCs</button>
+        <button class="tab2" data-tab="items" role="tab" aria-selected="false">Items</button>
+        <button class="tab2" data-tab="buildings" role="tab" aria-selected="false">Buildings</button>
+        <button class="tab2" data-tab="quests" role="tab" aria-selected="false">Quests</button>
+      </div>
+      <div class="tabpanes">
+        <fieldset class="card" id="npcCard" data-pane="npc">
+          <legend>NPCs</legend>
+          <div class="list" id="npcList"></div>
+          <button class="btn" type="button" id="newNPC">+ NPC</button>
+          <div id="npcEditor" style="display:none">
           <label>ID<input id="npcId" /></label>
           <label>Name<input id="npcName" /></label>
           <label>Description<textarea id="npcDesc" rows="2"></textarea></label>
@@ -297,23 +267,26 @@
           <button class="btn" id="delQuest" style="display:none">Delete Quest</button>
         </div>
       </fieldset>
-      <div id="dialogModal" class="modal">
-        <div class="card">
-          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
-            <div><b>Dialog Tree Editor</b></div>
-            <button class="btn" type="button" id="closeDialogModal">Close</button>
-          </div>
-          <div id="treeEditor"></div>
-          <div id="treeWarning" style="color:#f66;font-size:12px;margin-top:4px"></div>
-          <button class="btn" type="button" id="addNode">Add Node</button>
-        </div>
+      </div><!-- /.tabpanes -->
+    </aside>
+  </div><!-- /.ak-layout -->
+  <div id="dialogModal" class="modal">
+    <div class="card">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
+        <div><b>Dialog Tree Editor</b></div>
+        <button class="btn" type="button" id="closeDialogModal">Close</button>
       </div>
-      <button id="playtestFloat" class="btn btn--primary" style="
+      <div id="treeEditor"></div>
+      <div id="treeWarning" style="color:#f66;font-size:12px;margin-top:4px"></div>
+      <button class="btn" type="button" id="addNode">Add Node</button>
+    </div>
+  </div>
+  <button id="playtestFloat" class="btn btn--primary" style="
     position:fixed; right:20px; bottom:20px; z-index:9999; border-radius:999px; padding:10px 14px;">
-        ▶ Playtest
-      </button>
-      <script src="dustland-core.js"></script>
-      <script src="adventure-kit.js"></script>
+      ▶ Playtest
+  </button>
+  <script src="dustland-core.js"></script>
+  <script src="adventure-kit.js"></script>
 </body>
 
 </html>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1082,14 +1082,29 @@ function animate() {
 }
 animate();
 
-// ---- Simple right-rail tabs ----
+// ---- Right-rail tabs with wide-screen mode ----
 (function () {
   const panel = document.getElementById('editorPanel');
   if (!panel) return;
   const tabs = Array.from(panel.querySelectorAll('.tab2'));
   const panes = Array.from(panel.querySelectorAll('[data-pane]'));
+  const mq = window.matchMedia('(min-width: 1600px)');
+  let current = 'npc';
+
+  function setLayout() {
+    if (mq.matches) {
+      panel.classList.add('wide');
+      tabs.forEach(t => t.setAttribute('aria-selected', 'true'));
+      panes.forEach(p => p.style.display = '');
+    } else {
+      panel.classList.remove('wide');
+      show(current);
+    }
+  }
 
   function show(tabName) {
+    current = tabName;
+    if (mq.matches) return;
     tabs.forEach(t => {
       const on = t.dataset.tab === tabName;
       t.classList.toggle('active', on);
@@ -1099,7 +1114,8 @@ animate();
   }
 
   tabs.forEach(t => t.addEventListener('click', () => show(t.dataset.tab)));
-  show('npc'); // default
+  mq.addEventListener('change', setLayout);
+  setLayout();
 })();
 
 document.getElementById('playtestFloat').onclick =

--- a/dustland.css
+++ b/dustland.css
@@ -496,11 +496,20 @@
         }
     }
 
-    /* -- Right rail container -- */
-    .panel-right {
-        position: absolute;
-        right: 16px;
-        top: 16px;
+    /* -- Adventure Kit layout -- */
+    .ak-layout {
+        display: flex;
+        gap: 16px;
+        padding: 16px;
+        box-sizing: border-box;
+        align-items: flex-start;
+    }
+
+    .map-card {
+        width: 640px;
+    }
+
+    .editor-panel {
         width: 320px;
         background: #0b0d0b;
         border: 1px solid #273027;
@@ -612,4 +621,30 @@
     #editorPanel #dialogPreview {
         max-height: 40vh;
         overflow: auto;
+    }
+
+    /* Show all editor panes side-by-side on wide screens */
+    @media (min-width: 1600px) {
+        .editor-panel {
+            width: auto;
+            flex: 1;
+            max-height: none;
+        }
+
+        .editor-panel.wide .tabs2 {
+            display: none;
+        }
+
+        .editor-panel.wide .tabpanes {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            padding: 16px;
+            overflow: visible;
+        }
+
+        .editor-panel.wide .tabpanes .card {
+            flex: 1 1 320px;
+            margin: 0 8px 16px !important;
+        }
     }


### PR DESCRIPTION
## Summary
- Replace absolute positioning with flex-based layout for Adventure Kit editor
- Introduce reusable `editor-panel` and `map-card` styles
- Move modal and floating button outside editor for cleaner structure
- Display all editor panes simultaneously on wide screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc7bbfd488328a5a3a2944ea8c8cd