### PR TITLE
Use party as source of map position

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -41,7 +41,7 @@ loadBtn.onclick = () => {
 window.startGame = function(){
   if(moduleData) applyModule(moduleData);
   const start=moduleData && moduleData.start ? moduleData.start : {map:'world',x:2,y:Math.floor(WORLD_H/2)};
-  setPlayerPos(start.x, start.y);
+  setPartyPos(start.x, start.y);
   setMap(start.map||'world', 'Module');
   renderInv(); renderQuests(); renderParty(); updateHUD();
   log('Adventure begins.');

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -108,11 +108,11 @@ function handleGoto(g){
   if(!g) return;
   if(g.map==='world'){
     startWorld();
-    setPlayerPos(g.x, g.y);
+    setPartyPos(g.x, g.y);
     setMap('world');
   }else{
-    setPlayerPos(g.x, g.y);
-    if(g.map) setMap(g.map); else if(typeof centerCamera==='function') centerCamera(player.x,player.y,state.map);
+    setPartyPos(g.x, g.y);
+    if(g.map) setMap(g.map); else if(typeof centerCamera==='function') centerCamera(party.x,party.y,state.map);
   }
   updateHUD?.();
 }

--- a/core/inventory.js
+++ b/core/inventory.js
@@ -62,7 +62,7 @@ function equipItem(memberIndex, invIndex){
   if(typeof sfxTick==='function') sfxTick();
   if(it.equip && it.equip.teleport){
     const t=it.equip.teleport;
-    setPlayerPos(t.x, t.y);
+    setPartyPos(t.x, t.y);
     if(t.map) setMap(t.map);
     updateHUD();
   }

--- a/core/movement.js
+++ b/core/movement.js
@@ -59,10 +59,10 @@ function canWalk(x,y){
 }
 function move(dx,dy){
   if(state.map==='creator') return;
-  const nx=player.x+dx, ny=player.y+dy;
+  const nx=party.x+dx, ny=party.y+dy;
   if(canWalk(nx,ny)){
-    setPlayerPos(nx, ny);
-    centerCamera(player.x,player.y,state.map); updateHUD();
+    setPartyPos(nx, ny);
+    centerCamera(party.x,party.y,state.map); updateHUD();
     checkAggro();
   }
 }
@@ -72,7 +72,7 @@ function checkAggro(){
   for(const n of NPCS){
     if(!n.combat || !n.combat.auto) continue;
     if(n.map!==state.map) continue;
-    const d = Math.abs(n.x - player.x) + Math.abs(n.y - player.y);
+    const d = Math.abs(n.x - party.x) + Math.abs(n.y - party.y);
     if(d<=3){
       quickCombat({ ...n.combat, npc:n, name:n.name });
       break;
@@ -82,7 +82,7 @@ function checkAggro(){
 function adjacentNPC(){
   const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
   for(const [dx,dy] of dirs){
-    const info=queryTile(player.x+dx,player.y+dy);
+    const info=queryTile(party.x+dx,party.y+dy);
     if(info.entities.length) return info.entities[0];
   }
   return null;
@@ -90,7 +90,7 @@ function adjacentNPC(){
 function takeNearestItem(){
   const dirs=[[0,0],[1,0],[-1,0],[0,1],[0,-1]];
   for(const [dx,dy] of dirs){
-    const info=queryTile(player.x+dx,player.y+dy);
+    const info=queryTile(party.x+dx,party.y+dy);
     if(info.items.length){
       const it=info.items[0];
       const idx=itemDrops.indexOf(it);
@@ -105,7 +105,7 @@ function takeNearestItem(){
 }
 function interactAt(x,y){
   if(state.map==='creator') return false;
-  const dist=Math.abs(player.x-x)+Math.abs(player.y-y);
+  const dist=Math.abs(party.x-x)+Math.abs(party.y-y);
   if(dist>1) return false;
   const info=queryTile(x,y);
   if(info.entities.length){ openDialog(info.entities[0]); return true; }
@@ -117,13 +117,13 @@ function interactAt(x,y){
     addToInv(it.id); log('Took '+(def?def.name:it.id)+'.'); updateHUD();
     return true;
   }
-  if(x===player.x && y===player.y && info.tile===TILE.DOOR){
+  if(x===party.x && y===party.y && info.tile===TILE.DOOR){
     if(state.map==='world'){
       const b=buildings.find(b=> b.doorX===x && b.doorY===y);
       if(!b){ log('No entrance here.'); return true; }
       if(b.boarded){ log('The doorway is boarded up from the outside.'); return true; }
       const I=interiors[b.interiorId];
-      if(I){ setPlayerPos(I.entryX, I.entryY); }
+      if(I){ setPartyPos(I.entryX, I.entryY); }
       setMap(b.interiorId,'Interior');
       log('You step inside.'); updateHUD(); return true;
     }
@@ -134,13 +134,13 @@ function interactAt(x,y){
         const I=interiors[target];
         const px = (typeof p.toX==='number') ? p.toX : (I?I.entryX:0);
         const py = (typeof p.toY==='number') ? p.toY : (I?I.entryY:0);
-        setPlayerPos(px, py);
+        setPartyPos(px, py);
         setMap(target);
         log(p.desc || 'You move through the doorway.');
         updateHUD(); return true;
       }
       const b=buildings.find(b=> b.interiorId===state.map);
-      if(b){ setPlayerPos(b.doorX, b.doorY-1); setMap('world'); log('You step back outside.'); updateHUD(); return true; }
+      if(b){ setPartyPos(b.doorX, b.doorY-1); setMap('world'); log('You step back outside.'); updateHUD(); return true; }
     }
   }
   return false;
@@ -150,7 +150,7 @@ function interact(){
   lastInteract = Date.now();
   const dirs=[[0,0],[1,0],[-1,0],[0,1],[0,-1]];
   for(const [dx,dy] of dirs){
-    if(interactAt(player.x+dx,player.y+dy)) return true;
+    if(interactAt(party.x+dx,party.y+dy)) return true;
   }
   log('Nothing interesting.');
   return false;

--- a/core/party.js
+++ b/core/party.js
@@ -10,7 +10,6 @@ class Character {
     this.maxHp=10;
     this.hp=this.maxHp;
     this.ap=2;
-    this.map=state.map; this.x=player.x; this.y=player.y;
     this._bonus={ATK:0, DEF:0, LCK:0};
   }
   xpToNext(){ return 10*this.lvl; }
@@ -55,6 +54,12 @@ class Character {
 }
 
 class Party extends Array {
+  constructor(...args){
+    super(...args);
+    this.map = state.map;
+    this.x = 2;
+    this.y = 2;
+  }
   addMember(member){
     if(this.length >= 6){
       log('Party is full.');
@@ -77,7 +82,7 @@ class Party extends Array {
     renderParty(); updateHUD();
     if(typeof makeNPC==='function' && Array.isArray(NPCS)){
       const tree={ start:{ text:'', choices:[{label:'(Leave)', to:'bye'}] }, bye:{ text:'' } };
-      const npc=makeNPC(member.id, member.map, member.x, member.y, '#fff', member.name, '', '', tree);
+      const npc=makeNPC(member.id, this.map, this.x, this.y, '#fff', member.name, '', '', tree);
       NPCS.push(npc);
     }
     return true;

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -134,8 +134,9 @@ function mapLabel(id){
 }
 function setMap(id,label){
   state.map=id;
+  party.map = id;
   mapNameEl.textContent = label || mapLabel(id);
-  if(typeof centerCamera==='function') centerCamera(player.x,player.y,state.map);
+  if(typeof centerCamera==='function') centerCamera(party.x,party.y,state.map);
   if(id==='world') setGameState(GAME_STATE.WORLD);
   else if(id==='creator') setGameState(GAME_STATE.CREATOR);
   else setGameState(GAME_STATE.INTERIOR);
@@ -149,11 +150,12 @@ const WORLD_W=120, WORLD_H=90;
 // ===== Game state =====
 let world = [], interiors = {}, buildings = [], portals = [];
 const state = { map:'world' }; // default map
-const player = { x:2, y:2, hp:10, ap:2, flags:{}, inv:[], scrap:0 };
-function setPlayerPos(x, y){
-  if(typeof x === 'number') player.x = x;
-  if(typeof y === 'number') player.y = y;
+const player = { hp:10, ap:2, flags:{}, inv:[], scrap:0 };
+function setPartyPos(x, y){
+  if(typeof x === 'number') party.x = x;
+  if(typeof y === 'number') party.y = y;
 }
+const setPlayerPos = setPartyPos; // backward compatibility
 const GAME_STATE = Object.freeze({
   TITLE: 'title',
   CREATOR: 'creator',
@@ -628,7 +630,7 @@ const hiddenOrigins={ 'Rustborn':{desc:'You survived a machine womb. +1 PER, wei
 let step=1; let building=null; let built=[];
 function openCreator(){
   if(!creatorMap.grid || creatorMap.grid.length===0) genCreatorMap();
-  setPlayerPos(creatorMap.entryX, creatorMap.entryY);
+  setPartyPos(creatorMap.entryX, creatorMap.entryY);
   setMap('creator','Creator');
   creator.style.display='flex';
   step=1;
@@ -722,7 +724,7 @@ function startGame(){
 function startWorld(){
   const seed = Date.now();
   genWorld(seed);
-  setPlayerPos(2, Math.floor(WORLD_H/2));
+  setPartyPos(2, Math.floor(WORLD_H/2));
   setMap('world','Wastes');
   renderInv(); renderQuests(); renderParty(); updateHUD();
   log('You step into the wastes.');
@@ -731,7 +733,7 @@ function startWorld(){
 // Content pack moved to modules/dustland.module.js
 
 
-const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, quickCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, state, player, GAME_STATE, setGameState, setPlayerPos, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, npcsOnMap, queueNanoDialogForNPCs, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, createNpcFactory, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld, setRNGSeed, randRange, sample };
+const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, quickCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, state, player, GAME_STATE, setGameState, setPartyPos, setPlayerPos, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, npcsOnMap, queueNanoDialogForNPCs, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, createNpcFactory, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld, setRNGSeed, randRange, sample };
 
 Object.assign(globalThis, coreExports);
 

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -106,7 +106,7 @@ function render(gameState=state, dt){
 
   const items = gameState.itemDrops || itemDrops;
   const entities = gameState.entities || NPCS;
-  const ply = gameState.player || player;
+  const pos = gameState.party || party;
 
   // split entities into below/above
   const below = [], above = [];
@@ -151,7 +151,7 @@ function render(gameState=state, dt){
     }
     else if(layer==='entitiesBelow'){ drawEntities(ctx, below, offX, offY); }
     else if(layer==='player'){
-      const px=(ply.x-camX+offX)*TS, py=(ply.y-camY+offY)*TS;
+      const px=(pos.x-camX+offX)*TS, py=(pos.y-camY+offY)*TS;
       ctx.fillStyle='#d9ffbe'; ctx.fillRect(px,py,TS,TS);
       ctx.fillStyle='#000'; ctx.fillText('@',px+4,py+12);
     }
@@ -343,7 +343,7 @@ window.addEventListener('keydown',(e)=>{
         toast(`Leader: ${party[selectedMember].name}`);
         if(window.NanoDialog){
           const near = NPCS.filter(n => n.map === state.map
-            && Math.abs(n.x - player.x) + Math.abs(n.y - player.y) < 10);
+            && Math.abs(n.x - party.x) + Math.abs(n.y - party.y) < 10);
           near.forEach(n => NanoDialog.queueForNPC(n, 'start', 'leader change'));
         }
       }

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -363,7 +363,7 @@ startGame = function () {
   startWorld();
   applyModule(DUSTLAND_MODULE);
   const s = DUSTLAND_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-  setPlayerPos(s.x, s.y);
+  setPartyPos(s.x, s.y);
   setMap(s.map, s.map === 'world' ? 'Wastes' : 'Test Hall');
   renderInv();
   renderQuests();

--- a/modules/echoes.module.js
+++ b/modules/echoes.module.js
@@ -179,7 +179,7 @@ startGame = function () {
   startWorld();
   applyModule(ECHOES_MODULE);
   const s = ECHOES_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-  setPlayerPos(s.x, s.y);
+  setPartyPos(s.x, s.y);
   setMap(s.map, s.map === 'world' ? 'Wastes' : 'Echoes');
   renderInv();
   renderQuests();

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -453,7 +453,7 @@ startGame = function () {
       itemDrops.push({ id: charm.id, map: castleId, x: ix, y: iy });
     }
     const s = OFFICE_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-    setPlayerPos(s.x, s.y);
+    setPartyPos(s.x, s.y);
     setMap(s.map);
     renderInv();
     renderQuests();

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -97,7 +97,7 @@ test('cursed items reveal on unequip attempt and stay equipped', () => {
   assert.strictEqual(mem.equip.armor.name,'Mask');
 });
 
-test('equipping teleport item moves player and logs message', () => {
+test('equipping teleport item moves party and logs message', () => {
   const oldLog = global.log;
   const oldCenter = global.centerCamera;
   const logs = [];
@@ -108,14 +108,14 @@ test('equipping teleport item moves player and logs message', () => {
   party.length = 0;
   player.inv.length = 0;
   state.map = 'world';
-  player.x = 0; player.y = 0;
+  party.x = 0; party.y = 0;
   const mem = new Character('t2','Tele','Role');
   party.addMember(mem);
   const tp = normalizeItem({ id:'warp_ring', name:'Warp Ring', type:'trinket', slot:'trinket', equip:{ teleport:{ map:'world', x:5, y:6 }, msg:'whoosh' } });
   addToInv(tp);
   equipItem(0,0);
-  assert.strictEqual(player.x,5);
-  assert.strictEqual(player.y,6);
+  assert.strictEqual(party.x,5);
+  assert.strictEqual(party.y,6);
   assert.strictEqual(state.map,'world');
   assert.deepStrictEqual(centered,{x:5,y:6,map:'world'});
   assert.ok(logs.includes('whoosh'));
@@ -129,17 +129,17 @@ test('pathfinding blocks on NPCs', () => {
   const world = Array.from({length:H},()=>Array.from({length:W},()=>7));
   applyModule({world, npcs:[{id:'g', map:'world', x:1, y:0, name:'Guard'}]});
   state.map='world';
-  player.x=0; player.y=0;
+  party.x=0; party.y=0;
   assert.strictEqual(canWalk(1,0), false);
   move(1,0);
-  assert.strictEqual(player.x,0);
+  assert.strictEqual(party.x,0);
 });
 
 test('queryTile reports entities and items', () => {
   const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
   applyModule({world});
   state.map='world';
-  player.x=0; player.y=0;
+  party.x=0; party.y=0;
   NPCS.length=0; itemDrops.length=0;
   NPCS.push({id:'n',map:'world',x:1,y:1,name:'N'});
   registerItem({id:'i',name:'Item',type:'quest'});
@@ -158,7 +158,7 @@ test('interactAt picks up adjacent item', () => {
   const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
   applyModule({world});
   state.map='world';
-  player.x=0; player.y=0;
+  party.x=0; party.y=0;
   itemDrops.length=0; player.inv.length=0;
   registerItem({id:'gem',name:'Gem',type:'quest'});
   const itm={id:'gem',map:'world',x:1,y:0};
@@ -180,13 +180,13 @@ test('useItem heals party member and consumes item', () => {
   assert.strictEqual(player.inv.length, 0);
 });
 
-test('findFreeDropTile avoids water and player tiles', () => {
+test('findFreeDropTile avoids water and party tiles', () => {
   const W=120, H=90;
   const world = Array.from({length:H},()=>Array.from({length:W},()=>7));
   world[10][10] = 2; // water
   applyModule({world});
   state.map='world';
-  player.x=0; player.y=0;
+  party.x=0; party.y=0;
   NPCS.length=0;
   NPCS.push({map:'world', x:0, y:0});
   let spot = findFreeDropTile('world',0,0);
@@ -200,7 +200,7 @@ test('selected party member receives XP on dialog success', () => {
   const world = Array.from({length:H},()=>Array.from({length:W},()=>7));
   applyModule({world, npcs:[{id:'s', map:'world', x:1, y:0, name:'Sage', tree:{start:{text:'hi', choices:[{label:'learn', reward:'XP 5', to:'bye'}]}}}]});
   state.map='world';
-  player.x=0; player.y=0;
+  party.x=0; party.y=0;
   party.length=0;
   const a=new Character('a','A','Role');
   const b=new Character('b','B','Role');
@@ -245,14 +245,14 @@ test('advanceDialog respects goto with costItem', () => {
   registerItem({id:'key',name:'Key',type:'quest'});
   addToInv('key');
   state.map = 'world';
-  player.x = 0; player.y = 0;
+  party.x = 0; party.y = 0;
   const tree = {
     start: { text: '', next: [{ label: 'Go', costItem: 'key', goto: { map: 'room', x: 3, y: 4 } }] }
   };
   const dialog = { tree, node: 'start' };
   advanceDialog(dialog, 0);
-  assert.strictEqual(player.x, 3);
-  assert.strictEqual(player.y, 4);
+  assert.strictEqual(party.x, 3);
+  assert.strictEqual(party.y, 4);
   assert.ok(!player.inv.some(it => it.id === 'key'));
 });
 
@@ -261,14 +261,14 @@ test('advanceDialog uses reqItem without consuming and allows goto', () => {
   registerItem({id:'pass',name:'Pass',type:'quest'});
   addToInv('pass');
   state.map = 'world';
-  player.x = 1; player.y = 1;
+  party.x = 1; party.y = 1;
   const tree = {
     start: { text: '', next: [{ label: 'Enter', reqItem: 'pass', goto: { map: 'room', x: 5, y: 6 } }] }
   };
   const dialog = { tree, node: 'start' };
   advanceDialog(dialog, 0);
-  assert.strictEqual(player.x, 5);
-  assert.strictEqual(player.y, 6);
+  assert.strictEqual(party.x, 5);
+  assert.strictEqual(party.y, 6);
   assert.ok(player.inv.some(it => it.id === 'pass'));
 });
 
@@ -277,14 +277,14 @@ test('advanceDialog matches reqItem case-insensitively', () => {
   registerItem({id:'access_card',name:'access card',type:'quest',tags:['pass']});
   addToInv('access_card');
   state.map = 'world';
-  player.x = 2; player.y = 2;
+  party.x = 2; party.y = 2;
   const tree = {
     start: { text: '', next: [{ label: 'Up', reqItem: 'PASS', goto: { map: 'room', x: 7, y: 8 } }] }
   };
   const dialog = { tree, node: 'start' };
   advanceDialog(dialog, 0);
-  assert.strictEqual(player.x, 7);
-  assert.strictEqual(player.y, 8);
+  assert.strictEqual(party.x, 7);
+  assert.strictEqual(party.y, 8);
 });
 
 test('advanceDialog returns success flag on failure', () => {
@@ -311,7 +311,7 @@ test('door portals link interiors', () => {
   const forest = { id:'forest', w:3, h:3, grid:[[6,6,6],[6,8,6],[6,6,6]], entryX:1, entryY:1 };
   const castle = { id:'castle', w:3, h:3, grid:[[6,6,6],[6,8,6],[6,6,6]], entryX:1, entryY:1 };
   applyModule({world, interiors:[forest, castle], portals:[{ map:'forest', x:1, y:1, toMap:'castle', toX:1, toY:1 },{ map:'castle', x:1, y:1, toMap:'forest', toX:1, toY:1 }]});
-  state.map='forest'; player.x=1; player.y=1;
+  state.map='forest'; party.x=1; party.y=1;
   interactAt(1,1);
   assert.strictEqual(state.map, 'castle');
   interactAt(1,1);
@@ -504,7 +504,7 @@ test('cannot remove created party members', () => {
 
 test('removed member becomes NPC at current location', () => {
   party.length = 0; NPCS.length = 0;
-  state.map = 'world'; player.x = 0; player.y = 0;
+  state.map = 'world'; party.map = 'world'; party.x = 0; party.y = 0;
   const base = new Character('a','A','Role', {permanent:true});
   const recruit = new Character('b','B','Role');
   party.addMember(base); party.addMember(recruit);


### PR DESCRIPTION
## Summary
- Track x/y coordinates on the party instead of the player
- Update movement, dialogs, rendering and module startup to use party position
- Adjust tests for party-based positioning
- Remove map and coordinate fields from individual party members

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a59c98f6c083288fca482c80c2c0e8