### PR TITLE
feat: add movement bump, touch controls, and spawn checks

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -36,12 +36,13 @@ _______________________________________________________________________________
   Movement .......... WASD / Arrow Keys
   Interact .......... E / Space  (talk, doors, take nearby item)
   Take Item ......... T          (take from your tile or adjacent tiles)
-  Inventory ......... I
+  Inventory ......... I (click items to equip)
   Party ............. P          (radio button selects the acting member)
   Quests ............ Q
   Save / Load ....... G / L      (or UI buttons)
   Minimap ........... M
   Close Dialog ...... Esc
+  Touch Controls .... add ?touch=1 to URL for on-screen buttons
 
 [ KEY MECHANICS ]
   - You cannot stand on NPCs (!) or items; they block movement.

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -36,6 +36,11 @@ let bldgPaint = TILE.BUILDING;
 let bldgPainting = false;
 let bldgGrid = [];
 
+const note=document.createElement('div');
+note.textContent='Note: water (bright blue) is not walkable; spawns cannot go there.';
+note.style.cssText='padding:4px;background:#300;color:#f88;text-align:center;';
+document.body.prepend(note);
+
 function nextId(prefix, arr) {
   let i = 1; while (arr.some(o => o.id === prefix + i)) i++; return prefix + i;
 }
@@ -1552,7 +1557,19 @@ function applyLoadedModule(data) {
   showQuestEditor(false);
 }
 
+function validateSpawns(){
+  const walkable={0:true,1:true,2:false,3:true,4:true,5:true,6:false,7:true,8:true,9:false};
+  const issues=[];
+  const s=moduleData.start;
+  if(!walkable[world[s.y][s.x]]) issues.push('Player start is on blocked tile');
+  moduleData.npcs.filter(n=>n.map==='world').forEach(n=>{ if(!walkable[world[n.y][n.x]]) issues.push('NPC '+(n.id||'')+' on blocked tile'); });
+  moduleData.items.filter(it=>it.map==='world').forEach(it=>{ if(!walkable[world[it.y][it.x]]) issues.push('Item '+it.id+' on blocked tile'); });
+  if(issues.length){ alert('Fix spawn locations:\n'+issues.join('\n')+'\nHint: water tiles are bright blue and block spawns.'); return false; }
+  return true;
+}
+
 function saveModule() {
+  if(!validateSpawns()) return;
   const bldgs = buildings.map(({ under, ...rest }) => rest);
   const data = { ...moduleData, world, buildings: bldgs };
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });

--- a/core/movement.js
+++ b/core/movement.js
@@ -80,6 +80,7 @@ function move(dx,dy){
       player.hp = actor.hp;
     }
     setPartyPos(nx, ny);
+    if(typeof footstepBump==='function') footstepBump();
     onEnter(state.map, nx, ny, { player, party, state, actor, buffs });
     centerCamera(party.x,party.y,state.map); updateHUD();
     checkAggro();
@@ -120,6 +121,7 @@ function takeNearestItem(){
       const def = ITEMS[it.id];
       addToInv(getItem(it.id));
       log('Took '+(def?def.name:it.id)+'.'); updateHUD();
+      if(typeof pickupSparkle==='function') pickupSparkle(party.x+dx,party.y+dy);
       EventBus.emit('sfx','pickup');
       return true;
     }
@@ -136,16 +138,17 @@ function interactAt(x,y){
     EventBus.emit('sfx','confirm');
     return true;
   }
-  if(info.items.length){
-    const it=info.items[0];
-    const idx=itemDrops.indexOf(it);
-    if(idx>-1) itemDrops.splice(idx,1);
-    const def = ITEMS[it.id];
-    addToInv(getItem(it.id));
-    log('Took '+(def?def.name:it.id)+'.'); updateHUD();
-    EventBus.emit('sfx','pickup');
-    return true;
-  }
+    if(info.items.length){
+      const it=info.items[0];
+      const idx=itemDrops.indexOf(it);
+      if(idx>-1) itemDrops.splice(idx,1);
+      const def = ITEMS[it.id];
+      addToInv(getItem(it.id));
+      log('Took '+(def?def.name:it.id)+'.'); updateHUD();
+      if(typeof pickupSparkle==='function') pickupSparkle(x,y);
+      EventBus.emit('sfx','pickup');
+      return true;
+    }
   if(x===party.x && y===party.y && info.tile===TILE.DOOR){
     if(state.map==='world'){
       const b=buildings.find(b=> b.doorX===x && b.doorY===y);

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -96,6 +96,18 @@ sctx.font = '12px ui-monospace';
 
 let camX=0, camY=0, showMini=true;
 let _lastTime=0;
+let bumpX=0, bumpY=0, bumpEnd=0;
+const sparkles=[];
+
+function footstepBump(){
+  bumpX = (Math.random()-0.5)*2;
+  bumpY = (Math.random()-0.5)*2;
+  bumpEnd = performance.now() + 50;
+}
+
+function pickupSparkle(x,y){
+  sparkles.push({x,y});
+}
 
 function draw(t){
   if (disp.width < 16) {
@@ -103,8 +115,10 @@ function draw(t){
   }
   const dt=(t-_lastTime)||0; _lastTime=t;
   render(state, dt/1000);
-  dctx.globalAlpha=0.20; dctx.drawImage(prev, 1, 0);
-  dctx.globalAlpha=0.2; dctx.drawImage(scene, 0, 0);
+  const bx = bumpEnd > performance.now() ? bumpX : 0;
+  const by = bumpEnd > performance.now() ? bumpY : 0;
+  dctx.globalAlpha=0.20; dctx.drawImage(prev, 1 + bx, by);
+  dctx.globalAlpha=0.2; dctx.drawImage(scene, bx, by);
   pctx.clearRect(0,0,prev.width,prev.height); pctx.drawImage(scene,0,0);
   requestAnimationFrame(draw);
 }
@@ -186,20 +200,30 @@ function render(gameState=state, dt){
     else if(layer==='entitiesAbove'){ drawEntities(ctx, above, offX, offY); }
   }
 
+  if(sparkles.length){
+    for(const s of sparkles){
+      const sx = (s.x - camX + offX) * TS;
+      const sy = (s.y - camY + offY) * TS;
+      ctx.fillStyle = 'rgba(255,255,255,0.7)';
+      ctx.fillRect(sx, sy, TS, TS);
+    }
+    sparkles.length = 0;
+  }
+
   // UI border
   ctx.strokeStyle='#2a3b2a';
   ctx.strokeRect(0.5,0.5,VIEW_W*TS-1,VIEW_H*TS-1);
 }
 
 function drawEntities(ctx, list, offX, offY){
-  for(const n of list){
-    if(n.x>=camX&&n.y>=camY&&n.x<camX+VIEW_W&&n.y<camY+VIEW_H){
-      const vx=(n.x-camX+offX)*TS, vy=(n.y-camY+offY)*TS;
-      ctx.fillStyle=n.color; ctx.fillRect(vx,vy,TS,TS);
-      ctx.fillStyle='#000'; ctx.fillText('!',vx+5,vy+12);
+    for(const n of list){
+      if(n.x>=camX&&n.y>=camY&&n.x<camX+VIEW_W&&n.y<camY+VIEW_H){
+        const vx=(n.x-camX+offX)*TS, vy=(n.y-camY+offY)*TS;
+        ctx.fillStyle=n.color; ctx.fillRect(vx,vy,TS,TS);
+        ctx.fillStyle='#000'; ctx.fillText('!',vx+5,vy+12);
+      }
     }
   }
-}
 
 Object.assign(window, { renderOrderSystem: { order: renderOrder, render } });
 
@@ -307,6 +331,7 @@ function renderInv(){
     if(equipBtn) equipBtn.onclick=()=> equipItem(selectedMember, idx);
     const useBtn = row.querySelector('button[data-a="use"]');
     if(useBtn) useBtn.onclick=()=> useItem(idx);
+    row.onclick=e=>{ if(e.target.tagName==='BUTTON') return; if(it.slot) equipItem(selectedMember, idx); };
     inv.appendChild(row);
   });
 }
@@ -325,9 +350,9 @@ function renderQuests(){
     q.appendChild(div);
   });
 }
-function renderParty(){ const p=document.getElementById('party'); p.innerHTML=''; if(party.length===0){ p.innerHTML='<div class="pcard muted">(no party members yet)</div>'; return; } party.forEach((m,i)=>{ const c=document.createElement('div'); c.className='pcard'; const bonus=m._bonus||{}; const fmt=v=> (v>0? '+'+v : v); const wLabel=m.equip.weapon?(m.equip.weapon.cursed&&m.equip.weapon.cursedKnown?m.equip.weapon.name+' (cursed)':m.equip.weapon.name):'—'; const aLabel=m.equip.armor?(m.equip.armor.cursed&&m.equip.armor.cursedKnown?m.equip.armor.name+' (cursed)':m.equip.armor.name):'—'; const tLabel=m.equip.trinket?(m.equip.trinket.cursed&&m.equip.trinket.cursedKnown?m.equip.trinket.name+' (cursed)':m.equip.trinket.name):'—'; c.innerHTML = `<div class='row'><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div><div class='row small'>${statLine(m.stats)}</div><div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div><div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div><div class='row small'>XP ${m.xp}/${xpToNext(m.lvl)}</div><div class='row'><label><input type='radio' name='selMember' ${i===selectedMember?'checked':''}> Selected</label></div>`; c.querySelector('input').onchange=()=>{ selectedMember=i; }; c.querySelectorAll('button[data-a="unequip"]').forEach(b=>{ const sl=b.dataset.slot; b.onclick=()=> unequipItem(i,sl); }); p.appendChild(c); }); }
+function renderParty(){ const p=document.getElementById('party'); p.innerHTML=''; if(party.length===0){ p.innerHTML='<div class="pcard muted">(no party members yet)</div>'; return; } party.forEach((m,i)=>{ const c=document.createElement('div'); c.className='pcard'+(i===selectedMember?' selected':''); const bonus=m._bonus||{}; const fmt=v=> (v>0? '+'+v : v); const wLabel=m.equip.weapon?(m.equip.weapon.cursed&&m.equip.weapon.cursedKnown?m.equip.weapon.name+' (cursed)':m.equip.weapon.name):'—'; const aLabel=m.equip.armor?(m.equip.armor.cursed&&m.equip.armor.cursedKnown?m.equip.armor.name+' (cursed)':m.equip.armor.name):'—'; const tLabel=m.equip.trinket?(m.equip.trinket.cursed&&m.equip.trinket.cursedKnown?m.equip.trinket.name+' (cursed)':m.equip.trinket.name):'—'; c.innerHTML = `<div class='row'><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div><div class='row small'>${statLine(m.stats)}</div><div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div><div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div><div class='row small'>XP ${m.xp}/${xpToNext(m.lvl)}</div><div class='row'><label><input type='radio' name='selMember' ${i===selectedMember?'checked':''}> Selected</label></div>`; c.querySelector('input').onchange=()=>{ selectedMember=i; }; c.querySelectorAll('button[data-a="unequip"]').forEach(b=>{ const sl=b.dataset.slot; b.onclick=()=> unequipItem(i,sl); }); p.appendChild(c); }); }
 
-const engineExports = { log, updateHUD, renderInv, renderQuests, renderParty };
+const engineExports = { log, updateHUD, renderInv, renderQuests, renderParty, footstepBump, pickupSparkle };
 Object.assign(globalThis, engineExports);
 
 // ===== Minimal Unit Tests (#test) =====
@@ -411,6 +436,20 @@ disp.addEventListener('touchstart',e=>{
   interactAt(x,y);
   e.preventDefault();
 });
+
+if(new URLSearchParams(location.search).get('touch')==='1'){
+  const pad=document.createElement('div');
+  pad.style.cssText='position:fixed;bottom:20px;left:20px;display:grid;grid-template-columns:repeat(3,40px);grid-template-rows:repeat(3,40px);gap:6px;z-index:1000;';
+  const mk=(t,fn)=>{ const b=document.createElement('button'); b.textContent=t; b.style.cssText='width:40px;height:40px;'; b.onclick=fn; return b; };
+  const cells=[document.createElement('div'),mk('↑',()=>move(0,-1)),document.createElement('div'),mk('←',()=>move(-1,0)),document.createElement('div'),mk('→',()=>move(1,0)),document.createElement('div'),mk('↓',()=>move(0,1)),document.createElement('div')];
+  cells.forEach(c=>pad.appendChild(c));
+  document.body.appendChild(pad);
+  const ab=document.createElement('div');
+  ab.style.cssText='position:fixed;bottom:20px;right:20px;display:flex;gap:10px;z-index:1000;';
+  ab.appendChild(mk('A',interact));
+  ab.appendChild(mk('B',takeNearestItem));
+  document.body.appendChild(ab);
+}
 
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame

--- a/dustland.css
+++ b/dustland.css
@@ -175,6 +175,9 @@
         background: #0f120f;
         padding: 8px
     }
+    .pcard.selected {
+        box-shadow: 0 0 0 2px #8bd98d;
+    }
 
     .row {
         display: flex;


### PR DESCRIPTION
## Summary
- bump camera and flash items for moment-to-moment juice
- enable click-to-equip and highlight selected party slots
- add mobile touch controls and spawn tile validation in ACK

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73982e9cc8328931e7f708551dd7d