### PR TITLE
feat: improve editor UI

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -199,10 +199,11 @@
         <button class="btn" id="load">Load Module</button>
         <button class="btn" id="setStart">Set Start</button>
         <button class="btn btn--primary" id="playtest">Playtest</button>
+        <button class="btn" id="toggleEditor" aria-expanded="true">Hide Editor</button>
       </div>
       <input type="file" id="loadFile" accept="application/json" style="display:none" />
     </section>
-    <aside class="editor-panel" id="editorPanel">
+    <aside class="editor-panel" id="editorPanel" aria-hidden="false">
       <div class="tabs2" role="tablist" aria-label="Editors">
         <button class="tab2 active" data-tab="npc" role="tab" aria-selected="true">NPCs</button>
         <button class="tab2" data-tab="items" role="tab" aria-selected="false">Items</button>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1354,3 +1354,15 @@ animate();
 
 document.getElementById('playtestFloat').onclick =
   () => document.getElementById('playtest')?.click();
+
+const toggleEditorBtn = document.getElementById('toggleEditor');
+if (toggleEditorBtn) {
+  const panel = document.getElementById('editorPanel');
+  toggleEditorBtn.addEventListener('click', () => {
+    const isShown = panel.style.display !== 'none';
+    panel.style.display = isShown ? 'none' : '';
+    toggleEditorBtn.textContent = isShown ? 'Show Editor' : 'Hide Editor';
+    toggleEditorBtn.setAttribute('aria-expanded', String(!isShown));
+    panel.setAttribute('aria-hidden', String(isShown));
+  });
+}

--- a/dustland.css
+++ b/dustland.css
@@ -551,6 +551,9 @@
         flex-direction: column;
         max-height: calc(100vh - 32px);
         overflow: hidden;
+        resize: horizontal;
+        min-width: 240px;
+        max-width: 100%;
     }
 
     /* -- Tabs -- */


### PR DESCRIPTION
## Summary
- make right-side editor resizable horizontally
- add button to hide or show the editor panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c60355a883288cc79003b16fbb4f