### PR TITLE
Hide quest turn-in until quest accepted

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -233,7 +233,7 @@ function renderDialog(){
     const meta=currentNPC.quest;
     choices=choices.filter(({opt})=>{
       if(opt.q==='accept' && meta.status!=='available') return false;
-      if(opt.q==='turnin' && (meta.status==='completed' || (meta.item && !hasItem(meta.item)))) return false;
+      if(opt.q==='turnin' && (meta.status!=='active' || (meta.item && !hasItem(meta.item)))) return false;
       return true;
     });
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -45,6 +45,7 @@ global.toast = () => {};
 global.sfxTick = () => {};
 global.renderInv = () => {};
 global.renderParty = () => {};
+global.renderQuests = () => {};
 global.updateHUD = () => {};
 global.centerCamera = () => {};
 
@@ -300,4 +301,32 @@ test('quest turn-in grants reward item', () => {
   openDialog(npc);
   choicesEl.children[0].onclick();
   assert.ok(player.inv.some(it => it.id === 'cursed_vr_helmet'));
+});
+
+test('turn-in choice hidden until quest accepted', () => {
+  player.inv.length = 0;
+  NPCS.length = 0;
+  const quest = new Quest('q_hidden', 'Quest', '');
+  const tree = {
+    start: { text: '', choices: [
+      { label: 'accept', to: 'accept', q: 'accept' },
+      { label: 'turn in', to: 'do_turnin', q: 'turnin' }
+    ] },
+    accept: { text: '', choices: [ { label: 'bye', to: 'bye' } ] },
+    do_turnin: { text: '', choices: [ { label: 'bye', to: 'bye' } ] }
+  };
+  const npc = makeNPC('jen', 'world', 0, 0, '#fff', 'Jen', '', '', tree, quest);
+  NPCS.push(npc);
+
+  openDialog(npc);
+  let labels = choicesEl.children.map(c => c.textContent);
+  assert.ok(!labels.includes('turn in'));
+
+  // accept quest
+  choicesEl.children[0].onclick(); // accept
+  choicesEl.children[0].onclick(); // bye
+
+  openDialog(npc);
+  labels = choicesEl.children.map(c => c.textContent);
+  assert.ok(labels.includes('turn in'));
 });


### PR DESCRIPTION
## Summary
- Ensure quest turn-in options only appear once the quest is active
- Add regression test for turn-in visibility logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a34f41494883289e2039cd2efd0759