### PR TITLE
Add healing items and editor support

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -278,7 +278,9 @@
           </div>
           <label>Equip<textarea id="itemEquip" rows="2"></textarea></label>
           <label>Value<input id="itemValue" type="number" min="0" /></label>
-          <label>Use<textarea id="itemUse" rows="2"></textarea></label>
+          <label>Use Type<select id="itemUseType"><option value="">(none)</option><option value="heal">Heal</option></select></label>
+          <label id="itemUseAmtWrap" style="display:none">Heal Amount<input id="itemUseAmount" type="number" min="1" /></label>
+          <label id="itemUseWrap">Use<textarea id="itemUse" rows="2"></textarea></label>
           <button class="btn" id="addItem">Add Item</button>
           <button class="btn" id="delItem" style="display:none">Delete Item</button>
         </div>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -752,6 +752,11 @@ function updateModsWrap() {
   document.getElementById('modsWrap').style.display =
     ['weapon', 'armor', 'trinket'].includes(slot) ? 'block' : 'none';
 }
+function updateUseWrap() {
+  const type = document.getElementById('itemUseType').value;
+  document.getElementById('itemUseAmtWrap').style.display = type === 'heal' ? 'block' : 'none';
+  document.getElementById('itemUseWrap').style.display = type ? 'none' : 'block';
+}
 function startNewItem() {
   editItemIdx = -1;
   document.getElementById('itemName').value = '';
@@ -766,7 +771,10 @@ function startNewItem() {
   loadMods({});
   document.getElementById('itemValue').value = 0;
   document.getElementById('itemEquip').value = '';
+  document.getElementById('itemUseType').value = '';
+  document.getElementById('itemUseAmount').value = 0;
   document.getElementById('itemUse').value = '';
+  updateUseWrap();
   document.getElementById('addItem').textContent = 'Add Item';
   document.getElementById('delItem').style.display = 'none';
   placingType = 'item';
@@ -789,7 +797,13 @@ function addItem() {
   let equip = null;
   try { equip = JSON.parse(document.getElementById('itemEquip').value || 'null'); } catch (e) { equip = null; }
   let use = null;
-  try { use = JSON.parse(document.getElementById('itemUse').value || 'null'); } catch (e) { use = null; }
+  const useType = document.getElementById('itemUseType').value;
+  if (useType === 'heal') {
+    const amt = parseInt(document.getElementById('itemUseAmount').value, 10) || 0;
+    use = { type: 'heal', amount: amt };
+  } else {
+    try { use = JSON.parse(document.getElementById('itemUse').value || 'null'); } catch (e) { use = null; }
+  }
   const item = { id, name, type, tags, map, x, y, slot, mods, value, use, equip };
   if (editItemIdx >= 0) {
     moduleData.items[editItemIdx] = item;
@@ -820,7 +834,16 @@ function editItem(i) {
   loadMods(it.mods);
   document.getElementById('itemValue').value = it.value || 0;
   document.getElementById('itemEquip').value = it.equip ? JSON.stringify(it.equip, null, 2) : '';
-  document.getElementById('itemUse').value = it.use ? JSON.stringify(it.use, null, 2) : '';
+  if (it.use && it.use.type === 'heal') {
+    document.getElementById('itemUseType').value = 'heal';
+    document.getElementById('itemUseAmount').value = it.use.amount || 0;
+    document.getElementById('itemUse').value = '';
+  } else {
+    document.getElementById('itemUseType').value = '';
+    document.getElementById('itemUseAmount').value = 0;
+    document.getElementById('itemUse').value = it.use ? JSON.stringify(it.use, null, 2) : '';
+  }
+  updateUseWrap();
   document.getElementById('addItem').textContent = 'Update Item';
   document.getElementById('delItem').style.display = 'block';
   showItemEditor(true);
@@ -1088,6 +1111,7 @@ document.getElementById('delInterior').onclick = deleteInterior;
 document.getElementById('delQuest').onclick = deleteQuest;
 document.getElementById('addMod').onclick = () => modRow();
 document.getElementById('itemSlot').addEventListener('change', updateModsWrap);
+document.getElementById('itemUseType').addEventListener('change', updateUseWrap);
 document.getElementById('save').onclick = saveModule;
 document.getElementById('load').onclick = () => document.getElementById('loadFile').click();
 document.getElementById('loadFile').addEventListener('change', e => {

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -34,6 +34,8 @@ const DUSTLAND_MODULE = (() => {
     { map: 'world', x: 67, y: midY + 5, id: 'goggles', name: 'Goggles', type: 'trinket', slot: 'trinket', mods: { PER: 1 } },
     { map: 'world', x: 83, y: midY - 2, id: 'wrench', name: 'Wrench', type: 'trinket', slot: 'trinket', mods: { INT: 1 } },
     { map: 'world', x: 95, y: midY + 2, id: 'lucky_rabbit_foot', name: 'Lucky Rabbit Foot', type: 'trinket', slot: 'trinket', mods: { LCK: 1 } },
+    { map: 'world', x: 32, y: midY + 2, id: 'water_flask', name: 'Water Flask', type: 'consumable', use: { type: 'heal', amount: 3 } },
+    { map: 'world', x: 80, y: midY - 3, id: 'medkit', name: 'Medkit', type: 'consumable', use: { type: 'heal', amount: 5 } },
     { map: 'world', x: 18, y: midY - 2, id: 'valve', name: 'Valve', type: 'quest' },
     { map: 'world', x: 26, y: midY + 3, id: 'lost_satchel', name: 'Lost Satchel', type: 'quest' },
     { map: 'world', x: 60, y: midY - 1, id: 'rust_idol', name: 'Rust Idol', type: 'quest', tags: ['idol'] }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -37,7 +37,7 @@ global.document = {
   createElement: () => stubEl()
 };
 
-const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, randRange, sample, setRNGSeed } = require('../dustland-core.js');
+const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, randRange, sample, setRNGSeed, useItem } = require('../dustland-core.js');
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -166,6 +166,18 @@ test('interactAt picks up adjacent item', () => {
   interactAt(1,0);
   assert.ok(player.inv.some(it=>it.id==='gem'));
   assert.ok(!itemDrops.includes(itm));
+});
+
+test('useItem heals party member and consumes item', () => {
+  party.length = 0; player.inv.length = 0;
+  const m = new Character('h','Healer','Role');
+  m.hp = 5; m.maxHp = 10;
+  party.addMember(m);
+  registerItem({ id:'tonic', name:'Tonic', type:'consumable', use:{ type:'heal', amount:3 } });
+  addToInv('tonic');
+  useItem(0);
+  assert.strictEqual(m.hp, 8);
+  assert.strictEqual(player.inv.length, 0);
 });
 
 test('findFreeDropTile avoids water and player tiles', () => {


### PR DESCRIPTION
## Summary
- Introduce Water Flask and Medkit healing items to Dustland module
- Enhance Adventure Kit item editor with heal use-type fields
- Test healing item usage to ensure HP restoration and consumption

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c22f9750832889ff9038c5898aa2