### PR TITLE
Add basic Node tests and document test command

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -98,6 +98,7 @@ _______________________________________________________________________________
       * renderParty(), renderInv(), renderQuests()
       * takeNearestItem(), interact(), move()
   - Tiles: see TILE enum + colors[] + walkable[].
+  - Tests: run `npm test` for basic checks.
 
 [ LICENSE ]
   MIT License

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -985,3 +985,8 @@ function startWorld(){
 // Content pack moved to modules/dustland.module.js
 
 Object.assign(window, {Dice, Character, Party, Quest, NPC, questLog, quickCombat, removeNPC, makeNPC});
+
+// Export a few helpers for Node-based tests without affecting the browser build
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { clamp, createRNG, Dice };
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dustland",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "main": "dustland-core.js",
   "scripts": {
-    "test": "echo 'No tests specified'"
+    "test": "node --test"
   },
   "author": "",
   "license": "MIT"

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+function stubEl(){
+  return {
+    style:{},
+    classList:{ toggle: ()=>{} },
+    textContent:'',
+    onclick:null,
+    querySelector: () => stubEl()
+  };
+}
+
+global.window = global;
+global.document = {
+  getElementById: () => stubEl(),
+  createElement: () => stubEl()
+};
+
+const { clamp, createRNG, Dice } = require('../dustland-core.js');
+
+test('clamp restricts values to range', () => {
+  assert.strictEqual(clamp(5, 0, 10), 5);
+  assert.strictEqual(clamp(-1, 0, 10), 0);
+  assert.strictEqual(clamp(15, 0, 10), 10);
+});
+
+test('createRNG produces deterministic sequences', () => {
+  const rngA = createRNG(123);
+  const rngB = createRNG(123);
+  assert.strictEqual(rngA(), rngB());
+  assert.strictEqual(rngA(), rngB());
+});
+
+test('Dice.roll is within inclusive bounds', () => {
+  for(let i=0;i<100;i++){
+    const roll = Dice.roll(6);
+    assert.ok(roll >= 1 && roll <= 6);
+  }
+});


### PR DESCRIPTION
## Summary
- export core helpers for Node environments and add simple tests covering clamp, RNG, and dice rolling
- wire up `npm test` using Node's built-in test runner and bump package version
- note testing instructions in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689deab1fc288328ac49056f616a0f89