### PR TITLE
Add headless core tests for pathing, loot, and dialog XP

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -1117,6 +1117,14 @@ if (typeof module !== 'undefined' && module.exports) {
     player,
     party,
     state,
-    Character
+    Character,
+    applyModule,
+    findFreeDropTile,
+    canWalk,
+    move,
+    openDialog,
+    NPCS,
+    itemDrops,
+    setLeader: (idx)=>{ selectedMember = idx; }
   };
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -2,22 +2,42 @@ const assert = require('assert');
 const { test } = require('node:test');
 
 function stubEl(){
-  return {
+  const el = {
     style:{},
-    classList:{ toggle: ()=>{} },
+    classList:{ toggle: ()=>{}, add: ()=>{}, remove: ()=>{} },
     textContent:'',
     onclick:null,
-    querySelector: () => stubEl()
+    _innerHTML:'',
+    children:[],
+    appendChild(child){ this.children.push(child); child.parentElement=this; },
+    querySelector: () => stubEl(),
+    querySelectorAll: () => [],
+    parentElement:{ appendChild:()=>{}, querySelectorAll:()=>[] }
   };
+  Object.defineProperty(el,'innerHTML',{ get(){return this._innerHTML;}, set(v){ this._innerHTML=v; this.children=[]; }});
+  return el;
 }
 
 global.window = global;
+const overlay = stubEl();
+const choicesEl = stubEl();
+const dialogText = stubEl();
+const npcName = stubEl();
+const npcTitle = stubEl();
+const portEl = stubEl();
 global.document = {
-  getElementById: () => stubEl(),
+  getElementById: (id) => ({
+    overlay,
+    choices: choicesEl,
+    dialogText,
+    npcName,
+    npcTitle,
+    port: portEl
+  })[id] || stubEl(),
   createElement: () => stubEl()
 };
 
-const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character } = require('../dustland-core.js');
+const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, applyModule, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader } = require('../dustland-core.js');
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -76,4 +96,49 @@ test('equipping teleport item moves player', () => {
   assert.strictEqual(player.x,5);
   assert.strictEqual(player.y,6);
   assert.strictEqual(state.map,'world');
+});
+
+test('pathfinding blocks on NPCs', () => {
+  const W=120, H=90;
+  const world = Array.from({length:H},()=>Array.from({length:W},()=>7));
+  applyModule({world, npcs:[{id:'g', map:'world', x:1, y:0, name:'Guard'}]});
+  state.map='world';
+  player.x=0; player.y=0;
+  assert.strictEqual(canWalk(1,0), false);
+  move(1,0);
+  assert.strictEqual(player.x,0);
+});
+
+test('findFreeDropTile avoids water and player tiles', () => {
+  const W=120, H=90;
+  const world = Array.from({length:H},()=>Array.from({length:W},()=>7));
+  world[10][10] = 2; // water
+  applyModule({world});
+  state.map='world';
+  player.x=0; player.y=0;
+  NPCS.length=0;
+  NPCS.push({map:'world', x:0, y:0});
+  let spot = findFreeDropTile('world',0,0);
+  assert.ok(spot.x !== 0 || spot.y !== 0);
+  spot = findFreeDropTile('world',10,10);
+  assert.notStrictEqual(world[spot.y][spot.x],2);
+});
+
+test('selected party member receives XP on dialog success', () => {
+  const W=120, H=90;
+  const world = Array.from({length:H},()=>Array.from({length:W},()=>7));
+  applyModule({world, npcs:[{id:'s', map:'world', x:1, y:0, name:'Sage', tree:{start:{text:'hi', choices:[{label:'learn', reward:'XP 5', to:'bye'}]}}}]});
+  state.map='world';
+  player.x=0; player.y=0;
+  party.length=0;
+  const a=new Character('a','A','Role');
+  const b=new Character('b','B','Role');
+  party.addMember(a);
+  party.addMember(b);
+  setLeader(1);
+  a.xp=0; b.xp=0;
+  openDialog(NPCS[0]);
+  choicesEl.children[0].onclick();
+  assert.strictEqual(a.xp,0);
+  assert.strictEqual(b.xp,5);
 });


### PR DESCRIPTION
## Summary
- expose core helpers for module loading, movement, and dialogs
- add headless tests for NPC blocking, safe loot drops, and dialog XP assignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a13b98ceac8328979c7d1fdcb03bdf