### PR TITLE
fix: guard against missing dialog nodes

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -357,7 +357,12 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
   }
   return new NPC({id,map,x,y,color,name,title,desc,tree,quest,processNode,processChoice, ...(opts||{})});
 }
-function resolveNode(tree, nodeId){ const n = tree[nodeId]; const choices = n.choices||[]; return {...n, choices}; }
+function resolveNode(tree, nodeId){
+  // Provide a safe fallback when a dialog node is missing
+  const n = tree?.[nodeId] || {};
+  const choices = Array.isArray(n.choices) ? n.choices : [];
+  return { ...n, choices };
+}
 const NPCS=[];
 function npcsOnMap(map = state.map){
   return NPCS.filter(n => n.map === map);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -105,7 +105,7 @@ for (const f of files) {
   vm.runInThisContext(code, { filename: f });
 }
 
-const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey, uncurseItem, save } = globalThis;
+const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, resolveNode, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey, uncurseItem, save } = globalThis;
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -716,4 +716,10 @@ test('save serializes party when map method is shadowed', () => {
   const saved = JSON.parse(store['dustland_crt']);
   assert.strictEqual(saved.party[0].id, 'p1');
   assert.strictEqual(saved.party.length, 1);
+});
+
+test('resolveNode handles missing node', () => {
+  const tree = { start: { text: 'hi', choices: [] } };
+  const node = resolveNode(tree, 'missing');
+  assert.deepStrictEqual(node, { choices: [] });
 });


### PR DESCRIPTION
## Summary
- prevent crashes when resolving missing dialog nodes
- cover resolveNode fallback with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fac8406c83289b8cb41d2cd629e5