### PR TITLE
feat: add splash title and dust background

### DIFF
--- a/module-picker.js
+++ b/module-picker.js
@@ -1,3 +1,5 @@
+// Splash screen allowing the player to pick a module.
+// Displays a pulsing title and drifting dust background.
 const MODULES = [
   { id: 'dustland', name: 'Dustland', file: 'modules/dustland.module.js' },
   { id: 'echoes', name: 'Echoes', file: 'modules/echoes.module.js' },
@@ -9,6 +11,39 @@ const realOpenCreator = window.openCreator;
 const realShowStart = window.showStart;
 window.openCreator = () => {};
 window.showStart = () => {};
+
+function startDust(canvas){
+  const ctx = canvas.getContext('2d');
+  const particles = [];
+  function resize(){
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+  resize();
+  window.addEventListener('resize', resize);
+  for(let i=0;i<60;i++){
+    particles.push({
+      x: Math.random()*canvas.width,
+      y: Math.random()*canvas.height,
+      size: Math.random()*2+1,
+      speed: Math.random()*0.5+0.2
+    });
+  }
+  function update(){
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    ctx.fillStyle = 'rgba(255,255,255,.4)';
+    particles.forEach(p => {
+      ctx.fillRect(p.x,p.y,p.size,p.size);
+      p.x -= p.speed;
+      if(p.x < -p.size){
+        p.x = canvas.width + p.size;
+        p.y = Math.random()*canvas.height;
+      }
+    });
+    requestAnimationFrame(update);
+  }
+  update();
+}
 
 function loadModule(moduleInfo){
   const existingScript = document.getElementById('activeModuleScript');
@@ -38,8 +73,28 @@ function loadModule(moduleInfo){
 function showModulePicker(){
   const overlay = document.createElement('div');
   overlay.id = 'modulePicker';
-  overlay.style = 'position:fixed;inset:0;background:rgba(0,0,0,.8);display:flex;align-items:center;justify-content:center;z-index:40';
-  overlay.innerHTML = `<div class="win" style="width:min(420px,92vw);background:#0b0d0b;border:1px solid #2a382a;border-radius:12px;box-shadow:0 20px 80px rgba(0,0,0,.7);overflow:hidden"><header style="padding:10px 12px;border-bottom:1px solid #223022;font-weight:700">Select Module</header><main style="padding:12px" id="moduleButtons"></main></div>`;
+  overlay.style = 'position:fixed;inset:0;background:#000;display:flex;flex-direction:column;align-items:center;justify-content:center;overflow:hidden;z-index:40';
+  const styleTag = document.createElement('style');
+  styleTag.textContent = '@keyframes pulse{0%,100%{opacity:.8}50%{opacity:1}}';
+  document.head.appendChild(styleTag);
+
+  const canvas = document.createElement('canvas');
+  canvas.id = 'dustParticles';
+  canvas.style = 'position:absolute;inset:0;width:100%;height:100%;pointer-events:none';
+  overlay.appendChild(canvas);
+  startDust(canvas);
+
+  const title = document.createElement('div');
+  title.id = 'gameTitle';
+  title.textContent = 'Dustland CRT';
+  title.style = 'color:#0f0;text-shadow:0 0 10px #0f0;font-size:32px;margin-bottom:20px;animation:pulse 2s infinite';
+  overlay.appendChild(title);
+
+  const win = document.createElement('div');
+  win.className = 'win';
+  win.style = 'width:min(420px,92vw);background:#0b0d0b;border:1px solid #2a382a;border-radius:12px;box-shadow:0 20px 80px rgba(0,0,0,.7);overflow:hidden';
+  win.innerHTML = '<header style="padding:10px 12px;border-bottom:1px solid #223022;font-weight:700">Select Module</header><main style="padding:12px" id="moduleButtons"></main>';
+  overlay.appendChild(win);
   document.body.appendChild(overlay);
   const buttonContainer = overlay.querySelector('#moduleButtons');
   MODULES.forEach(moduleInfo => {

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -1,0 +1,54 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function stubEl(){
+  const el = {
+    id: '',
+    style: {},
+    children: [],
+    textContent: '',
+    className: '',
+    appendChild(child){ this.children.push(child); child.parentElement = this; },
+    querySelector: () => stubEl(),
+    querySelectorAll: () => [],
+    getContext: () => ({ clearRect(){}, fillRect(){}, fillStyle:'', })
+  };
+  return el;
+}
+
+global.requestAnimationFrame = () => {};
+Object.assign(global, {
+  window: global,
+  innerWidth: 800,
+  innerHeight: 600,
+  addEventListener(){},
+  localStorage: { getItem: () => null }
+});
+
+const bodyEl = stubEl();
+const headEl = stubEl();
+
+global.document = {
+  body: bodyEl,
+  head: headEl,
+  createElement: () => stubEl(),
+  getElementById: () => null
+};
+
+global.openCreator = () => {};
+global.showStart = () => {};
+
+const code = await fs.readFile(new URL('../module-picker.js', import.meta.url), 'utf8');
+vm.runInThisContext(code, { filename: '../module-picker.js' });
+
+test('module picker shows title and dust background', () => {
+  const overlay = bodyEl.children.find(c => c.id === 'modulePicker');
+  assert.ok(overlay);
+  const title = overlay.children.find(c => c.id === 'gameTitle');
+  assert.ok(title);
+  assert.strictEqual(title.textContent, 'Dustland CRT');
+  const canvas = overlay.children.find(c => c.id === 'dustParticles');
+  assert.ok(canvas);
+});


### PR DESCRIPTION
## Summary
- add pulsing green "Dustland CRT" title to module picker
- render drifting dust particle animation behind module menu
- cover module picker splash screen with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7803fb31c8328800496cc9289b25f