### PR TITLE
docs: note test setup requirement

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -111,7 +111,8 @@ _______________________________________________________________________________
       * takeNearestItem(), interact(), move()
       * applyModule(data), openCreator()
   - Tiles: see TILE enum + colors[] + walkable[].
-  - Tests: run `npm test` for basic checks.
+  - Tests: run `npm install` to fetch dev deps like jsdom, then `npm test` for basic checks.
+    The main game still runs from the repo download alone.
 
 [ LICENSE ]
   MIT License


### PR DESCRIPTION
## Summary
- clarify that running the test suite requires `npm install` for dev deps like jsdom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5c90aff708328b675d94e48d07b64