### PR TITLE
feat: add particle lifetime and edge respawn

### DIFF
--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -55,3 +55,14 @@ test('module picker shows title and dust background', () => {
   assert.ok(canvas);
   assert.ok(canvas.ctx.count > 0);
 });
+
+test('particles respawn at edges after aging', () => {
+  const canvas = stubEl();
+  const dust = startDust(canvas);
+  dust.particles.forEach(p => p.life = 1);
+  dust.update();
+  const allAtEdges = dust.particles.every(p => p.x === 0 || p.x === canvas.width || p.y === 0 || p.y === canvas.height);
+  assert.ok(allAtEdges);
+  const moving = dust.particles.some(p => p.vx !== 0 || p.vy !== 0);
+  assert.ok(moving);
+});


### PR DESCRIPTION
## Summary
- add particle lifespan system that respawns dust from random screen edges with random velocity
- expose dust state for tests
- test dust particles respawn after aging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78e567d088328a68d48469bce410f