### PR TITLE
test: verify NanoDialog generation

### DIFF
--- a/dustland-nano.js
+++ b/dustland-nano.js
@@ -288,7 +288,7 @@ CHOICE SCHEMA:
 - Skill check format: <label>|<STAT>|<DC>|<Reward>|<Success>|<Failure>
 - Only create a skill check if the reward is XP or an item.
 - STAT in {STR, AGI, INT, PER, LCK, CHA}; DC 6–12.
-- Reward must be "xp N" or an item name; otherwise, omit the skill check.
+- Reward must be "XP N" or an item name; otherwise, omit the skill check.
 - Simple dialog format (no roll): <label>|<Response>
 - Success/failure/response lines follow the same style rules as dialog lines.
  - Output 0–2 choices total. If no useful option fits, leave the Choices section empty.
@@ -300,7 +300,7 @@ Pump coughs at dusk but still runs.
 Keep the gears oiled and it behaves.
 If it wheezes, kick the intake gently.
 Choices:
-Check the intake|INT|9|xp 10|Mesh clears and hum steadies.|You drop a bolt, cursing softly.
+Check the intake|INT|9|XP 10|Mesh clears and hum steadies.|You drop a bolt, cursing softly.
 Ask about spare parts|Any for trade?|She shakes her head and turns away.
 
 Lines:
@@ -308,7 +308,7 @@ Tolls keep the road quiet and safe.
 Pay the price or pay in blood.
 Your choice decides your luck today.
 Choices:
-Intimidate her guard|STR|10|xp 12|Guard backs off, eyes wide.|He laughs and calls your bluff.
+Intimidate her guard|STR|10|XP 12|Guard backs off, eyes wide.|He laughs and calls your bluff.
 Ask for mercy|Can you cut the toll?|She snorts but lets you pass.
 
 Lines:
@@ -317,7 +317,7 @@ Keep your head low past the ruins.
 Trade if you must; run if you can’t.
 
 Choices:
-Check the intake|INT|9|xp 10|You tweak the valves and it purrs.|Steam hisses and you flinch back.
+Check the intake|INT|9|XP 10|You tweak the valves and it purrs.|Steam hisses and you flinch back.
 Offer spare gasket|CHA|8|Valve|She smiles and pockets the part.|She waves you off, unimpressed.
 
 EXACT OUTPUT FORMAT:

--- a/test/nano.test.js
+++ b/test/nano.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+// Setup minimal DOM and globals
+const noop = () => {};
+
+global.window = globalThis;
+global.document = { getElementById: () => null };
+
+global.NPCS = [{
+  id: 'npc1',
+  name: 'Scrap Dealer',
+  title: 'Trader',
+  desc: '',
+  map: 'world',
+  tree: {
+    start: { text: 'Greetings', choices: [] }
+  }
+}];
+
+global.resolveNode = (tree, id) => tree[id];
+
+global.party = [{ name: 'Hero', stats: { STR: 5 } }];
+global.selectedMember = 0;
+global.player = { inv: [] };
+global.quests = {};
+global.toast = noop;
+
+global.LanguageModel = {
+  availability: async () => 'available',
+  create: async () => ({
+    prompt: async () => `Lines:\nRust bites every gear, but we endure.\nKeep your scrap dry.\nNever trade hope for rust.\nChoices:\nAsk about wares|Got anything rare?\nInspect the stall|INT|8|XP 5|You spot a hidden coil.|You find only dust.\n`
+  })
+};
+
+test('NanoDialog generates lines and choices', async () => {
+  await import('../dustland-nano.js');
+  await window.NanoDialog.init();
+  window.NanoDialog.queueForNPC(NPCS[0], 'start', 'test');
+  await new Promise(r => setTimeout(r, 100));
+  const lines = window.NanoDialog.linesFor('npc1', 'start');
+  const choices = window.NanoDialog.choicesFor('npc1', 'start');
+  assert.ok(Array.isArray(lines) && lines.length > 0, 'lines generated');
+  assert.ok(Array.isArray(choices) && choices.length === 2, 'choices generated');
+  assert.strictEqual(choices[0].response, 'Got anything rare?');
+  assert.strictEqual(choices[1].check.stat, 'INT');
+  assert.strictEqual(choices[1].reward, 'XP 5');
+});


### PR DESCRIPTION
## Summary
- add unit test to ensure NanoDialog produces lines and choices
- use uppercase "XP" in the mocked reward to match dialog reward format
- require "XP N" in NanoDialog prompt examples so AI output matches game expectations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c8080fb08328973f31782fce1fee