### PR TITLE
feat: improve mobile layout and controls

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -77,12 +77,31 @@ function setMobileControls(on){
         b.onpointerleave=up;
         return b;
       };
-      const cells=[document.createElement('div'),mk("↑",()=>move(0,-1)),document.createElement('div'),mk("←",()=>move(-1,0)),document.createElement('div'),mk("→",()=>move(1,0)),document.createElement('div'),mk("↓",()=>move(0,1)),document.createElement('div')];
+      const mobileMove=(dx,dy,key)=>{
+        if(overlay?.classList?.contains('shown')){
+          handleDialogKey?.({ key });
+        }else{
+          move(dx,dy);
+        }
+      };
+      const cells=[
+        document.createElement('div'),
+        mk("↑",()=>mobileMove(0,-1,'ArrowUp')),
+        document.createElement('div'),
+        mk("←",()=>mobileMove(-1,0,'ArrowLeft')),
+        document.createElement('div'),
+        mk("→",()=>mobileMove(1,0,'ArrowRight')),
+        document.createElement('div'),
+        mk("↓",()=>mobileMove(0,1,'ArrowDown')),
+        document.createElement('div')
+      ];
       cells.forEach(c=>mobilePad.appendChild(c));
       document.body.appendChild(mobilePad);
       mobileAB=document.createElement('div');
       mobileAB.style.cssText='position:fixed;bottom:20px;right:20px;display:flex;gap:10px;z-index:1000;user-select:none;';
-      mobileAB.appendChild(mk('A',interact));
+      mobileAB.appendChild(mk('A',()=>{
+        if(overlay?.classList?.contains('shown')) handleDialogKey?.({ key:'Enter' }); else interact();
+      }));
       mobileAB.appendChild(mk('B',takeNearestItem));
       document.body.appendChild(mobileAB);
     }
@@ -452,6 +471,14 @@ if (document.getElementById('saveBtn')) {
     settingsBtn.onclick=()=>{ settings.style.display='flex'; };
     const closeBtn=document.getElementById('settingsClose');
     if(closeBtn) closeBtn.onclick=()=>{ settings.style.display='none'; };
+  }
+  const panelToggle=document.getElementById('panelToggle');
+  const panel=document.querySelector('.panel');
+  if(panelToggle && panel){
+    panelToggle.onclick=()=>{
+      const open=panel.classList.toggle('show');
+      panelToggle.textContent=open?'×':'☰';
+    };
   }
 
   window.addEventListener('keydown',(e)=>{

--- a/dustland.css
+++ b/dustland.css
@@ -38,7 +38,7 @@
         filter: contrast(1.06) saturate(1.1);
     }
 
-.panel {
+    .panel {
         width: 440px;
         background: #0b0d0b;
         border: 1px solid #2a382a;
@@ -50,6 +50,21 @@
         position: relative;
         z-index: 15;
         image-rendering: pixelated;
+    }
+
+    #panelToggle {
+        position: fixed;
+        top: 50%;
+        right: 0;
+        transform: translateY(-50%);
+        background: #0b0d0b;
+        border: 1px solid #2a382a;
+        border-right: none;
+        border-radius: 8px 0 0 8px;
+        padding: 8px;
+        display: none;
+        z-index: 30;
+        cursor: pointer;
     }
 
     .panel h1 {
@@ -221,6 +236,25 @@
         .tabwrap > #party,
         .tabwrap > #quests {
             display: grid !important;
+        }
+    }
+
+    @media (max-width: 900px) {
+        .panel {
+            position: fixed;
+            top: 0;
+            right: 0;
+            height: 100%;
+            width: 80vw;
+            max-width: 440px;
+            transform: translateX(100%);
+            transition: transform .2s;
+        }
+        .panel.show {
+            transform: translateX(0);
+        }
+        #panelToggle {
+            display: block;
         }
     }
 
@@ -411,6 +445,13 @@
         grid-template-columns: 300px 1fr;
         gap: 12px;
         padding: 12px
+    }
+
+    @media (max-width: 600px) {
+        #creator main {
+            grid-template-columns: 1fr;
+            grid-template-rows: auto auto;
+        }
     }
 
     .pbox {

--- a/dustland.html
+++ b/dustland.html
@@ -47,7 +47,9 @@
         </div>
       </aside>
     </div>
-  
+
+  <div id="panelToggle">☰</div>
+
   <!-- Settings Panel -->
   <div id="settings">
     <div class="win">

--- a/test/mobile-controls.test.js
+++ b/test/mobile-controls.test.js
@@ -4,35 +4,45 @@ import fs from 'node:fs/promises';
 import vm from 'node:vm';
 import { JSDOM } from 'jsdom';
 
+const full = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
+const code = full.split('function sfxTick')[0];
+
+class AudioCtx {
+  createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
+  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
+  get destination(){ return {}; }
+  get currentTime(){ return 0; }
+}
+
+async function setup(html, extras={}){
+  const dom = new JSDOM(html);
+  dom.window.AudioContext = AudioCtx;
+  dom.window.webkitAudioContext = AudioCtx;
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    requestAnimationFrame: () => 0,
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    Audio: class { constructor(){ this.addEventListener = () => {}; } },
+    EventBus: { on: () => {}, emit: () => {} },
+    NanoDialog: { enabled: true },
+    location: { hash: '' },
+    move: () => {},
+    interact: () => {},
+    takeNearestItem: () => {},
+    console,
+    ...extras
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  return { dom, context };
+}
+
 test('mobile buttons are non-selectable and glow on press', async () => {
-  const dom = new JSDOM('<body><canvas id="game" width="640" height="480"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>');
-  global.window = dom.window;
-  global.document = dom.window.document;
-  const dummyCtx = new Proxy({}, { get: () => () => {}, set: () => true });
-  window.HTMLCanvasElement.prototype.getContext = () => dummyCtx;
-  global.requestAnimationFrame = () => 0;
-  class AudioCtx {
-    createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
-    createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){}} }; }
-    get destination(){ return {}; }
-    get currentTime(){ return 0; }
-  }
-  global.AudioContext = AudioCtx;
-  global.webkitAudioContext = AudioCtx;
-  window.AudioContext = AudioCtx;
-  window.webkitAudioContext = AudioCtx;
-  global.Audio = class { constructor(){ this.addEventListener = () => {}; } };
-  global.EventBus = { on: () => {}, emit: () => {} };
-  global.NanoDialog = { enabled: true };
-  global.location = { hash: '' };
-  global.move = () => {};
-  global.interact = () => {};
-  global.takeNearestItem = () => {};
-  const full = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
-  const code = full.split('function sfxTick')[0];
-  vm.runInThisContext(code, { filename: 'dustland-engine.js' });
-  setMobileControls(true);
-  const btn = document.querySelector('button');
+  const { context } = await setup('<body><canvas id="game" width="640" height="480"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>');
+  context.setMobileControls(true);
+  const btn = context.document.querySelector('button');
   assert.ok(btn);
   assert.strictEqual(btn.style.userSelect, 'none');
   btn.onpointerdown();
@@ -41,3 +51,19 @@ test('mobile buttons are non-selectable and glow on press', async () => {
   assert.strictEqual(btn.style.boxShadow, 'none');
 });
 
+test('mobile arrows navigate dialog when overlay shown', async () => {
+  const keys=[];
+  const html = '<body><div id="overlay" class="shown"></div><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>';
+  const { dom, context } = await setup(html, {
+    handleDialogKey: e => { keys.push(e.key); return true; },
+    move: () => { keys.push('move'); },
+    overlay: null
+  });
+  context.overlay = dom.window.document.getElementById('overlay');
+  context.setMobileControls(true);
+  const up = [...context.document.querySelectorAll('button')].find(b => b.textContent === '↑');
+  up.onclick();
+  const down = [...context.document.querySelectorAll('button')].find(b => b.textContent === '↓');
+  down.onclick();
+  assert.deepStrictEqual(keys, ['ArrowUp', 'ArrowDown']);
+});

--- a/test/panel-toggle.test.js
+++ b/test/panel-toggle.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const full = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
+const code = full.split('// ===== Boot =====')[0];
+
+class AudioCtx {
+  createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
+  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
+  get destination(){ return {}; }
+  get currentTime(){ return 0; }
+}
+
+test('panel toggle shows and hides panel', async () => {
+  const html = `<body><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div><canvas id="game"></canvas><div class="panel"></div><div id="panelToggle"></div><button id="saveBtn"></button><button id="loadBtn"></button><button id="resetBtn"></button><button id="settingsBtn"></button><div id="settings"><button id="settingsClose"></button></div></body>`;
+  const dom = new JSDOM(html);
+  dom.window.AudioContext = AudioCtx;
+  dom.window.webkitAudioContext = AudioCtx;
+  const dummyCtx = new Proxy({}, { get: () => () => {}, set: () => true });
+  dom.window.HTMLCanvasElement.prototype.getContext = () => dummyCtx;
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    requestAnimationFrame: () => 0,
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    Audio: class { constructor(){ this.addEventListener = () => {}; } },
+    EventBus: { on: () => {}, emit: () => {} },
+    NanoDialog: { enabled: true },
+    location: { hash: '' },
+    move: () => {},
+    interact: () => {},
+    takeNearestItem: () => {},
+    save: () => {},
+    load: () => {},
+    resetAll: () => {},
+    console
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  const toggle = context.document.getElementById('panelToggle');
+  const panel = context.document.querySelector('.panel');
+  toggle.click();
+  assert.ok(panel.classList.contains('show'));
+  toggle.click();
+  assert.ok(!panel.classList.contains('show'));
+});


### PR DESCRIPTION
## Summary
- let mobile D-pad navigate dialogs and confirm choices
- reflow character creator vertically on small screens
- slide-in side panel with a floating toggle on narrow viewports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a77f2f75cc8328b3c10fc33e26cc64