### PR TITLE
fix: enable combat when choosing fight in dialog

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -109,6 +109,10 @@ function advanceDialog(stateObj, choiceIdx){
   const choice=node.next[choiceIdx];
   if(!choice){ stateObj.node=null; return {next:null, text:null, close:true, success:false}; }
 
+  if(currentNPC?.processChoice?.(choice)){
+    return {next:null, text:null, close:false, success:true};
+  }
+
   runEffects(choice.checks);
 
   const res={next:null, text:null, close:false, success:true};
@@ -241,6 +245,8 @@ function closeDialog(){
 
 function renderDialog(){
   if(!dialogState.tree) return;
+  currentNPC?.processNode?.(dialogState.node);
+  if(!dialogState.tree || !dialogState.node) return;
   const node=dialogState.tree[dialogState.node];
   if(!node){ closeDialog(); return; }
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -584,6 +584,20 @@ test('makeNPC normalizes existing fight choices', () => {
   assert.strictEqual(fights[0].q, 'turnin');
 });
 
+test('fight choice triggers combat', () => {
+  NPCS.length = 0;
+  const orig = Actions.startCombat;
+  let triggered = false;
+  Actions.startCombat = () => { triggered = true; };
+  const npc = makeNPC('rival', 'world', 0, 0, '#fff', 'Rival', '', '', null, null, null, null, { combat: { DEF: 1 } });
+  NPCS.push(npc);
+  openDialog(npc);
+  const fightBtn = choicesEl.children.find(c => c.textContent === '(Fight)');
+  fightBtn.onclick();
+  assert.ok(triggered);
+  Actions.startCombat = orig;
+});
+
 test('leave choice is rendered last', () => {
   NPCS.length = 0;
   const tree = { start: { text: '', choices: [ { label: 'Leave', to: 'bye' }, { label: 'Talk', to: 'talk' } ] }, talk: { text: '', choices: [] }, bye: { text: '', choices: [] } };


### PR DESCRIPTION
## Summary
- ensure dialog choices call NPC hooks so `(Fight)` triggers combat
- call NPC processNode before rendering so nodes like `do_fight` start combat
- add test to verify fight choice starts combat

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a79c60fcc48328a016a18c9ad15d94