### PR TITLE
Handle once-only dialog options only on successful outcomes

### DIFF
--- a/test/core.test.js
+++ b/test/core.test.js
@@ -225,6 +225,7 @@ test('advanceDialog handles cost and reward', () => {
   assert.ok(player.inv.some(it => it.id === 'gem'));
   assert.ok(!player.inv.some(it => it.id === 'key'));
   assert.ok(res.close);
+  assert.ok(res.success);
 });
 
 test('advanceDialog respects goto with costItem', () => {
@@ -272,6 +273,25 @@ test('advanceDialog matches reqItem case-insensitively', () => {
   advanceDialog(dialog, 0);
   assert.strictEqual(player.x, 7);
   assert.strictEqual(player.y, 8);
+});
+
+test('advanceDialog returns success flag on failure', () => {
+  const tree = {
+    start: { text: '', next: [{ label: 'Fail', check: { stat: 'str', dc: 999 } }] }
+  };
+  const dialog = { tree, node: 'start' };
+  const res = advanceDialog(dialog, 0);
+  assert.strictEqual(res.success, false);
+});
+
+test('once choice not consumed on failed check', () => {
+  globalThis.usedOnceChoices.clear();
+  const npc = { id: 'tester', name: 'Tester', tree: { start: { text: '', next: [{ label: 'Try', once: true, check: { stat: 'str', dc: 999 }, failure: 'nope' }] } } };
+  openDialog(npc);
+  const key = 'tester::start::Try';
+  choicesEl.children[0].onclick();
+  assert.ok(!globalThis.usedOnceChoices.has(key));
+  closeDialog();
 });
 
 test('door portals link interiors', () => {


### PR DESCRIPTION
## Summary
- Return success status from `advanceDialog`
- Only mark once-only choices after a successful selection
- Add regression tests for dialog success flag and once-only behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a37c4148f08328a6c556abc3a08132