### PR TITLE
fix: ignore lines header in NanoDialog outputs

### DIFF
--- a/dustland-nano.js
+++ b/dustland-nano.js
@@ -343,7 +343,10 @@ Choices:
     const linePart = parts[0] || '';
     const choicePart = parts[1] || '';
   
-    const lines = linePart.split(/\r?\n/)
+    const rawLines = linePart.split(/\r?\n/).map(s => s.trim());
+    if(rawLines[0]?.toLowerCase() !== 'lines:') return {lines:[], choices:[]};
+    rawLines.shift();
+    const lines = rawLines
       .map(s => _cleanLine(s))
       .filter(Boolean)
       .filter(s => s.length <= 80)

--- a/test/nano.test.js
+++ b/test/nano.test.js
@@ -44,7 +44,11 @@ test('NanoDialog generates lines and choices', async () => {
   await new Promise(r => setTimeout(r, 100));
   const lines = window.NanoDialog.linesFor('npc1', 'start');
   const choices = window.NanoDialog.choicesFor('npc1', 'start');
-  assert.ok(Array.isArray(lines) && lines.length > 0, 'lines generated');
+  assert.deepStrictEqual(lines, [
+    'Rust bites every gear, but we endure.',
+    'Keep your scrap dry.',
+    'Never trade hope for rust.'
+  ]);
   assert.ok(Array.isArray(choices) && choices.length === 2, 'choices generated');
   assert.strictEqual(choices[0].response, 'Got anything rare?');
   assert.strictEqual(choices[1].check.stat, 'INT');


### PR DESCRIPTION
## Summary
- ensure NanoDialog parsing removes leading `Lines:` token
- test that returned dialog lines exclude header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a723bc4fa08328b9140a90c291e3e4