### PR TITLE
feat: add palette-based building and interior editors

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -78,7 +78,8 @@ _______________________________________________________________________________
   - modules/dustland.module.js
     * NPCs, items, world data, and quests for the core adventure.
   - adventure-kit.html / adventure-kit.js
-    * Map/NPC/item/quest editor for making modules.
+    * Map/NPC/item/quest editor for making modules. Includes palette-based
+      interior and building editors with customizable door placement.
   - ack-player.html / ack-player.js
     * Loads a JSON module and runs it in the engine.
   - dustland-nano.js

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -310,9 +310,17 @@
         <div id="bldgEditor" style="display:none">
           <label>X<input id="bldgX" type="number" min="0" /></label>
           <label>Y<input id="bldgY" type="number" min="0" /></label>
+          <label>W<input id="bldgW" type="number" min="1" value="6" /></label>
+          <label>H<input id="bldgH" type="number" min="1" value="5" /></label>
+          <div id="bldgPalette">
+            <button type="button" data-tile="B" style="background:#fff"></button>
+            <button type="button" data-tile="D" style="background:#8bd98d"></button>
+            <button type="button" data-tile="E" style="background:#000"></button>
+          </div>
+          <canvas id="bldgCanvas" width="192" height="160" style="margin-top:4px"></canvas>
           <label>Interior<select id="bldgInterior"></select></label>
-          <button class="btn" id="addBldg">Place Hut</button>
-          <button class="btn" id="delBldg" style="display:none">Remove Hut</button>
+          <button class="btn" id="addBldg">Add Building</button>
+          <button class="btn" id="delBldg" style="display:none">Remove Building</button>
         </div>
       </fieldset>
       <fieldset class="card" id="intCard" data-pane="interiors" style="display:none">
@@ -321,6 +329,13 @@
         <button class="btn" type="button" id="newInterior">+ Interior</button>
         <div id="intEditor" style="display:none">
           <label>ID<input id="intId" readonly /></label>
+          <label>W<input id="intW" type="number" min="3" value="12" /></label>
+          <label>H<input id="intH" type="number" min="3" value="9" /></label>
+          <div id="intPalette">
+            <button type="button" data-tile="W" style="background:#444"></button>
+            <button type="button" data-tile="F" style="background:#222"></button>
+            <button type="button" data-tile="D" style="background:#8bd98d"></button>
+          </div>
           <canvas id="intCanvas" width="192" height="144" style="margin-top:4px"></canvas>
           <button class="btn" type="button" id="delInterior" style="display:none">Delete Interior</button>
         </div>

--- a/dustland.css
+++ b/dustland.css
@@ -739,8 +739,13 @@
             overflow: visible;
         }
 
-        .editor-panel.wide .tabpanes .card {
+.editor-panel.wide .tabpanes .card {
             flex: 1 1 320px;
             margin: 0 8px 16px !important;
         }
     }
+
+#intPalette button,
+#bldgPalette button { width:20px; height:20px; border:none; margin:2px; }
+#intPalette button.active,
+#bldgPalette button.active { outline:2px solid #fff; }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -108,7 +108,7 @@ for (const f of files) {
   vm.runInThisContext(code, { filename: f });
 }
 
-const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey, uncurseItem, save } = globalThis;
+const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey, uncurseItem, save, makeInteriorRoom, placeHut, TILE, getTile, interiors } = globalThis;
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -446,6 +446,28 @@ test('door portals link interiors', () => {
   assert.strictEqual(state.map, 'castle');
   interactAt(1,1);
   assert.strictEqual(state.map, 'forest');
+});
+
+test('makeInteriorRoom supports custom size', () => {
+  const id = makeInteriorRoom('big', 20, 15);
+  const I = interiors[id];
+  assert.strictEqual(I.w, 20);
+  assert.strictEqual(I.h, 15);
+  assert.strictEqual(I.grid.length, 15);
+  assert.strictEqual(I.grid[0].length, 20);
+});
+
+test('placeHut uses custom grid and door', () => {
+  const grid = [
+    [TILE.BUILDING, TILE.DOOR],
+    [null, TILE.BUILDING]
+  ];
+  const before = getTile('world', 0, 1);
+  const b = placeHut(0, 0, { interiorId: makeInteriorRoom(), grid });
+  assert.strictEqual(b.w, 2);
+  assert.strictEqual(b.h, 2);
+  assert.strictEqual(getTile('world', 1, 0), TILE.DOOR);
+  assert.strictEqual(getTile('world', 0, 1), before);
 });
 
 test('quest turn-in grants reward item', () => {


### PR DESCRIPTION
## Summary
- allow custom interior sizes and palette painting
- add building exterior editor with door placement
- support grid-based huts and document editor features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a710c1621083288dfac96a2420efb7