### PR TITLE
fix: allow case-insensitive item checks

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -865,8 +865,11 @@ function advanceDialog(stateObj, choiceIdx){
 
   // Required item/slot without consumption
   if(choice.reqItem || choice.reqSlot){
-    const idx = choice.reqItem ? player.inv.findIndex(it=> it.name===choice.reqItem)
-                               : player.inv.findIndex(it=> it.slot===choice.reqSlot);
+    const idx = choice.reqItem
+      ? player.inv.findIndex(
+          it => it.name?.trim().toLowerCase() === choice.reqItem.trim().toLowerCase()
+        )
+      : player.inv.findIndex(it => it.slot === choice.reqSlot);
     if(idx === -1){
       return finalize(choice.failure || 'You lack the required item.');
     }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -239,3 +239,17 @@ test('advanceDialog uses reqItem without consuming and allows goto', () => {
   assert.strictEqual(player.y, 6);
   assert.ok(player.inv.some(it => it.name === 'Pass'));
 });
+
+test('advanceDialog matches reqItem case-insensitively', () => {
+  player.inv.length = 0;
+  addToInv({ name: 'access card' });
+  state.map = 'world';
+  player.x = 2; player.y = 2;
+  const tree = {
+    start: { text: '', next: [{ label: 'Up', reqItem: 'Access Card', goto: { map: 'room', x: 7, y: 8 } }] }
+  };
+  const dialog = { tree, node: 'start' };
+  advanceDialog(dialog, 0);
+  assert.strictEqual(player.x, 7);
+  assert.strictEqual(player.y, 8);
+});


### PR DESCRIPTION
## Summary
- allow dialog required item checks to ignore name casing
- cover case-insensitive item requirement with new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a277258f888328a87ea304aff45022