### PR TITLE
Add tile enter hook and effects system

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -210,6 +210,7 @@
         <button class="tab2" type="button" data-tab="buildings" role="tab" aria-selected="false">Buildings</button>
         <button class="tab2" type="button" data-tab="interiors" role="tab" aria-selected="false">Interiors</button>
         <button class="tab2" type="button" data-tab="quests" role="tab" aria-selected="false">Quests</button>
+        <button class="tab2" type="button" data-tab="events" role="tab" aria-selected="false">Events</button>
       </div>
       <div class="tabpanes">
         <fieldset class="card" id="npcCard" data-pane="npc">
@@ -323,6 +324,32 @@
             </select></label>
           <button class="btn" id="addQuest">Add Quest</button>
           <button class="btn" id="delQuest" style="display:none">Delete Quest</button>
+        </div>
+      </fieldset>
+      <fieldset class="card" id="eventCard" data-pane="events" style="display:none">
+        <legend>Tile Events</legend>
+        <div class="list" id="eventList"></div>
+        <button class="btn" type="button" id="newEvent">+ Event</button>
+        <div id="eventEditor" style="display:none">
+          <label>Map<input id="eventMap" value="world" /></label>
+          <label>X<input id="eventX" type="number" min="0" /></label>
+          <label>Y<input id="eventY" type="number" min="0" /></label>
+          <button class="btn" type="button" id="eventPick">Select on Map</button>
+          <label>Effect<select id="eventEffect">
+              <option value="toast">Toast</option>
+              <option value="log">Log</option>
+              <option value="addFlag">Add Flag</option>
+              <option value="modStat">Mod Stat</option>
+            </select></label>
+          <label id="eventMsgWrap">Message<input id="eventMsg" /></label>
+          <label id="eventFlagWrap" style="display:none">Flag<input id="eventFlag" /></label>
+          <div id="eventStatWrap" style="display:none">
+            <label>Stat<select id="eventStat"></select></label>
+            <label>Delta<input id="eventDelta" type="number" /></label>
+            <label>Duration<input id="eventDuration" type="number" min="0" /></label>
+          </div>
+          <button class="btn" id="addEvent">Add Event</button>
+          <button class="btn" id="delEvent" style="display:none">Delete Event</button>
         </div>
       </fieldset>
       </div><!-- /.tabpanes -->

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -15,9 +15,9 @@ let placingType = null, placingPos = null;
 let hoverTile = null;
 let coordTarget = null;
 
-const moduleData = { seed: Date.now(), npcs: [], items: [], quests: [], buildings: [], interiors: [], start: { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) } };
+const moduleData = { seed: Date.now(), npcs: [], items: [], quests: [], buildings: [], interiors: [], events: [], start: { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) } };
 const STAT_OPTS = ['ATK', 'DEF', 'LCK', 'INT', 'PER', 'CHA'];
-let editNPCIdx = -1, editItemIdx = -1, editQuestIdx = -1, editBldgIdx = -1, editInteriorIdx = -1;
+let editNPCIdx = -1, editItemIdx = -1, editQuestIdx = -1, editBldgIdx = -1, editInteriorIdx = -1, editEventIdx = -1;
 let treeData = {};
 let selectedObj = null;
 const intCanvas = document.getElementById('intCanvas');
@@ -72,6 +72,18 @@ function drawWorld() {
     ctx.strokeRect(it.x * sx + 1, it.y * sy + 1, sx - 2, sy - 2);
     ctx.restore();
   });
+  // Draw Tile Event markers
+  moduleData.events.filter(ev => ev.map === 'world').forEach(ev => {
+    const hovering = hoverTarget && hoverTarget.type === 'event' && hoverTarget.obj === ev;
+    ctx.save();
+    ctx.fillStyle = hovering ? '#0ff' : '#0ff';
+    if (hovering) {
+      ctx.shadowColor = '#0ff';
+      ctx.shadowBlur = 8;
+    }
+    ctx.fillRect(ev.x * sx + sx / 4, ev.y * sy + sy / 4, sx / 2, sy / 2);
+    ctx.restore();
+  });
   // Highlight hovered building
   if (hoverTarget && hoverTarget.type === 'bldg') {
     const b = hoverTarget.obj;
@@ -103,6 +115,9 @@ function drawWorld() {
     } else if (selectedObj.type === 'bldg') {
       ctx.strokeStyle = '#fff';
       ctx.strokeRect(o.x * sx, o.y * sy, o.w * sx, o.h * sy);
+    } else if (selectedObj.type === 'event' && o.map === 'world') {
+      ctx.strokeStyle = '#0ff';
+      ctx.strokeRect(o.x * sx + 1, o.y * sy + 1, sx - 2, sy - 2);
     }
     ctx.restore();
   }
@@ -204,12 +219,14 @@ function regenWorld() {
   genWorld(moduleData.seed);
   moduleData.buildings = [...buildings];
   moduleData.interiors = [];
+  moduleData.events = [];
   for (const id in interiors) {
     if(id==='creator') continue;
     const I = interiors[id]; I.id = id; moduleData.interiors.push(I);
   }
   renderInteriorList();
   renderBldgList();
+  renderEventList();
   drawWorld();
 }
 
@@ -870,6 +887,109 @@ function deleteItem() {
   showItemEditor(false);
 }
 
+// --- Tile Events ---
+function showEventEditor(show) {
+  document.getElementById('eventEditor').style.display = show ? 'block' : 'none';
+}
+
+function updateEventEffectFields() {
+  const eff = document.getElementById('eventEffect').value;
+  document.getElementById('eventMsgWrap').style.display = (eff === 'toast' || eff === 'log') ? 'block' : 'none';
+  document.getElementById('eventFlagWrap').style.display = eff === 'addFlag' ? 'block' : 'none';
+  document.getElementById('eventStatWrap').style.display = eff === 'modStat' ? 'block' : 'none';
+}
+
+function startNewEvent() {
+  editEventIdx = -1;
+  document.getElementById('eventMap').value = 'world';
+  document.getElementById('eventX').value = 0;
+  document.getElementById('eventY').value = 0;
+  document.getElementById('eventEffect').value = 'toast';
+  document.getElementById('eventMsg').value = '';
+  document.getElementById('eventFlag').value = '';
+  document.getElementById('eventStat').value = STAT_OPTS[0];
+  document.getElementById('eventDelta').value = 0;
+  document.getElementById('eventDuration').value = 0;
+  updateEventEffectFields();
+  document.getElementById('addEvent').textContent = 'Add Event';
+  document.getElementById('delEvent').style.display = 'none';
+  showEventEditor(true);
+}
+
+function collectEvent() {
+  const map = document.getElementById('eventMap').value.trim() || 'world';
+  const x = parseInt(document.getElementById('eventX').value, 10) || 0;
+  const y = parseInt(document.getElementById('eventY').value, 10) || 0;
+  const eff = document.getElementById('eventEffect').value;
+  const ev = { when: 'enter', effect: eff };
+  if (eff === 'toast' || eff === 'log') ev.msg = document.getElementById('eventMsg').value;
+  if (eff === 'addFlag') ev.flag = document.getElementById('eventFlag').value;
+  if (eff === 'modStat') {
+    ev.stat = document.getElementById('eventStat').value;
+    ev.delta = parseInt(document.getElementById('eventDelta').value, 10) || 0;
+    ev.duration = parseInt(document.getElementById('eventDuration').value, 10) || 0;
+  }
+  return { map, x, y, events: [ev] };
+}
+
+function addEvent() {
+  const entry = collectEvent();
+  if (editEventIdx >= 0) {
+    moduleData.events[editEventIdx] = entry;
+  } else {
+    moduleData.events.push(entry);
+  }
+  editEventIdx = -1;
+  document.getElementById('addEvent').textContent = 'Add Event';
+  document.getElementById('delEvent').style.display = 'none';
+  renderEventList();
+  selectedObj = null;
+  drawWorld();
+  showEventEditor(false);
+}
+
+function editEvent(i) {
+  const e = moduleData.events[i];
+  editEventIdx = i;
+  document.getElementById('eventMap').value = e.map;
+  document.getElementById('eventX').value = e.x;
+  document.getElementById('eventY').value = e.y;
+  const ev = e.events[0] || { effect: 'toast' };
+  document.getElementById('eventEffect').value = ev.effect;
+  document.getElementById('eventMsg').value = ev.msg || '';
+  document.getElementById('eventFlag').value = ev.flag || '';
+  document.getElementById('eventStat').value = ev.stat || STAT_OPTS[0];
+  document.getElementById('eventDelta').value = ev.delta || 0;
+  document.getElementById('eventDuration').value = ev.duration || 0;
+  updateEventEffectFields();
+  document.getElementById('addEvent').textContent = 'Update Event';
+  document.getElementById('delEvent').style.display = 'block';
+  showEventEditor(true);
+  selectedObj = { type: 'event', obj: e };
+  drawWorld();
+}
+
+function renderEventList() {
+  const list = document.getElementById('eventList');
+  list.innerHTML = moduleData.events.map((e, i) => {
+    const eff = e.events[0]?.effect;
+    return `<div data-idx="${i}">${e.map} @(${e.x},${e.y}) - ${eff}</div>`;
+  }).join('');
+  Array.from(list.children).forEach(div => div.onclick = () => editEvent(parseInt(div.dataset.idx, 10)));
+}
+
+function deleteEvent() {
+  if (editEventIdx < 0) return;
+  moduleData.events.splice(editEventIdx, 1);
+  editEventIdx = -1;
+  document.getElementById('addEvent').textContent = 'Add Event';
+  document.getElementById('delEvent').style.display = 'none';
+  renderEventList();
+  selectedObj = null;
+  drawWorld();
+  showEventEditor(false);
+}
+
 // --- Buildings ---
 function showBldgEditor(show) {
   document.getElementById('bldgEditor').style.display = show ? 'block' : 'none';
@@ -1051,6 +1171,7 @@ function applyLoadedModule(data) {
   moduleData.quests = data.quests || [];
   moduleData.buildings = data.buildings || [];
   moduleData.interiors = data.interiors || [];
+  moduleData.events = data.events || [];
   moduleData.start = data.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   interiors = {};
   moduleData.interiors.forEach(I => { interiors[I.id] = I; });
@@ -1067,6 +1188,7 @@ function applyLoadedModule(data) {
   renderBldgList();
   renderInteriorList();
   renderQuestList();
+  renderEventList();
   updateQuestOptions();
   loadMods({});
   showItemEditor(false);
@@ -1103,15 +1225,20 @@ document.getElementById('newBldg').onclick = startNewBldg;
 document.getElementById('newQuest').onclick = startNewQuest;
 document.getElementById('addBldg').onclick = addBuilding;
 document.getElementById('addQuest').onclick = addQuest;
+document.getElementById('addEvent').onclick = addEvent;
+document.getElementById('newEvent').onclick = startNewEvent;
 document.getElementById('delNPC').onclick = deleteNPC;
 document.getElementById('delItem').onclick = deleteItem;
 document.getElementById('delBldg').onclick = deleteBldg;
 document.getElementById('newInterior').onclick = startNewInterior;
 document.getElementById('delInterior').onclick = deleteInterior;
 document.getElementById('delQuest').onclick = deleteQuest;
+document.getElementById('delEvent').onclick = deleteEvent;
 document.getElementById('addMod').onclick = () => modRow();
 document.getElementById('itemSlot').addEventListener('change', updateModsWrap);
 document.getElementById('itemUseType').addEventListener('change', updateUseWrap);
+document.getElementById('eventEffect').addEventListener('change', updateEventEffectFields);
+document.getElementById('eventPick').onclick = () => { coordTarget = { x: 'eventX', y: 'eventY' }; };
 document.getElementById('save').onclick = saveModule;
 document.getElementById('load').onclick = () => document.getElementById('loadFile').click();
 document.getElementById('loadFile').addEventListener('change', e => {
@@ -1177,7 +1304,8 @@ function updateCursor(x, y) {
     const overItem = moduleData.items.some(it => it.map === 'world' && it.x === x && it.y === y);
     const overBldg = moduleData.buildings.some(b => x >= b.x && x < b.x + b.w && y >= b.y && y < b.y + b.h);
     const overStart = moduleData.start && moduleData.start.map === 'world' && moduleData.start.x === x && moduleData.start.y === y;
-    canvas.style.cursor = (overNpc || overItem || overBldg || overStart) ? 'grab' : 'pointer';
+    const overEvent = moduleData.events.some(ev => ev.map === 'world' && ev.x === x && ev.y === y);
+    canvas.style.cursor = (overNpc || overItem || overBldg || overStart || overEvent) ? 'grab' : 'pointer';
   } else {
     canvas.style.cursor = 'pointer';
   }
@@ -1252,6 +1380,7 @@ canvas.addEventListener('mousedown', ev => {
   document.getElementById('npcX').value = x; document.getElementById('npcY').value = y;
   document.getElementById('itemX').value = x; document.getElementById('itemY').value = y;
   document.getElementById('bldgX').value = x; document.getElementById('bldgY').value = y;
+  document.getElementById('eventX').value = x; document.getElementById('eventY').value = y;
   selectedObj = null;
   drawWorld();
   updateCursor(x, y);
@@ -1307,6 +1436,8 @@ canvas.addEventListener('mousemove', ev => {
     ht = { obj, type: 'item' };
   } else if (obj = moduleData.buildings.find(b => x >= b.x && x < b.x + b.w && y >= b.y && y < b.y + b.h)) {
     ht = { obj, type: 'bldg' };
+  } else if (obj = moduleData.events.find(ev => ev.map === 'world' && ev.x === x && ev.y === y)) {
+    ht = { obj, type: 'event' };
   }
 
   if ((hoverTarget && (!ht || hoverTarget.obj !== ht.obj)) || (!hoverTarget && ht)) {
@@ -1348,6 +1479,12 @@ canvas.addEventListener('click', ev => {
   if (idx >= 0) {
     if (window.showEditorTab) window.showEditorTab('buildings');
     editBldg(idx);
+    return;
+  }
+  idx = moduleData.events.findIndex(ev => ev.map === 'world' && ev.x === x && ev.y === y);
+  if (idx >= 0) {
+    if (window.showEditorTab) window.showEditorTab('events');
+    editEvent(idx);
   }
 });
 
@@ -1367,8 +1504,11 @@ showItemEditor(false);
 showNPCEditor(false);
 showBldgEditor(false);
 showQuestEditor(false);
+showEventEditor(false);
 document.getElementById('npcId').value = nextId('npc', moduleData.npcs);
 document.getElementById('questId').value = nextId('quest', moduleData.quests);
+document.getElementById('eventStat').innerHTML = STAT_OPTS.map(s => `<option value="${s}">${s}</option>`).join('');
+renderEventList();
 loadTreeEditor();
 setPlaceholders();
 function animate() {

--- a/core/effects.js
+++ b/core/effects.js
@@ -1,0 +1,50 @@
+const Effects = {
+  apply(list = [], ctx = {}) {
+    for (const eff of list || []) {
+      if (!eff) continue;
+      const type = eff.effect || eff.type;
+      switch (type) {
+        case 'toast':
+          if (typeof toast === 'function') toast(eff.msg || '');
+          else if (typeof log === 'function') log(eff.msg || '');
+          break;
+        case 'log':
+          if (typeof log === 'function') log(eff.msg || '');
+          break;
+        case 'addFlag':
+          if (ctx.player) {
+            ctx.player.flags = ctx.player.flags || {};
+            ctx.player.flags[eff.flag] = true;
+          }
+          break;
+        case 'modStat': {
+          const target = ctx.actor || ctx.player;
+          if (target && target.stats && eff.stat) {
+            const delta = eff.delta || 0;
+            target.stats[eff.stat] = (target.stats[eff.stat] || 0) + delta;
+            if (eff.duration) {
+              ctx.buffs = ctx.buffs || [];
+              ctx.buffs.push({ target, stat: eff.stat, delta, remaining: eff.duration });
+            }
+          }
+          break; }
+      }
+    }
+  },
+  tick(ctx = {}) {
+    const list = ctx.buffs || [];
+    for (let i = list.length - 1; i >= 0; i--) {
+      const b = list[i];
+      if (--b.remaining <= 0) {
+        if (b.target && b.target.stats) {
+          b.target.stats[b.stat] = (b.target.stats[b.stat] || 0) - b.delta;
+        }
+        list.splice(i, 1);
+      }
+    }
+  }
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { Effects };
+}

--- a/core/movement.js
+++ b/core/movement.js
@@ -1,3 +1,8 @@
+const { Effects } = require('./effects.js');
+
+// active temporary stat modifiers
+const buffs = [];
+
 // ===== Helpers =====
 function mapIdForState(){ return state.map; }
 function mapWH(map=state.map){
@@ -52,6 +57,13 @@ function findFreeDropTile(map,x,y){
   return {x,y};
 }
 
+function onEnter(map,x,y,ctx){
+  const t = tileEvents.find(e => (e.map || 'world') === map && e.x === x && e.y === y);
+  if(!t) return;
+  const list = (t.events || []).filter(ev => ev.when === 'enter');
+  if(list.length) Effects.apply(list, ctx);
+}
+
 // ===== Interaction =====
 function canWalk(x,y){
   if(state.map==='creator') return false;
@@ -61,7 +73,9 @@ function move(dx,dy){
   if(state.map==='creator') return;
   const nx=player.x+dx, ny=player.y+dy;
   if(canWalk(nx,ny)){
+    Effects.tick({buffs});
     setPlayerPos(nx, ny);
+    onEnter(state.map, nx, ny, { player, state, actor: typeof leader==='function'? leader(): null, buffs });
     centerCamera(player.x,player.y,state.map); updateHUD();
     checkAggro();
   }
@@ -158,8 +172,8 @@ function interact(){
 const movementSystem = { canWalk, move };
 const collisionSystem = { queryTile, canWalk };
 const interactionSystem = { adjacentNPC, takeNearestItem, interact, interactAt };
-Object.assign(globalThis, { movementSystem, collisionSystem, interactionSystem, queryTile, interactAt, findFreeDropTile, canWalk, move, takeNearestItem });
+Object.assign(globalThis, { movementSystem, collisionSystem, interactionSystem, queryTile, interactAt, findFreeDropTile, canWalk, move, takeNearestItem, onEnter, buffs });
 
 if (typeof module !== 'undefined' && module.exports){
-  module.exports = { mapIdForState, mapWH, gridFor, getTile, setTile, currentGrid, queryTile, findFreeDropTile, canWalk, move, adjacentNPC, takeNearestItem, interactAt, interact, movementSystem, collisionSystem, interactionSystem };
+  module.exports = { mapIdForState, mapWH, gridFor, getTile, setTile, currentGrid, queryTile, findFreeDropTile, canWalk, move, adjacentNPC, takeNearestItem, interactAt, interact, movementSystem, collisionSystem, interactionSystem, onEnter, buffs };
 }

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -219,6 +219,8 @@ const WORLD_W=120, WORLD_H=90;
 
 // ===== Game state =====
 let world = [], interiors = {}, buildings = [], portals = [];
+const tileEvents = [];
+function registerTileEvents(list){ (list||[]).forEach(e => tileEvents.push(e)); }
 const state = { map:'world' }; // default map
 const player = { x:2, y:2, hp:10, ap:2, flags:{}, inv:[], scrap:0 };
 function setPlayerPos(x, y){
@@ -457,6 +459,9 @@ function applyModule(data){
     if (data.buildings) { buildings.length = 0; buildings.push(...data.buildings); }
     if (data.portals)   { portals.length = 0;   portals.push(...data.portals); }
   }
+
+  tileEvents.length = 0;
+  if (data.events) registerTileEvents(data.events);
 
   (data.interiors || []).forEach(I => {
     const { id, ...rest } = I;
@@ -785,7 +790,7 @@ function startWorld(){
 // Content pack moved to modules/dustland.module.js
 
 
-const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, quickCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, state, player, GAME_STATE, setGameState, setPlayerPos, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, npcsOnMap, queueNanoDialogForNPCs, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, createNpcFactory, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld, setRNGSeed, randRange, sample };
+const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, quickCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, tileEvents, registerTileEvents, state, player, GAME_STATE, setGameState, setPlayerPos, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, npcsOnMap, queueNanoDialogForNPCs, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, createNpcFactory, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld, setRNGSeed, randRange, sample };
 
 Object.assign(globalThis, coreExports);
 
@@ -794,5 +799,6 @@ if (typeof module !== 'undefined' && module.exports) {
   const inventory = require('./core/inventory.js');
   const movement = require('./core/movement.js');
   const dialog = require('./core/dialog.js');
-  module.exports = { ...coreExports, ...party, ...inventory, ...movement, ...dialog, getGameState: () => gameState };
+  const effects = require('./core/effects.js');
+  module.exports = { ...coreExports, ...party, ...inventory, ...movement, ...dialog, ...effects, getGameState: () => gameState };
 }

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -22,6 +22,10 @@ const DUSTLAND_MODULE = (() => {
   };
   const hall = makeHall();
 
+  const events = [
+    { map: 'hall', x: hall.entryX - 1, y: hall.entryY, events:[{ when:'enter', effect:'toast', msg:'You smell rot.' }] }
+  ];
+
   const items = [
     { id: 'rusted_key', name: 'Rusted Key', type: 'quest', tags: ['key'] },
     { id: 'toolkit', name: 'Toolkit', type: 'quest', tags: ['tool'] },
@@ -353,6 +357,7 @@ const DUSTLAND_MODULE = (() => {
     items,
     quests,
     npcs,
+    events,
     interiors: [hall],
     buildings: []
   };

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -37,7 +37,7 @@ global.document = {
   createElement: () => stubEl()
 };
 
-const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, randRange, sample, setRNGSeed, useItem } = require('../dustland-core.js');
+const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, randRange, sample, setRNGSeed, useItem, registerTileEvents, buffs } = require('../dustland-core.js');
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -436,4 +436,26 @@ test('leave choice is rendered last', () => {
   openDialog(npc);
   const labels = choicesEl.children.map(c => c.textContent);
   assert.strictEqual(labels[labels.length - 1], 'Leave');
+});
+
+test('onEnter triggers effects and temporary stat mod', () => {
+  const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
+  applyModule({world});
+  state.map='world';
+  player.x=0; player.y=0;
+  party.length=0;
+  const hero = new Character('h','Hero','Role');
+  party.addMember(hero);
+  registerTileEvents([{map:'world', x:1, y:0, events:[{when:'enter', effect:'toast', msg:'You smell rot.'},{when:'enter', effect:'modStat', stat:'CHA', delta:-1, duration:2}]}]);
+  const msgs=[];
+  global.toast = (m)=>msgs.push(m);
+  move(1,0);
+  assert.strictEqual(player.x,1);
+  assert.ok(msgs.includes('You smell rot.'));
+  assert.strictEqual(party[0].stats.CHA,3);
+  move(1,0);
+  assert.strictEqual(party[0].stats.CHA,3);
+  move(1,0);
+  assert.strictEqual(party[0].stats.CHA,4);
+  assert.strictEqual(buffs.length,0);
 });


### PR DESCRIPTION
## Summary
- dispatch onEnter hooks when moving onto tiles
- add lightweight Effects helper for toast/log/flag/stat mods
- include sample 'scented tile' event in Dustland module
- support temporary stat buffs with automatic expiry
- add editor tab to create and manage tile events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4cdeff27c83289f92522562deec0d