### PR TITLE
fix: guard resolveNode against missing nodes

### DIFF
--- a/core/npc.js
+++ b/core/npc.js
@@ -65,7 +65,12 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
   return new NPC({id,map,x,y,color,name,title,desc,tree,quest,processNode,processChoice, ...(opts || {})});
 }
 
-function resolveNode(tree, nodeId) { const n = tree[nodeId]; const choices = n.choices || []; return {...n, choices}; }
+function resolveNode(tree, nodeId) {
+  const n = tree && tree[nodeId];
+  if (!n) return null;
+  const choices = n.choices || [];
+  return { ...n, choices };
+}
 
 const NPCS = [];
 function npcsOnMap(map = state.map) {

--- a/dustland-nano.js
+++ b/dustland-nano.js
@@ -213,8 +213,8 @@
     }
   }
 
-  function _visibleLabels(npc, nodeId) {
-    const node = resolveNode(npc.tree, nodeId);
+  function _visibleLabels(npc, nodeId, node) {
+    node = node || resolveNode(npc.tree, nodeId);
     if (!node) return [];
     let labels = (node.choices || []).slice();
   
@@ -243,6 +243,11 @@
       console.warn("[Nano] NPC not found:", npcId);
       return null;
     }
+    const node = resolveNode(npc.tree, nodeId);
+    if(!node){
+      console.warn("[Nano] Node not found:", nodeId);
+      return null;
+    }
     const desc = npc.desc || '';
 
     const leader = party[typeof selectedMember==='number' ? selectedMember : 0] || null;
@@ -251,8 +256,8 @@
       .filter(([,q])=>q.status==='completed')
       .map(([id,q])=> q.title || id);
 
-    const existing = _visibleLabels(npc, nodeId);
-    const text = resolveNode(npc.tree, nodeId).text;
+    const existing = _visibleLabels(npc, nodeId, node);
+    const text = node.text;
 
     // Consider this in the prompt:
     //CURRENT UI CHOICES SHOWN TO PLAYER (do not duplicate these labels):

--- a/test/nano.test.js
+++ b/test/nano.test.js
@@ -18,7 +18,11 @@ global.NPCS = [{
   }
 }];
 
-global.resolveNode = (tree, id) => tree[id];
+global.resolveNode = (tree, id) => {
+  const n = tree[id];
+  if (!n) return null;
+  return { ...n, choices: n.choices || [] };
+};
 
 global.party = [{ name: 'Hero', stats: { STR: 5 } }];
 global.selectedMember = 0;
@@ -45,4 +49,15 @@ test('NanoDialog generates lines and choices', async () => {
   assert.strictEqual(choices[0].response, 'Got anything rare?');
   assert.strictEqual(choices[1].check.stat, 'INT');
   assert.strictEqual(choices[1].reward, 'XP 5');
+});
+
+test('NanoDialog skips missing dialog nodes', async () => {
+  await import('../dustland-nano.js');
+  await window.NanoDialog.init();
+  window.NanoDialog.queueForNPC(NPCS[0], 'bogus', 'test');
+  await new Promise(r => setTimeout(r, 100));
+  const lines = window.NanoDialog.linesFor('npc1', 'bogus');
+  const choices = window.NanoDialog.choicesFor('npc1', 'bogus');
+  assert.deepStrictEqual(lines, []);
+  assert.deepStrictEqual(choices, []);
 });


### PR DESCRIPTION
## Summary
- avoid crashing when dialog node is missing by returning null from `resolveNode`
- handle missing nodes in NanoDialog prompt builder and visible label helper
- test skipping unknown nodes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fc6ce8ac8328bfd60a3a5f4a5f0e