### PR TITLE
feat: style mobile controls

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -57,13 +57,31 @@ function setMobileControls(on){
   if(on){
     if(!mobilePad){
       mobilePad=document.createElement('div');
-      mobilePad.style.cssText='position:fixed;bottom:20px;left:20px;display:grid;grid-template-columns:repeat(3,40px);grid-template-rows:repeat(3,40px);gap:6px;z-index:1000;';
-      const mk=(t,fn)=>{ const b=document.createElement('button'); b.textContent=t; b.style.cssText='width:40px;height:40px;'; b.onclick=fn; return b; };
+      mobilePad.style.cssText='position:fixed;bottom:20px;left:20px;display:grid;grid-template-columns:repeat(3,48px);grid-template-rows:repeat(3,48px);gap:6px;z-index:1000;user-select:none;';
+      const mk=(t,fn)=>{
+        const b=document.createElement('button');
+        b.textContent=t;
+        b.style.cssText='width:48px;height:48px;border:2px solid #0f0;border-radius:8px;background:#000;color:#0f0;font-size:20px;user-select:none;outline:none;';
+        b.onclick=fn;
+        b.onpointerdown=()=>{
+          b.style.background='#0f0';
+          b.style.color='#000';
+          b.style.boxShadow='0 0 8px #0f0';
+        };
+        const up=()=>{
+          b.style.background='#000';
+          b.style.color='#0f0';
+          b.style.boxShadow='none';
+        };
+        b.onpointerup=up;
+        b.onpointerleave=up;
+        return b;
+      };
       const cells=[document.createElement('div'),mk("↑",()=>move(0,-1)),document.createElement('div'),mk("←",()=>move(-1,0)),document.createElement('div'),mk("→",()=>move(1,0)),document.createElement('div'),mk("↓",()=>move(0,1)),document.createElement('div')];
       cells.forEach(c=>mobilePad.appendChild(c));
       document.body.appendChild(mobilePad);
       mobileAB=document.createElement('div');
-      mobileAB.style.cssText='position:fixed;bottom:20px;right:20px;display:flex;gap:10px;z-index:1000;';
+      mobileAB.style.cssText='position:fixed;bottom:20px;right:20px;display:flex;gap:10px;z-index:1000;user-select:none;';
       mobileAB.appendChild(mk('A',interact));
       mobileAB.appendChild(mk('B',takeNearestItem));
       document.body.appendChild(mobileAB);

--- a/test/mobile-controls.test.js
+++ b/test/mobile-controls.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+test('mobile buttons are non-selectable and glow on press', async () => {
+  const dom = new JSDOM('<body><canvas id="game" width="640" height="480"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  const dummyCtx = new Proxy({}, { get: () => () => {}, set: () => true });
+  window.HTMLCanvasElement.prototype.getContext = () => dummyCtx;
+  global.requestAnimationFrame = () => 0;
+  class AudioCtx {
+    createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
+    createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){}} }; }
+    get destination(){ return {}; }
+    get currentTime(){ return 0; }
+  }
+  global.AudioContext = AudioCtx;
+  global.webkitAudioContext = AudioCtx;
+  window.AudioContext = AudioCtx;
+  window.webkitAudioContext = AudioCtx;
+  global.Audio = class { constructor(){ this.addEventListener = () => {}; } };
+  global.EventBus = { on: () => {}, emit: () => {} };
+  global.NanoDialog = { enabled: true };
+  global.location = { hash: '' };
+  global.move = () => {};
+  global.interact = () => {};
+  global.takeNearestItem = () => {};
+  const full = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
+  const code = full.split('function sfxTick')[0];
+  vm.runInThisContext(code, { filename: 'dustland-engine.js' });
+  setMobileControls(true);
+  const btn = document.querySelector('button');
+  assert.ok(btn);
+  assert.strictEqual(btn.style.userSelect, 'none');
+  btn.onpointerdown();
+  assert.strictEqual(btn.style.boxShadow, '0 0 8px #0f0');
+  btn.onpointerup();
+  assert.strictEqual(btn.style.boxShadow, 'none');
+});
+


### PR DESCRIPTION
## Summary
- restyle mobile onscreen buttons with green/black theme and glowing press effect
- ensure mobile buttons are non-selectable to avoid text highlighting
- add test covering mobile control styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76e3f117083289dbd2c6b284c89e1