### PR TITLE
Hide unaccepted quests

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -179,15 +179,26 @@ class Quest {
 class QuestLog {
   constructor(){ this.quests={}; }
   add(quest){
-    if(!this.quests[quest.id]){
-      quest.status = 'active';
-      this.quests[quest.id]=quest;
-      renderQuests();
-      log('Quest added: '+quest.title);
-      if (window.NanoDialog) {
-        NPCS.filter(n=> n.map === state.map)
-            .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'quest update'));
+    const existing=this.quests[quest.id];
+    if(existing){
+      if(existing.status==='available'){
+        existing.status='active';
+        renderQuests();
+        log('Quest added: '+existing.title);
+        if (window.NanoDialog) {
+          NPCS.filter(n=> n.map === state.map)
+              .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'quest update'));
+        }
       }
+      return;
+    }
+    quest.status = 'active';
+    this.quests[quest.id]=quest;
+    renderQuests();
+    log('Quest added: '+quest.title);
+    if (window.NanoDialog) {
+      NPCS.filter(n=> n.map === state.map)
+          .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'quest update'));
     }
   }
   complete(id){

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -266,7 +266,21 @@ function renderInv(){
     inv.appendChild(row);
   });
 }
-function renderQuests(){ const q=document.getElementById('quests'); q.innerHTML=''; const ids=Object.keys(quests); if(ids.length===0){ q.innerHTML='<div class="q muted">(no quests)</div>'; return; } ids.forEach(id=>{ const v=quests[id]; const div=document.createElement('div'); div.className='q'; div.innerHTML=`<div><b>${v.title}</b></div><div class="small">${v.desc}</div><div class="status">${v.status}</div>`; q.appendChild(div); }); }
+function renderQuests(){
+  const q=document.getElementById('quests');
+  q.innerHTML='';
+  const shown=Object.values(quests).filter(v=> v.status!=='available');
+  if(shown.length===0){
+    q.innerHTML='<div class="q muted">(no quests)</div>';
+    return;
+  }
+  shown.forEach(v=>{
+    const div=document.createElement('div');
+    div.className='q';
+    div.innerHTML=`<div><b>${v.title}</b></div><div class="small">${v.desc}</div><div class="status">${v.status}</div>`;
+    q.appendChild(div);
+  });
+}
 function renderParty(){ const p=document.getElementById('party'); p.innerHTML=''; if(party.length===0){ p.innerHTML='<div class="pcard muted">(no party members yet)</div>'; return; } party.forEach((m,i)=>{ const c=document.createElement('div'); c.className='pcard'; const bonus=m._bonus||{}; const fmt=v=> (v>0? '+'+v : v); const wLabel=m.equip.weapon?(m.equip.weapon.cursed&&m.equip.weapon.cursedKnown?m.equip.weapon.name+' (cursed)':m.equip.weapon.name):'—'; const aLabel=m.equip.armor?(m.equip.armor.cursed&&m.equip.armor.cursedKnown?m.equip.armor.name+' (cursed)':m.equip.armor.name):'—'; const tLabel=m.equip.trinket?(m.equip.trinket.cursed&&m.equip.trinket.cursedKnown?m.equip.trinket.name+' (cursed)':m.equip.trinket.name):'—'; c.innerHTML = `<div class='row'><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div><div class='row small'>${statLine(m.stats)}</div><div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div><div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div><div class='row small'>XP ${m.xp}/${xpToNext(m.lvl)}</div><div class='row'><label><input type='radio' name='selMember' ${i===selectedMember?'checked':''}> Selected</label></div>`; c.querySelector('input').onchange=()=>{ selectedMember=i; }; c.querySelectorAll('button[data-a="unequip"]').forEach(b=>{ const sl=b.dataset.slot; b.onclick=()=> unequipItem(i,sl); }); p.appendChild(c); }); }
 
 // ===== Minimal Unit Tests (#test) =====


### PR DESCRIPTION
## Summary
- Hide unaccepted quests from the quest list to avoid spoilers
- Mark quests as active when accepted even if preloaded from module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a34f8efa088328999308c64d5e65ce