### PR TITLE
feat: add settings panel for controls

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -532,6 +532,38 @@
         padding: 12px
     }
 
+    #settings {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, .8);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        z-index: 40
+    }
+
+    #settings .win {
+        width: min(340px, 92vw);
+        background: #0b0d0b;
+        border: 1px solid #2a382a;
+        border-radius: 12px;
+        box-shadow: 0 20px 80px rgba(0, 0, 0, .7);
+        overflow: hidden
+    }
+
+    #settings header {
+        padding: 10px 12px;
+        border-bottom: 1px solid #223022;
+        font-weight: 700
+    }
+
+    #settings main {
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px
+    }
+
     #nanoStatus {
         position: fixed;
         top: 6px;

--- a/dustland.html
+++ b/dustland.html
@@ -42,12 +42,24 @@
           <button class="btn" id="saveBtn">Save</button>
           <button class="btn" id="loadBtn">Load</button>
           <button class="btn" id="resetBtn">Reset</button>
-          <button class="btn" id="nanoToggle">Nano Dialog</button>
-          <button class="btn" id="audioToggle">Audio: On</button>
+          <button class="btn" id="settingsBtn">Settings</button>
         </div>
         </div>
       </aside>
     </div>
+  
+  <!-- Settings Panel -->
+  <div id="settings">
+    <div class="win">
+      <header>Settings</header>
+      <main>
+        <button class="btn" id="nanoToggle">Nano Dialog</button>
+        <button class="btn" id="audioToggle">Audio: On</button>
+        <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
+        <button class="btn" id="settingsClose">Close</button>
+      </main>
+    </div>
+  </div>
 
   <!-- Start Menu -->
   <div id="start">


### PR DESCRIPTION
## Summary
- group Nano, audio, and mobile control toggles into a settings panel
- auto-enable mobile controls based on user agent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76bd6a8808328b4ca1beb9a9b5ef4