### PR TITLE
feat: add map clear button

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -205,6 +205,7 @@
         <button class="btn" id="noiseToggle" style="margin-top:4px">Noise: On</button>
         <div class="controls">
         <button class="btn" id="regen">Generate World</button>
+        <button class="btn" id="clear">Clear Map</button>
         <button class="btn btn--primary" id="save">Download Module</button>
         <button class="btn" id="load">Load Module</button>
         <button class="btn" id="setStart">Set Start</button>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -315,17 +315,45 @@ function updateInteriorOptions() {
 
 function regenWorld() {
   moduleData.seed = Date.now();
-  genWorld(moduleData.seed);
-  moduleData.buildings = [...buildings];
+  genWorld(moduleData.seed, { buildings: [] });
+  moduleData.buildings = [];
   moduleData.interiors = [];
   moduleData.events = [];
   moduleData.portals = [];
   for (const id in interiors) {
-    if(id==='creator') continue;
+    if (id === 'creator') continue;
     const I = interiors[id]; I.id = id; moduleData.interiors.push(I);
   }
   renderInteriorList();
   renderBldgList();
+  renderEventList();
+  renderPortalList();
+  drawWorld();
+}
+
+function clearWorld() {
+  if (!confirm('Clear the world map?')) return;
+  for (let y = 0; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) {
+      setTile('world', x, y, TILE.SAND);
+    }
+  }
+  moduleData.npcs = [];
+  moduleData.items = [];
+  moduleData.quests = [];
+  moduleData.buildings = [];
+  moduleData.interiors = [];
+  moduleData.portals = [];
+  moduleData.events = [];
+  buildings.length = 0;
+  portals.length = 0;
+  globalThis.interiors = {};
+  interiors = globalThis.interiors;
+  renderNPCList();
+  renderItemList();
+  renderQuestList();
+  renderBldgList();
+  renderInteriorList();
   renderEventList();
   renderPortalList();
   drawWorld();
@@ -1676,6 +1704,7 @@ function playtestModule() {
 }
 
 document.getElementById('regen').onclick = regenWorld;
+document.getElementById('clear').onclick = clearWorld;
 document.getElementById('addNPC').onclick = addNPC;
 document.getElementById('addItem').onclick = addItem;
 document.getElementById('newItem').onclick = startNewItem;

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -360,14 +360,14 @@ function genWorld(seed=Date.now(), data={}){
   interiors = {};
   if(creatorMap.grid && creatorMap.grid.length) interiors['creator']=creatorMap;
   (data.interiors||[]).forEach(I=>{ const {id,...rest}=I; interiors[id]={...rest}; });
-  buildings.length=0;
-  if(data.buildings && data.buildings.length){
-    data.buildings.forEach(b=> placeHut(b.x, b.y, b));
+  buildings.length = 0;
+  if (data.buildings) {
+    data.buildings.forEach(b => placeHut(b.x, b.y, b));
   } else {
-    for(let i=0;i<10;i++){
-      let x=8+rand(WORLD_W-16), y=6+rand(WORLD_H-12);
-      if(getTile('world',x,y)===TILE.WATER){ const p=findNearestLand(x,y); x=p.x; y=p.y; }
-      placeHut(x,y);
+    for (let i = 0; i < 10; i++) {
+      let x = 8 + rand(WORLD_W - 16), y = 6 + rand(WORLD_H - 12);
+      if (getTile('world', x, y) === TILE.WATER) { const p = findNearestLand(x, y); x = p.x; y = p.y; }
+      placeHut(x, y);
     }
   }
   portals.length=0;

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -41,6 +41,7 @@ function stubEl(){
 
 global.requestAnimationFrame = () => {};
 global.alert = () => {};
+global.confirm = () => true;
 global.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
 global.window = global;
 window.matchMedia = () => ({ matches:false, addEventListener(){}, removeEventListener(){} });
@@ -155,4 +156,21 @@ test('painting over building restores tiles', () => {
   canvasEl._listeners.mousemove[0]({ clientX:5, clientY:5 });
   canvasEl._listeners.mouseup[0]({});
   assert.strictEqual(world[5][5], TILE.BUILDING);
+});
+
+test('regenWorld creates empty map without buildings', () => {
+  regenWorld();
+  assert.strictEqual(globalThis.buildings.length, 0);
+  assert.ok(world.every(row => row.every(t => t !== TILE.BUILDING)));
+});
+
+test('clearWorld wipes tiles and data', () => {
+  genWorld(1, { buildings: [] });
+  moduleData.npcs = [{ id:'n1', map:'world', x:0, y:0 }];
+  setTile('world',0,0,TILE.BUILDING);
+  globalThis.buildings.push({ x:0, y:0, w:1, h:1, under:[[TILE.SAND]] });
+  clearWorld();
+  assert.strictEqual(world[0][0], TILE.SAND);
+  assert.strictEqual(moduleData.npcs.length, 0);
+  assert.strictEqual(globalThis.buildings.length, 0);
 });


### PR DESCRIPTION
## Summary
- add Clear Map button with confirmation to Adventure Kit
- ensure regenWorld produces empty maps without default huts
- provide tests for clearing and regen behaviors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e2f8def4832896b0d2a8e2dcbfd9