### PR TITLE
Add riverbank trinket to office module

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -361,6 +361,16 @@ const OFFICE_MODULE = (() => {
             teleport: { map: 'world', x: 2, y: WORLD_MIDY },
             msg: 'You step into the forest.'
           }
+        },
+        {
+          map: 'world',
+          x: WORLD_MID - 2,
+          y: WORLD_MIDY,
+          id: 'river_trinket',
+          name: 'River Trinket',
+          type: 'trinket',
+          slot: 'trinket',
+          mods: { LCK: 1 }
         }
       ],
       quests: [


### PR DESCRIPTION
## Summary
- place a River Trinket on the forest's west bank so players can pay the bridge toll

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a355c0693c8328b3ff23fbbae40079