### PR TITLE
feat: add module picker

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -25,6 +25,7 @@ _______________________________________________________________________________
   - Play the latest build in your browser:
     https://weatheredclown.github.io/dustland/dustland.html
   - Just open:  dustland.html  (double-click or serve from any static server).
+  - Pick a module on startup (e.g. Dustland or Echoes).
   - Build a module with: adventure-kit.html  (save to JSON).
   - Play a module with: ack-player.html and load your JSON.
   - No build step. No dependencies. Works offline.

--- a/dustland.html
+++ b/dustland.html
@@ -100,8 +100,14 @@
   </div>
 
   <script src="dustland-core.js"></script>
-  <script src="modules/dustland.module.js"></script>
+  <script>
+    window._realOpenCreator = window.openCreator;
+    window._realShowStart = window.showStart;
+    window.openCreator = function(){};
+    window.showStart = function(){};
+  </script>
   <script src="dustland-nano.js"></script>
   <script src="dustland-engine.js"></script>
+  <script src="module-picker.js"></script>
 </body>
 </html>

--- a/module-picker.js
+++ b/module-picker.js
@@ -1,0 +1,42 @@
+const MODULES = [
+  { id: 'dustland', name: 'Dustland', file: 'modules/dustland.module.js' },
+  { id: 'echoes', name: 'Echoes', file: 'modules/echoes.module.js' }
+];
+
+function loadModule(mod){
+  const s = document.createElement('script');
+  s.src = mod.file;
+  s.onload = () => {
+    const picker = document.getElementById('modulePicker');
+    if(picker) picker.remove();
+    window.openCreator = window._realOpenCreator;
+    window.showStart = window._realShowStart;
+    const saveStr = localStorage.getItem('dustland_crt');
+    if(saveStr){
+      showStart();
+    } else {
+      openCreator();
+    }
+  };
+  document.body.appendChild(s);
+}
+
+function showModulePicker(){
+  const overlay = document.createElement('div');
+  overlay.id = 'modulePicker';
+  overlay.style = 'position:fixed;inset:0;background:rgba(0,0,0,.8);display:flex;align-items:center;justify-content:center;z-index:40';
+  overlay.innerHTML = `<div class="win" style="width:min(420px,92vw);background:#0b0d0b;border:1px solid #2a382a;border-radius:12px;box-shadow:0 20px 80px rgba(0,0,0,.7);overflow:hidden"><header style="padding:10px 12px;border-bottom:1px solid #223022;font-weight:700">Select Module</header><main style="padding:12px" id="moduleButtons"></main></div>`;
+  document.body.appendChild(overlay);
+  const btnWrap = overlay.querySelector('#moduleButtons');
+  MODULES.forEach(m => {
+    const btn = document.createElement('button');
+    btn.className = 'btn';
+    btn.textContent = m.name;
+    btn.style.display = 'block';
+    btn.style.margin = '4px 0';
+    btn.onclick = () => loadModule(m);
+    btnWrap.appendChild(btn);
+  });
+}
+
+showModulePicker();


### PR DESCRIPTION
## Summary
- add module picker overlay to select between built-in modules
- load chosen module dynamically and restore game boot flow
- document module selection in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a078aff95c8328b1273f7e826d85b6