### PR TITLE
feat: add golden sample module

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -27,7 +27,7 @@ _______________________________________________________________________________
   - Just open:  dustland.html  (double-click or serve from any static server).
   - Pick a module on startup (e.g. Dustland or Echoes).
   - Build a module with: adventure-kit.html  (save to JSON).
-  - Play a module with: ack-player.html and load your JSON.
+  - Play a module with: ack-player.html (fetch a module URL, load a local JSON, or pass ?module=URL to auto-load; defaults to modules/golden.module.json).
   - No build step. No dependencies. Works offline.
   - Tip: Use a modern Chromium, Firefox, or Safari.
 
@@ -76,10 +76,12 @@ _______________________________________________________________________________
     * Renderer, input handling, HUD, and tiny sfx.
   - modules/dustland.module.js
     * NPCs, items, world data, and quests for the core adventure.
+  - modules/golden.module.json
+    * Sample module showcasing a fetch quest, stat gate, joinable NPC, timed spawn, event toasts, portal, chest loot drop, healing potion, and combat; default module for ACK player.
   - adventure-kit.html / adventure-kit.js
     * Map/NPC/item/quest editor for making modules.
   - ack-player.html / ack-player.js
-    * Loads a JSON module and runs it in the engine.
+    * Fetch a module JSON from the web or load a local file into the engine.
   - dustland-nano.js
     * Micro helper utilities.
   - dustland.css

--- a/ack-player.html
+++ b/ack-player.html
@@ -117,9 +117,12 @@
     <div class="win" style="width:min(420px,92vw);background:#0b0d0b;border:1px solid #2a382a;border-radius:12px;box-shadow:0 20px 80px rgba(0,0,0,.7);overflow:hidden">
       <header style="padding:10px 12px;border-bottom:1px solid #223022;font-weight:700">Load Adventure Module</header>
       <main style="padding:12px">
-        <p class="muted" style="margin-bottom:8px">Select an ACK module JSON file to begin.</p>
+        <p class="muted" style="margin-bottom:8px">Load a module from the web or a local JSON file.</p>
+        <input type="text" id="modUrl" value="modules/golden.module.json" style="width:100%" />
+        <button class="btn" id="modUrlBtn" style="margin-top:8px">Load from URL</button>
+        <hr style="margin:12px 0" />
         <input type="file" id="modFile" accept="application/json" />
-        <button class="btn" id="modLoadBtn" style="margin-top:8px">Load Module</button>
+        <button class="btn" id="modFileBtn" style="margin-top:8px">Load from File</button>
       </main>
     </div>
   </div>

--- a/ack-player.js
+++ b/ack-player.js
@@ -12,8 +12,10 @@ window.openCreator = () => {};
 let moduleData = null;
 const PLAYTEST_KEY = 'ack_playtest';
 const loader = document.getElementById('moduleLoader');
+const urlInput = document.getElementById('modUrl');
+const urlBtn = document.getElementById('modUrlBtn');
 const fileInput = document.getElementById('modFile');
-const loadBtn = document.getElementById('modLoadBtn');
+const fileBtn = document.getElementById('modFileBtn');
 
 const playData = localStorage.getItem(PLAYTEST_KEY);
 if (playData) {
@@ -28,16 +30,42 @@ if (playData) {
   }
 }
 
-loadBtn.onclick = () => {
+const params = new URLSearchParams(location.search);
+const autoUrl = params.get('module');
+if (!moduleData && autoUrl) {
+  urlInput.value = autoUrl;
+  fetch(autoUrl)
+    .then((r) => r.json())
+    .then((data) => loadModule(data))
+    .catch((err) => alert('Invalid module:' + err));
+}
+
+async function loadModule(data) {
+  moduleData = data;
+  loader.style.display = 'none';
+  window.openCreator = realOpenCreator;
+  realOpenCreator();
+}
+
+urlBtn.onclick = async () => {
+  const url = urlInput.value.trim();
+  if (!url) return;
+  try {
+    const res = await fetch(url);
+    const data = await res.json();
+    await loadModule(data);
+  } catch (err) {
+    alert('Invalid module:' + err);
+  }
+};
+
+fileBtn.onclick = () => {
   const file = fileInput.files[0];
   if (!file) return;
   const reader = new FileReader();
   reader.onload = () => {
     try {
-      moduleData = JSON.parse(reader.result);
-      loader.style.display = 'none';
-      window.openCreator = realOpenCreator;
-      realOpenCreator();
+      loadModule(JSON.parse(reader.result));
     } catch (err) {
       alert('Invalid module:' + err);
     }

--- a/module-picker.js
+++ b/module-picker.js
@@ -1,7 +1,8 @@
 const MODULES = [
   { id: 'dustland', name: 'Dustland', file: 'modules/dustland.module.js' },
   { id: 'echoes', name: 'Echoes', file: 'modules/echoes.module.js' },
-  { id: 'office', name: 'Office', file: 'modules/office.module.js' }
+  { id: 'office', name: 'Office', file: 'modules/office.module.js' },
+  { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' }
 ];
 
 const realOpenCreator = window.openCreator;
@@ -12,6 +13,10 @@ window.showStart = () => {};
 function loadModule(moduleInfo){
   const existingScript = document.getElementById('activeModuleScript');
   if (existingScript) existingScript.remove();
+  if (moduleInfo.file.endsWith('.json')) {
+    window.location.href = `ack-player.html?module=${encodeURIComponent(moduleInfo.file)}`;
+    return;
+  }
   const script = document.createElement('script');
   script.id = 'activeModuleScript';
   script.src = `${moduleInfo.file}?_=${Date.now()}`;

--- a/modules/golden.module.json
+++ b/modules/golden.module.json
@@ -1,0 +1,177 @@
+{
+  "seed": 1,
+  "start": { "map": "world", "x": 7, "y": 7 },
+  "items": [
+    { "id": "golden_coin", "name": "Golden Coin", "type": "quest" },
+    { "id": "thanks_medal", "name": "Thanks Medal", "type": "trinket", "slot": "trinket", "mods": { "LCK": 1 } },
+    { "id": "bonus_potion", "name": "Healing Potion", "type": "consumable", "use": { "type": "heal", "amount": 5 } },
+    { "map": "world", "x": 6, "y": 7, "id": "spare_potion", "name": "Spare Potion", "type": "consumable", "use": { "type": "heal", "amount": 5 } }
+  ],
+  "quests": [
+    { "id": "q_fetch", "title": "Fetch the Coin", "desc": "Retrieve the coin from the cabin.", "item": "golden_coin", "reward": "thanks_medal", "xp": 2 }
+  ],
+  "npcs": [
+    {
+      "id": "villager",
+      "map": "world",
+      "x": 7,
+      "y": 7,
+      "color": "#cfa",
+      "name": "Worried Villager",
+      "desc": "Lost a coin in the cabin.",
+      "questId": "q_fetch",
+      "tree": {
+        "start": {
+          "text": "My lucky coin is in the cabin. Can you fetch it?",
+          "choices": [
+            { "label": "(Accept)", "to": "accept", "q": "accept" },
+            { "label": "(INT) Any advance?", "to": "advance", "check": { "stat": "INT", "dc": 5 } },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "advance": {
+          "text": "Sharp mind! Take this potion.",
+          "choices": [ { "label": "(Thanks)", "to": "accept", "reward": "bonus_potion", "q": "accept" } ]
+        },
+        "accept": {
+          "text": "Please bring it soon.",
+          "choices": [
+            { "label": "(I have the coin)", "to": "turnin", "q": "turnin" },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "turnin": {
+          "text": "You found it! Here is your reward.",
+          "choices": [ { "label": "(Continue)", "to": "bye", "reward": "thanks_medal" } ]
+        }
+      }
+    },
+    {
+      "id": "chest",
+      "map": "cabin",
+      "x": 3,
+      "y": 2,
+      "color": "#ddf",
+      "name": "Dusty Chest",
+      "desc": "Maybe it holds the coin.",
+      "tree": {
+        "start": {
+          "text": "A locked chest sits here.",
+          "choices": [
+            { "label": "(Open)", "to": "open", "once": true },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "open": {
+          "text": "Inside is a shiny coin.",
+          "choices": [ { "label": "(Take Coin)", "to": "empty", "reward": "golden_coin" } ]
+        },
+        "empty": {
+          "text": "The chest is empty.",
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        }
+      }
+    },
+    {
+      "id": "rat",
+      "map": "cabin",
+      "x": 5,
+      "y": 2,
+      "color": "#f88",
+      "name": "Big Rat",
+      "title": "Pest",
+      "desc": "It guards the cabin.",
+      "tree": {
+        "start": { "text": "The rat snarls.", "choices": [ { "label": "(Leave)", "to": "bye" } ] }
+      },
+      "combat": { "HP": 4, "ATK": 2, "DEF": 0, "loot": null, "auto": true }
+    },
+    {
+      "id": "bandit",
+      "map": "world",
+      "x": 7,
+      "y": 8,
+      "color": "#f66",
+      "name": "Sneaky Bandit",
+      "desc": "Blocks the path.",
+      "tree": {
+        "start": { "text": "Hand over your loot!", "choices": [ { "label": "(Leave)", "to": "bye" } ] }
+      },
+      "combat": { "HP": 6, "ATK": 3, "DEF": 1, "loot": null, "auto": true }
+    },
+    {
+      "id": "scout",
+      "map": "world",
+      "x": 8,
+      "y": 7,
+      "color": "#afa",
+      "name": "Friendly Scout",
+      "desc": "Offers to join your journey.",
+      "tree": {
+        "start": {
+          "text": "Need a companion?",
+          "choices": [
+            { "label": "(Join me)", "to": "join", "join": { "id": "scout", "name": "Scout", "role": "Guide" } },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "join": { "text": "Let's go.", "choices": [ { "label": "(Leave)", "to": "bye" } ] }
+      }
+    },
+    {
+      "id": "trader",
+      "map": "world",
+      "x": 8,
+      "y": 6,
+      "color": "#caffc6",
+      "name": "Traveling Trader",
+      "desc": "Sells basic goods.",
+      "shop": true,
+      "tree": { "start": { "text": "Trade wares?", "choices": [ { "label": "(Leave)", "to": "bye" } ] } }
+    },
+    {
+      "id": "wanderer",
+      "hidden": true,
+      "map": "world",
+      "x": 4,
+      "y": 7,
+      "color": "#b8ffb6",
+      "name": "Mysterious Wanderer",
+      "desc": "Appears after you linger.",
+      "tree": { "start": { "text": "You finally noticed me.", "choices": [ { "label": "(Leave)", "to": "bye" } ] } },
+      "reveal": { "flag": "visits@world@7,7", "op": ">=", "value": 3 }
+    }
+  ],
+  "events": [
+    {
+      "map": "world",
+      "x": 6,
+      "y": 6,
+      "events": [
+        { "when": "enter", "effect": "toast", "msg": "A warm breeze soothes you." },
+        { "when": "enter", "effect": "modStat", "stat": "CHA", "delta": 1, "duration": 2 }
+      ]
+    }
+  ],
+  "portals": [
+    { "map": "world", "x": 9, "y": 6, "toMap": "world", "toX": 1, "toY": 1 },
+    { "map": "world", "x": 1, "y": 1, "toMap": "world", "toX": 9, "toY": 6 }
+  ],
+  "interiors": [
+    {
+      "id": "cabin",
+      "w": 7,
+      "h": 5,
+      "grid": [
+        [0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 1, 1, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 0],
+        [0, 0, 0, 2, 0, 0, 0]
+      ],
+      "entryX": 3,
+      "entryY": 3
+    }
+  ],
+  "buildings": [ { "x": 5, "y": 5, "interiorId": "cabin" } ]
+}

--- a/test/ack-player.param.test.js
+++ b/test/ack-player.param.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+test('ack-player auto-loads module from URL param', async () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const html = `<!DOCTYPE html><body>
+    <div id="moduleLoader"></div>
+    <input id="modUrl" />
+    <button id="modUrlBtn"></button>
+    <input id="modFile" />
+    <button id="modFileBtn"></button>
+  </body>`;
+  const dom = new JSDOM(html, { url: 'http://localhost/ack-player.html?module=modules/golden.module.json' });
+  const { window } = dom;
+  let started = false;
+  window.openCreator = () => { started = true; };
+  window.applyModule = () => {};
+  global.window = window;
+  global.document = window.document;
+  global.openCreator = window.openCreator;
+  global.applyModule = window.applyModule;
+  global.location = window.location;
+  global.alert = () => {};
+  window.fetch = () => Promise.resolve({ json: () => Promise.resolve({}) });
+  global.fetch = window.fetch;
+  const store = {};
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k) => store[k],
+      setItem: (k, v) => {
+        store[k] = String(v);
+      },
+      removeItem: (k) => {
+        delete store[k];
+      }
+    },
+    configurable: true
+  });
+  global.localStorage = window.localStorage;
+  const scriptPath = path.join(__dirname, '..', 'ack-player.js');
+  window.eval(fs.readFileSync(scriptPath, 'utf8'));
+  await new Promise((r) => setTimeout(r, 10));
+  assert.ok(started, 'openCreator called after auto load');
+});

--- a/test/golden.module.json.test.js
+++ b/test/golden.module.json.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('golden module json exposes core features', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'golden.module.json');
+  const mod = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.ok(mod.quests.some((q) => q.id === 'q_fetch'));
+  assert.ok(mod.npcs.some((n) => n.combat), 'has combat npc');
+  assert.ok(
+    mod.npcs.some((n) => n.id === 'bandit' && n.combat),
+    'has bandit combat NPC'
+  );
+  assert.ok(
+    mod.npcs.some((n) =>
+      Object.values(n.tree || {}).some((s) =>
+        (s.choices || []).some((c) => c.join)
+      )
+    ),
+    'has joinable npc'
+  );
+  assert.ok(
+    mod.npcs.some((n) =>
+      Object.values(n.tree || {}).some((s) =>
+        (s.choices || []).some((c) => c.check)
+      )
+    ),
+    'has stat gated dialog'
+  );
+  assert.ok(mod.interiors.some((i) => i.id === 'cabin'));
+  assert.ok(mod.buildings.some((b) => b.interiorId === 'cabin'));
+  assert.ok(
+    mod.events?.some((e) => (e.events || []).some((ev) => ev.effect === 'toast')),
+    'has toast event'
+  );
+  assert.ok(
+    mod.npcs.some((n) => n.hidden && n.reveal),
+    'has hidden npc reveal'
+  );
+  assert.ok(mod.items.some((i) => i.use?.type === 'heal'), 'has healing item');
+  assert.ok(mod.portals && mod.portals.length > 0, 'has portals');
+});


### PR DESCRIPTION
## Summary
- send JSON modules to ACK player with a `?module=` URL param and auto-load support
- add bandit enemy to Golden module and test combat presence
- cover module auto-load in docs and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a65e114294832899519576f04ffa6b