### PR TITLE
fix: keep log visible during combat

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -38,7 +38,7 @@
         filter: contrast(1.06) saturate(1.1);
     }
 
-    .panel {
+.panel {
         width: 440px;
         background: #0b0d0b;
         border: 1px solid #2a382a;
@@ -47,6 +47,8 @@
         flex-direction: column;
         overflow: hidden;
         box-shadow: 0 4px 20px rgba(0, 0, 0, 0.6);
+        position: relative;
+        z-index: 15;
         image-rendering: pixelated;
     }
 
@@ -287,7 +289,7 @@
     }
 
 /* Combat UI */
-#combatOverlay { background:rgba(0,0,0,.8); pointer-events:auto; }
+#combatOverlay { background:rgba(0,0,0,.8); pointer-events:auto; z-index:10; }
 #combatOverlay .combat-window {
   pointer-events:auto;
   width:min(640px,92vw);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -754,3 +754,9 @@ test('save serializes party when map method is shadowed', () => {
   assert.strictEqual(saved.party[0].id, 'p1');
   assert.strictEqual(saved.party.length, 1);
 });
+
+test('combat overlay sits behind the log panel', async () => {
+  const css = await fs.readFile(new URL('../dustland.css', import.meta.url), 'utf8');
+  assert.match(css, /\.panel\s*{[\s\S]*z-index:\s*15/);
+  assert.match(css, /#combatOverlay\s*{[\s\S]*z-index:\s*10/);
+});


### PR DESCRIPTION
## Summary
- Keep side log panel above combat overlay so combat messages stay visible
- Add regression test verifying combat overlay z-index is behind panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6074292708328a6d56aa56fa83ac4