### PR TITLE
Fix global state resets and dialog navigation

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -144,9 +144,10 @@ function advanceDialog(stateObj, choiceIdx){
     res.close=true; stateObj.node=null; return res;
   }
 
-  if(choice.to){
-    res.next=choice.to;
-    stateObj.node=choice.to;
+  const nextId = choice.to || choice.id;
+  if (nextId) {
+    res.next = nextId;
+    stateObj.node = nextId;
     return res;
   }
 


### PR DESCRIPTION
## Summary
- Ensure `applyModule` mutates world and interior collections in place so shared references stay updated
- Allow `advanceDialog` to follow choices using either `to` or `id`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a34be78e4883288d6f6e520077b0a7