### PR TITLE
Prefill random character names and enlarge mobile menu button

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -545,6 +545,17 @@ const quirks={
 };
 const hiddenOrigins={ 'Rustborn':{desc:'You survived a machine womb. +1 PER, weird dialog tags.'} };
 
+// Pool of placeholder names to auto-fill the creator
+const randomNames=['Ash','Rex','Nova','Jax','Mara','Zed','Iris','Knox','Luna','Kai'];
+function randomName(){
+  const used=new Set(built.map(m=>m.name));
+  const avail=randomNames.filter(n=>!used.has(n));
+  return avail.length? avail[Math.floor(Math.random()*avail.length)] : 'Drifter '+(built.length+1);
+}
+function newBuilding(){
+  return { id:'pc'+(built.length+1), name:randomName(), role:'Wanderer', stats:baseStats(), quirk:null, spec:null, origin:null };
+}
+
 let step=1; let building=null; let built=[];
 function openCreator(){
   if(!creatorMap.grid || creatorMap.grid.length===0) genCreatorMap();
@@ -552,7 +563,7 @@ function openCreator(){
   setMap('creator','Creator');
   creator.style.display='flex';
   step=1;
-  building={ id:'pc'+(built.length+1), name:'', role:'Wanderer', stats:baseStats(), quirk:null, spec:null, origin:null };
+  building=newBuilding();
   renderStep();
 }
 function closeCreator(){ creator.style.display='none'; }
@@ -619,7 +630,7 @@ if (ccNext) ccNext.onclick=()=>{
       closeCreator();
       startGame();
     } else {
-      building={ id:'pc'+(built.length+1), name:'', role:'Wanderer', stats:baseStats(), quirk:null, spec:null, origin:null };
+      building=newBuilding();
       step=1;
       renderStep();
       log('Member added. You can add up to '+(3-built.length)+' more, or press Start Now.');

--- a/dustland.css
+++ b/dustland.css
@@ -255,6 +255,8 @@
         }
         #panelToggle {
             display: block;
+            padding: 12px;
+            font-size: 24px;
         }
     }
 

--- a/test/character-names.test.js
+++ b/test/character-names.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const code = await fs.readFile(new URL('../dustland-core.js', import.meta.url), 'utf8');
+
+function setup(){
+  const html = `<body><div id="mapname"></div><div id="creator"></div><div id="ccStep"></div><div id="ccRight"></div><div id="ccHint"></div><button id="ccBack"></button><button id="ccNext"></button><div id="ccPortrait"></div><button id="ccStart"></button><button id="ccLoad"></button></body>`;
+  const dom = new JSDOM(html);
+  const party=[]; party.flags={}; party.map='world'; party.x=0; party.y=0;
+  const context={
+    window:dom.window,
+    document:dom.window.document,
+    EventBus:{ on:()=>{}, emit:()=>{} },
+    baseStats:()=>({STR:4,AGI:4,INT:4,PER:4,LCK:4,CHA:4}),
+    makeMember:(id,name,role)=>({id,name,role,stats:{}}),
+    addPartyMember:m=>{ party.push(m); },
+    addToInv:()=>{},
+    rand:()=>0,
+    log:()=>{},
+    party,
+    Math:Object.assign(Object.create(Math),{random:()=>0})
+  };
+  vm.createContext(context);
+  vm.runInContext(code,context);
+  return {context,dom};
+}
+
+test('random names prefill and stay unique',()=>{
+  const {context,dom}=setup();
+  const names=[];
+  const val=()=>dom.window.document.getElementById('nm').value;
+  context.openCreator();
+  names.push(val());
+  assert.ok(names[0]);
+  context.finalizeCurrentMember();
+  context.openCreator();
+  names.push(val());
+  context.finalizeCurrentMember();
+  context.openCreator();
+  names.push(val());
+  assert.strictEqual(new Set(names).size,names.length);
+});


### PR DESCRIPTION
## Summary
- Auto-fill character creator with random, unique placeholder names for rapid party setup
- Increase mobile menu toggle size for easier tapping
- Add tests covering random name generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a79ae540248328b6f6a647737ab97c