### PR TITLE
feat: add simple game state machine and dialog engine

### DIFF
--- a/test/core.test.js
+++ b/test/core.test.js
@@ -17,7 +17,7 @@ global.document = {
   createElement: () => stubEl()
 };
 
-const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character } = require('../dustland-core.js');
+const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog } = require('../dustland-core.js');
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -76,4 +76,14 @@ test('equipping teleport item moves player', () => {
   assert.strictEqual(player.x,5);
   assert.strictEqual(player.y,6);
   assert.strictEqual(state.map,'world');
+});
+
+test('advanceDialog moves to next node', () => {
+  const tree = {
+    start: { text: 'hi', next: [{ id: 'bye', label: 'Bye' }] },
+    bye: { text: 'bye', next: [] }
+  };
+  const dialog = { tree, node: 'start' };
+  advanceDialog(dialog, 0);
+  assert.strictEqual(dialog.node, 'bye');
 });


### PR DESCRIPTION
## Summary
- track global game phases through a tiny state machine
- rework dialog system around pure data nodes with advanceDialog()
- cover new dialog engine with a basic test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a13aefbe4c8328943ec21563962d3f