### PR TITLE
feat: add noisy terrain painting

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -21,6 +21,7 @@ _______________________________________________________________________________
   module player so you can craft and try your own wasteland tales. It’s
   still built to be easy to run and easy to hack. Tiny inline SFX add a bit of
   snap without requiring extra assets.
+  The terrain editor lets you paint features with organic noise.
 
 [ HOW TO RUN ]
   - Play the latest build in your browser:

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -192,9 +192,16 @@
 <body>
   <canvas id="game" width="0" height="0" class="glow" aria-label="Dustland CRT"></canvas>
   <div class="ak-layout">
-    <section class="card map-card" id="mapCard">
-      <canvas id="map" width="640" height="480" aria-label="Map preview"></canvas>
-      <div class="controls">
+      <section class="card map-card" id="mapCard">
+        <canvas id="map" width="640" height="480" aria-label="Map preview"></canvas>
+        <div id="worldPalette" style="margin-top:4px">
+          <button type="button" data-tile="0" style="background:#1e271d"></button>
+          <button type="button" data-tile="1" style="background:#2c342c"></button>
+          <button type="button" data-tile="2" style="background:#1573ff"></button>
+          <button type="button" data-tile="3" style="background:#203320"></button>
+          <button type="button" data-tile="5" style="background:#304326"></button>
+        </div>
+        <div class="controls">
         <button class="btn" id="regen">Generate World</button>
         <button class="btn btn--primary" id="save">Download Module</button>
         <button class="btn" id="load">Load Module</button>


### PR DESCRIPTION
## Summary
- add world palette to terrain editor and paint with organic noise
- note terrain painting in docs
- test noisy feature painting
- avoid painting while dragging existing objects
- test building drag doesn't paint
- allow object clicks while paint palette active
- test clicking building still opens editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b4d510f8832898659b4cdcb08220