### PR TITLE
fix: allow castle entry from the forest

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -394,8 +394,7 @@ const OFFICE_MODULE = (() => {
         }
       ],
     npcs,
-    interiors: [floor1, floor2, floor3, castle],
-    buildings: []
+    interiors: [floor1, floor2, floor3, castle]
   };
 })();
 


### PR DESCRIPTION
## Summary
- keep worldgen buildings when applying office module so hut to castle persists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a38cbf4a44832895eca8b98bfd5f02