### PR TITLE
fix: restore module select on startup

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -122,5 +122,6 @@
   <script defer src="./dustland-core.js"></script>
   <script defer src="./dustland-nano.js"></script>
   <script defer src="./dustland-engine.js"></script>
+  <script defer src="./module-picker.js"></script>
 </body>
 </html>

--- a/module-picker.js
+++ b/module-picker.js
@@ -4,6 +4,11 @@ const MODULES = [
   { id: 'office', name: 'Office', file: 'modules/office.module.js' }
 ];
 
+const realOpenCreator = window.openCreator;
+const realShowStart = window.showStart;
+window.openCreator = () => {};
+window.showStart = () => {};
+
 function loadModule(moduleInfo){
   const existingScript = document.getElementById('activeModuleScript');
   if (existingScript) existingScript.remove();
@@ -13,8 +18,8 @@ function loadModule(moduleInfo){
   script.onload = () => {
     const picker = document.getElementById('modulePicker');
     if(picker) picker.remove();
-    window.openCreator = window._realOpenCreator;
-    window.showStart = window._realShowStart;
+    window.openCreator = realOpenCreator;
+    window.showStart = realShowStart;
     const savedGame = localStorage.getItem('dustland_crt');
     if(savedGame){
       showStart();


### PR DESCRIPTION
## Summary
- load module-picker.js so module selection shows at startup
- preserve start and creator functions while loading a module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5e60f59848328b664bc3cc46289a1