### PR TITLE
feat: regenerate hp while walking

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -50,6 +50,7 @@ _______________________________________________________________________________
   - World buildings appear as black structures; their doors lead to
     simple interiors you can enter directly from the overworld.
   - Water is bright blue and is not walkable; items won’t spawn in water.
+  - Walking gradually restores HP for the selected party member.
 
 [ CHARACTER CREATION ]
   - Start a new game at boot if no save is present.

--- a/core/movement.js
+++ b/core/movement.js
@@ -74,8 +74,13 @@ function move(dx,dy){
   const nx=party.x+dx, ny=party.y+dy;
   if(canWalk(nx,ny)){
     Effects.tick({buffs});
+    const actor = typeof leader==='function'? leader(): null;
+    if(actor){
+      actor.hp = Math.min(actor.hp + 1, actor.maxHp);
+      player.hp = actor.hp;
+    }
     setPartyPos(nx, ny);
-    onEnter(state.map, nx, ny, { player, party, state, actor: typeof leader==='function'? leader(): null, buffs });
+    onEnter(state.map, nx, ny, { player, party, state, actor, buffs });
     centerCamera(party.x,party.y,state.map); updateHUD();
     checkAggro();
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -227,6 +227,30 @@ test('pathfinding blocks on NPCs', () => {
   assert.strictEqual(party.x,0);
 });
 
+test('walking regenerates leader HP', () => {
+  const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
+  applyModule({world});
+  state.map='world';
+  party.length = 0; player.inv.length = 0;
+  const hero = new Character('h', 'Hero', 'Role');
+  hero.hp = 5; hero.maxHp = 10;
+  party.addMember(hero);
+  party.x = 0; party.y = 0;
+
+  move(1,0);
+  assert.strictEqual(hero.hp, 6);
+  assert.strictEqual(player.hp, 6);
+
+  hero.hp = 9; player.hp = 9;
+  move(1,0);
+  assert.strictEqual(hero.hp, 10);
+  assert.strictEqual(player.hp, 10);
+
+  move(1,0);
+  assert.strictEqual(hero.hp, 10);
+  assert.strictEqual(player.hp, 10);
+});
+
 test('queryTile reports entities and items', () => {
   const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
   applyModule({world});


### PR DESCRIPTION
## Summary
- heal the leading party member by 1 HP each step
- document walking-based HP regen in README
- test that walking restores HP up to the max

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fb47d5648328a5427e140f2432a7