### PR TITLE
Widen office elevator and add cursed VR helmet

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -21,15 +21,19 @@ const OFFICE_MODULE = (() => {
   }
 
   function addElevator(grid) {
-    // Larger elevator placed outside the main office square
+    // Wider elevator placed outside the main office rectangle
     for (let y = 1; y <= 4; y++) {
-      grid[y][midX - 1] = TILE.WALL;
-      grid[y][midX + 1] = TILE.WALL;
+      grid[y][midX - 2] = TILE.WALL;
+      grid[y][midX + 2] = TILE.WALL;
     }
     for (let y = 1; y < 4; y++) {
+      grid[y][midX - 1] = TILE.FLOOR;
       grid[y][midX] = TILE.FLOOR; // NPC spot and elevator floor
+      grid[y][midX + 1] = TILE.FLOOR;
     }
+    grid[4][midX - 1] = TILE.DOOR;
     grid[4][midX] = TILE.DOOR;
+    grid[4][midX + 1] = TILE.DOOR;
   }
 
   function makeFloor1() {
@@ -102,7 +106,17 @@ const OFFICE_MODULE = (() => {
   return {
     seed: Date.now(),
     start: { map: 'floor1', x: midX, y: FLOOR_H - 2 },
-    items: [],
+    items: [
+      {
+        map: 'floor3',
+        x: midX,
+        y: 6,
+        name: 'Cursed VR Helmet',
+        slot: 'armor',
+        cursed: true,
+        equip: { teleport: { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) } }
+      }
+    ],
     quests: [],
     npcs,
     interiors: [floor1, floor2, floor3],

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -141,6 +141,8 @@ test('selected party member receives XP on dialog success', () => {
   choicesEl.children[0].onclick();
   assert.strictEqual(a.xp,0);
   assert.strictEqual(b.xp,5);
+});
+
 test('advanceDialog moves to next node', () => {
   const tree = {
     start: { text: 'hi', next: [{ id: 'bye', label: 'Bye' }] },


### PR DESCRIPTION
## Summary
- Broadened the office elevator shaft so it protrudes above the roof and offers a three-tile-wide entrance.
- Added a cursed VR helmet on the top floor that teleports its wearer to the world map.
- Repaired a malformed unit test to restore passing test suite.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23fd3219883288886e57582c59028