### PR TITLE
Add party flag support and NPC visibility builder

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -227,7 +227,17 @@
           <label>Y<input id="npcY" type="number" min="0" /></label>
           <label><input type="checkbox" id="npcHidden"> Hidden NPC</label>
           <div id="revealOpts" style="display:none">
-            <label>Flag<input id="npcFlag" /></label>
+            <label>Flag Type<select id="npcFlagType"><option value="visits">Visited Tile</option><option value="party">Party Flag</option></select></label>
+            <div id="revealVisit">
+              <label>Map<input id="npcFlagMap" value="world" /></label>
+              <label>X<input id="npcFlagX" type="number" min="0" /></label>
+              <label>Y<input id="npcFlagY" type="number" min="0" /></label>
+              <button class="btn" type="button" id="npcFlagPick">Pick Tile</button>
+            </div>
+            <div id="revealParty" style="display:none">
+              <label>Name<input id="npcFlagName" list="npcFlagList" /></label>
+              <datalist id="npcFlagList"></datalist>
+            </div>
             <label>Op<select id="npcOp"><option value=">=">&ge;</option><option value=">">&gt;</option><option value="==">==</option><option value="!=">!=</option><option value="<=">&le;</option><option value="<">&lt;</option></select></label>
             <label>Value<input id="npcVal" type="number" value="1" /></label>
           </div>

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -67,7 +67,10 @@ function runEffects(effects){
   for(const fn of effects||[]){ if(typeof fn==='function') fn({player,party,state}); }
 }
 
-function flagValue(flag){ return worldFlags?.[flag]?.count || 0; }
+function flagValue(flag){
+  if (worldFlags?.[flag]) return worldFlags[flag].count;
+  return party.flags?.[flag] ? 1 : 0;
+}
 
 function checkFlagCondition(cond){
   if(!cond) return true;

--- a/core/effects.js
+++ b/core/effects.js
@@ -11,12 +11,14 @@ const Effects = {
         case 'log':
           if (typeof log === 'function') log(eff.msg || '');
           break;
-        case 'addFlag':
-          if (ctx.player) {
-            ctx.player.flags = ctx.player.flags || {};
-            ctx.player.flags[eff.flag] = true;
+        case 'addFlag': {
+          const p = ctx.party || globalThis.party;
+          if (p) {
+            p.flags = p.flags || {};
+            p.flags[eff.flag] = true;
+            if (typeof revealHiddenNPCs === 'function') revealHiddenNPCs();
           }
-          break;
+          break; }
         case 'modStat': {
           const target = ctx.actor || ctx.player;
           if (target && target.stats && eff.stat) {

--- a/core/movement.js
+++ b/core/movement.js
@@ -75,7 +75,7 @@ function move(dx,dy){
   if(canWalk(nx,ny)){
     Effects.tick({buffs});
     setPartyPos(nx, ny);
-    onEnter(state.map, nx, ny, { player, state, actor: typeof leader==='function'? leader(): null, buffs });
+    onEnter(state.map, nx, ny, { player, party, state, actor: typeof leader==='function'? leader(): null, buffs });
     centerCamera(party.x,party.y,state.map); updateHUD();
     checkAggro();
   }

--- a/core/party.js
+++ b/core/party.js
@@ -59,6 +59,7 @@ class Party extends Array {
     this.map = state.map;
     this.x = 2;
     this.y = 2;
+    this.flags = {};
   }
   addMember(member){
     if(this.length >= 6){

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -123,7 +123,7 @@ let world = [], interiors = {}, buildings = [], portals = [];
 const tileEvents = [];
 function registerTileEvents(list){ (list||[]).forEach(e => tileEvents.push(e)); }
 const state = { map:'world' }; // default map
-const player = { hp:10, ap:2, flags:{}, inv:[], scrap:0 };
+const player = { hp:10, ap:2, inv:[], scrap:0 };
 function setPartyPos(x, y){
   if(typeof x === 'number') party.x = x;
   if(typeof y === 'number') party.y = y;
@@ -342,7 +342,10 @@ function createNpcFactory(defs){
   return npcFactory;
 }
 
-function flagValue(flag){ return worldFlags[flag]?.count || 0; }
+function flagValue(flag){
+  if (worldFlags[flag]) return worldFlags[flag].count;
+  return party.flags?.[flag] ? 1 : 0;
+}
 
 function checkFlagCondition(cond){
   if(!cond) return true;
@@ -619,7 +622,7 @@ if (startContinue) startContinue.onclick = () => { load(); hideStart(); };
 if (startNew) startNew.onclick = () => { hideStart(); resetAll(); };
 
 function resetAll(){
-  party.length=0; player.inv=[]; player.flags={}; player.scrap=0;
+  party.length=0; player.inv=[]; party.flags={}; player.scrap=0;
   state.map='creator'; openCreator();
   log('Reset. Back to character creation.');
 }

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -25,8 +25,8 @@ function toast(msg) {
   requestAnimationFrame(()=>{ t.style.opacity = '1'; t.style.transform='translateY(0)'; });
   setTimeout(()=>{ t.style.opacity='0'; t.style.transform='translateY(-6px)'; setTimeout(()=> t.remove(), 180); }, 1600);
   if(/end of demo/i.test(msg) || /demo complete/i.test(msg)){
-    player.flags = player.flags || {};
-    player.flags.demoComplete = true;
+    party.flags = party.flags || {};
+    party.flags.demoComplete = true;
     if(typeof save === 'function') save();
   }
 }


### PR DESCRIPTION
## Summary
- Add UI builder for NPC reveal conditions that supports visited tiles and party flags
- Move player flags onto the party and expose them in flag condition checks
- Allow events to add party flags and reveal hidden NPCs when flags change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b881dda88328a19162ad99fea509