### PR TITLE
fix: apply editor changes immediately

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -268,6 +268,7 @@
           <div id="dialogPreview" style="margin-top:6px"></div>
           <button class="btn" id="addNPC">Add NPC</button>
           <button class="btn" id="delNPC" style="display:none">Delete NPC</button>
+          <button class="btn" type="button" id="closeNPC">Done</button>
         </div>
       </fieldset>
       <fieldset class="card" id="itemCard" data-pane="items" style="display:none">


### PR DESCRIPTION
## Summary
- apply NPC and building edits instantly while reserving Add for new entries
- insert new NPCs/buildings into the world immediately and continue editing the active object
- add a Done button to exit NPC editing before creating another

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a71ec4983c8328a29f94bf4acac5d0