### PR TITLE
Allow flag-gated dialog choices in editor and core

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -380,6 +380,7 @@
       <div id="treeEditor"></div>
       <div id="treeWarning" style="color:#f66;font-size:12px;margin-top:4px"></div>
       <button class="btn" type="button" id="addNode">Add Node</button>
+      <datalist id="choiceFlagList"></datalist>
     </div>
   </div>
   <button id="playtestFloat" class="btn btn--primary" style="

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -277,6 +277,10 @@ function renderDialogPreview() {
 
 function addChoiceRow(container, ch = {}) {
   const { label = '', to = '', reward = '', stat = '', dc = '', success = '', failure = '', once = false, costItem = '', costSlot = '', reqItem = '', reqSlot = '', join = null, q = '' } = ch || {};
+  const cond = ch && ch.if ? ch.if : null;
+  const flag = cond?.flag || '';
+  const op = cond?.op || '>=';
+  const val = cond?.value != null ? cond.value : 1;
   const joinId = join?.id || '', joinName = join?.name || '', joinRole = join?.role || '';
   const goto = ch.goto || {};
   const gotoMap = goto.map || '', gotoX = goto.x != null ? goto.x : '', gotoY = goto.y != null ? goto.y : '';
@@ -308,6 +312,16 @@ function addChoiceRow(container, ch = {}) {
       <label>Goto Y<input type="number" class="choiceGotoY" value="${gotoY}"/><span class="small">Y coordinate.</span></label>
       <label>Quest<select class="choiceQ"><option value=""></option><option value="accept" ${q==='accept'?'selected':''}>accept</option><option value="turnin" ${q==='turnin'?'selected':''}>turnin</option></select></label>
       <label class="onceWrap"><input type="checkbox" class="choiceOnce" ${once ? 'checked' : ''}/> once</label>
+      <label>Flag<input class="choiceFlag" list="choiceFlagList" value="${flag}"/></label>
+      <label>Op<select class="choiceOp">
+        <option value=">=" ${op === '>=' ? 'selected' : ''}>>=</option>
+        <option value=">" ${op === '>' ? 'selected' : ''}>></option>
+        <option value="<=" ${op === '<=' ? 'selected' : ''}><=</option>
+        <option value="<" ${op === '<' ? 'selected' : ''}><</option>
+        <option value="==" ${op === '==' ? 'selected' : ''}>=</option>
+        <option value="!=" ${op === '!=' ? 'selected' : ''}>!=</option>
+      </select></label>
+      <label>Value<input type="number" class="choiceVal" value="${val}"/></label>
     </details>`;
   container.appendChild(row);
   populateChoiceDropdown(row.querySelector('.choiceTo'), to);
@@ -471,6 +485,10 @@ function updateTreeData() {
       const gotoYTxt = chEl.querySelector('.choiceGotoY').value.trim();
       const q = chEl.querySelector('.choiceQ').value.trim();
       const once = chEl.querySelector('.choiceOnce').checked;
+      const flag = chEl.querySelector('.choiceFlag').value.trim();
+      const op = chEl.querySelector('.choiceOp').value;
+      const valTxt = chEl.querySelector('.choiceVal').value.trim();
+      const val = valTxt ? parseInt(valTxt, 10) : undefined;
 
       choiceRefs.push({ to, el: toEl });
 
@@ -496,6 +514,7 @@ function updateTreeData() {
         }
         if (q) c.q = q;
         if (once) c.once = true;
+        if (flag) c.if = { flag, op, value: val != null && !Number.isNaN(val) ? val : 0 };
         choices.push(c);
       }
     });
@@ -635,9 +654,11 @@ function gatherEventFlags() {
   return [...flags];
 }
 function populateFlagList() {
-  const list = document.getElementById('npcFlagList');
-  if (!list) return;
-  list.innerHTML = gatherEventFlags().map(f => `<option value="${f}"></option>`).join('');
+  const flags = gatherEventFlags().map(f => `<option value="${f}"></option>`).join('');
+  const npcList = document.getElementById('npcFlagList');
+  if (npcList) npcList.innerHTML = flags;
+  const choiceList = document.getElementById('choiceFlagList');
+  if (choiceList) choiceList.innerHTML = flags;
 }
 function getRevealFlag() {
   const type = document.getElementById('npcFlagType').value;

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -67,27 +67,6 @@ function runEffects(effects){
   for(const fn of effects||[]){ if(typeof fn==='function') fn({player,party,state}); }
 }
 
-function flagValue(flag){
-  if (worldFlags?.[flag]) return worldFlags[flag].count;
-  return party.flags?.[flag] ? 1 : 0;
-}
-
-function checkFlagCondition(cond){
-  if(!cond) return true;
-  const v = flagValue(cond.flag);
-  const val = cond.value ?? 0;
-  switch(cond.op){
-    case '>=': return v >= val;
-    case '>': return v > val;
-    case '<=': return v <= val;
-    case '<': return v < val;
-    case '!=': return v !== val;
-    case '=':
-    case '==': return v === val;
-  }
-  return false;
-}
-
 function resolveCheck(check, actor=leader(), rng=Math.random){
   const roll = Dice.skill(actor, check.stat, 0, ROLL_SIDES, rng);
   const dc = check.dc || 0;

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -758,7 +758,7 @@ function startWorld(){
 // Content pack moved to modules/dustland.module.js
 
 
-const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, startCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, tileEvents, registerTileEvents, state, player, GAME_STATE, setGameState, setPartyPos, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, npcsOnMap, queueNanoDialogForNPCs, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, createNpcFactory, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld, setRNGSeed, worldFlags, incFlag };
+const coreExports = { ROLL_SIDES, clamp, createRNG, Dice, startCombat, TILE, walkable, mapLabels, mapLabel, setMap, isWalkable, VIEW_W, VIEW_H, TS, WORLD_W, WORLD_H, world, interiors, buildings, portals, tileEvents, registerTileEvents, state, player, GAME_STATE, setGameState, setPartyPos, doorPulseUntil, lastInteract, creatorMap, genCreatorMap, Quest, NPC, questLog, NPCS, npcsOnMap, queueNanoDialogForNPCs, addQuest, completeQuest, defaultQuestProcessor, removeNPC, makeNPC, createNpcFactory, applyModule, genWorld, isWater, findNearestLand, makeInteriorRoom, placeHut, startGame, startWorld, setRNGSeed, worldFlags, incFlag, flagValue, checkFlagCondition };
 
 Object.assign(globalThis, coreExports);
 


### PR DESCRIPTION
## Summary
- Export shared `flagValue`/`checkFlagCondition` helpers and use them to gate dialog choices
- Add flag gating controls to the dialog editor and persist them when saving

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5bcaf6d2c8328866cb57963cb1ad9