### PR TITLE
Add thick pixelated white borders to windows

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -25,7 +25,8 @@
 
     canvas {
         background: #000;
-        border: 1px solid #263026;
+        border: 4px solid #fff;
+        border-radius: 8px;
         box-shadow: 0 0 0 2px #000 inset, 0 0 40px #000;
         image-rendering: pixelated;
         filter: contrast(1.06) saturate(1.1);
@@ -34,12 +35,13 @@
     .panel {
         width: 440px;
         background: #0b0d0b;
-        border: 1px solid #273027;
-        border-radius: 10px;
+        border: 4px solid #fff;
+        border-radius: 8px;
         display: flex;
         flex-direction: column;
         overflow: hidden;
         box-shadow: 0 4px 20px rgba(0, 0, 0, 0.6);
+        image-rendering: pixelated;
     }
 
     .panel h1 {


### PR DESCRIPTION
## Summary
- add 4px white borders with pixelated rounded corners to canvas and panels for a crisper window look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c9e01d0c8328b92295fc972f31a5