### PR TITLE
fix: restore building tiles after painting

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1443,6 +1443,20 @@ function moveBuilding(b, x, y) {
   return nb;
 }
 
+function redrawBuildings() {
+  moduleData.buildings.forEach(b => {
+    const grid = b.grid || Array.from({ length: b.h }, () => Array.from({ length: b.w }, () => TILE.BUILDING));
+    for (let yy = 0; yy < b.h; yy++) {
+      for (let xx = 0; xx < b.w; xx++) {
+        const t = grid[yy][xx];
+        if (t === TILE.DOOR || t === TILE.BUILDING) {
+          setTile('world', b.x + xx, b.y + yy, t);
+        }
+      }
+    }
+  });
+}
+
 // Update the currently edited building when fields or tiles change
 function applyBldgChanges() {
   if (editBldgIdx < 0) return;
@@ -1927,13 +1941,21 @@ canvas.addEventListener('mouseup', () => {
   worldPainting = false;
   if (dragTarget) delete dragTarget._type;
   dragTarget = null;
+  if (didPaint) {
+    redrawBuildings();
+    drawWorld();
+  }
   updateCursor();
 });
 canvas.addEventListener('mouseleave', () => {
+  if (didPaint) {
+    redrawBuildings();
+  }
   worldPainting = false;
   if (dragTarget) delete dragTarget._type;
   dragTarget = null;
   hoverTile = null;
+  didPaint = false;
   drawWorld();
   updateCursor();
 });

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -128,3 +128,31 @@ test('clicking building while paint palette active still edits', () => {
   globalThis.editBldg = orig;
   assert.strictEqual(edited, true);
 });
+
+test('painting then leaving map keeps next click', () => {
+  genWorld(1);
+  moduleData.buildings = [{ x:5, y:5, w:1, h:1 }];
+  setTile('world',5,5,TILE.BUILDING);
+  worldPaint = TILE.ROCK;
+  canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0 });
+  canvasEl._listeners.mouseleave[0]({});
+  let edited = false;
+  const orig = globalThis.editBldg;
+  globalThis.editBldg = () => { edited = true; };
+  canvasEl._listeners.mousedown[0]({ clientX:5, clientY:5 });
+  canvasEl._listeners.mouseup[0]({});
+  canvasEl._listeners.click[0]({ clientX:5, clientY:5 });
+  globalThis.editBldg = orig;
+  assert.strictEqual(edited, true);
+});
+
+test('painting over building restores tiles', () => {
+  genWorld(1);
+  moduleData.buildings = [{ x:5, y:5, w:1, h:1 }];
+  setTile('world',5,5,TILE.BUILDING);
+  worldPaint = TILE.ROCK;
+  canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0 });
+  canvasEl._listeners.mousemove[0]({ clientX:5, clientY:5 });
+  canvasEl._listeners.mouseup[0]({});
+  assert.strictEqual(world[5][5], TILE.BUILDING);
+});


### PR DESCRIPTION
## Summary
- redraw building tiles when painting ends to keep buildings visible
- add regression test covering painting over a building

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87bbda1ec832889c65296a5e0f4b5