### PR TITLE
Fix VR headset reward in office module

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -40,10 +40,9 @@ loadBtn.onclick = () => {
 window.startGame = function(){
   if(moduleData) applyModule(moduleData);
   const start=moduleData && moduleData.start ? moduleData.start : {map:'world',x:2,y:Math.floor(WORLD_H/2)};
-  setMap(start.map||'world', 'Module');
   player.x = start.x;
   player.y = start.y;
-  centerCamera(player.x, player.y, start.map||'world');
+  setMap(start.map||'world', 'Module');
   renderInv(); renderQuests(); renderParty(); updateHUD();
   log('Adventure begins.');
 };

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -275,6 +275,7 @@
             <div id="modBuilder"></div>
             <button class="btn" type="button" id="addMod">Add Mod</button>
           </div>
+          <label>Equip<textarea id="itemEquip" rows="2"></textarea></label>
           <label>Value<input id="itemValue" type="number" min="0" /></label>
           <label>Use<textarea id="itemUse" rows="2"></textarea></label>
           <button class="btn" id="addItem">Add Item</button>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -683,6 +683,7 @@ function startNewItem() {
   updateModsWrap();
   loadMods({});
   document.getElementById('itemValue').value = 0;
+  document.getElementById('itemEquip').value = '';
   document.getElementById('itemUse').value = '';
   document.getElementById('addItem').textContent = 'Add Item';
   document.getElementById('delItem').style.display = 'none';
@@ -703,9 +704,11 @@ function addItem() {
   const slot = document.getElementById('itemSlot').value || null;
   const mods = collectMods();
   const value = parseInt(document.getElementById('itemValue').value, 10) || 0;
+  let equip = null;
+  try { equip = JSON.parse(document.getElementById('itemEquip').value || 'null'); } catch (e) { equip = null; }
   let use = null;
   try { use = JSON.parse(document.getElementById('itemUse').value || 'null'); } catch (e) { use = null; }
-  const item = { id, name, type, tags, map, x, y, slot, mods, value, use };
+  const item = { id, name, type, tags, map, x, y, slot, mods, value, use, equip };
   if (editItemIdx >= 0) {
     moduleData.items[editItemIdx] = item;
   } else {
@@ -734,6 +737,7 @@ function editItem(i) {
   updateModsWrap();
   loadMods(it.mods);
   document.getElementById('itemValue').value = it.value || 0;
+  document.getElementById('itemEquip').value = it.equip ? JSON.stringify(it.equip, null, 2) : '';
   document.getElementById('itemUse').value = it.use ? JSON.stringify(it.use, null, 2) : '';
   document.getElementById('addItem').textContent = 'Update Item';
   document.getElementById('delItem').style.display = 'block';

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -350,10 +350,9 @@ startGame = function () {
   startWorld();
   applyModule(DUSTLAND_MODULE);
   const s = DUSTLAND_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-  setMap(s.map, s.map === 'world' ? 'Wastes' : 'Test Hall');
   player.x = s.x;
   player.y = s.y;
-  centerCamera(player.x, player.y, s.map);
+  setMap(s.map, s.map === 'world' ? 'Wastes' : 'Test Hall');
   renderInv();
   renderQuests();
   renderParty();

--- a/modules/echoes.module.js
+++ b/modules/echoes.module.js
@@ -179,10 +179,9 @@ startGame = function () {
   startWorld();
   applyModule(ECHOES_MODULE);
   const s = ECHOES_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-  setMap(s.map, s.map === 'world' ? 'Wastes' : 'Echoes');
   player.x = s.x;
   player.y = s.y;
-  centerCamera(player.x, player.y, s.map);
+  setMap(s.map, s.map === 'world' ? 'Wastes' : 'Echoes');
   renderInv();
   renderQuests();
   renderParty();

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -350,28 +350,25 @@ const OFFICE_MODULE = (() => {
       castle: 'Castle'
     },
       items: [
-        { id: 'access_card', name: 'Access Card', type: 'quest', tags: ['pass'] }
+        { id: 'access_card', name: 'Access Card', type: 'quest', tags: ['pass'] },
+        {
+          id: 'cursed_vr_helmet',
+          name: 'Cursed VR Helmet',
+          type: 'armor',
+          slot: 'armor',
+          cursed: true,
+          equip: {
+            teleport: { map: 'world', x: 2, y: WORLD_MIDY },
+            msg: 'You step into the forest.'
+          }
+        }
       ],
       quests: [
         {
           id: 'q_card',
           title: 'Access Granted',
           desc: 'Convince security to lend you an access card and join Jen in the sim.',
-          reward: {
-            id: 'cursed_vr_helmet',
-            name: 'Cursed VR Helmet',
-            type: 'armor',
-            slot: 'armor',
-            cursed: true,
-            equip: {
-              teleport: { map: 'world', x: 2, y: WORLD_MIDY },
-              onEquip: ({ setMap, log, centerCamera, player }) => {
-                setMap('world');
-                centerCamera(player.x, player.y, 'world');
-                log('You step into the forest.');
-              }
-            }
-          }
+          reward: 'cursed_vr_helmet'
         },
         { id: 'q_toll', title: 'Bridge Tax', desc: 'Pay the Toll Keeper with a trinket.' }
       ],
@@ -400,10 +397,9 @@ startGame = function () {
       itemDrops.push({ id: charm.id, map: castleId, x: ix, y: iy });
     }
     const s = OFFICE_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-    setMap(s.map);
     player.x = s.x;
     player.y = s.y;
-    centerCamera(player.x, player.y, s.map);
+    setMap(s.map);
     renderInv();
     renderQuests();
     renderParty();


### PR DESCRIPTION
## Summary
- Register cursed VR headset item in the office module
- Provide VR headset quest reward by item id
- Center camera on map changes and allow items to define equip messages
- Test quest turn-in grants VR headset and teleport equip behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ad8a4f108328ae2b5f50d38157d7