### PR TITLE
fix: module selection and inventory items

### DIFF
--- a/core/inventory.js
+++ b/core/inventory.js
@@ -33,10 +33,11 @@ function notifyInventoryChanged(){
   emit('inventory:changed');
 }
 function addToInv(item){
-  if(!item || typeof item !== 'object' || !item.id){
+  const it = resolveItem(item);
+  if(!it || !it.id){
     throw new Error('Unknown item');
   }
-  const base = cloneItem(ITEMS[item.id] || registerItem(item));
+  const base = cloneItem(ITEMS[it.id] || registerItem(it));
   player.inv.push(base);
   emit('item:picked', base);
   notifyInventoryChanged();

--- a/module-picker.js
+++ b/module-picker.js
@@ -4,6 +4,11 @@ const MODULES = [
   { id: 'office', name: 'Office', file: 'modules/office.module.js' }
 ];
 
+const realOpenCreator = window.openCreator;
+const realShowStart = window.showStart;
+window.openCreator = () => {};
+window.showStart = () => {};
+
 function loadModule(moduleInfo){
   const existingScript = document.getElementById('activeModuleScript');
   if (existingScript) existingScript.remove();
@@ -13,8 +18,8 @@ function loadModule(moduleInfo){
   script.onload = () => {
     const picker = document.getElementById('modulePicker');
     if(picker) picker.remove();
-    window.openCreator = window._realOpenCreator;
-    window.showStart = window._realShowStart;
+    window.openCreator = realOpenCreator;
+    window.showStart = realShowStart;
     const savedGame = localStorage.getItem('dustland_crt');
     if(savedGame){
       showStart();

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -130,18 +130,25 @@ test('createRNG produces deterministic sequences', () => {
   assert.strictEqual(rngA(), rngB());
 });
 
-test('resolveCheck uses rng and runs effects', () => {
-  const actor = new Character('t','Tester','Role');
-  const events = [];
-  const check = { stat:'CHA', dc:5, onSuccess:[()=>events.push('s')], onFail:[()=>events.push('f')] };
-  const failRes = resolveCheck(check, actor, () => 0);
-  assert.strictEqual(failRes.success, false);
-  assert.deepStrictEqual(events, ['f']);
-  events.length = 0;
-  const winRes = resolveCheck(check, actor, () => 0.99);
-  assert.strictEqual(winRes.success, true);
-  assert.deepStrictEqual(events, ['s']);
-});
+  test('resolveCheck uses rng and runs effects', () => {
+    const actor = new Character('t','Tester','Role');
+    const events = [];
+    const check = { stat:'CHA', dc:5, onSuccess:[()=>events.push('s')], onFail:[()=>events.push('f')] };
+    const failRes = resolveCheck(check, actor, () => 0);
+    assert.strictEqual(failRes.success, false);
+    assert.deepStrictEqual(events, ['f']);
+    events.length = 0;
+    const winRes = resolveCheck(check, actor, () => 0.99);
+    assert.strictEqual(winRes.success, true);
+    assert.deepStrictEqual(events, ['s']);
+  });
+
+  test('addToInv accepts item ids', () => {
+    player.inv.length = 0;
+    registerItem({ id:'apple', name:'Apple' });
+    addToInv('apple');
+    assert.ok(player.inv.some(it=>it.id==='apple'));
+  });
 
 test('cursed items reveal on unequip attempt and stay equipped', () => {
   party.length = 0;


### PR DESCRIPTION
## Summary
- prevent module picker from clobbering startup hooks and restore them after selection
- allow `addToInv` to accept item ids
- add test for item-id inventory adds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5e3c60038832882aef905b45a8641