### PR TITLE
fix: await movement delay in tests

### DIFF
--- a/core/movement.js
+++ b/core/movement.js
@@ -147,21 +147,23 @@ function move(dx,dy){
   if(canWalk(nx,ny)){
     const actor = typeof leader==='function'? leader(): null;
     moveDelay = calcMoveDelay(getTile(state.map, party.x, party.y), actor);
-    // Schedule the move logic to run after the delay
-    setTimeout(() => {
-      Effects.tick({buffs});
-      if(actor){
-        actor.hp = Math.min(actor.hp + 1, actor.maxHp);
-        player.hp = actor.hp;
-      }
-      setPartyPos(nx, ny);
-      if(typeof footstepBump==='function') footstepBump();
-      onEnter(state.map, nx, ny, { player, party, state, actor, buffs });
-      centerCamera(party.x,party.y,state.map); updateHUD();
-      checkAggro();
-      EventBus.emit('sfx','step');
-      moveDelay = 0;
-    }, moveDelay);
+    return new Promise(resolve => {
+      setTimeout(() => {
+        Effects.tick({buffs});
+        if(actor){
+          actor.hp = Math.min(actor.hp + 1, actor.maxHp);
+          player.hp = actor.hp;
+        }
+        setPartyPos(nx, ny);
+        if(typeof footstepBump==='function') footstepBump();
+        onEnter(state.map, nx, ny, { player, party, state, actor, buffs });
+        centerCamera(party.x,party.y,state.map); updateHUD();
+        checkAggro();
+        EventBus.emit('sfx','step');
+        moveDelay = 0;
+        resolve();
+      }, moveDelay);
+    });
   } else {
     EventBus.emit('sfx','denied');
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -242,7 +242,7 @@ test('pathfinding blocks on NPCs', () => {
   assert.strictEqual(party.x,0);
 });
 
-test('walking regenerates leader HP', () => {
+test('walking regenerates leader HP', async () => {
   const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
   applyModule({world});
   state.map='world';
@@ -252,21 +252,21 @@ test('walking regenerates leader HP', () => {
   party.addMember(hero);
   party.x = 0; party.y = 0;
 
-  move(1,0);
+  await move(1,0);
   assert.strictEqual(hero.hp, 6);
   assert.strictEqual(player.hp, 6);
 
   hero.hp = 9; player.hp = 9;
-  move(1,0);
+  await move(1,0);
   assert.strictEqual(hero.hp, 10);
   assert.strictEqual(player.hp, 10);
 
-  move(1,0);
+  await move(1,0);
   assert.strictEqual(hero.hp, 10);
   assert.strictEqual(player.hp, 10);
 });
 
-test('movement delay improves with agility and equipment', () => {
+test('movement delay improves with agility and equipment', async () => {
   const world = Array.from({ length:5 }, () => Array.from({ length:5 }, () => 7));
   applyModule({ world });
   state.map = 'world';
@@ -277,17 +277,19 @@ test('movement delay improves with agility and equipment', () => {
   party.addMember(hero);
   party.x = 0; party.y = 0;
 
-  move(1,0);
+  const firstMove = move(1,0);
   const baseDelay = getMoveDelay();
+  await firstMove;
 
   addToInv({ id:'agi_charm', name:'AGI Charm', type:'trinket', slot:'trinket', mods:{ AGI:2 } });
   equipItem(0,0);
 
-  move(1,0);
+  const secondMove = move(1,0);
   const boostedDelay = getMoveDelay();
   assert.ok(boostedDelay < baseDelay);
   const expected = calcMoveDelay(getTile(state.map, party.x, party.y), hero);
   assert.strictEqual(boostedDelay, expected);
+  await secondMove;
 });
 
 test('queryTile reports entities and items', () => {
@@ -685,7 +687,7 @@ test('board/unboard effects toggle building access', () => {
   assert.strictEqual(globalThis.buildings[0].boarded, true);
   globalThis.buildings.length = 0;
 });
-test('onEnter triggers effects and temporary stat mod', () => {
+test('onEnter triggers effects and temporary stat mod', async () => {
   const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
   applyModule({world});
   state.map='world';
@@ -696,13 +698,13 @@ test('onEnter triggers effects and temporary stat mod', () => {
   registerTileEvents([{map:'world', x:1, y:0, events:[{when:'enter', effect:'toast', msg:'You smell rot.'},{when:'enter', effect:'modStat', stat:'CHA', delta:-1, duration:2}]}]);
   const msgs=[];
   global.toast = (m)=>msgs.push(m);
-  move(1,0);
+  await move(1,0);
   assert.strictEqual(party.x,1);
   assert.ok(msgs.includes('You smell rot.'));
   assert.strictEqual(party[0].stats.CHA,3);
-  move(1,0);
+  await move(1,0);
   assert.strictEqual(party[0].stats.CHA,3);
-  move(1,0);
+  await move(1,0);
   assert.strictEqual(party[0].stats.CHA,4);
   assert.strictEqual(buffs.length,0);
 });


### PR DESCRIPTION
## Summary
- return a promise from move so callers can await movement completion
- await move in tests instead of manual timers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8771d39588328bd455697e6318846