### PR TITLE
fix: import inventory renderer from engine

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -1,5 +1,7 @@
 import { on } from './event-bus.js';
 
+let renderInv, renderParty, updateHUD;
+
 /**
  * @typedef {Object} Item
  * @property {string} name
@@ -994,3 +996,17 @@ export * from './core/dialog.js';
 export * from './core/effects.js';
 export * from './core/combat.js';
 export const getGameState = () => gameState;
+
+if (typeof process === 'undefined') {
+  const engine = await import('./dustland-engine.js');
+  renderInv = engine.renderInv;
+  renderParty = engine.renderParty;
+  updateHUD = engine.updateHUD;
+  Object.assign(globalThis, {
+    renderInv,
+    renderParty,
+    updateHUD,
+    log: engine.log,
+    renderQuests: engine.renderQuests
+  });
+}

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -15,16 +15,40 @@ function stubEl(){
     onclick:null,
     _innerHTML:'',
     children:[],
+    width:0,
+    height:0,
     appendChild(child){ this.children.push(child); child.parentElement=this; },
+    prepend(child){ this.children.unshift(child); child.parentElement=this; },
     querySelector: () => stubEl(),
     querySelectorAll: () => [],
+    getContext: () => ({
+      clearRect(){}, drawImage(){}, fillRect(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){},
+      save(){}, restore(){}, translate(){}, font:'', fillText(){}, globalAlpha:1
+    }),
+    addEventListener(){},
     parentElement:{ appendChild:()=>{}, querySelectorAll:()=>[] }
   };
   Object.defineProperty(el,'innerHTML',{ get(){return this._innerHTML;}, set(v){ this._innerHTML=v; this.children=[]; }});
   return el;
 }
 
+class AudioCtxStub {
+  createOscillator(){ return { type:'', frequency:{ value:0 }, connect(){}, start(){}, stop(){} }; }
+  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
+  get destination(){ return {}; }
+}
+
+global.requestAnimationFrame = () => {};
+Object.assign(global, {
+  addEventListener: () => {},
+  innerWidth: 800,
+  AudioContext: AudioCtxStub,
+  webkitAudioContext: AudioCtxStub
+});
 global.window = global;
+global.location = { hash: '' };
+global.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+
 const overlay = stubEl();
 const choicesEl = stubEl();
 const dialogText = stubEl();
@@ -35,7 +59,9 @@ const combatOverlay = stubEl();
 const combatEnemies = stubEl();
 const combatParty = stubEl();
 const combatCmd = stubEl();
+const bodyEl = stubEl();
 global.document = {
+  body: bodyEl,
   getElementById: (id) => ({
     overlay,
     choices: choicesEl,
@@ -48,7 +74,8 @@ global.document = {
     combatParty,
     combatCmd
   })[id] || stubEl(),
-  createElement: () => stubEl()
+  createElement: () => stubEl(),
+  querySelector: () => stubEl()
 };
 
 const core = await import('../dustland-core.js');


### PR DESCRIPTION
## Summary
- dynamically import `dustland-engine.js` in core to provide `renderInv` and related helpers
- stub browser APIs in tests so engine code can load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb48cd548328840d28d36d0afdb9