### PR TITLE
style: soften borders and load npc portraits

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -242,8 +242,8 @@ function defaultQuestProcessor(npc, nodeId){
 }
 
 class NPC {
-  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false}){
-    Object.assign(this,{id,map,x,y,color,name,title,desc,tree,quest,combat,shop});
+  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null}){
+    Object.assign(this,{id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet});
     const capNode = (node)=>{
       if(this.combat && node==='do_fight'){
         const {DEF=0, loot} = this.combat;
@@ -331,6 +331,7 @@ function createNpcFactory(defs){
       const opts={};
       if(n.combat) opts.combat=n.combat;
       if(n.shop) opts.shop=n.shop;
+      if(n.portraitSheet) opts.portraitSheet=n.portraitSheet;
       return makeNPC(
         n.id,
         n.map||'world',
@@ -409,6 +410,7 @@ function applyModule(data){
     const opts = {};
     if(n.combat) opts.combat = n.combat;
     if(n.shop) opts.shop = n.shop;
+    if(n.portraitSheet) opts.portraitSheet = n.portraitSheet;
     const npc = makeNPC(n.id, n.map||'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, n.title||'', n.desc||'', tree, quest, null, null, opts);
     NPCS.push(npc);
   });

--- a/dustland.css
+++ b/dustland.css
@@ -25,7 +25,7 @@
 
     canvas {
         background: #000;
-        border: 4px solid #fff;
+        border: 1px solid #2a382a;
         border-radius: 8px;
         box-shadow: 0 0 0 2px #000 inset, 0 0 40px #000;
         image-rendering: pixelated;
@@ -35,7 +35,7 @@
     .panel {
         width: 440px;
         background: #0b0d0b;
-        border: 4px solid #fff;
+        border: 1px solid #2a382a;
         border-radius: 8px;
         display: flex;
         flex-direction: column;

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -367,6 +367,15 @@ test('createNpcFactory builds NPCs from definitions', () => {
   assert.strictEqual(npc.tree.start.text, 'hi');
 });
 
+test('openDialog displays portrait when sheet provided', () => {
+  NPCS.length = 0;
+  const tree = { start: { text: '', choices: [] } };
+  const npc = makeNPC('p', 'world', 0, 0, '#fff', 'Port', '', '', tree, null, null, null, { portraitSheet: 'assets/portraits/kesh_4.png' });
+  NPCS.push(npc);
+  openDialog(npc);
+  assert.ok(portEl.style.backgroundImage.includes('kesh_4.png'));
+});
+
 test('clamp swaps reversed bounds', () => {
   assert.strictEqual(clamp(5, 10, 0), 5);
 });


### PR DESCRIPTION
## Summary
- tone down heavy white borders around canvas and side panel for a subtler frame
- preserve `portraitSheet` when building NPCs so dialog portraits render
- add regression test ensuring portrait images appear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3cd44cfc083288ae5ad5e1cc53dbd