### PR TITLE
feat: uncurse helmet and update coworker dialog

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -110,6 +110,9 @@ _______________________________________________________________________________
       * renderParty(), renderInv(), renderQuests()
       * takeNearestItem(), interact(), move()
       * applyModule(data), openCreator()
+      * uncurseItem(id)
+  - NPC trees can be functions for dynamic dialog.
+  - Items support `equip.flag` and `unequip` teleport/message effects.
   - Tiles: see TILE enum + colors[] + walkable[].
   - Tests: run `npm install` to fetch dev deps like jsdom, then `npm test` for basic checks.
     The main game still runs from the repo download alone.

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -211,7 +211,8 @@ function setPortrait(portEl, npc){
 
 function openDialog(npc, node='start'){
   currentNPC=npc;
-  dialogState.tree=normalizeDialogTree(npc.tree||{});
+  const rawTree = typeof npc.tree === 'function' ? npc.tree() : npc.tree;
+  dialogState.tree=normalizeDialogTree(rawTree||{});
   dialogState.node=node;
   nameEl.textContent=npc.name;
   titleEl.textContent=npc.title;

--- a/core/inventory.js
+++ b/core/inventory.js
@@ -73,6 +73,9 @@ function equipItem(memberIndex, invIndex){
     if(t.map) setMap(t.map);
     updateHUD();
   }
+  if(it.equip && it.equip.flag){
+    incFlag(it.equip.flag);
+  }
   if(it.equip && it.equip.msg){
     log(it.equip.msg);
   }
@@ -96,6 +99,32 @@ function unequipItem(memberIndex, slot){
     log(`${m.name} unequips ${it.name}.`);
   if(typeof toast==='function') toast(`${m.name} unequips ${it.name}`);
   if(typeof sfxTick==='function') sfxTick();
+  if(it.unequip && it.unequip.teleport){
+    const t=it.unequip.teleport;
+    setPartyPos(t.x, t.y);
+    if(t.map) setMap(t.map);
+    updateHUD();
+  }
+  if(it.unequip && it.unequip.msg){
+    log(it.unequip.msg);
+  }
+}
+
+// Remove curse flag from item with given id in inventory or equipped slots
+function uncurseItem(id){
+  if(!id) return false;
+  let found=false;
+  for(const it of player.inv){
+    if(it.id===id){ it.cursed=false; it.cursedKnown=false; found=true; }
+  }
+  for(const m of party){
+    ['weapon','armor','trinket'].forEach(sl=>{
+      const eq=m.equip[sl];
+      if(eq && eq.id===id){ eq.cursed=false; eq.cursedKnown=false; found=true; }
+    });
+  }
+  if(found) notifyInventoryChanged();
+  return found;
 }
 
 function normalizeItem(it){
@@ -109,6 +138,7 @@ function normalizeItem(it){
     mods: it.mods ? { ...it.mods } : {},
     use: it.use || null,
     equip: it.equip || null,
+    unequip: it.unequip || null,
     cursed: !!it.cursed,
     cursedKnown: !!it.cursedKnown,
     rarity: it.rarity || 'common',
@@ -156,7 +186,7 @@ function useItem(invIndex){
   return false;
 }
 
-const inventoryExports = { ITEMS, itemDrops, registerItem, getItem, resolveItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem };
+const inventoryExports = { ITEMS, itemDrops, registerItem, getItem, resolveItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem, uncurseItem };
 Object.assign(globalThis, inventoryExports);
 
-export { ITEMS, itemDrops, registerItem, getItem, resolveItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem };
+export { ITEMS, itemDrops, registerItem, getItem, resolveItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem, uncurseItem };

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -52,7 +52,7 @@ global.document = {
 };
 
 const core = await import('../dustland-core.js');
-const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey } = core;
+const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey, uncurseItem } = core;
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -103,6 +103,30 @@ test('cursed items reveal on unequip attempt and stay equipped', () => {
   assert.ok(mem.equip.armor.cursed);
   assert.ok(mem.equip.armor.cursedKnown);
   assert.strictEqual(mem.equip.armor.name,'Mask');
+});
+
+test('uncursed gear can be removed and triggers unequip effects', () => {
+  party.length = 0;
+  player.inv.length = 0;
+  state.map = 'world';
+  const mem = new Character('t1','Tester','Role');
+  party.addMember(mem);
+  const helm = normalizeItem({
+    id: 'helm',
+    name: 'Helm',
+    type: 'armor',
+    slot: 'armor',
+    cursed: true,
+    unequip: { teleport: { map: 'office', x: 1, y: 1 }, msg: 'back' }
+  });
+  addToInv(helm);
+  equipItem(0,0);
+  unequipItem(0,'armor');
+  assert.ok(mem.equip.armor); // still cursed
+  uncurseItem('helm');
+  unequipItem(0,'armor');
+  assert.strictEqual(mem.equip.armor, null);
+  assert.strictEqual(state.map, 'office');
 });
 
 test('equipping teleport item moves party and logs message', () => {


### PR DESCRIPTION
## Summary
- Allow NPC dialog trees to be dynamic functions
- Add unequip effects and uncurse utility for items
- Fae King lifts VR helmet curse so it can be removed to return to the office
- Coworker dialog shifts after visiting the forest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5cccb894883288ab6540b83a618ac