### PR TITLE
fix: space out building and bandit in golden module

### DIFF
--- a/modules/golden.module.json
+++ b/modules/golden.module.json
@@ -89,7 +89,7 @@
     {
       "id": "bandit",
       "map": "world",
-      "x": 7,
+      "x": 9,
       "y": 8,
       "color": "#f66",
       "name": "Sneaky Bandit",
@@ -173,5 +173,5 @@
       "entryY": 3
     }
   ],
-  "buildings": [ { "x": 5, "y": 5, "interiorId": "cabin" } ]
+  "buildings": [ { "x": 2, "y": 1, "interiorId": "cabin", "boarded": false } ]
 }

--- a/test/golden.module.json.test.js
+++ b/test/golden.module.json.test.js
@@ -42,4 +42,22 @@ test('golden module json exposes core features', () => {
   );
   assert.ok(mod.items.some((i) => i.use?.type === 'heal'), 'has healing item');
   assert.ok(mod.portals && mod.portals.length > 0, 'has portals');
+
+  const hut = mod.buildings.find((b) => b.interiorId === 'cabin');
+  assert.strictEqual(hut.boarded, false, 'cabin is enterable');
+  const w = hut.w || 6;
+  const h = hut.h || 5;
+  const overlaps = mod.npcs.some(
+    (n) =>
+      n.map === 'world' &&
+      n.x >= hut.x &&
+      n.x < hut.x + w &&
+      n.y >= hut.y &&
+      n.y < hut.y + h
+  );
+  assert.ok(!overlaps, 'npcs avoid building area');
+
+  const bandit = mod.npcs.find((n) => n.id === 'bandit');
+  const dist = Math.abs(bandit.x - mod.start.x) + Math.abs(bandit.y - mod.start.y);
+  assert.ok(dist > 2, 'bandit is spaced away from start');
 });


### PR DESCRIPTION
## Summary
- move cabin building away from NPC cluster so its door can be reached
- relocate bandit further from starting area
- mark cabin unboarded so players can enter
- add regression tests for building overlap, bandit spacing, and cabin accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a732d303148328a0cdfd21ca95d892