### PR TITLE
refactor: remove ES modules for file loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/ack-player.html
+++ b/ack-player.html
@@ -124,6 +124,16 @@
     </div>
   </div>
 
-  <script type="module" src="ack-player.js"></script>
+  <script defer src="./event-bus.js"></script>
+  <script defer src="./core/effects.js"></script>
+  <script defer src="./core/inventory.js"></script>
+  <script defer src="./core/movement.js"></script>
+  <script defer src="./core/dialog.js"></script>
+  <script defer src="./core/combat.js"></script>
+  <script defer src="./core/party.js"></script>
+  <script defer src="./dustland-core.js"></script>
+  <script defer src="./dustland-nano.js"></script>
+  <script defer src="./dustland-engine.js"></script>
+  <script defer src="./ack-player.js"></script>
 </body>
 </html>

--- a/ack-player.js
+++ b/ack-player.js
@@ -1,24 +1,13 @@
 // ACK Module Player (ESM)
 // Loads a module JSON and starts the game using its data.
 
-import { applyModule, setPartyPos, setMap, WORLD_H, openCreator } from './dustland-core.js';
-import './core/party.js';
-import './core/inventory.js';
-import './core/effects.js';
-import './core/movement.js';
-import './core/dialog.js';
-import './core/combat.js';
-import './dustland-nano.js';
+// use globals from core and engine
 
 // Prevent the engine from auto-starting the creator or start menu
 window.showStart = () => {};
 const realOpenCreator = openCreator;
 window.openCreator = () => {};
 
-let renderInv, renderQuests, renderParty, updateHUD, log;
-const enginePromise = import('./dustland-engine.js').then(mod => {
-  ({ renderInv, renderQuests, renderParty, updateHUD, log } = mod);
-});
 
 let moduleData = null;
 const PLAYTEST_KEY = 'ack_playtest';
@@ -58,7 +47,6 @@ loadBtn.onclick = () => {
 
 // After party creation, start the loaded module
 window.startGame = async function () {
-  await enginePromise;
   if (moduleData) applyModule(moduleData);
   const start = moduleData && moduleData.start ? moduleData.start : { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   setPartyPos(start.x, start.y);

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -405,7 +405,17 @@
     position:fixed; right:20px; bottom:20px; z-index:9999; border-radius:999px; padding:10px 14px;">
       ▶ Playtest
   </button>
-  <script type="module" src="adventure-kit.js"></script>
+  <script defer src="./event-bus.js"></script>
+  <script defer src="./core/effects.js"></script>
+  <script defer src="./core/inventory.js"></script>
+  <script defer src="./core/movement.js"></script>
+  <script defer src="./core/dialog.js"></script>
+  <script defer src="./core/combat.js"></script>
+  <script defer src="./core/party.js"></script>
+  <script defer src="./dustland-core.js"></script>
+  <script defer src="./dustland-nano.js"></script>
+  <script defer src="./dustland-engine.js"></script>
+  <script defer src="./adventure-kit.js"></script>
 </body>
 
 </html>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1,5 +1,3 @@
-import './dustland-core.js';
-import { setTile } from './core/movement.js';
 
 // Adventure Construction Kit
 // Provides basic tools to build Dustland modules.

--- a/core/combat.js
+++ b/core/combat.js
@@ -258,4 +258,3 @@ function startPartyTurn(){
 
 const combatExports = { openCombat, closeCombat, handleCombatKey };
 Object.assign(globalThis, combatExports);
-export { openCombat, closeCombat, handleCombatKey };

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -319,5 +319,3 @@ function renderDialog(){
 
 const dialogExports = { overlay, choicesEl, textEl, nameEl, titleEl, portEl, openDialog, closeDialog, renderDialog, advanceDialog, resolveCheck, handleDialogKey };
 Object.assign(globalThis, dialogExports);
-
-export { overlay, choicesEl, textEl, nameEl, titleEl, portEl, openDialog, closeDialog, renderDialog, advanceDialog, resolveCheck, handleDialogKey };

--- a/core/effects.js
+++ b/core/effects.js
@@ -1,50 +1,54 @@
-export const Effects = {
-  apply(list = [], ctx = {}) {
-    for (const eff of list || []) {
-      if (!eff) continue;
-      const type = eff.effect || eff.type;
-      switch (type) {
-        case 'toast':
-          if (typeof toast === 'function') toast(eff.msg || '');
-          else if (typeof log === 'function') log(eff.msg || '');
-          break;
-        case 'log':
-          if (typeof log === 'function') log(eff.msg || '');
-          break;
-        case 'addFlag': {
-          const p = ctx.party || globalThis.party;
-          if (p) {
-            p.flags = p.flags || {};
-            p.flags[eff.flag] = true;
-            if (typeof revealHiddenNPCs === 'function') revealHiddenNPCs();
-          }
-          break; }
-        case 'modStat': {
-          const target = ctx.actor || ctx.player;
-          if (target && target.stats && eff.stat) {
-            const delta = eff.delta || 0;
-            target.stats[eff.stat] = (target.stats[eff.stat] || 0) + delta;
-            if (eff.duration) {
-              ctx.buffs = ctx.buffs || [];
-              ctx.buffs.push({ target, stat: eff.stat, delta, remaining: eff.duration });
+// ===== Effects =====
+(function(){
+  const Effects = {
+    apply(list = [], ctx = {}) {
+      for (const eff of list || []) {
+        if (!eff) continue;
+        const type = eff.effect || eff.type;
+        switch (type) {
+          case 'toast':
+            if (typeof toast === 'function') toast(eff.msg || '');
+            else if (typeof log === 'function') log(eff.msg || '');
+            break;
+          case 'log':
+            if (typeof log === 'function') log(eff.msg || '');
+            break;
+          case 'addFlag': {
+            const p = ctx.party || globalThis.party;
+            if (p) {
+              p.flags = p.flags || {};
+              p.flags[eff.flag] = true;
+              if (typeof revealHiddenNPCs === 'function') revealHiddenNPCs();
             }
-          }
-          break; }
-      }
-    }
-  },
-  tick(ctx = {}) {
-    const list = ctx.buffs || [];
-    for (let i = list.length - 1; i >= 0; i--) {
-      const b = list[i];
-      if (--b.remaining <= 0) {
-        if (b.target && b.target.stats) {
-          b.target.stats[b.stat] = (b.target.stats[b.stat] || 0) - b.delta;
+            break; }
+          case 'modStat': {
+            const target = ctx.actor || ctx.player;
+            if (target && target.stats && eff.stat) {
+              const delta = eff.delta || 0;
+              target.stats[eff.stat] = (target.stats[eff.stat] || 0) + delta;
+              if (eff.duration) {
+                ctx.buffs = ctx.buffs || [];
+                ctx.buffs.push({ target, stat: eff.stat, delta, remaining: eff.duration });
+              }
+            }
+            break; }
         }
-        list.splice(i, 1);
+      }
+    },
+    tick(ctx = {}) {
+      const list = ctx.buffs || [];
+      for (let i = list.length - 1; i >= 0; i--) {
+        const b = list[i];
+        if (--b.remaining <= 0) {
+          if (b.target && b.target.stats) {
+            b.target.stats[b.stat] = (b.target.stats[b.stat] || 0) - b.delta;
+          }
+          list.splice(i, 1);
+        }
       }
     }
-  }
-};
+  };
 
-export default Effects;
+  globalThis.Effects = Effects;
+})();
+

--- a/core/inventory.js
+++ b/core/inventory.js
@@ -1,5 +1,5 @@
 // ===== Inventory / equipment =====
-import { emit } from '../event-bus.js';
+const { emit } = globalThis.EventBus;
 
 const ITEMS = {}; // item definitions by id
 const itemDrops = []; // {map,x,y,id}
@@ -158,5 +158,3 @@ function useItem(invIndex){
 
 const inventoryExports = { ITEMS, itemDrops, registerItem, getItem, resolveItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem };
 Object.assign(globalThis, inventoryExports);
-
-export { ITEMS, itemDrops, registerItem, getItem, resolveItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem };

--- a/core/movement.js
+++ b/core/movement.js
@@ -1,4 +1,4 @@
-import { Effects } from './effects.js';
+const { Effects } = globalThis;
 
 // active temporary stat modifiers
 const buffs = [];
@@ -188,5 +188,3 @@ Object.assign(globalThis, {
   onEnter,
   buffs
 });
-
-export { mapIdForState, mapWH, gridFor, getTile, setTile, currentGrid, queryTile, findFreeDropTile, canWalk, move, adjacentNPC, takeNearestItem, interactAt, interact, movementSystem, collisionSystem, interactionSystem, onEnter, buffs };

--- a/core/party.js
+++ b/core/party.js
@@ -106,5 +106,3 @@ function setLeader(idx){ selectedMember = idx; }
 
 const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, leader, setLeader, selectedMember };
 Object.assign(globalThis, partyExports);
-
-export { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, leader, setLeader, selectedMember };

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -1,6 +1,4 @@
-import { on } from './event-bus.js';
-
-let renderInv, renderParty, updateHUD;
+const { on } = globalThis.EventBus;
 
 /**
  * @typedef {Object} Item
@@ -924,89 +922,5 @@ const coreExports = {
   resetAll
 };
 
+Object.assign(coreExports, { getGameState: () => gameState });
 Object.assign(globalThis, coreExports);
-
-export {
-  ROLL_SIDES,
-  DC,
-  clamp,
-  createRNG,
-  Dice,
-  startCombat,
-  TILE,
-  walkable,
-  mapLabels,
-  mapLabel,
-  setMap,
-  isWalkable,
-  VIEW_W,
-  VIEW_H,
-  TS,
-  WORLD_W,
-  WORLD_H,
-  world,
-  interiors,
-  buildings,
-  portals,
-  tileEvents,
-  registerTileEvents,
-  state,
-  player,
-  GAME_STATE,
-  setGameState,
-  setPartyPos,
-  doorPulseUntil,
-  lastInteract,
-  creatorMap,
-  genCreatorMap,
-  Quest,
-  NPC,
-  questLog,
-  NPCS,
-  npcsOnMap,
-  queueNanoDialogForNPCs,
-  addQuest,
-  completeQuest,
-  defaultQuestProcessor,
-  removeNPC,
-  makeNPC,
-  createNpcFactory,
-  applyModule,
-  genWorld,
-  isWater,
-  findNearestLand,
-  makeInteriorRoom,
-  placeHut,
-  startGame,
-  startWorld,
-  setRNGSeed,
-  worldFlags,
-  incFlag,
-  showStart,
-  hideStart,
-  openCreator,
-  closeCreator,
-  resetAll
-};
-
-export * from './core/party.js';
-export * from './core/inventory.js';
-export * from './core/movement.js';
-export * from './core/dialog.js';
-export * from './core/effects.js';
-export * from './core/combat.js';
-export const getGameState = () => gameState;
-
-if (typeof process === 'undefined') {
-  const engine = await import('./dustland-engine.js');
-  renderInv = engine.renderInv;
-  renderParty = engine.renderParty;
-  updateHUD = engine.updateHUD;
-  Object.assign(globalThis, {
-    renderInv,
-    renderParty,
-    updateHUD,
-    log: engine.log,
-    renderQuests: engine.renderQuests
-  });
-}

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -1,4 +1,3 @@
-import { getTile, mapWH, mapIdForState } from './core/movement.js';
 
 // ===== Rendering & Utilities =====
 
@@ -8,7 +7,7 @@ const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');
 const scrEl = document.getElementById('scrap');
 
-export function log(msg){
+function log(msg){
   const p=document.createElement('div');
   p.textContent=msg;
   logEl.prepend(p);
@@ -181,7 +180,7 @@ Object.assign(window, { renderOrderSystem: { order: renderOrder, render } });
 const TAB_BREAKPOINT = 1600;
 let activeTab = 'inv';
 
-export function updateHUD(){
+function updateHUD(){
   hpEl.textContent=player.hp;
   apEl.textContent=player.ap;
   if(scrEl) scrEl.textContent = player.scrap;
@@ -223,7 +222,7 @@ document.getElementById('tabParty').onclick=()=>showTab('party');
 document.getElementById('tabQuests').onclick=()=>showTab('quests');
 
 // ===== Renderers =====
-export function renderInv(){
+function renderInv(){
   const inv=document.getElementById('inv');
   inv.innerHTML='';
   if(player.inv.length===0){
@@ -275,7 +274,7 @@ export function renderInv(){
     inv.appendChild(row);
   });
 }
-export function renderQuests(){
+function renderQuests(){
   const q=document.getElementById('quests');
   q.innerHTML='';
   const shown=Object.values(quests).filter(v=> v.status!=='available');
@@ -290,7 +289,10 @@ export function renderQuests(){
     q.appendChild(div);
   });
 }
-export function renderParty(){ const p=document.getElementById('party'); p.innerHTML=''; if(party.length===0){ p.innerHTML='<div class="pcard muted">(no party members yet)</div>'; return; } party.forEach((m,i)=>{ const c=document.createElement('div'); c.className='pcard'; const bonus=m._bonus||{}; const fmt=v=> (v>0? '+'+v : v); const wLabel=m.equip.weapon?(m.equip.weapon.cursed&&m.equip.weapon.cursedKnown?m.equip.weapon.name+' (cursed)':m.equip.weapon.name):'—'; const aLabel=m.equip.armor?(m.equip.armor.cursed&&m.equip.armor.cursedKnown?m.equip.armor.name+' (cursed)':m.equip.armor.name):'—'; const tLabel=m.equip.trinket?(m.equip.trinket.cursed&&m.equip.trinket.cursedKnown?m.equip.trinket.name+' (cursed)':m.equip.trinket.name):'—'; c.innerHTML = `<div class='row'><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div><div class='row small'>${statLine(m.stats)}</div><div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div><div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div><div class='row small'>XP ${m.xp}/${xpToNext(m.lvl)}</div><div class='row'><label><input type='radio' name='selMember' ${i===selectedMember?'checked':''}> Selected</label></div>`; c.querySelector('input').onchange=()=>{ selectedMember=i; }; c.querySelectorAll('button[data-a="unequip"]').forEach(b=>{ const sl=b.dataset.slot; b.onclick=()=> unequipItem(i,sl); }); p.appendChild(c); }); }
+function renderParty(){ const p=document.getElementById('party'); p.innerHTML=''; if(party.length===0){ p.innerHTML='<div class="pcard muted">(no party members yet)</div>'; return; } party.forEach((m,i)=>{ const c=document.createElement('div'); c.className='pcard'; const bonus=m._bonus||{}; const fmt=v=> (v>0? '+'+v : v); const wLabel=m.equip.weapon?(m.equip.weapon.cursed&&m.equip.weapon.cursedKnown?m.equip.weapon.name+' (cursed)':m.equip.weapon.name):'—'; const aLabel=m.equip.armor?(m.equip.armor.cursed&&m.equip.armor.cursedKnown?m.equip.armor.name+' (cursed)':m.equip.armor.name):'—'; const tLabel=m.equip.trinket?(m.equip.trinket.cursed&&m.equip.trinket.cursedKnown?m.equip.trinket.name+' (cursed)':m.equip.trinket.name):'—'; c.innerHTML = `<div class='row'><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div><div class='row small'>${statLine(m.stats)}</div><div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div><div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div><div class='row small'>XP ${m.xp}/${xpToNext(m.lvl)}</div><div class='row'><label><input type='radio' name='selMember' ${i===selectedMember?'checked':''}> Selected</label></div>`; c.querySelector('input').onchange=()=>{ selectedMember=i; }; c.querySelectorAll('button[data-a="unequip"]').forEach(b=>{ const sl=b.dataset.slot; b.onclick=()=> unequipItem(i,sl); }); p.appendChild(c); }); }
+
+const engineExports = { log, updateHUD, renderInv, renderQuests, renderParty };
+Object.assign(globalThis, engineExports);
 
 // ===== Minimal Unit Tests (#test) =====
 function assert(name, cond){ const msg = (cond? '✅ ':'❌ ') + name; log(msg); if(!cond) console.error('Test failed:', name); }
@@ -377,7 +379,7 @@ if (window.NanoDialog) NanoDialog.init();
 
 if(location.hash.includes('test')){ runTests(); }
 else {
-  const saveStr = localStorage.getItem('dustland_crt');
+const saveStr = globalThis.localStorage?.getItem('dustland_crt');
   if(saveStr){
     showStart();
   } else {

--- a/dustland.html
+++ b/dustland.html
@@ -112,24 +112,15 @@
     </div>
   </div>
 
-  <script type="module">
-    import { applyModule, genWorld, interact } from './dustland-core.js';
-    import './core/party.js';
-    import './core/inventory.js';
-    import './core/effects.js';
-    import './core/movement.js';
-    import './core/dialog.js';
-    import './core/combat.js';
-    window._realOpenCreator = window.openCreator;
-    window._realShowStart = window.showStart;
-    window.openCreator = function(){};
-    window.showStart = function(){};
-    import './dustland-nano.js';
-    import './dustland-engine.js';
-    import './module-picker.js';
-    window.applyModule = applyModule;
-    window.genWorld = genWorld;
-    window.interact = interact;
-  </script>
+  <script defer src="./event-bus.js"></script>
+  <script defer src="./core/effects.js"></script>
+  <script defer src="./core/inventory.js"></script>
+  <script defer src="./core/movement.js"></script>
+  <script defer src="./core/dialog.js"></script>
+  <script defer src="./core/combat.js"></script>
+  <script defer src="./core/party.js"></script>
+  <script defer src="./dustland-core.js"></script>
+  <script defer src="./dustland-nano.js"></script>
+  <script defer src="./dustland-engine.js"></script>
 </body>
 </html>

--- a/event-bus.js
+++ b/event-bus.js
@@ -3,34 +3,23 @@
  * Simple pub/sub bus.
  * @typedef {(payload:any)=>void} EventHandler
  */
-const listeners = new Map();
+(function(){
+  const listeners = new Map();
 
-/**
- * Subscribe to an event.
- * @param {string} evt
- * @param {EventHandler} handler
- */
-export function on(evt, handler){
-  if(!listeners.has(evt)) listeners.set(evt, new Set());
-  listeners.get(evt).add(handler);
-}
+  function on(evt, handler){
+    if(!listeners.has(evt)) listeners.set(evt, new Set());
+    listeners.get(evt).add(handler);
+  }
 
-/**
- * Unsubscribe from an event.
- * @param {string} evt
- * @param {EventHandler} handler
- */
-export function off(evt, handler){
-  listeners.get(evt)?.delete(handler);
-}
+  function off(evt, handler){
+    listeners.get(evt)?.delete(handler);
+  }
 
-/**
- * Emit an event to listeners.
- * @param {string} evt
- * @param {any} payload
- */
-export function emit(evt, payload){
-  listeners.get(evt)?.forEach(fn => fn(payload));
-}
+  function emit(evt, payload){
+    listeners.get(evt)?.forEach(fn => fn(payload));
+  }
 
-export default { on, off, emit };
+  const bus = { on, off, emit };
+  Object.assign(globalThis, bus, { EventBus: bus });
+})();
+

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,5 +1,7 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
 
 function stubEl(){
   const el = {
@@ -78,8 +80,32 @@ global.document = {
   querySelector: () => stubEl()
 };
 
-const core = await import('../dustland-core.js');
-const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey } = core;
+// Stub globals used during module evaluation
+global.log = () => {};
+global.toast = () => {};
+global.sfxTick = () => {};
+global.renderInv = () => {};
+global.renderParty = () => {};
+global.renderQuests = () => {};
+global.updateHUD = () => {};
+global.centerCamera = () => {};
+
+const files = [
+  '../event-bus.js',
+  '../core/effects.js',
+  '../core/party.js',
+  '../core/inventory.js',
+  '../core/movement.js',
+  '../core/dialog.js',
+  '../core/combat.js',
+  '../dustland-core.js'
+];
+for (const f of files) {
+  const code = await fs.readFile(new URL(f, import.meta.url), 'utf8');
+  vm.runInThisContext(code, { filename: f });
+}
+
+const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey } = globalThis;
 
 // Stub out globals used by equipment functions
 global.log = () => {};


### PR DESCRIPTION
## Summary
- replace ES module imports/exports with global scripts and event bus
- load core scripts via classic `<script>` tags so `dustland.html` runs from file://
- adapt tests to run against global APIs

## Testing
- `npm test` *(fails: smoke tests report missing browser APIs; unit tests pass)*
- `node --test test/smoke.test.js` *(fails: adventure-kit.html cannot load required DOM APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d00ca5b88328854aa04bf98b91e6