### PR TITLE
fix: avoid repeated item pickup log

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -644,28 +644,6 @@ on('item:picked', (it) => {
   log?.(`Picked up ${it.name}`);
 });
 
-on('inventory:changed', () => {
-  renderInv?.();
-  renderParty?.();
-  updateHUD?.();
-  queueNanoDialogForNPCs?.('start', 'inventory change');
-});
-
-on('item:picked', (it) => {
-  log?.(`Picked up ${it.name}`);
-});
-
-on('inventory:changed', () => {
-  renderInv?.();
-  renderParty?.();
-  updateHUD?.();
-  queueNanoDialogForNPCs?.('start', 'inventory change');
-});
-
-on('item:picked', (it) => {
-  log?.(`Picked up ${it.name}`);
-});
-
 // Content pack moved to modules/dustland.module.js
 
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -152,6 +152,17 @@ test('createRNG produces deterministic sequences', () => {
     assert.ok(player.inv.some(it=>it.id==='apple'));
   });
 
+  test('picking up an item logs once', () => {
+    player.inv.length = 0;
+    const oldLog = global.log;
+    const logs = [];
+    global.log = (msg) => logs.push(msg);
+    registerItem({ id: 'stone', name: 'Stone' });
+    addToInv('stone');
+    assert.deepStrictEqual(logs, ['Picked up Stone']);
+    global.log = oldLog;
+  });
+
 test('cursed items reveal on unequip attempt and stay equipped', () => {
   party.length = 0;
   player.inv.length = 0;


### PR DESCRIPTION
## Summary
- remove duplicate inventory change and item pickup handlers so items log once
- add regression test ensuring item pickup emits a single log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fd517fe4832887d2d5197e80ff0e