### PR TITLE
Add terrain variety to office forest

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -12,9 +12,14 @@ const OFFICE_MODULE = (() => {
   function genForestWorld(seed = Date.now()) {
     setRNGSeed(seed);
     world = Array.from({ length: WORLD_H }, () =>
-      Array.from({ length: WORLD_W }, (_, x) =>
-        x === WORLD_MID ? TILE.WATER : TILE.BRUSH
-      )
+      Array.from({ length: WORLD_W }, (_, x) => {
+        if (x === WORLD_MID) return TILE.WATER;
+        // Add variety so the forest isn't a featureless expanse
+        const roll = rand(100);
+        if (roll < 10) return TILE.ROCK;
+        if (roll < 30) return TILE.SAND;
+        return TILE.BRUSH;
+      })
     );
     setTile('world', WORLD_MID, WORLD_MIDY, TILE.ROAD);
     interiors = {};


### PR DESCRIPTION
## Summary
- Mix brush, sand, and rock in the office module's forest to avoid a featureless landscape

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5bd4310ec8328929578f80704c8c6