### PR TITLE
fix coreExports duplication causing load errors

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -685,9 +685,6 @@ function startWorld(){
 
 const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, quickCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, state, player, GAME_STATE, setGameState, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, createNpcFactory, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld };
 
-
-const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, quickCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, state, player, GAME_STATE, setGameState, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld };
-
 Object.assign(globalThis, coreExports);
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## Summary
- remove duplicate `coreExports` declaration in dustland-core.js to avoid syntax errors when loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a38a4452ac832889de8228458600dc