### PR TITLE
fix: prevent double quest XP

### DIFF
--- a/core/quests.js
+++ b/core/quests.js
@@ -13,7 +13,6 @@ class Quest {
       renderQuests();
       log('Quest completed: ' + this.title);
       if (typeof toast === 'function') toast(`QUEST COMPLETE: ${this.title}`);
-      party.forEach(p => awardXP(p, 5));
       queueNanoDialogForNPCs?.('start', 'quest update');
     }
   }
@@ -65,7 +64,8 @@ function defaultQuestProcessor(npc, nodeId) {
           const rewardIt = resolveItem(meta.reward);
           if (rewardIt) addToInv(rewardIt);
         }
-        if (meta.xp) { awardXP(leader(), meta.xp); }
+        const xp = meta.xp ?? 5;
+        party.forEach(p => awardXP(p, xp));
         if (meta.moveTo) { npc.x = meta.moveTo.x; npc.y = meta.moveTo.y; }
       } else {
         const def = ITEMS[meta.item];

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -487,6 +487,18 @@ test('quest turn-in grants reward item', () => {
   assert.ok(player.inv.some(it => it.id === 'cursed_vr_helmet'));
 });
 
+test('quest turn-in awards XP once', () => {
+  for (const k in quests) delete quests[k];
+  NPCS.length = 0;
+  party.length = 0;
+  const char = new Character('g', 'Gil', 'Role');
+  party.addMember(char);
+  const quest = new Quest('q_xp', 'Quest', '', { xp: 4 });
+  const npc = { quest };
+  defaultQuestProcessor(npc, 'do_turnin');
+  assert.strictEqual(char.xp, 4);
+});
+
 test('turn-in choice hidden until quest accepted', () => {
   player.inv.length = 0;
   NPCS.length = 0;


### PR DESCRIPTION
## Summary
- avoid granting baseline quest XP twice
- test quest XP to ensure single award

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a791433220832880648683fe889024