### PR TITLE
feat: add world flags and hidden NPC reveals

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -224,6 +224,12 @@
           <label>Map<input id="npcMap" value="world" /></label>
           <label>X<input id="npcX" type="number" min="0" /></label>
           <label>Y<input id="npcY" type="number" min="0" /></label>
+          <label><input type="checkbox" id="npcHidden"> Hidden NPC</label>
+          <div id="revealOpts" style="display:none">
+            <label>Flag<input id="npcFlag" /></label>
+            <label>Op<select id="npcOp"><option value=">=">&ge;</option><option value=">">&gt;</option><option value="==">==</option><option value="!=">!=</option><option value="<=">&le;</option><option value="<">&lt;</option></select></label>
+            <label>Value<input id="npcVal" type="number" value="1" /></label>
+          </div>
           <button class="btn" type="button" id="npcPick">Select on Map</button>
           <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
           <label>Quest<select id="npcQuest">

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -600,6 +600,8 @@ function updateNPCOptSections() {
     document.getElementById('npcCombat').checked ? 'block' : 'none';
   document.getElementById('shopOpts').style.display =
     document.getElementById('npcShop').checked ? 'block' : 'none';
+  document.getElementById('revealOpts').style.display =
+    document.getElementById('npcHidden').checked ? 'block' : 'none';
 }
 function showNPCEditor(show) {
   document.getElementById('npcEditor').style.display = show ? 'block' : 'none';
@@ -613,6 +615,10 @@ function startNewNPC() {
   document.getElementById('npcMap').value = 'world';
   document.getElementById('npcX').value = 0;
   document.getElementById('npcY').value = 0;
+  document.getElementById('npcHidden').checked = false;
+  document.getElementById('npcFlag').value = '';
+  document.getElementById('npcOp').value = '>=';
+  document.getElementById('npcVal').value = 1;
   document.getElementById('npcDialog').value = '';
   document.getElementById('npcQuest').value = '';
   document.getElementById('npcAccept').value = 'Good luck.';
@@ -646,6 +652,10 @@ function addNPC() {
   const turnin = document.getElementById('npcTurnin').value.trim();
   const combat = document.getElementById('npcCombat').checked;
   const shop = document.getElementById('npcShop').checked;
+  const hidden = document.getElementById('npcHidden').checked;
+  const flag = document.getElementById('npcFlag').value.trim();
+  const op = document.getElementById('npcOp').value;
+  const val = parseInt(document.getElementById('npcVal').value, 10) || 0;
   updateTreeData();
   let tree = null;
   const treeTxt = document.getElementById('npcTree').value.trim();
@@ -673,6 +683,7 @@ function addNPC() {
   const npc = { id, name, desc, color, map, x, y, tree, questId };
   if (combat) npc.combat = { DEF: 5 };
   if (shop) npc.shop = true;
+  if (hidden && flag) npc.hidden = true, npc.reveal = { flag, op, value: val };
   if (editNPCIdx >= 0) {
     moduleData.npcs[editNPCIdx] = npc;
   } else {
@@ -686,6 +697,10 @@ function addNPC() {
   document.getElementById('npcDesc').value = '';
   document.getElementById('npcCombat').checked = false;
   document.getElementById('npcShop').checked = false;
+  document.getElementById('npcHidden').checked = false;
+  document.getElementById('npcFlag').value = '';
+  document.getElementById('npcOp').value = '>=';
+  document.getElementById('npcVal').value = 1;
   updateNPCOptSections();
   selectedObj = null;
   drawWorld();
@@ -702,6 +717,10 @@ function editNPC(i) {
   document.getElementById('npcMap').value = n.map;
   document.getElementById('npcX').value = n.x;
   document.getElementById('npcY').value = n.y;
+  document.getElementById('npcHidden').checked = !!n.hidden;
+  document.getElementById('npcFlag').value = n.reveal?.flag || '';
+  document.getElementById('npcOp').value = n.reveal?.op || '>=';
+  document.getElementById('npcVal').value = n.reveal?.value ?? 1;
   document.getElementById('npcDialog').value = n.tree?.start?.text || '';
   document.getElementById('npcQuest').value = n.questId || '';
   document.getElementById('npcAccept').value = n.tree?.accept?.text || 'Good luck.';
@@ -1148,6 +1167,7 @@ document.getElementById('npcQuest').addEventListener('change', () => {
 });
 document.getElementById('npcCombat').addEventListener('change', updateNPCOptSections);
 document.getElementById('npcShop').addEventListener('change', updateNPCOptSections);
+document.getElementById('npcHidden').addEventListener('change', updateNPCOptSections);
 document.getElementById('genQuestDialog').onclick = generateQuestTree;
 
 // --- Map interactions ---

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -59,6 +59,24 @@ function runEffects(effects){
   for(const fn of effects||[]){ if(typeof fn==='function') fn({player,party,state}); }
 }
 
+function flagValue(flag){ return worldFlags?.[flag]?.count || 0; }
+
+function checkFlagCondition(cond){
+  if(!cond) return true;
+  const v = flagValue(cond.flag);
+  const val = cond.value ?? 0;
+  switch(cond.op){
+    case '>=': return v >= val;
+    case '>': return v > val;
+    case '<=': return v <= val;
+    case '<': return v < val;
+    case '!=': return v !== val;
+    case '=':
+    case '==': return v === val;
+  }
+  return false;
+}
+
 function resolveCheck(check, actor=leader(), rng=Math.random){
   const roll = Dice.skill(actor, check.stat, 0, ROLL_SIDES, rng);
   const dc = check.dc || 0;
@@ -259,6 +277,8 @@ function renderDialog(){
   }
 
   let choices=node.next.map((opt,idx)=>({opt,idx}));
+
+  choices = choices.filter(({opt})=> !opt.if || checkFlagCondition(opt.if));
 
   if(currentNPC?.quest){
     const meta=currentNPC.quest;

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -306,6 +306,19 @@ const DUSTLAND_MODULE = (() => {
       }
     },
     {
+      id: 'hidden_hermit',
+      hidden: true,
+      map: 'world',
+      x: 20,
+      y: midY + 2,
+      color: '#b8ffb6',
+      name: 'Hidden Hermit',
+      title: 'Lurker',
+      desc: 'A hermit steps out when you return.',
+      tree: { start: { text: 'Didn\'t expect company twice.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      reveal: { flag: `visits@world@20,${midY + 2}`, op: '>=', value: 2 }
+    },
+    {
       id: 'raider',
       map: 'world',
       x: 56,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -37,7 +37,7 @@ global.document = {
   createElement: () => stubEl()
 };
 
-const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, randRange, sample, setRNGSeed, useItem } = require('../dustland-core.js');
+const { clamp, createRNG, Dice, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, randRange, sample, setRNGSeed, useItem, setPlayerPos, worldFlags, makeNPC } = require('../dustland-core.js');
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -436,4 +436,34 @@ test('leave choice is rendered last', () => {
   openDialog(npc);
   const labels = choicesEl.children.map(c => c.textContent);
   assert.strictEqual(labels[labels.length - 1], 'Leave');
+});
+
+test('hidden NPC reveals after visit condition met', () => {
+  Object.keys(worldFlags).forEach(k => delete worldFlags[k]);
+  state.map = 'world';
+  NPCS.length = 0;
+  applyModule({ npcs: [ { id: 'herm', map: 'world', x: 1, y: 1, name: 'Herm', hidden: true, reveal: { flag: 'visits@world@1,1', op: '>=', value: 2 } } ] });
+  assert.strictEqual(NPCS.length, 0);
+  setPlayerPos(1,1);
+  assert.strictEqual(NPCS.length, 0);
+  setPlayerPos(0,0);
+  setPlayerPos(1,1);
+  assert.strictEqual(NPCS.length, 1);
+  assert.strictEqual(NPCS[0].id, 'herm');
+});
+
+test('dialog choices can be gated by world flags', () => {
+  Object.keys(worldFlags).forEach(k => delete worldFlags[k]);
+  state.map = 'world';
+  NPCS.length = 0;
+  const tree = { start:{ text:'hi', choices:[ { label:'always', to:'bye' }, { label:'secret', to:'bye', if:{ flag:'visits@world@5,5', op:">=", value:1 } } ] }, bye:{ text:'', choices:[] } };
+  const npc = makeNPC('t', 'world', 0, 0, '#fff', 'T', '', '', tree);
+  NPCS.push(npc);
+  openDialog(npc);
+  assert.strictEqual(choicesEl.children.length, 1);
+  closeDialog();
+  setPlayerPos(5,5);
+  openDialog(npc);
+  assert.strictEqual(choicesEl.children.length, 2);
+  closeDialog();
 });


### PR DESCRIPTION
## Summary
- track visit counts and world state with `worldFlags`
- reveal hidden NPCs when flag conditions are met
- allow dialog choices to depend on world flags and add tests
- add hidden hermit NPC to dustland module
- let adventure-kit editor create hidden NPCs with reveal conditions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ce12258c8328807668be793f8593