### PR TITLE
Add runed arrow quest to office module

### DIFF
--- a/modules/office-story.md
+++ b/modules/office-story.md
@@ -1,0 +1,275 @@
+# Office Module Opening Plot
+
+Chapter One — The Silver Wolf
+
+The forest held its breath when she arrived.
+
+Elena stood with damp ferns brushing her calves and a hush pressed against her ears like a hand. Pine resin thickened the air. Mist lay low, silvering the undergrowth. The light had that late-before-dusk quality that makes edges soft and colors truer than they are at noon. She didn’t remember the step before this step. She only knew the earth gave a little under her boot and that somewhere close water ran over stone.
+
+She moved because standing still made the silence louder. A rag of bark peeled under her thumb, leaving a clean, pale wound on the trunk. The scent of it came up sharp and green. She touched it to convince herself the world wouldn’t fold at her fingers.
+
+A twig snapped behind her—clean, deliberate. She turned too quickly, breath caught high in her chest. Not a person. Not a deer.
+
+A wolf, tall enough at the shoulder to take her eye line, stepped through the curtains of alder. Not gray or white but silver, truly silver, as if each hair had been drawn from a moonlit river. Its pelt took the light and returned it in slow ripples. Its eyes were not animal-bright but deep—dark pupils pricked with starlight, steady as if she were the one being studied.
+
+Elena’s fear should have come with teeth. It didn’t. Something like reverence rose up instead, a knowledge without source that she had stepped uninvited into an old room and found the rightful heir inside. The wolf’s chest lifted and fell once. It lowered its head, not in threat but in attention.
+
+She opened her mouth without a sentence. The word that wanted to come wasn’t a word she knew.
+
+A bowstring sang.
+
+The arrow hissed past her cheek and drove into the pine behind with enough force to make the trunk shiver. The wolf flinched—not from fear but annoyance—and sprang, a soundless silver arc. It landed beyond a tangle of fallen limbs, then blurred. Not the speed of muscle; a refusal to be seen. Where it had been, mist dripped into itself and became only mist again.
+
+Elena stood very still until her breath found itself. Then she turned her head and stared at the arrow, because looking at anything else meant looking at the place the wolf had made in her and she wasn’t prepared to see it.
+
+The fletching was pale, with a faint sheen as if someone had varnished the feathers in moonlight. The shaft had been stained a soft smoke-gray. The head was long and narrow, a leaf of metal etched with lines so fine they read as hairline fractures. She wrapped her fingers around the shaft to pull it free.
+
+Heat ran into her palm as if the arrow had been resting by a hearth. Not burn, not shock—warmth, and under the warmth a small, precise hum that seemed less like sound than the shape of a note in bone. Her breath turned short. She tightened her grip and tugged. The arrow came out clean, leaving a black circle in the bark. Sap welled and beaded, catching light.
+
+Another twig broke. Not far. Footsteps laid into the earth with the care of an animal and the purpose of a man. Elena turned, arrow in hand. A crow called once and fell quiet.
+
+Shadows were not only absence here; they had weight. They gathered between trunks and drew a man forward by the shoulders. He wore a cloak the color of river rock and a circlet of pale metal that had collected the small scars of long use. He was lean rather than broad, and he carried his height like something he had bargained for and would keep. His face was not the fair-smooth of storybook princes. He had a mouth that had learned how not to show surprise and eyes that kept the world where he could see it.
+
+Elena had the brief, disorienting sense that she was looking at someone who had already decided who he was and the forest had agreed.
+
+He did not raise a weapon. He did not need to. The hunters behind him did that—men in weather-colored cloaks, bows half drawn, their attention arrow-straight. A fifth figure slid between them, thinner than the rest, hands lifted at his ribs as if holding an invisible bowl. Light moved around his fingers in narrow threads, like the marks a needle leaves when it slips through fabric.
+
+The man in the circlet’s gaze fell to Elena’s hands, rose to her face. He said something in a language she had never heard and understood almost anyway. The meaning came to her like tide through kelp: Stay. Do not run.
+
+“I—” she began, and the word didn’t choose a language. It was only a sound of air and uncertainty.
+
+He said another word. Not a question. An assignation. He spoke as if naming the world and expecting it to hold.
+
+She couldn’t say what in his voice made her want to do as he said and what made her want to oppose him simply to prove a point she could not articulate. She lifted the arrow an inch without meaning to, and every bowstring eased and tightened in the same heartbeat, a quiet animal reaction shared by human hands.
+
+Elena put her heel back to brace. The ground was a damp spring. Something drew fast and fine over her ankles, a tightening like a thread winding twice around bone. She looked down and saw at first only leaf litter and the paler fingers of roots. Then she saw light chasing itself through the detritus, thin and exact, finding a path where there was none and chalking invisible symbols that woke as her gaze touched them.
+
+She tested the feeling not by pulling hard but by thinking of pulling hard. The circle noticed the thought and answered it. Her calves buzzed. The small deep muscles along her spine fluttered and decided against her.
+
+The thin man’s hands shifted half an inch. The light held.
+
+Elena’s mouth went dry. She lifted the arrow higher, as if elevation would absolve her of its possession. “I didn’t—” she tried, and the man in the circlet looked at her mouth as if listening to the shape of her would yield more sense than her words did.
+
+He called to her again in that not-quite language. The music of it should have been foreign. Instead it felt like a tune she’d heard once, late at night, and then dreamt different versions of until the original had been replaced by a dozen truer ones. The tone was not unkind. It was very sure.
+
+“Tell me,” she said, because her voice had to do something or it would shake, “what you think this is.”
+
+The least of the hunters moved in a fraction. The thin man’s fingers trembled, whether from effort or excitement she couldn’t tell. The man in the circlet let his gaze drift to the arrow again, and what moved in his face then was not greed or relief but recognition. He lifted his hand, and the hunters held their breath without orders because they knew him.
+
+Elena looked where he looked and for the first time saw the difference between this arrow and any other thing. The runes on the head—she could call them nothing else—were not markings on metal. They were seams where light refused to join metal, channels where something older than heat ran. The warmth in the shaft was not residual. It was a pulse. Her palm had found a chord on an instrument she hadn’t known existed and plucked it by accident.
+
+Across the clearing the man’s mouth shaped something like mine.
+
+The circle tightened—not around her throat, nothing dramatic; around her wrists, her ankles, small closures that suggested the idea of stillness and then enforced it. She held the arrow the way you hold a newborn animal you are terrified of dropping and more terrified of keeping. The world narrowed to her hand and his eyes. The silence pressed her eardrums again.
+
+Elena did the only thing left that felt like hers.
+
+She left.
+
+It wasn’t a plan. It was a refusal. She made the outline of herself step backward while her body stayed where it had been placed, and the outline found a seam. Light pushed up through her like water through a pipe, bright enough to bleach the trees into bones of brightness, and columned—yes, columned—around her. For a sliver of a moment she thought she heard him speak her name though she had not given it. For a sliver of a moment she thought the arrow moved toward him without her hand.
+
+Mist blew sideways. The circle snapped like a thought interrupted.
+
+The forest became a room.
+
+Fluorescent tubes buzzed. The cool, antiseptic tang of lemon solvent overlaid coffee gone old. Glass walls threw back beholder images of a woman in a work chair with her hands closed around nothing. The contact at the base of her neck chilled as if a mouth had stopped breathing there. Elena’s gag reflex kicked on the tail of the sudden absence of air the other place had held.
+
+Her own voice came back to her in her own ears. A machine somewhere registered her heart rate and pretended not to care. She tore the collar loose with both hands and sat while the world she knew resumed doing its steady, ordinary trick of existing without asking permission.
+
+In her palm there was no arrow. The warmth of it remained, not on the skin but below it, like a memory of fever that hadn’t belonged to her body.
+
+She flexed her hand to make the ghost leave. It didn’t.
+
+“That wasn’t a dream,” she said into the empty lab, because speaking made the room commit to being the room. After a beat she added, quieter, as if the truth needed a lower register to fit: “And it sure as hell wasn’t code.”
+
+Chapter Two — The Eighteenth Floor
+
+The elevator to the eighteenth floor never announced itself. It just opened, soundless, into filtered white light and the steady hush of machines breathing.
+
+Elena stepped out, still rubbing the phantom heat from her palm. No mark. No arrow. Just the ghost of warmth where it had hummed in her hand.
+
+Badge, iris, fingertip: the door accepted her with a soft click. Glass walls made a corridor of aquarium-blue reflections—labs on either side where racks blinked and people pretended not to look up when she passed. The air smelled faintly of ozone and lemon solvent. Somewhere, a fan spun up and held like a drawn bow.
+
+“Star of Stage and Screen,” Jonah said, jogging to catch up, two lidded coffees in one hand, a tablet tucked under his arm. He wore his badge crooked, as always. “Your kingdom demands a status update.”
+
+“Don’t call it that,” Elena said, taking the coffee. “And there is no update. I’m in a holding pattern.”
+
+“You look like you stayed up arguing with kernel logs,” he observed, falling into step. “Did the trees insult your mother again? The birds whisper the Wi-Fi password? Blink twice if you saw Bigfoot.”
+
+“None of those,” she said. “And stop trying to make ‘forest comedy’ happen.”
+
+“Disaster. You’re immune to charm.” He bumped her shoulder with his. “Priya’s looking for you. Meeting room two. She has the face.”
+
+“What face?”
+
+“The one where she remembers she used to code and now she has to babysit coders.”
+
+Meeting room two was a glass box with an austere table and a wall of hand-sketched diagrams that no one had had the heart to erase in months: lattices of nodes, arrows, a scribbled “DON’T TOUCH THIS” next to a line that had, at some point, been touched. Priya was already there, hair clipped back, sleeves rolled, two pens uncapped and parallel to a notebook like she stacked thoughts in twos. She looked up as Elena entered, then at Jonah, who hovered with his tablet like a kid caught with contraband.
+
+“Out,” Priya said to Jonah, with zero heat. “You can have her after I get five sentences.”
+
+“One sentence,” Jonah bargained.
+
+“Three,” Priya said. “Facts only.”
+
+Elena sat. Her coffee tasted like burnt almonds and necessity.
+
+Priya studied her face, not unkindly. “You were on late.”
+
+“I wanted to reproduce the anomaly.” Elena kept her voice even. “There’s a latency jitter in the haptic stack—twenty-seven milliseconds, sometimes thirty-one. It spikes when geometry density exceeds expected thresholds. Might be a feedback loop in the immersion layer.”
+
+“Translation,” Jonah said from the doorway, “the forest is extra foresty.”
+
+Priya’s mouth twitched. “Was there anything—” She searched for a neutral word and found one. “—unprogrammed?”
+
+Elena thought of silver fur that moved like moonlit water, of an arrow thrumming in her palm. She thought of how all of it had felt not like code showing off but like something deciding its own weight in the world.
+
+“Render artifacts,” she said. “Transient. I’ll isolate them. I think I can patch the spike and go in for a quick verify.”
+
+Priya’s gaze flicked to the clock, then to Elena’s hands. “You’re pale,” she said. “Eat something before you strap in. And file the anomaly as ‘visual instability’ for now. No poetry in the bug tracker. You know how upstairs feels about adjectives.”
+
+“Upstairs” meant the executive corridor, two floors above, where directives flowed down like weather. Elena nodded. “I’ll keep it clean.”
+
+Jonah made a face. “Bureaucrats fear metaphor.”
+
+“Bureaucrats fear budgets,” Priya said. She closed her pen cap with a click. “Elena, I trust you. You know that. But we are being watched. If you see anything that feels off in a… non-technical way, you come out. Immediately. No heroics.”
+
+“I’m not a hero,” Elena said, standing. “I’m a person who hates not understanding things.”
+
+“That’s worse,” Jonah said, following her back into the corridor. “Curiosity killed the neuro-link.”
+
+“Helpful,” she said, deadpan.
+
+Her station recognized her and unfurled like a flower: monitors blooming to life, graphs spiking and evening, log windows ready to swallow more lines. She ran diff scripts, watched red turn to green. The patch she’d rushed last night settled into place with satisfying stability across the stack. The jitter curve smoothed, mostly. Not perfect, but enough for a quick verify.
+
+“Food,” Jonah said, depositing a granola bar by her keyboard like a sacrament. “Don’t let Priya see me enabling you.”
+
+“Thank you,” Elena said, meaning it.
+
+He saluted with the granola wrapper and retreated to his test bench, already narrating sarcastically into a bug report. Priya moved past once more, tapping the glass with a knuckle to get Elena’s attention. “Thirty minutes,” she said, soft emphasis carrying more weight than a shout. “If it’s not obvious by then, we regroup.”
+
+“Thirty,” Elena agreed.
+
+She settled the collar where neck met spine. Its contacts kissed skin and cooled. For a beat she stared at her hand, half expecting the warmth to flicker back. It didn’t. She closed her eyes. The room faded to breath and hum.
+
+Load.
+
+Darkness, then the faintest glow: light combing through leaves, a sky the color of bruised violets, air washed clean by rain. Her boots sank a fraction into spongy ground. The forest breathed around her, a hush that felt deliberate. No birdsong. No insect rasp.
+
+Elena exhaled and took one step—and hit the wall.
+
+Not a wall. A boundary. The air itself stiffened and held her ankles where they met the ground. Light tracked along the deadfall around her in a looped script she didn’t know. Symbols woke and watched.
+
+Shadows leaned out of the trees.
+
+Four men with bows stepped into view, fletching whispering against leather. They wore cloaks the color of riverbed stones, faces calm, eyes bright with a focus she knew from certain kinds of surgeons. Behind them a thin man in layered robes braced both hands in the air. The light around his fingers laced the glowing ring at Elena’s feet. The ring held. Every small muscle in her calves fluttered and failed.
+
+And then the last one emerged. The figure she’d glimpsed before, now not a shadow but a man with a circlet of pale metal like captured frost. He was not beautiful in the way renderers tended to make people: no symmetry for symmetry’s sake. He was beautiful in the way cliffs were, in the way weather could be—danger built into the line of a body that expected the world to get out of its way.
+
+His gaze slid over the circle to her mouth, her hands, the line of her shoulders, reading her like a problem without showing where his eyes lingered. He nodded once to the robed man. The light at the mage’s hands intensified; Elena’s knees locked.
+
+“Do you understand me now?” the prince asked. His voice carried like a bell under water, clear without shouting. The language fell strange on her ears and then, by some trick, resolved into meaning. “Last we spoke, you vanished in a column of light. That is thief’s magic.”
+
+“I’m not a thief,” Elena said. Her own voice sounded normal, irritated, a little breathless. “And I’m not your… anything. I’m here to—” Verify, document, patch. None of those words fit this clearing. “—to look.”
+
+“Then look at the circle you step within,” he said. “It is made to bind a truth. You hold what is mine.”
+
+“Elena,” Priya’s caution whispered from nowhere, from memory. If anything feels off, you come out. Elena flexed her fingers. The ring answered with a faint tightening at her ankles and wrists, as if invisible vines had noticed the idea of movement and disallowed it.
+
+“What do you think I took?” she asked, keeping her tone flat. If this was emergent behavior, it deserved data. If it wasn’t—she cut that thought off. “Name it.”
+
+He lifted a hand. One of the hunters stepped forward, bow lowered in respect rather than fear. From his quiver he drew an arrow. Not the arrow—Elena knew it wasn’t the same even before she truly saw it. The fletching was good but ordinary, the head a clever twist of steel, the shaft stained the color of smoke. He held it up in comparison to something imagined, something remembered.
+
+“The twin to this,” the prince said. “Though there is no twin. It was forged for me alone. If you have wit, return it whole. If you do not, I will take it from you.”
+
+“I don’t have it,” Elena said. “It vanished. Like I did.”
+
+“Then you lie,” the mage said through clenched teeth, sweat beading at his temple as he fed the circle. “The binding burns when we lie.”
+
+“The binding burns when you make it burn,” Elena said, because irritation was safer than fear. She tried to step back and could not. The circle tightened to a fine pressure on her wrists, like a watchstrap drawn one notch too far.
+
+“Try to leave,” the prince said, eyes on her face as if her answer mattered more than her words.
+
+“Gladly.” She opened her palm in the air where the menu should bloom and said the exit command. Nothing happened. The forest did not flicker. The circle did not loosen. She breathed once, slow, and tried the emergency voice override. She blink-coded the failsafe sequence. The collar at her neck remained a rumor. Panic pricked, quick and mean; she ground her molars until the taste of metal softened it.
+
+The prince watched her with keen interest, like a scholar who’s found a new hinge in an old mechanism. “Small sorceries,” he murmured. “You make signs and the world ignores them.”
+
+“It usually doesn’t,” Elena said, more to herself than to him.
+
+He took a step closer, close enough that she could see the tiny nicks in the circlet, the way they caught light. “Return it,” he said, softer now. Not pleading—command reduced to something intimate. “It is one of a kind.”
+
+Her right hand tingled.
+
+She didn’t look down at first. Looking was a kind of surrender. The sensation concentrated, a line of warmth radiating from her palm to the base of her thumb. When she finally glanced, there it was: the arrow, impossibly, where no inventory or menu had delivered it. Its shaft breathed light along runes cut so fine they looked like hairline cracks in frost. It hummed—no speaker, no actuator—just a tone in the bones.
+
+Elena’s throat worked. She lifted it a fraction, testing the circle’s tolerance, and the light tightened as if the ring itself wanted the thing back.
+
+“See,” the mage hissed, vindicated. “Thief.”
+
+“I didn’t—” Elena stopped. Arguing origin with light and metal would not get her out.
+
+She let out a breath she hadn’t meant to hold. “If I give this back,” she said to the prince, “you let me go.”
+
+He considered her, expression unreadable, and then inclined his head. “Yes.”
+
+“Your yes means something?” she asked, because words mattered and she wanted him on record even if the record was only hers.
+
+He flicked a look at the mage, at the bowed hunters, at the unbroken forest. “More than most.”
+
+“Fine,” Elena said. She extended the arrow across the boundary. Heat from its runes lapped at her skin like the shallow edge of a lake. The prince reached into the circle’s light without flinching. For a fraction of a heartbeat his fingers touched hers—skin warm, callused at thumb and forefinger from archery or swordwork—before he took the arrow and the contact broke.
+
+The ring relaxed.
+
+It wasn’t dramatic. No flare, no explosion of light. The symbols around her feet dimmed to a pulse and then to nothing. The pressure on her joints eased as if a hand unclenched. The mage exhaled an exhausted sound. The hunters lowered their bows, not in relief but in attention, waiting to see what their sovereign would decide next.
+
+He did not step back.
+
+“You vanish like smoke, stranger,” he said, weighing the arrow as if it could tell him where she went when she went. “You return what you stole. Are we finished?”
+
+“God, I hope so,” Elena said, and tried the exit again.
+
+This time the world listened.
+
+Leaves telescoped into pixels and shattered into dark. The hum of servers came up through the floor as if she’d been underwater and broke the surface. The collar released with a soft sigh. She tore it off and sat breathing in a room she had always lived in and suddenly did not trust.
+
+Jonah’s chair squeaked as he spun toward her. “You were only in twenty-one minutes,” he announced, pretending indifference and missing. “How’s the forest?”
+
+“Full of boundary conditions,” she said, voice hoarse.
+
+Priya was at the glass immediately, scanning her face. “Did you see it again? The—” She bit off whatever she had been about to say and switched to neutral. “—artifact?”
+
+Elena swallowed and reached for her coffee just to give her hands a task. They shook anyway. “I saw a lot.”
+
+“Any instability?” Priya asked.
+
+“Yes,” Elena said. She angled her wrist under the desk and checked the skin where light had pressed against her. A faint red lattice ghosted there like the memory of pressure. She tugged her sleeve down. “Emergency exit didn’t fire on the first try.”
+
+Priya’s eyes sharpened. “Didn’t fire, or fired slowly?”
+
+“Didn’t fire,” Elena said. She set the cup down. Coffee sloshed, tiny waves hitting cardboard. “Then, after… conditions changed, it did.”
+
+Jonah’s brows went up. “Conditions changed how?”
+
+Elena thought of a hand that did not flinch in light. Of a voice saying yes in a way that sounded like law. She kept those to herself.
+
+“I returned a thing,” she said. “And it let me go.”
+
+Priya didn’t blink. “Let?”
+
+Elena glanced at the collar on the desk, small and neat and suddenly obscene. The lab was the same as it had been an hour ago. The lemon-solvent smell. The blue of the glass. The hiss of the air. Her skin still remembered pressure that shouldn’t exist.
+
+“I’m going to find the bug,” she said, more to the code than to either of them. “Because it’s there. And when I find it, it will make sense.”
+
+“And if it doesn’t?” Jonah asked lightly, but not lightly enough.
+
+“Then it’s not a bug,” Elena said.
+
+They were silent for a heartbeat. The rack fans thrummed like distant rain.
+
+“Eat,” Priya said at last. “File the report with no adjectives. Then you and I are going to look at the haptic stack line by line.”
+
+Elena nodded. She tore open the granola bar and chewed and tasted nothing. On the inside of her wrist, the red lattice mark faded, then steadied, like something that had decided not to leave.
+
+Outside the glass, the elevator did what elevators do: opened on cue, let people out, swallowed them again. Inside, Elena pulled logs, spun up tests, and told herself the same lie she’d been telling since the forest: that everything would behave if she only knew the right words.
+
+It was almost true.

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -299,6 +299,21 @@ const OFFICE_MODULE = (() => {
       }
     },
     {
+      id: 'silver_wolf',
+      map: 'world',
+      x: WORLD_MID + 5,
+      y: WORLD_MIDY - 4,
+      color: '#ddd',
+      name: 'Silver Wolf',
+      desc: 'Its fur ripples like moonlit water.',
+      tree: {
+        start: {
+          text: 'The wolf watches in silence.',
+          choices: [ { label: '(Leave)', to: 'bye' } ]
+        }
+      }
+    },
+    {
       id: 'fae_prince',
       map: 'world',
       x: WORLD_MID + 9,
@@ -306,17 +321,30 @@ const OFFICE_MODULE = (() => {
       color: '#caffc6',
       name: 'Fae Prince',
       desc: 'An ethereal figure with an enigmatic smile.',
+      questId: 'q_arrow',
       tree: {
         start: {
-          text: 'Welcome, wanderer. Is this real or dream?',
+          text: 'Welcome, wanderer. Have you seen my silver arrow?',
           choices: [
-            { label: '(Ask)', to: 'ask' },
+            { label: '(Ask about the arrow)', to: 'accept', q: 'accept' },
+            {
+              label: '(Return arrow)',
+              to: 'do_turnin',
+              q: 'turnin',
+              costItem: 'runed_arrow',
+              reward: 'prince_token',
+              success: 'He accepts the arrow, eyes bright.'
+            },
             { label: '(Leave)', to: 'bye' }
           ]
         },
-        ask: {
-          text: 'He only laughs and vanishes into mist.',
-          choices: [ { label: '(Contemplate)', to: 'bye' } ]
+        accept: {
+          text: 'I loosed it at a wolf of silver. Bring it back to me if you find it.',
+          choices: [ { label: '(Leave)', to: 'bye' } ]
+        },
+        do_turnin: {
+          text: 'His fingers brush yours as he takes the arrow.',
+          choices: [ { label: '(Continue)', to: 'bye' } ]
         }
       }
     },
@@ -377,6 +405,21 @@ const OFFICE_MODULE = (() => {
           type: 'trinket',
           slot: 'trinket',
           mods: { LCK: 1 }
+        },
+        {
+          map: 'world',
+          x: WORLD_MID + 7,
+          y: WORLD_MIDY - 3,
+          id: 'runed_arrow',
+          name: 'Runed Arrow',
+          type: 'quest'
+        },
+        {
+          id: 'prince_token',
+          name: "Prince's Token",
+          type: 'trinket',
+          slot: 'trinket',
+          mods: { CHA: 1 }
         }
       ],
       quests: [
@@ -391,6 +434,12 @@ const OFFICE_MODULE = (() => {
           title: 'Bridge Tax',
           desc: 'Pay the Toll Keeper with a trinket.',
           moveTo: { x: WORLD_MID + 2, y: WORLD_MIDY }
+        },
+        {
+          id: 'q_arrow',
+          title: 'Silver Return',
+          desc: 'Return the runed arrow to the Fae Prince.',
+          reward: 'prince_token'
         }
       ],
     npcs,


### PR DESCRIPTION
## Summary
- integrate Silver Wolf and quest to return a runed arrow to the Fae Prince
- add runed arrow item and prince's token reward to office module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cdfed780832886a3d3330df60b17