### PR TITLE
Fix toll keeper blocking path after payment

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -342,7 +342,12 @@ function applyModule(data){
   });
   Object.keys(quests).forEach(k=> delete quests[k]);
   (data.quests||[]).forEach(q=>{
-    quests[q.id] = new Quest(q.id, q.title, q.desc, {item:q.item, reward:q.reward, xp:q.xp});
+    quests[q.id] = new Quest(
+      q.id,
+      q.title,
+      q.desc,
+      { item: q.item, reward: q.reward, xp: q.xp, moveTo: q.moveTo }
+    );
   });
   NPCS.length = 0;
   (data.npcs||[]).forEach(n=>{

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -291,8 +291,7 @@ const OFFICE_MODULE = (() => {
           choices: [
             {
               label: '(Continue)',
-              to: 'bye',
-              effects: [() => removeNPC(currentNPC)]
+              to: 'bye'
             }
           ]
         }
@@ -386,7 +385,12 @@ const OFFICE_MODULE = (() => {
           desc: 'Convince security to lend you an access card and join Jen in the sim.',
           reward: 'cursed_vr_helmet'
         },
-        { id: 'q_toll', title: 'Bridge Tax', desc: 'Pay the Toll Keeper with a trinket.' }
+        {
+          id: 'q_toll',
+          title: 'Bridge Tax',
+          desc: 'Pay the Toll Keeper with a trinket.',
+          moveTo: { x: WORLD_MID + 1, y: WORLD_MIDY }
+        }
       ],
     npcs,
     interiors: [floor1, floor2, floor3, castle],


### PR DESCRIPTION
## Summary
- Support quest `moveTo` data in core so NPCs can relocate after turn-in
- Update Toll Keeper quest to move aside instead of disappearing after payment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3794a1cc883288567912d4feed492