### PR TITLE
Improve ACK dialog rewards and fix module loader

### DIFF
--- a/ack-player.html
+++ b/ack-player.html
@@ -112,6 +112,10 @@
   </div>
 
   <script src="dustland-core.js"></script>
+  <script src="core/party.js"></script>
+  <script src="core/inventory.js"></script>
+  <script src="core/movement.js"></script>
+  <script src="core/dialog.js"></script>
   <script>
     window._realOpenCreator = window.openCreator;
     window.openCreator = function(){};


### PR DESCRIPTION
## Summary
- Replace dialog reward text field with dropdown for XP or item, showing relevant inputs including item list for the map
- Include missing core scripts in ACK player to define baseStats and other essentials

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3b869bf4c8328a78478ea17825d7c