### PR TITLE
feat: add adventure kit glyph

### DIFF
--- a/module-picker.js
+++ b/module-picker.js
@@ -126,6 +126,14 @@ function showModulePicker(){
   styleTag.textContent = '@keyframes pulse{0%,100%{opacity:.8}50%{opacity:1}}';
   document.head.appendChild(styleTag);
 
+  const ackBtn = document.createElement('div');
+  ackBtn.id = 'ackGlyph';
+  ackBtn.textContent = '✎';
+  ackBtn.title = 'Adventure Kit';
+  ackBtn.style = 'position:absolute;top:10px;right:10px;z-index:1;color:#0f0;font-size:24px;cursor:pointer';
+  ackBtn.onclick = () => { window.location.href = 'adventure-kit.html'; };
+  overlay.appendChild(ackBtn);
+
   const canvas = document.createElement('canvas');
   canvas.id = 'dustParticles';
   // Background dust layer; z-index keeps UI elements in front.

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -26,7 +26,8 @@ Object.assign(global, {
   innerWidth: 800,
   innerHeight: 600,
   addEventListener(){},
-  localStorage: { getItem: () => null }
+  localStorage: { getItem: () => null },
+  location: { href: '' }
 });
 
 const bodyEl = stubEl();
@@ -54,6 +55,14 @@ test('module picker shows title and dust background', () => {
   const canvas = overlay.children.find(c => c.id === 'dustParticles');
   assert.ok(canvas);
   assert.ok(canvas.ctx.count > 0);
+});
+
+test('adventure kit glyph navigates to editor', () => {
+  const overlay = bodyEl.children.find(c => c.id === 'modulePicker');
+  const glyph = overlay.children.find(c => c.id === 'ackGlyph');
+  assert.ok(glyph);
+  glyph.onclick();
+  assert.strictEqual(global.location.href, 'adventure-kit.html');
 });
 
 test('particles respawn at edges after aging', () => {


### PR DESCRIPTION
## Summary
- add floating Adventure Kit glyph on module picker screen
- test glyph navigation to editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e260a93c83288f2287763cdaaf55