### PR TITLE
Ensure module picker uses fresh module files

### DIFF
--- a/module-picker.js
+++ b/module-picker.js
@@ -5,8 +5,11 @@ const MODULES = [
 ];
 
 function loadModule(moduleInfo){
+  const existingScript = document.getElementById('activeModuleScript');
+  if (existingScript) existingScript.remove();
   const script = document.createElement('script');
-  script.src = moduleInfo.file;
+  script.id = 'activeModuleScript';
+  script.src = `${moduleInfo.file}?_=${Date.now()}`;
   script.onload = () => {
     const picker = document.getElementById('modulePicker');
     if(picker) picker.remove();


### PR DESCRIPTION
## Summary
- prevent browser cache from reusing old module scripts
- attach cache-busting timestamp and remove prior module script before loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cc02b4d0832894ba6940f144729e