### PR TITLE
Avoid global naming collisions in core modules

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -153,7 +153,7 @@ function advanceDialog(stateObj, choiceIdx){
   return finalize(choice.text || '');
 }
 
-const usedOnceChoices=new Set();
+const onceChoices = globalThis.usedOnceChoices || (globalThis.usedOnceChoices = new Set());
 
 function setPortrait(portEl, npc){
   if(!npc.portraitSheet){
@@ -240,7 +240,7 @@ function renderDialog(){
   choices=choices.filter(({opt})=>{
     if(!opt.once) return true;
     const key=`${currentNPC.id}::${dialogState.node}::${opt.label}`;
-    return !usedOnceChoices.has(key);
+    return !onceChoices.has(key);
   });
 
   choices.forEach(({opt,idx})=>{
@@ -249,7 +249,7 @@ function renderDialog(){
     div.textContent=opt.label||'(Continue)';
     div.onclick=()=>{
       const key=`${currentNPC.id}::${dialogState.node}::${opt.label}`;
-      if(opt.once) usedOnceChoices.add(key);
+      if(opt.once) onceChoices.add(key);
 
       const result=advanceDialog(dialogState,idx);
       if(result && result.text!==null){

--- a/core/inventory.js
+++ b/core/inventory.js
@@ -164,9 +164,9 @@ function useItem(invIndex){
   return false;
 }
 
-const exportsObj = { ITEMS, itemDrops, registerItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem };
-Object.assign(globalThis, exportsObj);
+const inventoryExports = { ITEMS, itemDrops, registerItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem };
+Object.assign(globalThis, inventoryExports);
 
 if (typeof module !== 'undefined' && module.exports){
-  module.exports = exportsObj;
+  module.exports = inventoryExports;
 }

--- a/core/party.js
+++ b/core/party.js
@@ -75,9 +75,9 @@ function applyEquipmentStats(m){ m.applyEquipmentStats(); }
 function leader(){ return party.leader(); }
 function setLeader(idx){ selectedMember = idx; }
 
-const exportsObj = { baseStats, Character, Party, party, makeMember, addPartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, leader, setLeader, selectedMember };
-Object.assign(globalThis, exportsObj);
+const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, leader, setLeader, selectedMember };
+Object.assign(globalThis, partyExports);
 
 if (typeof module !== 'undefined' && module.exports){
-  module.exports = exportsObj;
+  module.exports = partyExports;
 }


### PR DESCRIPTION
## Summary
- prevent party and inventory modules from redefining a shared `exportsObj`
- reuse global `usedOnceChoices` in dialog module to avoid duplicate declarations

## Testing
- `npm test` *(fails: 13 passed, 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a34c5109b083289ab6d672d46eba68