### PR TITLE
feat: extend portrait range and add npc picker

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -236,6 +236,12 @@
           <label>Map<input id="npcMap" value="world" /></label>
           <label>X<input id="npcX" type="number" min="0" /></label>
           <label>Y<input id="npcY" type="number" min="0" /></label>
+          <div class="portrait" id="npcPort"></div>
+          <div class="row" style="margin:8px 0">
+            <span class="pill" id="npcPrevP">&lt;</span>
+            <span class="pill">Portrait</span>
+            <span class="pill" id="npcNextP">&gt;</span>
+          </div>
           <label><input type="checkbox" id="npcHidden"> Hidden NPC</label>
           <div id="revealOpts" style="display:none">
             <label>Flag Type<select id="npcFlagType"><option value="visits">Visited Tile</option><option value="party">Party Flag</option></select></label>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -732,6 +732,13 @@ function toggleQuestTextWrap() {
 }
 
 // --- NPCs ---
+const npcPortraits = [null, ...Array.from({ length: 90 }, (_, i) => `assets/portraits/portrait_${1000 + i}.png`)];
+let npcPortraitIndex = 0;
+function setNpcPortrait() {
+  const el = document.getElementById('npcPort');
+  const img = npcPortraits[npcPortraitIndex];
+  if (el) el.style.backgroundImage = img ? `url(${img})` : '';
+}
 function applyCombatTree(tree) {
   tree.start = tree.start || { text: '', choices: [] };
   if (!tree.start.choices.some(c => c.to === 'do_fight'))
@@ -808,6 +815,8 @@ function startNewNPC() {
   document.getElementById('npcMap').value = 'world';
   document.getElementById('npcX').value = 0;
   document.getElementById('npcY').value = 0;
+  npcPortraitIndex = 0;
+  setNpcPortrait();
   document.getElementById('npcHidden').checked = false;
   document.getElementById('npcFlagType').value = 'visits';
   document.getElementById('npcFlagMap').value = 'world';
@@ -883,6 +892,7 @@ function collectNPCFromForm() {
   if (combat) npc.combat = { DEF: 5 };
   if (shop) npc.shop = true;
   if (hidden && flag) npc.hidden = true, npc.reveal = { flag, op, value: val };
+  if (npcPortraitIndex > 0) npc.portraitSheet = npcPortraits[npcPortraitIndex];
   return npc;
 }
 
@@ -917,6 +927,9 @@ function editNPC(i) {
   document.getElementById('npcMap').value = n.map;
   document.getElementById('npcX').value = n.x;
   document.getElementById('npcY').value = n.y;
+  npcPortraitIndex = npcPortraits.indexOf(n.portraitSheet);
+  if (npcPortraitIndex < 0) npcPortraitIndex = 0;
+  setNpcPortrait();
   document.getElementById('npcHidden').checked = !!n.hidden;
   if (n.reveal?.flag?.startsWith('visits@')) {
     document.getElementById('npcFlagType').value = 'visits';
@@ -1677,6 +1690,16 @@ document.getElementById('addPortal').onclick = addPortal;
 document.getElementById('newPortal').onclick = startNewPortal;
 document.getElementById('delNPC').onclick = deleteNPC;
 document.getElementById('closeNPC').onclick = closeNPCEditor;
+document.getElementById('npcPrevP').onclick = () => {
+  npcPortraitIndex = (npcPortraitIndex + npcPortraits.length - 1) % npcPortraits.length;
+  setNpcPortrait();
+  applyNPCChanges();
+};
+document.getElementById('npcNextP').onclick = () => {
+  npcPortraitIndex = (npcPortraitIndex + 1) % npcPortraits.length;
+  setNpcPortrait();
+  applyNPCChanges();
+};
 document.getElementById('delItem').onclick = deleteItem;
 document.getElementById('delBldg').onclick = deleteBldg;
 document.getElementById('newInterior').onclick = startNewInterior;

--- a/core/party.js
+++ b/core/party.js
@@ -4,6 +4,7 @@ class Character {
   constructor(id, name, role, opts={}){
     this.id=id; this.name=name; this.role=role;
     this.permanent=!!opts.permanent;
+    this.portraitSheet = opts.portraitSheet || null;
     this.lvl=1; this.xp=0;
     this.stats=baseStats();
     this.equip={weapon:null, armor:null, trinket:null};

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -531,7 +531,19 @@ const ccPortrait=document.getElementById('ccPortrait');
 const ccStart=document.getElementById('ccStart');
 const ccLoad=document.getElementById('ccLoad');
 if(ccNext) ccNext.classList.add('btn--primary');
-const portraits=['@','&','#','%','*']; let portraitIndex=0;
+// Pre-generated character portraits available for player selection
+const portraits = Array.from({ length: 90 }, (_, i) => `assets/portraits/portrait_${1000 + i}.png`);
+let portraitIndex = 0;
+function setCreatorPortrait(){
+  const img = portraits[portraitIndex];
+  if(ccPortrait){
+    ccPortrait.style.backgroundImage = `url(${img})`;
+    ccPortrait.style.backgroundSize = '100% 100%';
+    ccPortrait.style.backgroundPosition = 'center';
+    ccPortrait.textContent = '';
+  }
+  if(building) building.portraitSheet = img;
+}
 const specializations={
   'Scavenger':{desc:'Finds better loot from ruins; starts with crowbar.', gear:[{id:'crowbar',name:'Crowbar',slot:'weapon',mods:{ATK:+1}}]},
   'Gunslinger':{desc:'Higher chance to win quick fights; starts with pipe rifle.', gear:[{id:'pipe_rifle',name:'Pipe Rifle',slot:'weapon',mods:{ATK:+2}}]},
@@ -553,7 +565,8 @@ function randomName(){
   return avail.length? avail[Math.floor(Math.random()*avail.length)] : 'Drifter '+(built.length+1);
 }
 function newBuilding(){
-  return { id:'pc'+(built.length+1), name:randomName(), role:'Wanderer', stats:baseStats(), quirk:null, spec:null, origin:null };
+  portraitIndex = 0;
+  return { id:'pc'+(built.length+1), name:randomName(), role:'Wanderer', stats:baseStats(), quirk:null, spec:null, origin:null, portraitSheet: portraits[portraitIndex] };
 }
 
 let step=1; let building=null; let built=[];
@@ -576,9 +589,10 @@ function renderStep(){
   if(step===1){
     ccHint.textContent='Pick a name and portrait.';
     r.innerHTML=`<div class='field'><label>Name</label><input id='nm' value='${building.name||''}' class='slot' style='padding:6px;background:#0c0f0c;color:var(--ink);border:1px solid #2b382b;border-radius:6px'></div><div class='row' style='margin-top:8px'><span class='pill' id='prevP'>&lt;</span><span class='pill'>Portrait</span><span class='pill' id='nextP'>&gt;</span></div>`;
-    document.getElementById('prevP').onclick=()=>{ portraitIndex=(portraitIndex+portraits.length-1)%portraits.length; ccPortrait.textContent=portraits[portraitIndex]; };
-    document.getElementById('nextP').onclick=()=>{ portraitIndex=(portraitIndex+1)%portraits.length; ccPortrait.textContent=portraits[portraitIndex]; };
+    document.getElementById('prevP').onclick=()=>{ portraitIndex=(portraitIndex+portraits.length-1)%portraits.length; setCreatorPortrait(); };
+    document.getElementById('nextP').onclick=()=>{ portraitIndex=(portraitIndex+1)%portraits.length; setCreatorPortrait(); };
     const nm=document.getElementById('nm'); nm.oninput=()=>{ building.name=nm.value; updateCreatorButtons(); };
+    setCreatorPortrait();
   }
   if(step===2){
     ccHint.textContent='Distribute 6 points among stats.';
@@ -610,7 +624,7 @@ function renderStep(){
 function finalizeCurrentMember(){
   if(!building) return null;
   if(!building.name || !building.name.trim()) building.name = 'Drifter '+(built.length+1);
-  const m=makeMember(building.id, building.name, building.spec||'Wanderer', {permanent:true});
+  const m=makeMember(building.id, building.name, building.spec||'Wanderer', {permanent:true, portraitSheet: building.portraitSheet});
   m.stats=building.stats; m.origin=building.origin; m.quirk=building.quirk;
   addPartyMember(m);
   const spec = specializations[building.spec]; if(spec){ spec.gear.forEach(g=> addToInv(g)); }

--- a/dustland.html
+++ b/dustland.html
@@ -111,7 +111,7 @@
       </header>
       <main>
         <div class="pbox">
-          <div class="p" id="ccPortrait">@</div>
+          <div class="p" id="ccPortrait"></div>
         </div>
         <div id="ccRight"></div>
       </main>

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -559,7 +559,8 @@ test('createNpcFactory builds NPCs from definitions', () => {
     id: 't',
     map: 'world',
     name: 'Tester',
-    tree: '{"start":{"text":"hi","choices":[{"label":"bye","to":"bye"}]}}'
+    tree: '{"start":{"text":"hi","choices":[{"label":"bye","to":"bye"}]}}',
+    portraitSheet: 'assets/portraits/portrait_1000.png'
   }];
   const factory = createNpcFactory(defs);
   const npc = factory.t(2, 3);
@@ -568,6 +569,7 @@ test('createNpcFactory builds NPCs from definitions', () => {
   assert.strictEqual(npc.y, 3);
   assert.strictEqual(npc.map, 'world');
   assert.strictEqual(npc.tree.start.text, 'hi');
+  assert.strictEqual(npc.portraitSheet, 'assets/portraits/portrait_1000.png');
 });
 
 test('openDialog displays portrait when sheet provided', () => {

--- a/test/portraits.test.js
+++ b/test/portraits.test.js
@@ -1,0 +1,58 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const coreCode = await fs.readFile(new URL('../dustland-core.js', import.meta.url), 'utf8');
+const combatCode = await fs.readFile(new URL('../core/combat.js', import.meta.url), 'utf8');
+
+function setup(){
+  const html = `<body><div id="mapname"></div><div id="creator"></div><div id="ccStep"></div><div id="ccRight"></div><div id="ccHint"></div><button id="ccBack"></button><button id="ccNext"></button><div id="ccPortrait"></div><button id="ccStart"></button><button id="ccLoad"></button><div id="combatOverlay"></div><div id="combatEnemies"></div><div id="combatParty"></div><div id="combatCmd"></div></body>`;
+  const dom = new JSDOM(html);
+  const party=[]; party.flags={}; party.map='world'; party.x=0; party.y=0;
+  const context={
+    window:dom.window,
+    document:dom.window.document,
+    EventBus:{ on:()=>{}, emit:()=>{} },
+    baseStats:()=>({STR:4,AGI:4,INT:4,PER:4,LCK:4,CHA:4}),
+    makeMember:(id,name,role,opts={})=>({id,name,role,stats:{},...opts}),
+    addPartyMember:m=>{ party.push(m); },
+    addToInv:()=>{},
+    rand:()=>0,
+    log:()=>{},
+    party,
+    player:{inv:[]},
+    Math:Object.assign(Object.create(Math),{random:()=>0})
+  };
+  vm.createContext(context);
+  vm.runInContext(coreCode,context);
+  vm.runInContext(combatCode,context);
+  return {context,dom};
+}
+
+test('creator assigns chosen portrait to member', () => {
+  const {context,dom} = setup();
+  context.openCreator();
+  dom.window.document.getElementById('nextP').onclick();
+  context.finalizeCurrentMember();
+  assert.strictEqual(context.party[0].portraitSheet, 'assets/portraits/portrait_1001.png');
+});
+
+test('creator supports highest portrait id', () => {
+  const {context} = setup();
+  context.openCreator();
+  vm.runInContext('portraitIndex = 89;', context);
+  context.setCreatorPortrait();
+  context.finalizeCurrentMember();
+  assert.strictEqual(context.party[0].portraitSheet, 'assets/portraits/portrait_1089.png');
+});
+
+test('combat uses member portrait', () => {
+  const {context,dom} = setup();
+  context.openCreator();
+  context.finalizeCurrentMember();
+  const el = dom.window.document.createElement('div');
+  context.setPortraitDiv(el, context.party[0]);
+  assert.ok(el.style.backgroundImage.includes('assets/portraits/portrait_1000.png'));
+});


### PR DESCRIPTION
## Summary
- extend player portrait options to IDs 1000-1089
- allow selecting NPC portraits in Adventure Kit editor
- persist chosen portraits into combat

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8ba54ba5883289626f76f4ded3fc7