### PR TITLE
Fix door and combat interactions in Echoes module

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -291,7 +291,15 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
   if(opts?.combat){
     tree = tree || {};
     tree.start = tree.start || {text:'', choices:[]};
-    tree.start.choices.unshift({label:'(Fight)', to:'do_fight'});
+    let fightChoice = tree.start.choices.find(c => c.label === '(Fight)' || c.to === 'do_fight');
+    if(fightChoice){
+      fightChoice.label = '(Fight)';
+      fightChoice.to = 'do_fight';
+    } else {
+      fightChoice = {label:'(Fight)', to:'do_fight'};
+      tree.start.choices.unshift(fightChoice);
+    }
+    tree.start.choices = tree.start.choices.filter(c => c === fightChoice || c.label !== '(Fight)');
     tree.do_fight = tree.do_fight || {text:'', choices:[{label:'(Continue)', to:'bye'}]};
   }
   if(opts?.shop){

--- a/modules/echoes.module.js
+++ b/modules/echoes.module.js
@@ -65,11 +65,11 @@ const ECHOES_MODULE = (() => {
         start: {
           text: 'The door is sealed.',
           choices: [
-            { label: '(Use Spark Key)', to: 'open', q: 'turnin' },
+            { label: '(Use Spark Key)', to: 'do_turnin', q: 'turnin' },
             { label: '(Leave)', to: 'bye' }
           ]
         },
-        open: { text: 'The door slides aside.', choices: [ { label: '(Continue)', to: 'bye', goto: { map: 'workshop', x: 1, y: workshop.entryY } } ] }
+        do_turnin: { text: 'The door slides aside.', choices: [ { label: '(Continue)', to: 'bye', goto: { map: 'workshop', x: 1, y: workshop.entryY } } ] }
       }
     },
     {
@@ -106,11 +106,11 @@ const ECHOES_MODULE = (() => {
         start: {
           text: 'The door is locked tight.',
           choices: [
-            { label: '(Use Cog Key)', to: 'open', q: 'turnin' },
+            { label: '(Use Cog Key)', to: 'do_turnin', q: 'turnin' },
             { label: '(Leave)', to: 'bye' }
           ]
         },
-        open: { text: 'The door creaks open.', choices: [ { label: '(Continue)', to: 'bye', goto: { map: 'archive', x: 1, y: archive.entryY } } ] }
+        do_turnin: { text: 'The door creaks open.', choices: [ { label: '(Continue)', to: 'bye', goto: { map: 'archive', x: 1, y: archive.entryY } } ] }
       }
     },
     {
@@ -122,7 +122,7 @@ const ECHOES_MODULE = (() => {
       name: 'Dust Rat',
       title: 'Menace',
       desc: 'A rat swollen with dust.',
-      tree: { start: { text: 'The rat bares its teeth.', choices: [ { label: '(Fight)', to: 'bye' } ] } },
+      tree: { start: { text: 'The rat bares its teeth.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
       combat: { HP: 5, ATK: 2, DEF: 1, loot: { name: 'Rat Tail' } }
     },
     {
@@ -135,7 +135,7 @@ const ECHOES_MODULE = (() => {
       title: 'Guardian',
       desc: 'A whirring husk hungry for scraps.',
       questId: 'q_beacon',
-      tree: { start: { text: 'The ghoul clanks forward.', choices: [ { label: '(Fight)', to: 'bye', q: 'turnin' } ] } },
+      tree: { start: { text: 'The ghoul clanks forward.', choices: [ { label: '(Fight)', to: 'do_fight', q: 'turnin' }, { label: '(Leave)', to: 'bye' } ] } },
       combat: { HP: 8, ATK: 3, DEF: 2, loot: { name: 'Copper Cog' } }
     },
     {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -404,3 +404,14 @@ test('sample returns deterministic element and handles edge cases', () => {
   assert.strictEqual(sample([]), undefined);
   assert.strictEqual(sample('nope'), undefined);
 });
+
+test('makeNPC normalizes existing fight choices', () => {
+  const quest = new Quest('q_boss', 'Boss', '');
+  quest.status = 'active';
+  const tree = { start: { text: 'growl', choices: [ { label: '(Fight)', to: 'bye', q: 'turnin' }, { label: '(Leave)', to: 'bye' } ] } };
+  const npc = makeNPC('beast', 'world', 0, 0, '#fff', 'Beast', '', '', tree, quest, null, null, { combat: { DEF: 1 } });
+  const fights = npc.tree.start.choices.filter(c => c.label === '(Fight)');
+  assert.strictEqual(fights.length, 1);
+  assert.strictEqual(fights[0].to, 'do_fight');
+  assert.strictEqual(fights[0].q, 'turnin');
+});


### PR DESCRIPTION
## Summary
- Correct Echoes module doors to turn in keys and open destinations
- Remove broken fight options and ensure boss fight completes quest
- Normalize existing combat choices when creating NPCs and add regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4bd78904c832899482d1f4b6a89c0