### PR TITLE
feat: add swirling dust particles

### DIFF
--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import vm from 'node:vm';
 
 function stubEl(){
+  const ctx = { clearRect(){}, fillRect(){ ctx.count++; }, fillStyle:'', count:0 };
   const el = {
     id: '',
     style: {},
@@ -13,7 +14,8 @@ function stubEl(){
     appendChild(child){ this.children.push(child); child.parentElement = this; },
     querySelector: () => stubEl(),
     querySelectorAll: () => [],
-    getContext: () => ({ clearRect(){}, fillRect(){}, fillStyle:'', })
+    ctx,
+    getContext: () => ctx
   };
   return el;
 }
@@ -51,4 +53,5 @@ test('module picker shows title and dust background', () => {
   assert.strictEqual(title.textContent, 'Dustland CRT');
   const canvas = overlay.children.find(c => c.id === 'dustParticles');
   assert.ok(canvas);
+  assert.ok(canvas.ctx.count > 0);
 });


### PR DESCRIPTION
## Summary
- add vortex-based swirling dust animation on module picker splash screen
- test that dust particles render on splash screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78c72f7148328a3f795d63449a07a