### PR TITLE
refactor: centralize player positioning and nano updates

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -40,8 +40,7 @@ loadBtn.onclick = () => {
 window.startGame = function(){
   if(moduleData) applyModule(moduleData);
   const start=moduleData && moduleData.start ? moduleData.start : {map:'world',x:2,y:Math.floor(WORLD_H/2)};
-  player.x = start.x;
-  player.y = start.y;
+  setPlayerPos(start.x, start.y);
   setMap(start.map||'world', 'Module');
   renderInv(); renderQuests(); renderParty(); updateHUD();
   log('Adventure begins.');

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -97,12 +97,10 @@ function handleGoto(g){
   if(!g) return;
   if(g.map==='world'){
     startWorld();
-    if(typeof g.x==='number') player.x=g.x;
-    if(typeof g.y==='number') player.y=g.y;
+    setPlayerPos(g.x, g.y);
     setMap('world');
   }else{
-    if(typeof g.x==='number') player.x=g.x;
-    if(typeof g.y==='number') player.y=g.y;
+    setPlayerPos(g.x, g.y);
     if(g.map) setMap(g.map); else if(typeof centerCamera==='function') centerCamera(player.x,player.y,state.map);
   }
   updateHUD?.();

--- a/core/inventory.js
+++ b/core/inventory.js
@@ -5,7 +5,7 @@ function cloneItem(it){
   return {
     ...it,
     mods: { ...it.mods },
-    tags: [...it.tags],
+    tags: Array.isArray(it.tags) ? [...it.tags] : [],
     use: it.use ? JSON.parse(JSON.stringify(it.use)) : null,
     equip: it.equip ? JSON.parse(JSON.stringify(it.equip)) : null
   };
@@ -31,18 +31,12 @@ function addToInv(item){
   if(!base) throw new Error('Unknown item');
   player.inv.push(base);
   renderInv();
-  if (window.NanoDialog) {
-    NPCS.filter(n=> n.map === state.map)
-        .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'inventory change'));
-  }
+  queueNanoDialogForNPCs('start', 'inventory change');
 }
 function removeFromInv(invIndex){
   player.inv.splice(invIndex,1);
   renderInv();
-  if (window.NanoDialog) {
-    NPCS.filter(n=> n.map === state.map)
-        .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'inventory change'));
-  }
+  queueNanoDialogForNPCs('start', 'inventory change');
 }
 
 function equipItem(memberIndex, invIndex){
@@ -68,8 +62,7 @@ function equipItem(memberIndex, invIndex){
   if(typeof sfxTick==='function') sfxTick();
   if(it.equip && it.equip.teleport){
     const t=it.equip.teleport;
-    if(typeof t.x==='number') player.x=t.x;
-    if(typeof t.y==='number') player.y=t.y;
+    setPlayerPos(t.x, t.y);
     if(t.map) setMap(t.map);
     updateHUD();
   }
@@ -140,10 +133,7 @@ function useItem(invIndex){
     if (typeof sfxTick === 'function') sfxTick();
     player.inv.splice(invIndex,1);
     renderInv(); renderParty(); updateHUD();
-    if (window.NanoDialog) {
-      NPCS.filter(n=> n.map === state.map)
-          .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'inventory change'));
-    }
+    queueNanoDialogForNPCs('start', 'inventory change');
     return true;
   }
   if(typeof it.use.onUse === 'function'){
@@ -153,10 +143,7 @@ function useItem(invIndex){
       renderInv(); renderParty(); updateHUD();
       if(typeof toast==='function') toast(`Used ${it.name}`);
       if(typeof sfxTick==='function') sfxTick();
-      if (window.NanoDialog) {
-        NPCS.filter(n=> n.map === state.map)
-            .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'inventory change'));
-      }
+      queueNanoDialogForNPCs('start', 'inventory change');
     }
     return !!ok;
   }

--- a/core/movement.js
+++ b/core/movement.js
@@ -61,7 +61,7 @@ function move(dx,dy){
   if(state.map==='creator') return;
   const nx=player.x+dx, ny=player.y+dy;
   if(canWalk(nx,ny)){
-    player.x=nx; player.y=ny;
+    setPlayerPos(nx, ny);
     centerCamera(player.x,player.y,state.map); updateHUD();
   }
 }
@@ -109,7 +109,7 @@ function interactAt(x,y){
       if(!b){ log('No entrance here.'); return true; }
       if(b.boarded){ log('The doorway is boarded up from the outside.'); return true; }
       const I=interiors[b.interiorId];
-      if(I){ player.x=I.entryX; player.y=I.entryY; }
+      if(I){ setPlayerPos(I.entryX, I.entryY); }
       setMap(b.interiorId,'Interior');
       log('You step inside.'); updateHUD(); return true;
     }
@@ -118,14 +118,15 @@ function interactAt(x,y){
       if(p){
         const target=p.toMap;
         const I=interiors[target];
-        player.x = (typeof p.toX==='number') ? p.toX : (I?I.entryX:0);
-        player.y = (typeof p.toY==='number') ? p.toY : (I?I.entryY:0);
+        const px = (typeof p.toX==='number') ? p.toX : (I?I.entryX:0);
+        const py = (typeof p.toY==='number') ? p.toY : (I?I.entryY:0);
+        setPlayerPos(px, py);
         setMap(target);
         log(p.desc || 'You move through the doorway.');
         updateHUD(); return true;
       }
       const b=buildings.find(b=> b.interiorId===state.map);
-      if(b){ player.x=b.doorX; player.y=b.doorY-1; setMap('world'); log('You step back outside.'); updateHUD(); return true; }
+      if(b){ setPlayerPos(b.doorX, b.doorY-1); setMap('world'); log('You step back outside.'); updateHUD(); return true; }
     }
   }
   return false;

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -132,6 +132,10 @@ const WORLD_W=120, WORLD_H=90;
 let world = [], interiors = {}, buildings = [], portals = [];
 const state = { map:'world' }; // default map
 const player = { x:2, y:2, hp:10, ap:2, flags:{}, inv:[], scrap:0 };
+function setPlayerPos(x, y){
+  if(typeof x === 'number') player.x = x;
+  if(typeof y === 'number') player.y = y;
+}
 const GAME_STATE = Object.freeze({
   TITLE: 'title',
   CREATOR: 'creator',
@@ -168,10 +172,7 @@ class Quest {
       log('Quest completed: '+this.title);
       if (typeof toast === 'function') toast(`QUEST COMPLETE: ${this.title}`);
       party.forEach(p=> awardXP(p,5));
-      if (window.NanoDialog) {
-        NPCS.filter(n=> n.map === state.map)
-            .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'quest update'));
-      }
+      queueNanoDialogForNPCs('start', 'quest update');
     }
   }
 }
@@ -185,10 +186,7 @@ class QuestLog {
         existing.status='active';
         renderQuests();
         log('Quest added: '+existing.title);
-        if (window.NanoDialog) {
-          NPCS.filter(n=> n.map === state.map)
-              .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'quest update'));
-        }
+        queueNanoDialogForNPCs('start', 'quest update');
       }
       return;
     }
@@ -196,10 +194,7 @@ class QuestLog {
     this.quests[quest.id]=quest;
     renderQuests();
     log('Quest added: '+quest.title);
-    if (window.NanoDialog) {
-      NPCS.filter(n=> n.map === state.map)
-          .forEach(n=> NanoDialog.queueForNPC(n, 'start', 'quest update'));
-    }
+    queueNanoDialogForNPCs('start', 'quest update');
   }
   complete(id){
     const q=this.quests[id];
@@ -298,6 +293,14 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
 }
 function resolveNode(tree, nodeId){ const n = tree[nodeId]; const choices = n.choices||[]; return {...n, choices}; }
 const NPCS=[];
+function npcsOnMap(map = state.map){
+  return NPCS.filter(n => n.map === map);
+}
+
+function queueNanoDialogForNPCs(nodeId='start', reason='inventory change', map = state.map){
+  if(!window.NanoDialog) return;
+  npcsOnMap(map).forEach(n => NanoDialog.queueForNPC(n, nodeId, reason));
+}
 
 function removeNPC(npc){
   const idx = NPCS.indexOf(npc);
@@ -597,7 +600,7 @@ const hiddenOrigins={ 'Rustborn':{desc:'You survived a machine womb. +1 PER, wei
 let step=1; let building=null; let built=[];
 function openCreator(){
   if(!creatorMap.grid || creatorMap.grid.length===0) genCreatorMap();
-  player.x=creatorMap.entryX; player.y=creatorMap.entryY;
+  setPlayerPos(creatorMap.entryX, creatorMap.entryY);
   setMap('creator','Creator');
   creator.style.display='flex';
   step=1;
@@ -674,7 +677,7 @@ function startGame(){
 function startWorld(){
   const seed = Date.now();
   genWorld(seed);
-  player.x=2; player.y=Math.floor(WORLD_H/2);
+  setPlayerPos(2, Math.floor(WORLD_H/2));
   setMap('world','Wastes');
   renderInv(); renderQuests(); renderParty(); updateHUD();
   log('You step into the wastes.');
@@ -683,7 +686,7 @@ function startWorld(){
 // Content pack moved to modules/dustland.module.js
 
 
-const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, quickCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, state, player, GAME_STATE, setGameState, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, createNpcFactory, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld };
+const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, quickCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, state, player, GAME_STATE, setGameState, setPlayerPos, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, npcsOnMap, queueNanoDialogForNPCs, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, createNpcFactory, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld };
 
 Object.assign(globalThis, coreExports);
 

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -361,8 +361,7 @@ startGame = function () {
   startWorld();
   applyModule(DUSTLAND_MODULE);
   const s = DUSTLAND_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-  player.x = s.x;
-  player.y = s.y;
+  setPlayerPos(s.x, s.y);
   setMap(s.map, s.map === 'world' ? 'Wastes' : 'Test Hall');
   renderInv();
   renderQuests();

--- a/modules/echoes.module.js
+++ b/modules/echoes.module.js
@@ -179,8 +179,7 @@ startGame = function () {
   startWorld();
   applyModule(ECHOES_MODULE);
   const s = ECHOES_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-  player.x = s.x;
-  player.y = s.y;
+  setPlayerPos(s.x, s.y);
   setMap(s.map, s.map === 'world' ? 'Wastes' : 'Echoes');
   renderInv();
   renderQuests();

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -417,8 +417,7 @@ startGame = function () {
       itemDrops.push({ id: charm.id, map: castleId, x: ix, y: iy });
     }
     const s = OFFICE_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-    player.x = s.x;
-    player.y = s.y;
+    setPlayerPos(s.x, s.y);
     setMap(s.map);
     renderInv();
     renderQuests();


### PR DESCRIPTION
## Summary
- central helper `setPlayerPos` to update player coordinates consistently
- new `npcsOnMap` and `queueNanoDialogForNPCs` to streamline Nano dialog scheduling
- inventory, quests, movement and module loaders use the new helpers
- safer `cloneItem` when tags are missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c5d4272c83289e37d39d097da084