### PR TITLE
Enforce canonical item loot

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -83,10 +83,8 @@ function applyReward(reward){
     awardXP(leader(), amt);
     if(typeof toast==='function') toast(`+${amt} XP`);
   } else {
-    addToInv(reward);
-    const id = typeof reward === 'string' ? reward : reward.id;
-    const def = ITEMS[id] || (typeof reward === 'object' ? reward : null);
-    if(typeof toast==='function') toast(`Received ${def?.name || id}`);
+    const rewardIt = resolveItem(reward);
+    if(rewardIt){ addToInv(rewardIt); if(typeof toast==='function') toast(`Received ${rewardIt.name}`); }
   }
 }
 

--- a/core/inventory.js
+++ b/core/inventory.js
@@ -20,15 +20,18 @@ function getItem(id){
   const it = ITEMS[id];
   return it ? cloneItem(it) : null;
 }
+function resolveItem(def){
+  if(!def) return null;
+  const id = typeof def === 'string' ? def : def.id;
+  let it = id ? getItem(id) : null;
+  if(!it && typeof def === 'object') it = def;
+  return it;
+}
 function addToInv(item){
-  let base = null;
-  if(typeof item === 'string'){
-    base = getItem(item);
-  } else if(item && item.id){
-    base = ITEMS[item.id] || registerItem(item);
-    base = cloneItem(base);
+  if(!item || typeof item !== 'object' || !item.id){
+    throw new Error('Unknown item');
   }
-  if(!base) throw new Error('Unknown item');
+  const base = cloneItem(ITEMS[item.id] || registerItem(item));
   player.inv.push(base);
   renderInv();
   queueNanoDialogForNPCs('start', 'inventory change');
@@ -151,7 +154,7 @@ function useItem(invIndex){
   return false;
 }
 
-const inventoryExports = { ITEMS, itemDrops, registerItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem };
+const inventoryExports = { ITEMS, itemDrops, registerItem, getItem, resolveItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem };
 Object.assign(globalThis, inventoryExports);
 
 if (typeof module !== 'undefined' && module.exports){

--- a/core/movement.js
+++ b/core/movement.js
@@ -96,7 +96,7 @@ function takeNearestItem(){
       const idx=itemDrops.indexOf(it);
       if(idx>-1) itemDrops.splice(idx,1);
       const def = ITEMS[it.id];
-      addToInv(it.id);
+      addToInv(getItem(it.id));
       log('Took '+(def?def.name:it.id)+'.'); updateHUD();
       return true;
     }
@@ -114,7 +114,7 @@ function interactAt(x,y){
     const idx=itemDrops.indexOf(it);
     if(idx>-1) itemDrops.splice(idx,1);
     const def = ITEMS[it.id];
-    addToInv(it.id); log('Took '+(def?def.name:it.id)+'.'); updateHUD();
+    addToInv(getItem(it.id)); log('Took '+(def?def.name:it.id)+'.'); updateHUD();
     return true;
   }
   if(x===player.x && y===player.y && info.tile===TILE.DOOR){

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -98,7 +98,10 @@ async function quickCombat(defender){
       player.hp = attacker.hp;
     }
     if(result.result==='loot'){
-      if(defender.loot) addToInv(defender.loot);
+      if(defender.loot){
+        const lootIt = resolveItem(defender.loot);
+        if(lootIt) addToInv(lootIt);
+      }
       if(defender.npc) removeNPC(defender.npc);
     }
     renderInv?.(); renderParty?.(); updateHUD?.();
@@ -116,7 +119,10 @@ async function quickCombat(defender){
   if(result==='bruise'){
     attacker.hp = Math.max(0,(attacker.hp||0)-1);
   } else if(result==='loot'){
-    if(defender.loot) addToInv(defender.loot);
+    if(defender.loot){
+      const lootIt = resolveItem(defender.loot);
+      if(lootIt) addToInv(lootIt);
+    }
     if(defender.npc) removeNPC(defender.npc);
   }
   player.hp = attacker.hp; player.ap = attacker.ap;
@@ -237,7 +243,10 @@ function defaultQuestProcessor(npc, nodeId){
       if(!meta.item || hasItem(meta.item)){
         if(meta.item){ const i = findItemIndex(meta.item); if(i>-1) removeFromInv(i); }
         questLog.complete(meta.id);
-        if(meta.reward){ addToInv(meta.reward); }
+        if(meta.reward){
+          const rewardIt = resolveItem(meta.reward);
+          if(rewardIt) addToInv(rewardIt);
+        }
         if(meta.xp){ awardXP(leader(), meta.xp); }
         if(meta.moveTo){ npc.x=meta.moveTo.x; npc.y=meta.moveTo.y; }
       } else {
@@ -613,10 +622,10 @@ const ccLoad=document.getElementById('ccLoad');
 if(ccNext) ccNext.classList.add('btn--primary');
 const portraits=['@','&','#','%','*']; let portraitIndex=0;
 const specializations={
-  'Scavenger':{desc:'Finds better loot from ruins; starts with crowbar.', gear:[{name:'Crowbar',slot:'weapon',mods:{ATK:+1}}]},
-  'Gunslinger':{desc:'Higher chance to win quick fights; starts with pipe rifle.', gear:[{name:'Pipe Rifle',slot:'weapon',mods:{ATK:+2}}]},
-  'Snakeoil Preacher':{desc:'Can sway naive foes; +1 CHA trinket.', gear:[{name:'Tin Sun',slot:'trinket',mods:{LCK:+1}}]},
-  'Cogwitch':{desc:'Tinker checks succeed more often; starts with toolkit.', gear:[{name:'Toolkit',slot:'trinket',mods:{INT:+1}}]}
+  'Scavenger':{desc:'Finds better loot from ruins; starts with crowbar.', gear:[{id:'crowbar',name:'Crowbar',slot:'weapon',mods:{ATK:+1}}]},
+  'Gunslinger':{desc:'Higher chance to win quick fights; starts with pipe rifle.', gear:[{id:'pipe_rifle',name:'Pipe Rifle',slot:'weapon',mods:{ATK:+2}}]},
+  'Snakeoil Preacher':{desc:'Can sway naive foes; +1 CHA trinket.', gear:[{id:'tin_sun',name:'Tin Sun',slot:'trinket',mods:{LCK:+1}}]},
+  'Cogwitch':{desc:'Tinker checks succeed more often; starts with toolkit.', gear:[{id:'toolkit',name:'Toolkit',slot:'trinket',mods:{INT:+1}}]}
 };
 const quirks={
   'Lucky Lint':{desc:'+1 LCK. Occasionally avoid mishaps.'},

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -38,7 +38,8 @@ const DUSTLAND_MODULE = (() => {
     { map: 'world', x: 80, y: midY - 3, id: 'medkit', name: 'Medkit', type: 'consumable', use: { type: 'heal', amount: 5 } },
     { map: 'world', x: 18, y: midY - 2, id: 'valve', name: 'Valve', type: 'quest' },
     { map: 'world', x: 26, y: midY + 3, id: 'lost_satchel', name: 'Lost Satchel', type: 'quest' },
-    { map: 'world', x: 60, y: midY - 1, id: 'rust_idol', name: 'Rust Idol', type: 'quest', tags: ['idol'] }
+    { map: 'world', x: 60, y: midY - 1, id: 'rust_idol', name: 'Rust Idol', type: 'quest', tags: ['idol'] },
+    { id: 'raider_knife', name: 'Raider Knife', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } }
   ];
 
   const quests = [
@@ -330,7 +331,7 @@ const DUSTLAND_MODULE = (() => {
           ]
         }
       },
-      combat: { DEF: 5, loot: { id: 'raider_knife', name: 'Raider Knife', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } } }
+      combat: { DEF: 5, loot: 'raider_knife' }
     },
     {
       id: 'trader',

--- a/modules/echoes.module.js
+++ b/modules/echoes.module.js
@@ -21,7 +21,9 @@ const ECHOES_MODULE = (() => {
   const items = [
     { map: 'atrium', x: 3, y: 2, id: 'spark_key', name: 'Spark Key', type: 'quest', tags: ['key'] },
     { map: 'workshop', x: 4, y: 5, id: 'cog_key', name: 'Cog Key', type: 'quest', tags: ['key'] },
-    { map: 'archive', x: 8, y: 4, id: 'sun_charm', name: 'Sun Charm', type: 'trinket', slot: 'trinket', mods: { LCK: 1 } }
+    { map: 'archive', x: 8, y: 4, id: 'sun_charm', name: 'Sun Charm', type: 'trinket', slot: 'trinket', mods: { LCK: 1 } },
+    { id: 'rat_tail', name: 'Rat Tail', type: 'quest' },
+    { id: 'copper_cog', name: 'Copper Cog', type: 'quest' }
   ];
 
   const quests = [
@@ -123,7 +125,7 @@ const ECHOES_MODULE = (() => {
       title: 'Menace',
       desc: 'A rat swollen with dust.',
       tree: { start: { text: 'The rat bares its teeth.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
-      combat: { HP: 5, ATK: 2, DEF: 1, loot: { name: 'Rat Tail' } }
+      combat: { HP: 5, ATK: 2, DEF: 1, loot: 'rat_tail' }
     },
     {
       id: 'ghoul',
@@ -136,7 +138,7 @@ const ECHOES_MODULE = (() => {
       desc: 'A whirring husk hungry for scraps.',
       questId: 'q_beacon',
       tree: { start: { text: 'The ghoul clanks forward.', choices: [ { label: '(Fight)', to: 'do_fight', q: 'turnin' }, { label: '(Leave)', to: 'bye' } ] } },
-      combat: { HP: 8, ATK: 3, DEF: 2, loot: { name: 'Copper Cog' } }
+      combat: { HP: 8, ATK: 3, DEF: 2, loot: 'copper_cog' }
     },
     {
       id: 'beacon',

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -328,7 +328,7 @@ const OFFICE_MODULE = (() => {
       color: '#ffb6b6',
       name: 'Giant Rat',
       desc: 'It bares its teeth.',
-      combat: { HP: 3, ATK: 1, DEF: 0, loot: { name: 'Rat Tail' }, auto: true },
+      combat: { HP: 3, ATK: 1, DEF: 0, loot: 'rat_tail', auto: true },
       tree: { start: { text: 'The rat lunges!', choices: [ { label: '(Leave)', to: 'bye' } ] } }
     },
     {
@@ -339,7 +339,7 @@ const OFFICE_MODULE = (() => {
       color: '#f88',
       name: 'Bandit',
       desc: 'Lurks among the trees.',
-      combat: { HP: 6, ATK: 2, DEF: 1, loot: { name: 'Rusty Dagger' }, auto: true },
+      combat: { HP: 6, ATK: 2, DEF: 1, loot: 'rusty_dagger', auto: true },
       tree: { start: { text: 'Your coin or your life!', choices: [ { label: '(Leave)', to: 'bye' } ] } }
     },
     {
@@ -350,7 +350,7 @@ const OFFICE_MODULE = (() => {
       color: '#f55',
       name: 'Forest Ogre',
       desc: 'Towering and enraged.',
-      combat: { HP: 12, ATK: 4, DEF: 2, loot: { name: 'Ogre Tooth' }, auto: true },
+      combat: { HP: 12, ATK: 4, DEF: 2, loot: 'ogre_tooth', auto: true },
       tree: { start: { text: 'The ogre roars.', choices: [ { label: '(Leave)', to: 'bye' } ] } }
     },
     {
@@ -373,7 +373,7 @@ const OFFICE_MODULE = (() => {
       name: 'Rogue Janitor',
       desc: 'Wields a dripping mop.',
       tree: { start: { text: 'He blocks your path.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
-      combat: { DEF: 3, loot: { id: 'rusty_mop', name: 'Rusty Mop', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } } }
+      combat: { DEF: 3, loot: 'rusty_mop' }
     }
   ];
 
@@ -414,6 +414,10 @@ const OFFICE_MODULE = (() => {
         { map: 'world', x: WORLD_MID - 4, y: WORLD_MIDY - 2, id: 'healing_potion1', name: 'Healing Potion', type: 'consumable', use: { type: 'heal', amount: 5 } },
         { map: 'world', x: WORLD_MID + 5, y: WORLD_MIDY + 3, id: 'healing_potion2', name: 'Healing Potion', type: 'consumable', use: { type: 'heal', amount: 5 } },
         { map: 'world', x: WORLD_MID - 6, y: WORLD_MIDY + 5, id: 'healing_potion3', name: 'Healing Potion', type: 'consumable', use: { type: 'heal', amount: 5 } },
+        { id: 'rat_tail', name: 'Rat Tail', type: 'quest' },
+        { id: 'rusty_dagger', name: 'Rusty Dagger', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } },
+        { id: 'ogre_tooth', name: 'Ogre Tooth', type: 'quest' },
+        { id: 'rusty_mop', name: 'Rusty Mop', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } },
       ],
       quests: [
         {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -37,7 +37,7 @@ global.document = {
   createElement: () => stubEl()
 };
 
-const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, randRange, sample, setRNGSeed, useItem, handleDialogKey } = require('../dustland-core.js');
+const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, randRange, sample, setRNGSeed, useItem, handleDialogKey } = require('../dustland-core.js');
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -173,8 +173,8 @@ test('useItem heals party member and consumes item', () => {
   const m = new Character('h','Healer','Role');
   m.hp = 5; m.maxHp = 10;
   party.addMember(m);
-  registerItem({ id:'tonic', name:'Tonic', type:'consumable', use:{ type:'heal', amount:3 } });
-  addToInv('tonic');
+  const tonic = registerItem({ id:'tonic', name:'Tonic', type:'consumable', use:{ type:'heal', amount:3 } });
+  addToInv(tonic);
   useItem(0);
   assert.strictEqual(m.hp, 8);
   assert.strictEqual(player.inv.length, 0);
@@ -226,9 +226,9 @@ test('advanceDialog moves to next node', () => {
 
 test('advanceDialog handles cost and reward', () => {
   player.inv.length = 0;
-  registerItem({id:'key',name:'Key',type:'quest'});
+  const key = registerItem({id:'key',name:'Key',type:'quest'});
   registerItem({id:'gem',name:'Gem',type:'quest'});
-  addToInv('key');
+  addToInv(key);
   const tree = {
     start: { text: '', next: [{ label: 'Use Key', costItem: 'key', reward: 'gem' }] }
   };
@@ -242,8 +242,8 @@ test('advanceDialog handles cost and reward', () => {
 
 test('advanceDialog respects goto with costItem', () => {
   player.inv.length = 0;
-  registerItem({id:'key',name:'Key',type:'quest'});
-  addToInv('key');
+  const key = registerItem({id:'key',name:'Key',type:'quest'});
+  addToInv(key);
   state.map = 'world';
   player.x = 0; player.y = 0;
   const tree = {
@@ -258,8 +258,8 @@ test('advanceDialog respects goto with costItem', () => {
 
 test('advanceDialog uses reqItem without consuming and allows goto', () => {
   player.inv.length = 0;
-  registerItem({id:'pass',name:'Pass',type:'quest'});
-  addToInv('pass');
+  const pass = registerItem({id:'pass',name:'Pass',type:'quest'});
+  addToInv(pass);
   state.map = 'world';
   player.x = 1; player.y = 1;
   const tree = {
@@ -274,8 +274,8 @@ test('advanceDialog uses reqItem without consuming and allows goto', () => {
 
 test('advanceDialog matches reqItem case-insensitively', () => {
   player.inv.length = 0;
-  registerItem({id:'access_card',name:'access card',type:'quest',tags:['pass']});
-  addToInv('access_card');
+  const accessCard = registerItem({id:'access_card',name:'access card',type:'quest',tags:['pass']});
+  addToInv(accessCard);
   state.map = 'world';
   player.x = 2; player.y = 2;
   const tree = {


### PR DESCRIPTION
## Summary
- Centralize string/object to item coercion with resolveItem
- Use resolveItem for combat loot, quest rewards, and dialog gifts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a0640404832893b20b12dc0e543b