### PR TITLE
feat: add action layer and event sfx

### DIFF
--- a/core/actions.js
+++ b/core/actions.js
@@ -1,0 +1,29 @@
+(function(){
+  const Actions = {
+    applyQuestReward(reward){
+      if(!reward) return;
+      if(typeof reward==='string' && /^xp\s*\d+/i.test(reward)){
+        const amt = parseInt(reward.replace(/[^0-9]/g,''),10)||0;
+        if(typeof leader==='function' && typeof awardXP==='function'){
+          awardXP(leader(), amt);
+        }
+        if(typeof toast==='function') toast(`+${amt} XP`);
+      } else {
+        const item = typeof resolveItem==='function'? resolveItem(reward) : null;
+        if(item){
+          if(typeof addToInv==='function') addToInv(item);
+          if(typeof toast==='function') toast(`Received ${item.name}`);
+        }
+      }
+    },
+    startCombat(defender){
+      if(typeof globalThis.startCombat==='function') return globalThis.startCombat(defender);
+    },
+    openShop(npc){
+      if(globalThis.EventBus && typeof EventBus.emit==='function'){
+        EventBus.emit('shop:open', npc);
+      }
+    }
+  };
+  Object.assign(globalThis, { Actions });
+})();

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -76,17 +76,6 @@ function resolveCheck(check, actor=leader(), rng=Math.random){
   return { success, roll, dc, stat: check.stat };
 }
 
-function applyReward(reward){
-  if(!reward) return;
-  if(typeof reward==='string' && /^xp\s*\d+/i.test(reward)){
-    const amt=parseInt(reward.replace(/[^0-9]/g,''),10)||0;
-    awardXP(leader(), amt);
-    if(typeof toast==='function') toast(`+${amt} XP`);
-  } else {
-    const rewardIt = resolveItem(reward);
-    if(rewardIt){ addToInv(rewardIt); if(typeof toast==='function') toast(`Received ${rewardIt.name}`); }
-  }
-}
 
 function processQuestFlag(c){
   if(!currentNPC?.quest || !c?.q) return;
@@ -132,7 +121,7 @@ function advanceDialog(stateObj, choiceIdx){
     if(idx === -1){
       return finalize(choice.failure || 'You lack the required item.', false);
     }
-    applyReward(choice.reward);
+    Actions.applyQuestReward(choice.reward);
     joinParty(choice.join);
     processQuestFlag(choice);
     runEffects(choice.effects);
@@ -151,7 +140,7 @@ function advanceDialog(stateObj, choiceIdx){
     }
     const removed = player.inv[idx];
     player.inv.splice(idx,1);
-    applyReward(choice.reward);
+    Actions.applyQuestReward(choice.reward);
     joinParty(choice.join);
     processQuestFlag(choice);
     runEffects(choice.effects);
@@ -170,7 +159,7 @@ function advanceDialog(stateObj, choiceIdx){
     }
   }
 
-  applyReward(choice.reward);
+  Actions.applyQuestReward(choice.reward);
   joinParty(choice.join);
   processQuestFlag(choice);
   runEffects(choice.effects);

--- a/core/inventory.js
+++ b/core/inventory.js
@@ -67,7 +67,7 @@ function equipItem(memberIndex, invIndex){
     notifyInventoryChanged();
     log(`${m.name} equips ${it.name}.`);
   if(typeof toast==='function') toast(`${m.name} equips ${it.name}`);
-  if(typeof sfxTick==='function') sfxTick();
+  emit('sfx','tick');
   if(it.equip && it.equip.teleport){
     const t=it.equip.teleport;
     setPartyPos(t.x, t.y);
@@ -99,7 +99,7 @@ function unequipItem(memberIndex, slot){
     notifyInventoryChanged();
     log(`${m.name} unequips ${it.name}.`);
   if(typeof toast==='function') toast(`${m.name} unequips ${it.name}`);
-  if(typeof sfxTick==='function') sfxTick();
+  emit('sfx','tick');
   if(it.unequip && it.unequip.teleport){
     const t=it.unequip.teleport;
     setPartyPos(t.x, t.y);
@@ -168,7 +168,7 @@ function useItem(invIndex){
     const healed = who.hp - before;
     log(`${who.name} drinks ${it.name} (+${healed} HP).`);
     if (typeof toast === 'function') toast(`${who.name} +${healed} HP`);
-    if (typeof sfxTick === 'function') sfxTick();
+    emit('sfx','tick');
     player.inv.splice(invIndex,1);
     notifyInventoryChanged();
     return true;
@@ -179,7 +179,7 @@ function useItem(invIndex){
         player.inv.splice(invIndex,1);
         notifyInventoryChanged();
         if(typeof toast==='function') toast(`Used ${it.name}`);
-        if(typeof sfxTick==='function') sfxTick();
+        emit('sfx','tick');
     }
     return !!ok;
   }

--- a/core/movement.js
+++ b/core/movement.js
@@ -93,7 +93,7 @@ function checkAggro(){
     if(n.map!==state.map) continue;
     const d = Math.abs(n.x - party.x) + Math.abs(n.y - party.y);
     if(d<=3){
-      startCombat({ ...n.combat, npc:n, name:n.name });
+      Actions.startCombat({ ...n.combat, npc:n, name:n.name });
       break;
     }
   }

--- a/core/npc.js
+++ b/core/npc.js
@@ -5,7 +5,7 @@ class NPC {
     const capNode = (node) => {
       if (this.combat && node === 'do_fight') {
         closeDialog();
-        startCombat({ ...this.combat, npc: this, name: this.name });
+        Actions.startCombat({ ...this.combat, npc: this, name: this.name });
       } else if (this.shop && node === 'sell') {
         const items = player.inv.map((it, idx) => ({label: `Sell ${it.name} (${Math.max(1, it.value || 0)} ${CURRENCY})`, to: 'sell', sellIndex: idx}));
         this.tree.sell.text = items.length ? 'What are you selling?' : 'Nothing to sell.';

--- a/core/party.js
+++ b/core/party.js
@@ -17,7 +17,7 @@ class Character {
     this.xp += amt;
     log(`${this.name} gains ${amt} XP.`);
     if(typeof toast==='function') toast(`${this.name} +${amt} XP`);
-    if(typeof sfxTick==='function') sfxTick();
+    EventBus.emit('sfx','tick');
     while(this.xp >= this.xpToNext()){
       this.xp -= this.xpToNext();
       this.lvl++;
@@ -36,7 +36,7 @@ class Character {
     if(this.lvl%2===0){
       this.ap += 1;
       if(typeof hudBadge==='function') hudBadge('AP +1');
-      if(typeof sfxTick==='function') sfxTick();
+      EventBus.emit('sfx','tick');
     }
     log(`${this.name} leveled up to ${this.lvl}! (+HP, stats)`);
   }

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -45,6 +45,7 @@ function sfxTick(){
   g.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime+0.1);
   o.stop(audioCtx.currentTime+0.1);
 }
+EventBus.on('sfx', id => { if(id==='tick') sfxTick(); });
 function hudBadge(msg){
   const ap=document.getElementById('ap');
   if(!ap) return;

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -92,6 +92,7 @@ global.centerCamera = () => {};
 
 const files = [
   '../event-bus.js',
+  '../core/actions.js',
   '../core/effects.js',
   '../core/party.js',
   '../core/inventory.js',


### PR DESCRIPTION
## Summary
- centralize side effects in new Actions helper
- route combat through Actions and move quest rewards into Actions
- play tick SFX via EventBus to decouple core systems

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a609c697f48328ba70bc44def2045f