### PR TITLE
Enable keyboard dialog navigation and toll quest acceptance

### DIFF
--- a/ack-player.html
+++ b/ack-player.html
@@ -93,7 +93,7 @@
           <button class="btn" id="ccLoad">Load Game</button>
           <button class="btn" id="ccStart">Start Now</button>
           <button class="btn" id="ccBack">Back</button>
-          <button class="btn" id="ccNext">Next</button>
+          <button class="btn btn--primary" id="ccNext">Next</button>
         </div>
       </div>
     </div>

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -7,6 +7,37 @@ const titleEl=document.getElementById('npcTitle');
 const portEl=document.getElementById('port');
 let currentNPC=null;
 const dialogState={ tree:null, node:null };
+let selectedChoice=0;
+
+function highlightChoice(){
+  [...choicesEl.children].forEach((c,i)=>{
+    if(c.classList?.toggle) c.classList.toggle('sel', i===selectedChoice);
+  });
+}
+
+function moveChoice(dir){
+  const total=choicesEl.children.length;
+  if(total===0) return;
+  selectedChoice=(selectedChoice+dir+total)%total;
+  highlightChoice();
+}
+
+function handleDialogKey(e){
+  if(!dialogState.tree) return false;
+  switch(e.key){
+    case 'ArrowUp':
+    case 'ArrowLeft':
+      moveChoice(-1); return true;
+    case 'ArrowDown':
+    case 'ArrowRight':
+      moveChoice(1); return true;
+    case 'Enter':{
+      const el=choicesEl.children[selectedChoice];
+      if(el?.click) el.click(); else el?.onclick?.();
+      return true; }
+  }
+  return false;
+}
 
 function normalizeDialogTree(tree){
   const out={};
@@ -224,6 +255,8 @@ function renderDialog(){
     cont.textContent='(Continue)';
     cont.onclick=()=> closeDialog();
     choicesEl.appendChild(cont);
+    selectedChoice=0;
+    highlightChoice();
     return;
   }
 
@@ -268,9 +301,11 @@ function renderDialog(){
     };
     choicesEl.appendChild(div);
   });
+  selectedChoice=0;
+  highlightChoice();
 }
 
-const dialogExports = { overlay, choicesEl, textEl, nameEl, titleEl, portEl, openDialog, closeDialog, renderDialog, advanceDialog, resolveCheck };
+const dialogExports = { overlay, choicesEl, textEl, nameEl, titleEl, portEl, openDialog, closeDialog, renderDialog, advanceDialog, resolveCheck, handleDialogKey };
 Object.assign(globalThis, dialogExports);
 
 if (typeof module !== 'undefined' && module.exports){

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -525,6 +525,7 @@ const ccNext=document.getElementById('ccNext');
 const ccPortrait=document.getElementById('ccPortrait');
 const ccStart=document.getElementById('ccStart');
 const ccLoad=document.getElementById('ccLoad');
+if(ccNext) ccNext.classList.add('btn--primary');
 const portraits=['@','&','#','%','*']; let portraitIndex=0;
 const specializations={
   'Scavenger':{desc:'Finds better loot from ruins; starts with crowbar.', gear:[{name:'Crowbar',slot:'weapon',mods:{ATK:+1}}]},
@@ -587,6 +588,7 @@ function renderStep(){
     if(got){ building.stats.PER+=1; }
   }
   updateCreatorButtons();
+  ccNext?.focus?.();
 }
 
 function finalizeCurrentMember(){
@@ -604,6 +606,12 @@ if  (ccBack) ccBack.onclick=()=>{ if(step>1) { step--; renderStep(); } };
 if (ccNext) ccNext.onclick=()=>{ if(step<5){ step++; renderStep(); } else { finalizeCurrentMember(); building={ id:'pc'+(built.length+1), name:'', role:'Wanderer', stats:baseStats(), quirk:null, spec:null, origin:null }; step=1; renderStep(); log('Member added. You can add up to 2 more, or press Start Now.'); } };
 if (ccStart) ccStart.onclick=()=>{ if(built.length===0){ finalizeCurrentMember(); } closeCreator(); startGame(); };
 if (ccLoad) ccLoad.onclick=()=>{ load(); closeCreator(); };
+if (creator?.addEventListener) creator.addEventListener('keydown', e => {
+  if(e.key==='Enter'){
+    e.preventDefault();
+    if(ccNext?.click) ccNext.click(); else ccNext?.onclick?.();
+  }
+});
 
 function startGame(){
   startWorld();

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -310,6 +310,7 @@ document.getElementById('nanoToggle').onclick=()=>{
 window.addEventListener('keydown',(e)=>{
   if(overlay.classList.contains('shown')){
     if(e.key==='Escape') closeDialog();
+    else if(handleDialogKey?.(e)) e.preventDefault();
     return;
   }
   switch(e.key){

--- a/dustland.css
+++ b/dustland.css
@@ -270,6 +270,11 @@
         background: #111711
     }
 
+    .choice.sel {
+        border-color: #5c8a5c;
+        background: #111711
+    }
+
     .small {
         font-size: 12px;
         color: #9ab09a

--- a/dustland.html
+++ b/dustland.html
@@ -93,7 +93,7 @@
           <button class="btn" id="ccLoad">Load Game</button>
           <button class="btn" id="ccStart">Start Now</button>
           <button class="btn" id="ccBack">Back</button>
-          <button class="btn" id="ccNext">Next</button>
+          <button class="btn btn--primary" id="ccNext">Next</button>
         </div>
       </div>
     </div>

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -270,6 +270,11 @@ const OFFICE_MODULE = (() => {
           text: 'Pay a trinket to cross.',
           choices: [
             {
+              label: '(Accept quest)',
+              to: 'accept',
+              q: 'accept'
+            },
+            {
               label: '(Pay)',
               to: 'do_turnin',
               q: 'turnin',
@@ -280,6 +285,7 @@ const OFFICE_MODULE = (() => {
             { label: '(Leave)', to: 'bye' }
           ]
         },
+        accept: { text: 'Bring me a trinket and you may cross.', choices: [ { label: '(Leave)', to: 'bye' } ] },
         do_turnin: {
           text: 'The toll keeper steps aside.',
           choices: [


### PR DESCRIPTION
## Summary
- Add keyboard navigation for dialog choices, supporting arrow keys and Enter
- Make character creation's Next button the default action and Enter key advance steps
- Allow Toll Keeper to offer and accept the trinket quest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3761f088c83289a9bfcb29790c29e