### PR TITLE
refactor: improve maintainability

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -2,20 +2,21 @@
 // Loads a module JSON and starts the game using its data.
 
 let moduleData = null;
+const PLAYTEST_KEY = 'ack_playtest';
 const loader = document.getElementById('moduleLoader');
 const fileInput = document.getElementById('modFile');
 const loadBtn = document.getElementById('modLoadBtn');
 
-const playData = localStorage.getItem('ack_playtest');
+const playData = localStorage.getItem(PLAYTEST_KEY);
 if(playData){
   try{
     moduleData = JSON.parse(playData);
-    localStorage.removeItem('ack_playtest');
+    localStorage.removeItem(PLAYTEST_KEY);
     loader.style.display='none';
     window.openCreator = window._realOpenCreator;
     openCreator();
   }catch(e){
-    localStorage.removeItem('ack_playtest');
+    localStorage.removeItem(PLAYTEST_KEY);
   }
 }
 

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -4,6 +4,8 @@
 // Ensure world generation doesn't pull default content
 window.seedWorldContent = () => { };
 
+const PLAYTEST_KEY = 'ack_playtest';
+
 const colors = { 0: '#1e271d', 1: '#2c342c', 2: '#1573ff', 3: '#203320', 4: '#394b39', 5: '#304326', 6: '#4d5f4d', 7: '#233223', 8: '#8bd98d', 9: '#000' };
 const canvas = document.getElementById('map');
 const ctx = canvas.getContext('2d');
@@ -1065,7 +1067,7 @@ function saveModule() {
 function playtestModule() {
   const bldgs = buildings.map(({ under, ...rest }) => rest);
   const data = { ...moduleData, world, buildings: bldgs };
-  localStorage.setItem('ack_playtest', JSON.stringify(data));
+  localStorage.setItem(PLAYTEST_KEY, JSON.stringify(data));
   window.open('ack-player.html#play', '_blank');
 }
 

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -38,7 +38,7 @@
 
 // ===== Core helpers =====
 const ROLL_SIDES = 12;
-const DC = { TALK:8, REPAIR:9 };
+const DC = Object.freeze({ TALK:8, REPAIR:9 });
 const CURRENCY = 'Scrap';
 
 // Placeholder; actual content provided by modules (e.g. Dustland)
@@ -107,8 +107,8 @@ function quickCombat(defender){
 }
 
 // ===== Tiles =====
-const TILE = { SAND:0, ROCK:1, WATER:2, BRUSH:3, ROAD:4, RUIN:5, WALL:6, FLOOR:7, DOOR:8, BUILDING:9 };
-const walkable = {0:true,1:true,2:false,3:true,4:true,5:true,6:false,7:true,8:true,9:false};
+const TILE = Object.freeze({ SAND:0, ROCK:1, WATER:2, BRUSH:3, ROAD:4, RUIN:5, WALL:6, FLOOR:7, DOOR:8, BUILDING:9 });
+const walkable = Object.freeze({0:true,1:true,2:false,3:true,4:true,5:true,6:false,7:true,8:true,9:false});
 const mapNameEl = document.getElementById('mapname');
 const mapLabels = { world: 'Wastes', creator: 'Creator' };
 function mapLabel(id){

--- a/module-picker.js
+++ b/module-picker.js
@@ -4,22 +4,22 @@ const MODULES = [
   { id: 'office', name: 'Office', file: 'modules/office.module.js' }
 ];
 
-function loadModule(mod){
-  const s = document.createElement('script');
-  s.src = mod.file;
-  s.onload = () => {
+function loadModule(moduleInfo){
+  const script = document.createElement('script');
+  script.src = moduleInfo.file;
+  script.onload = () => {
     const picker = document.getElementById('modulePicker');
     if(picker) picker.remove();
     window.openCreator = window._realOpenCreator;
     window.showStart = window._realShowStart;
-    const saveStr = localStorage.getItem('dustland_crt');
-    if(saveStr){
+    const savedGame = localStorage.getItem('dustland_crt');
+    if(savedGame){
       showStart();
     } else {
       openCreator();
     }
   };
-  document.body.appendChild(s);
+  document.body.appendChild(script);
 }
 
 function showModulePicker(){
@@ -28,15 +28,15 @@ function showModulePicker(){
   overlay.style = 'position:fixed;inset:0;background:rgba(0,0,0,.8);display:flex;align-items:center;justify-content:center;z-index:40';
   overlay.innerHTML = `<div class="win" style="width:min(420px,92vw);background:#0b0d0b;border:1px solid #2a382a;border-radius:12px;box-shadow:0 20px 80px rgba(0,0,0,.7);overflow:hidden"><header style="padding:10px 12px;border-bottom:1px solid #223022;font-weight:700">Select Module</header><main style="padding:12px" id="moduleButtons"></main></div>`;
   document.body.appendChild(overlay);
-  const btnWrap = overlay.querySelector('#moduleButtons');
-  MODULES.forEach(m => {
+  const buttonContainer = overlay.querySelector('#moduleButtons');
+  MODULES.forEach(moduleInfo => {
     const btn = document.createElement('button');
     btn.className = 'btn';
-    btn.textContent = m.name;
+    btn.textContent = moduleInfo.name;
     btn.style.display = 'block';
     btn.style.margin = '4px 0';
-    btn.onclick = () => loadModule(m);
-    btnWrap.appendChild(btn);
+    btn.onclick = () => loadModule(moduleInfo);
+    buttonContainer.appendChild(btn);
   });
 }
 


### PR DESCRIPTION
## Summary
- centralize playtest storage key to avoid magic strings
- protect core tables from mutation by freezing constant objects
- rename variables in module picker for clarity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c5f631688328bb3348b10d865136