### PR TITLE
fix: clear old buildings on module load

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1493,13 +1493,21 @@ function applyLoadedModule(data) {
   interiors = globalThis.interiors;
   moduleData.interiors.forEach(I => { interiors[I.id] = I; });
 
-  globalThis.world = data.world || world;
-  world = globalThis.world;
-  globalThis.buildings = moduleData.buildings.map(b => ({
-    ...b,
-    under: Array.from({ length: b.h }, () => Array.from({ length: b.w }, () => TILE.SAND))
-  }));
-  buildings = globalThis.buildings;
+  if (data.world) {
+    globalThis.world = data.world;
+    world = globalThis.world;
+  } else {
+    buildings.forEach(b => {
+      for (let yy = 0; yy < b.h; yy++) {
+        for (let xx = 0; xx < b.w; xx++) {
+          setTile('world', b.x + xx, b.y + yy, b.under[yy][xx]);
+        }
+      }
+    });
+  }
+  buildings.length = 0;
+  moduleData.buildings.forEach(b => buildings.push(placeHut(b.x, b.y, b)));
+  moduleData.buildings = [...buildings];
 
   drawWorld();
   renderNPCList();

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -1,0 +1,77 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function stubEl(){
+  const el = {
+    style:{},
+    classList:{ _set:new Set(), toggle(c){this._set.has(c)?this._set.delete(c):this._set.add(c);}, add(c){this._set.add(c);}, remove(c){this._set.delete(c);}, contains(c){return this._set.has(c);}},
+    textContent:'',
+    onclick:null,
+    value:'',
+    _innerHTML:'',
+    children:[],
+    width:0,
+    height:0,
+    appendChild(child){ this.children.push(child); child.parentElement=this; },
+    prepend(child){ this.children.unshift(child); child.parentElement=this; },
+    querySelector: () => stubEl(),
+    querySelectorAll: () => [],
+    getContext: () => ({
+      clearRect(){}, drawImage(){}, fillRect(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){}, strokeRect(){},
+      save(){}, restore(){}, translate(){}, font:'', fillText(){}, globalAlpha:1
+    }),
+    addEventListener(){},
+    removeEventListener(){},
+    parentElement:{ appendChild(){}, querySelectorAll(){ return []; } },
+    setAttribute(){},
+    click(){},
+  };
+  Object.defineProperty(el,'innerHTML',{ get(){return this._innerHTML;}, set(v){ this._innerHTML=v; this.children=[]; }});
+  return el;
+}
+
+global.requestAnimationFrame = () => {};
+global.alert = () => {};
+global.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+global.window = global;
+window.matchMedia = () => ({ matches:false, addEventListener(){}, removeEventListener(){} });
+const bodyEl = stubEl();
+global.document = {
+  body: bodyEl,
+  getElementById: () => stubEl(),
+  createElement: () => stubEl(),
+  querySelector: () => stubEl(),
+  querySelectorAll: () => []
+};
+
+const files = [
+  '../event-bus.js',
+  '../core/movement.js',
+  '../dustland-core.js',
+  '../adventure-kit.js'
+];
+for (const f of files) {
+  const code = await fs.readFile(new URL(f, import.meta.url), 'utf8');
+  vm.runInThisContext(code, { filename: f });
+}
+
+const { applyLoadedModule, TILE, setTile, placeHut, genWorld } = globalThis;
+
+test('applyLoadedModule clears previous building tiles', () => {
+  genWorld(123);
+  globalThis.buildings.forEach(b => {
+    for (let y=0; y<b.h; y++) {
+      for (let x=0; x<b.w; x++) {
+        setTile('world', b.x + x, b.y + y, b.under[y][x]);
+      }
+    }
+  });
+  globalThis.buildings.length = 0;
+  placeHut(1,1);
+  assert.strictEqual(world[1][1], TILE.BUILDING);
+  applyLoadedModule({ seed: 123, buildings: [] });
+  assert.notStrictEqual(world[1][1], TILE.BUILDING);
+  assert.strictEqual(globalThis.buildings.length, 0);
+});


### PR DESCRIPTION
## Summary
- reset world tiles from previous buildings when loading a module in the Adventure Kit
- test module loading to ensure old buildings vanish

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a71c48eaa4832897f98cce72659977