### PR TITLE
fix: load effects without require

### DIFF
--- a/ack-player.html
+++ b/ack-player.html
@@ -127,6 +127,7 @@
   <script src="dustland-core.js"></script>
   <script src="core/party.js"></script>
   <script src="core/inventory.js"></script>
+  <script src="core/effects.js"></script>
   <script src="core/movement.js"></script>
   <script src="core/dialog.js"></script>
   <script src="core/combat.js"></script>

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -379,6 +379,7 @@
   <script src="dustland-core.js"></script>
   <script src="core/party.js"></script>
   <script src="core/inventory.js"></script>
+  <script src="core/effects.js"></script>
   <script src="core/movement.js"></script>
   <script src="core/dialog.js"></script>
   <script src="adventure-kit.js"></script>

--- a/core/movement.js
+++ b/core/movement.js
@@ -1,4 +1,6 @@
-const { Effects } = require('./effects.js');
+const Effects = (typeof module !== 'undefined' && module.exports)
+  ? require('./effects.js').Effects
+  : globalThis.Effects;
 
 // active temporary stat modifiers
 const buffs = [];

--- a/dustland.html
+++ b/dustland.html
@@ -115,6 +115,7 @@
   <script src="dustland-core.js"></script>
   <script src="core/party.js"></script>
   <script src="core/inventory.js"></script>
+  <script src="core/effects.js"></script>
   <script src="core/movement.js"></script>
   <script src="core/dialog.js"></script>
   <script src="core/combat.js"></script>


### PR DESCRIPTION
## Summary
- prevent browser crash by only requiring effects in Node
- load effects module in HTML harnesses

## Testing
- `npm test` *(fails: SyntaxError in test/core.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bb102f1c8328a4b5dfa4370ed22e