### PR TITLE
feat: move NPC actions to core

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -161,17 +161,20 @@ function renderDialogPreview() {
   function show(id) {
     const node = tree[id]; if (!node) return;
     const html = (node.choices || [])
-      .filter(c => c.to)
-      .map(c => `<button class="btn" data-to="${c.to}" style="margin-top:4px">${c.label}</button>`)
+      .map(c => `<button class="btn" data-to="${c.to || ''}" style="margin-top:4px">${c.label}</button>`)
       .join('');
     prev.innerHTML = `<div>${node.text || ''}</div>` + html;
-    Array.from(prev.querySelectorAll('button')).forEach(btn => btn.onclick = () => show(btn.dataset.to));
+    Array.from(prev.querySelectorAll('button')).forEach(btn => btn.onclick = () => {
+      const t = btn.dataset.to;
+      if (t) show(t);
+    });
   }
   show('start');
 }
 
 function addChoiceRow(container, ch = {}) {
-  const { label = '', to = '', reward = '', stat = '', dc = '', success = '', failure = '', once = false } = ch || {};
+  const { label = '', to = '', reward = '', stat = '', dc = '', success = '', failure = '', once = false, costItem = '', costSlot = '', join = null, q = '' } = ch || {};
+  const joinId = join?.id || '', joinName = join?.name || '', joinRole = join?.role || '';
   const row = document.createElement('div');
   row.innerHTML = `<input class="choiceLabel" placeholder="label" value="${label}"/>
     <select class="choiceTo"></select>
@@ -180,6 +183,12 @@ function addChoiceRow(container, ch = {}) {
     <input class="choiceDC" placeholder="dc" value="${dc || ''}"/>
     <input class="choiceSuccess" placeholder="success text" value="${success || ''}"/>
     <input class="choiceFailure" placeholder="failure text" value="${failure || ''}"/>
+    <input class="choiceCostItem" placeholder="cost item" value="${costItem || ''}"/>
+    <input class="choiceCostSlot" placeholder="cost slot" value="${costSlot || ''}"/>
+    <input class="choiceJoinId" placeholder="join id" value="${joinId}"/>
+    <input class="choiceJoinName" placeholder="join name" value="${joinName}"/>
+    <input class="choiceJoinRole" placeholder="join role" value="${joinRole}"/>
+    <input class="choiceQ" placeholder="q" value="${q || ''}"/>
     <label><input type="checkbox" class="choiceOnce" ${once ? 'checked' : ''}/> once</label>
     <button class="btn delChoice" type="button">x</button>`;
   container.appendChild(row);
@@ -260,6 +269,12 @@ function updateTreeData() {
       const dc = dcTxt ? parseInt(dcTxt, 10) : undefined;
       const success = chEl.querySelector('.choiceSuccess').value.trim();
       const failure = chEl.querySelector('.choiceFailure').value.trim();
+      const costItem = chEl.querySelector('.choiceCostItem').value.trim();
+      const costSlot = chEl.querySelector('.choiceCostSlot').value.trim();
+      const joinId = chEl.querySelector('.choiceJoinId').value.trim();
+      const joinName = chEl.querySelector('.choiceJoinName').value.trim();
+      const joinRole = chEl.querySelector('.choiceJoinRole').value.trim();
+      const q = chEl.querySelector('.choiceQ').value.trim();
       const once = chEl.querySelector('.choiceOnce').checked;
 
       choiceRefs.push({ to, el: toEl });
@@ -272,6 +287,10 @@ function updateTreeData() {
         if (dc != null && !Number.isNaN(dc)) c.dc = dc;
         if (success) c.success = success;
         if (failure) c.failure = failure;
+        if (costItem) c.costItem = costItem;
+        if (costSlot) c.costSlot = costSlot;
+        if (joinId || joinName || joinRole) c.join = { id: joinId, name: joinName, role: joinRole };
+        if (q) c.q = q;
         if (once) c.once = true;
         choices.push(c);
       }

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -700,14 +700,57 @@ function renderDialog(){
       const success = roll >= c.dc;
       textEl.textContent = success ? (c.success||'') : (c.failure||'');
       textEl.textContent += ` (Roll ${roll} vs DC ${c.dc}.)`;
-      if(success && c.reward){
-        if(/^xp\s*\d+/i.test(c.reward)){
-          const amt=parseInt(c.reward.replace(/[^0-9]/g,''),10)||0;
-          awardXP(leader(), amt);
-          textEl.textContent += ` Reward: ${amt} XP.`;
-        } else {
-          addToInv({name:c.reward});
-          textEl.textContent += ` You receive ${c.reward}.`;
+      if(success){
+        if(c.reward){
+          if(/^xp\s*\d+/i.test(c.reward)){
+            const amt=parseInt(c.reward.replace(/[^0-9]/g,''),10)||0;
+            awardXP(leader(), amt);
+            textEl.textContent += ` Reward: ${amt} XP.`;
+          } else {
+            addToInv({name:c.reward});
+            textEl.textContent += ` You receive ${c.reward}.`;
+          }
+        }
+        if(c.join){
+          const j=c.join;
+          const m=makeMember(j.id, j.name, j.role);
+          addPartyMember(m);
+          removeNPC(currentNPC);
+        }
+        if(c.q==='turnin' && currentNPC?.quest){
+          defaultQuestProcessor(currentNPC,'do_turnin');
+        }
+      }
+      if(c.nano && c.key) usedNanoChoices.add(c.key);
+      setContinueOnly();
+      return true;
+    }
+    if(c.costItem || c.costSlot){
+      const idx = c.costItem ? player.inv.findIndex(it=> it.name===c.costItem)
+                             : player.inv.findIndex(it=> it.slot===c.costSlot);
+      if(idx === -1){
+        textEl.textContent = c.failure || 'You lack the required item.';
+      } else {
+        removeFromInv(idx);
+        textEl.textContent = c.success || '';
+        if(c.reward){
+          if(/^xp\s*\d+/i.test(c.reward)){
+            const amt=parseInt(c.reward.replace(/[^0-9]/g,''),10)||0;
+            awardXP(leader(), amt);
+            if(typeof toast==='function') toast(`+${amt} XP`);
+          } else {
+            addToInv({name:c.reward});
+            if(typeof toast==='function') toast(`Received ${c.reward}`);
+          }
+        }
+        if(c.join){
+          const j=c.join;
+          const m=makeMember(j.id, j.name, j.role);
+          addPartyMember(m);
+          removeNPC(currentNPC);
+        }
+        if(c.q==='turnin' && currentNPC?.quest){
+          defaultQuestProcessor(currentNPC,'do_turnin');
         }
       }
       if(c.nano && c.key) usedNanoChoices.add(c.key);
@@ -729,6 +772,18 @@ function renderDialog(){
         addToInv({name:c.reward});
         if(typeof toast==='function') toast(`Received ${c.reward}`);
       }
+    }
+    if(c.join){
+      const j=c.join;
+      const m=makeMember(j.id, j.name, j.role);
+      addPartyMember(m);
+      removeNPC(currentNPC);
+      if(c.q==='turnin' && currentNPC?.quest){
+        defaultQuestProcessor(currentNPC,'do_turnin');
+      }
+      if(c.nano && c.key) usedNanoChoices.add(c.key);
+      setContinueOnly();
+      return true;
     }
     if(currentNPC && typeof currentNPC.processChoice==='function'){
       return currentNPC.processChoice(c)===true;

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -110,57 +110,23 @@ function npc_Grin(x,y){
     'Recruit Grin',
     'Convince or pay Grin to join.'
   );
-  const processNode = function(node){
-    if(node==='start'){
-      defaultQuestProcessor(this,'accept');
-    }
-    if(node==='rollcha'){
-      const r = skillRoll('CHA'); const dc = DC.TALK;
-      textEl.textContent = `Roll: ${r} vs DC ${dc}. ${r>=dc ? 'Grin smirks: "Alright."' : 'Grin shrugs: "Not buying it."'}`;
-      if(r>=dc){
-        const m = makeMember('grin', 'Grin', 'Scavenger');
-        m.stats.AGI += 1; m.stats.PER += 1;
-        addPartyMember(m);
-        removeNPC(this);
-        defaultQuestProcessor(this,'do_turnin');
-      }
-    }
-    if(node==='dopay'){
-      const tIndex = player.inv.findIndex(it=> it.slot==='trinket');
-      if(tIndex>-1){
-        removeFromInv(tIndex);
-        const m = makeMember('grin', 'Grin', 'Scavenger');
-        addPartyMember(m);
-        removeNPC(this);
-        log('Grin joins you.');
-        defaultQuestProcessor(this,'do_turnin');
-      } else {
-        textEl.textContent = 'You have no trinket to pay with.';
-      }
-    }
-  };
   return makeNPC('grin','world',x,y,'#caffc6','Grin','Scav-for-Hire','Lean scav with a crowbar and half a smile.',{
     start:{ text:['Got two hands and a crowbar. You got a plan?','Crowbar’s itching for work. You hiring?'],
       choices:[
-        {label:'(Recruit) Join me.', to:'rec'},
+        {label:'(Recruit) Join me.', to:'accept', q:'accept'},
         {label:'(Chat)', to:'chat'},
         {label:'(Leave)', to:'bye'}
       ]},
+    accept:{ text:'', choices:[{label:'(Continue)', to:'rec'}] },
     chat:{ text:['Keep to the road. The sand eats soles and souls.','Stay off the dunes. Sand chews boots.'],
       choices:[{label:'(Nod)', to:'bye'}] },
     rec:{ text:'Convince me. Or pay me.',
       choices:[
-        {label:'(CHA) Talk up the score', to:'cha'},
-        {label:'(Pay) Give 1 trinket as hire bonus', to:'pay'},
+        {label:'(CHA) Talk up the score', stat:'CHA', dc:DC.TALK, success:'Grin smirks: "Alright."', failure:'Grin shrugs: "Not buying it."', join:{id:'grin',name:'Grin',role:'Scavenger'}, q:'turnin'},
+        {label:'(Pay) Give 1 trinket as hire bonus', costSlot:'trinket', success:'Deal.', failure:'You have no trinket to pay with.', join:{id:'grin',name:'Grin',role:'Scavenger'}, q:'turnin'},
         {label:'(Back)', to:'start'}
       ]},
-    cha:{ text:'Roll vs CHA...',
-      choices:[{label:'(Roll)', to:'rollcha'}] },
-    rollcha:{ text:'…', choices:[{label:'(Ok)', to:'bye'}] },
-    pay:{ text:'Hand me something shiny.',
-      choices:[{label:'(Give random trinket)', to:'dopay'}] },
-    dopay:{ text:'Deal.', choices:[{label:'(Ok)', to:'bye'}] },
-  }, quest, processNode);
+  }, quest);
 }
 
 function npc_Postmaster(x,y){
@@ -192,31 +158,15 @@ function npc_TowerTech(x,y){
     'Repair the radio tower console (Toolkit helps).',
     { item:'Toolkit', reward:{name:'Tuner Charm', slot:'trinket', mods:{PER:+1}}, xp:5 }
   );
-  const processNode = function(node){
-    if(node==='rollint'){
-      if(!player.inv.some(it=> it.name==='Toolkit')){
-        textEl.textContent = 'You need a Toolkit to even try.';
-        return;
-      }
-      const r = skillRoll('INT'); const dc = DC.REPAIR;
-      textEl.textContent = `Roll: ${r} vs DC ${dc}. ${r>=dc ? 'Static fades. The tower hums.' : 'You cross a wire and pop a fuse.'}`;
-      if(r>=dc){
-        defaultQuestProcessor(this,'do_turnin');
-      }
-    }
-  };
   return makeNPC('tower','world',x,y,'#a9f59f','Rella','Radio Tech','Tower technician with grease-stained hands.',{
     start:{ text:'Tower’s console fried. If you got a Toolkit and brains, lend both.',
       choices:[
         {label:'(Accept) I will help.', to:'accept', q:'accept'},
-        {label:'(Repair) INT check with Toolkit', to:'repair', q:'turnin'},
+        {label:'(Repair) INT check with Toolkit', stat:'INT', dc:DC.REPAIR, success:'Static fades. The tower hums.', failure:'You cross a wire and pop a fuse.', q:'turnin'},
         {label:'(Leave)', to:'bye'}
       ]},
-    accept:{ text:'I owe you static and thanks.', choices:[{label:'(Ok)', to:'bye'}] },
-    repair:{ text:'Roll vs INT...',
-      choices:[{label:'(Roll)', to:'rollint'}] },
-    rollint:{ text:'…', choices:[{label:'(Ok)', to:'bye'}] }
-  }, quest, processNode);
+    accept:{ text:'I owe you static and thanks.', choices:[{label:'(Ok)', to:'bye'}] }
+  }, quest);
 }
 
 function npc_IdolHermit(x,y){


### PR DESCRIPTION
## Summary
- add join, cost, and quest handling to core dialog choices
- let adventure kit editor define cost and party-join options for NPC choices
- refactor Grin and Tower Tech NPCs to use data-driven dialogs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check dustland-core.js`
- `node --check adventure-kit.js`
- `node --check modules/dustland.module.js`


------
https://chatgpt.com/codex/tasks/task_e_689dd40c20e48328b23f6a7b0c526b16