### PR TITLE
Enhance combat flow and UI

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -31,6 +31,8 @@ function renderCombat(){
     const p=document.createElement('div'); p.className='portrait';
     setPortraitDiv(p,e);
     wrap.appendChild(p);
+    const lab=document.createElement('div'); lab.className='label'; lab.textContent=e.name||'';
+    wrap.appendChild(lab);
     enemyRow.appendChild(wrap);
   }
   partyRow.innerHTML='';
@@ -40,6 +42,8 @@ function renderCombat(){
     const p=document.createElement('div'); p.className='portrait';
     setPortraitDiv(p,m);
     wrap.appendChild(p);
+    const lab=document.createElement('div'); lab.className='label'; lab.textContent=m.name||'';
+    wrap.appendChild(lab);
     const cmd=document.createElement('div');
     cmd.className='cmd';
     cmd.style.display='none';

--- a/core/movement.js
+++ b/core/movement.js
@@ -74,7 +74,7 @@ function checkAggro(){
     if(n.map!==state.map) continue;
     const d = Math.abs(n.x - player.x) + Math.abs(n.y - player.y);
     if(d<=3){
-      quickCombat(n.combat).then(res=>{ if(res.result==='loot') removeNPC(n); });
+      quickCombat({ ...n.combat, npc:n, name:n.name });
       break;
     }
   }

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -320,6 +320,11 @@ window.addEventListener('keydown',(e)=>{
     else if(handleDialogKey?.(e)) e.preventDefault();
     return;
   }
+  const combat = document.getElementById('combatOverlay');
+  if(combat?.classList?.contains('shown')){
+    if(handleCombatKey?.(e)) e.preventDefault();
+    return;
+  }
   switch(e.key){
     case 'ArrowUp': case 'w': case 'W': move(0,-1); break;
     case 'ArrowDown': case 's': case 'S': move(0,1); break;

--- a/dustland.css
+++ b/dustland.css
@@ -288,15 +288,17 @@
 
 /* Combat UI */
 #combatOverlay { background: transparent; pointer-events: none; }
-#combatOverlay .combat-window { pointer-events:auto; width:min(480px,92vw); background:#0b0d0b; border:1px solid #2a382a; border-radius:10px; padding:8px; display:flex; flex-direction:column; align-items:center; }
+#combatOverlay .combat-window { pointer-events:auto; width:min(480px,92vw); background:#0b0d0b; border:1px solid #2a382a; border-radius:10px; padding:8px 8px 120px; display:flex; flex-direction:column; align-items:center; box-shadow:0 0 8px #000; }
 #combatOverlay .enemy-row, #combatOverlay .party-row { display:flex; gap:12px; }
 #combatOverlay .enemy-row { justify-content:center; margin-bottom:8px; }
 #combatOverlay .party-row { justify-content:center; margin-top:8px; }
 #combatOverlay .member { position:relative; display:flex; flex-direction:column; align-items:center; }
+#combatOverlay .label { margin-top:4px; text-align:center; }
 #combatOverlay .enemy.active .portrait, #combatOverlay .member.active .portrait { border-color:#5c8a5c; }
-#combatOverlay .cmd { position:absolute; top:70px; background:#0f120f; border:1px solid #253525; padding:4px 12px; border-radius:6px; }
+#combatOverlay .cmd { position:absolute; top:80px; background:#0f120f; border:1px solid #253525; padding:4px 12px; border-radius:6px; }
 #combatOverlay .cmd div { padding:2px 0; }
-#combatOverlay .cmd div.sel::before { content:'>'; margin-right:4px; }
+#combatOverlay .cmd div::before { content:''; display:inline-block; width:1em; }
+#combatOverlay .cmd div.sel::before { content:'>'; }
 
     .small {
         font-size: 12px;


### PR DESCRIPTION
## Summary
- Block world navigation while combat overlay is shown
- Remove defeated NPCs after winning combat
- Polish combat window with centered name labels and improved command menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ebf24ea0832888b422ccfa6ac965