### PR TITLE
Ensure lobby guard only hands over one access card

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -189,7 +189,8 @@ const OFFICE_MODULE = (() => {
               check: { stat: 'CHA', dc: DC.TALK },
               success: 'He sighs and hands over a spare card.',
               failure: 'Rules are rules.',
-              reward: 'access_card'
+              reward: 'access_card',
+              once: true
             },
             { label: '(Leave)', to: 'bye' }
           ]


### PR DESCRIPTION
## Summary
- Prevent security guard from handing out unlimited access cards by marking persuasion dialog as one-time use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a378f5590483289a4c032e38bfa7c8