### PR TITLE
feat: toggle door boarding via dialog

### DIFF
--- a/core/effects.js
+++ b/core/effects.js
@@ -21,6 +21,18 @@
               if (typeof revealHiddenNPCs === 'function') revealHiddenNPCs();
             }
             break; }
+          case 'unboardDoor': {
+            if (eff.interiorId && Array.isArray(globalThis.buildings)) {
+              const b = globalThis.buildings.find(b => b.interiorId === eff.interiorId);
+              if (b) b.boarded = false;
+            }
+            break; }
+          case 'boardDoor': {
+            if (eff.interiorId && Array.isArray(globalThis.buildings)) {
+              const b = globalThis.buildings.find(b => b.interiorId === eff.interiorId);
+              if (b) b.boarded = true;
+            }
+            break; }
           case 'modStat': {
             const target = ctx.actor || ctx.player;
             if (target && target.stats && eff.stat) {

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -44,7 +44,10 @@ const OFFICE_MODULE = (() => {
     interiors = {};
     if (creatorMap.grid && creatorMap.grid.length) interiors['creator'] = creatorMap;
     buildings.length = 0;
-    const hut = placeHut(WORLD_MID + 3, WORLD_MIDY - 2, { interiorId: 'castle' });
+    const hut = placeHut(WORLD_MID + 3, WORLD_MIDY - 2, {
+      interiorId: 'castle',
+      boarded: true
+    });
     return { castleId: hut?.interiorId };
   }
 
@@ -359,6 +362,11 @@ const OFFICE_MODULE = (() => {
           choices: [
             { label: '(Ask)', to: 'ask' },
             {
+              label: '(Open Castle)',
+              to: 'unlock',
+              once: true
+            },
+            {
               label: '(Request Boon)',
               to: 'gift',
               if: { flag: 'visited_castle', op: '>=', value: 1 },
@@ -368,6 +376,11 @@ const OFFICE_MODULE = (() => {
             },
             { label: '(Leave)', to: 'bye' }
           ]
+        },
+        unlock: {
+          text: 'He gestures; the castle doors creak open.',
+          effects: [ { effect: 'unboardDoor', interiorId: 'castle' } ],
+          choices: [ { label: '(Thanks)', to: 'bye' } ]
         },
         ask: {
           text: 'He only laughs and vanishes into mist.',
@@ -389,7 +402,15 @@ const OFFICE_MODULE = (() => {
       desc: 'It bares its teeth.',
       portraitSheet: portraits.rat,
       combat: { HP: 3, ATK: 1, DEF: 0, loot: 'rat_tail', auto: true },
-      tree: { start: { text: 'The rat lunges!', choices: [ { label: '(Leave)', to: 'bye' } ] } }
+      tree: {
+        start: {
+          text: 'The rat lunges!',
+          choices: [
+            { label: '(Fight)', to: 'do_fight' },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        }
+      }
     },
     {
       id: 'forest_bandit',
@@ -401,7 +422,15 @@ const OFFICE_MODULE = (() => {
       desc: 'Lurks among the trees.',
       portraitSheet: portraits.bandit,
       combat: { HP: 6, ATK: 2, DEF: 1, loot: 'rusty_dagger', auto: true },
-      tree: { start: { text: 'Your coin or your life!', choices: [ { label: '(Leave)', to: 'bye' } ] } }
+      tree: {
+        start: {
+          text: 'Your coin or your life!',
+          choices: [
+            { label: '(Fight)', to: 'do_fight' },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        }
+      }
     },
     {
       id: 'forest_ogre',
@@ -413,7 +442,15 @@ const OFFICE_MODULE = (() => {
       desc: 'Towering and enraged.',
       portraitSheet: portraits.ogre,
       combat: { HP: 12, ATK: 4, DEF: 2, loot: 'ogre_tooth', auto: true },
-      tree: { start: { text: 'The ogre roars.', choices: [ { label: '(Leave)', to: 'bye' } ] } }
+      tree: {
+        start: {
+          text: 'The ogre roars.',
+          choices: [
+            { label: '(Fight)', to: 'do_fight' },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        }
+      }
     },
     {
       id: 'vending',
@@ -436,7 +473,15 @@ const OFFICE_MODULE = (() => {
       name: 'Rogue Janitor',
       desc: 'Wields a dripping mop.',
       portraitSheet: portraits.janitor,
-      tree: { start: { text: 'He blocks your path.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      tree: {
+        start: {
+          text: 'He blocks your path.',
+          choices: [
+            { label: '(Fight)', to: 'do_fight' },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        }
+      },
       combat: { DEF: 3, loot: 'rusty_mop' }
     }
   ];

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -626,6 +626,14 @@ test('dialog choices can be gated by party flags', () => {
   assert.strictEqual(choicesEl.children.length, 1);
   closeDialog();
 });
+test('board/unboard effects toggle building access', () => {
+  globalThis.buildings = [ { interiorId: 'castle', boarded: true } ];
+  Effects.apply([{ effect: 'unboardDoor', interiorId: 'castle' }]);
+  assert.strictEqual(globalThis.buildings[0].boarded, false);
+  Effects.apply([{ effect: 'boardDoor', interiorId: 'castle' }]);
+  assert.strictEqual(globalThis.buildings[0].boarded, true);
+  globalThis.buildings.length = 0;
+});
 test('onEnter triggers effects and temporary stat mod', () => {
   const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
   applyModule({world});

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('office module boards castle and unboards via dialog', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(
+    src,
+    /placeHut\(WORLD_MID \+ 3, WORLD_MIDY - 2, {\s*\n\s*interiorId: 'castle',\s*\n\s*boarded: true\s*\n\s*}\)/
+  );
+  assert.match(src, /effect: 'unboardDoor',\s*interiorId: 'castle'/);
+  assert.match(src, /label: '\(Fight\)'/);
+});


### PR DESCRIPTION
## Summary
- allow effects to board or unboard doors by interior id
- gate castle entrance behind Fae King dialog option
- cover door boarding effects with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a738e3f7b8832890ebc021933a52f7