### PR TITLE
feat: add data-driven skill checks

### DIFF
--- a/dustland-nano.js
+++ b/dustland-nano.js
@@ -351,7 +351,7 @@ Choices:
     const choices = choicePart.split(/\r?\n/)
       .map(_parseChoice)
       .filter(Boolean)
-      .filter(c => !(c.stat && (!c.reward || c.reward.toLowerCase() === 'none')))
+      .filter(c => !(c.check && (!c.reward || c.reward.toLowerCase() === 'none')))
       .slice(0, 2);
   
     console.log("Produced:", lines, choices);
@@ -367,8 +367,7 @@ Choices:
       const dc = parseInt(parts[2],10);
       return {
         label: parts[0],
-        stat: parts[1].toUpperCase(),
-        dc: isNaN(dc)?0:dc,
+        check: { stat: parts[1].toUpperCase(), dc: isNaN(dc)?0:dc },
         reward: parts[3],
         success: parts[4],
         failure: parts[5]

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -171,8 +171,7 @@ const DUSTLAND_MODULE = (() => {
           choices: [
             {
               label: '(CHA) Talk up the score',
-              stat: 'CHA',
-              dc: DC.TALK,
+              check: { stat: 'CHA', dc: DC.TALK },
               success: 'Grin smirks: "Alright."',
               failure: 'Grin shrugs: "Not buying it."',
               join: { id: 'grin', name: 'Grin', role: 'Scavenger' },
@@ -235,8 +234,7 @@ const DUSTLAND_MODULE = (() => {
             { label: '(Accept) I will help.', to: 'accept', q: 'accept' },
             {
               label: '(Repair) INT check with Toolkit',
-              stat: 'INT',
-              dc: DC.REPAIR,
+              check: { stat: 'INT', dc: DC.REPAIR },
               success: 'Static fades. The tower hums.',
               failure: 'You cross a wire and pop a fuse.',
               q: 'turnin'
@@ -309,8 +307,7 @@ const DUSTLAND_MODULE = (() => {
           choices: [
             {
               label: '(Talk) Stand down',
-              stat: 'CHA',
-              dc: DC.TALK,
+              check: { stat: 'CHA', dc: DC.TALK },
               success: 'He grunts and lets you pass.',
               failure: 'He tightens his grip.',
               to: 'bye'

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -37,7 +37,7 @@ global.document = {
   createElement: () => stubEl()
 };
 
-const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader } = require('../dustland-core.js');
+const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader, resolveCheck } = require('../dustland-core.js');
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -66,6 +66,19 @@ test('Dice.roll is within inclusive bounds', () => {
     const roll = Dice.roll(6);
     assert.ok(roll >= 1 && roll <= 6);
   }
+});
+
+test('resolveCheck uses rng and runs effects', () => {
+  const actor = new Character('t','Tester','Role');
+  const events = [];
+  const check = { stat:'CHA', dc:5, onSuccess:[()=>events.push('s')], onFail:[()=>events.push('f')] };
+  const failRes = resolveCheck(check, actor, () => 0);
+  assert.strictEqual(failRes.success, false);
+  assert.deepStrictEqual(events, ['f']);
+  events.length = 0;
+  const winRes = resolveCheck(check, actor, () => 0.99);
+  assert.strictEqual(winRes.success, true);
+  assert.deepStrictEqual(events, ['s']);
 });
 
 test('cursed items reveal on unequip attempt and stay equipped', () => {


### PR DESCRIPTION
## Summary
- add Check data type and RNG-injectable resolveCheck to centralize stat rolls
- convert dialog choices and content modules to use check objects instead of ad-hoc stat/dc pairs
- update nano generator and tests for new skill check API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a26f3b15c48328b72153ca4a7dae64