### PR TITLE
fix: group Adventure Kit controls

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -72,8 +72,13 @@
       margin-top: 6px;
     }
 
-    #mapCard .controls {
-      text-align: center;
+    .btn-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      justify-content: center;
+      border: 1px solid #2b3b2b;
+      padding: 4px;
       margin-top: 8px;
     }
 
@@ -194,24 +199,26 @@
   <div class="ak-layout">
       <section class="card map-card" id="mapCard">
         <canvas id="map" width="640" height="480" aria-label="Map preview"></canvas>
-        <div id="worldPalette" style="margin-top:4px">
-          <button type="button" data-tile="0" style="background:#1e271d"></button>
-          <button type="button" data-tile="1" style="background:#2c342c"></button>
-          <button type="button" data-tile="2" style="background:#1573ff"></button>
-          <button type="button" data-tile="3" style="background:#203320"></button>
-          <button type="button" data-tile="4" style="background:#777777"></button>
-          <button type="button" data-tile="5" style="background:#304326"></button>
+        <div class="btn-group" id="paletteGroup">
+          <div id="worldPalette">
+            <button type="button" data-tile="0" style="background:#1e271d"></button>
+            <button type="button" data-tile="1" style="background:#2c342c"></button>
+            <button type="button" data-tile="2" style="background:#1573ff"></button>
+            <button type="button" data-tile="3" style="background:#203320"></button>
+            <button type="button" data-tile="4" style="background:#777777"></button>
+            <button type="button" data-tile="5" style="background:#304326"></button>
+          </div>
+          <button class="btn" id="noiseToggle">Noise: On</button>
+          <button class="btn" id="clear">Clear Map</button>
         </div>
-        <button class="btn" id="noiseToggle" style="margin-top:4px">Noise: On</button>
-        <div class="controls">
-        <button class="btn" id="regen">Generate World</button>
-        <button class="btn" id="clear">Clear Map</button>
-        <button class="btn btn--primary" id="save">Download Module</button>
-        <button class="btn" id="load">Load Module</button>
-        <button class="btn" id="setStart">Set Start</button>
-        <button class="btn btn--primary" id="playtest">Playtest</button>
-        <button class="btn" id="toggleEditor" aria-expanded="true">Hide Editor</button>
-      </div>
+        <div class="btn-group">
+          <button class="btn btn--primary" id="save">Download Module</button>
+          <button class="btn" id="load">Load Module</button>
+        </div>
+        <div class="btn-group">
+          <button class="btn" id="setStart">Set Start</button>
+          <button class="btn btn--primary" id="playtest">Playtest</button>
+        </div>
       <input type="file" id="loadFile" accept="application/json" style="display:none" />
     </section>
     <aside class="editor-panel" id="editorPanel" aria-hidden="false">

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1703,7 +1703,6 @@ function playtestModule() {
   window.open('dustland.html?ack-player=1#play', '_blank');
 }
 
-document.getElementById('regen').onclick = regenWorld;
 document.getElementById('clear').onclick = clearWorld;
 document.getElementById('addNPC').onclick = addNPC;
 document.getElementById('addItem').onclick = addItem;
@@ -2115,15 +2114,3 @@ animate();
 
 document.getElementById('playtestFloat').onclick =
   () => document.getElementById('playtest')?.click();
-
-const toggleEditorBtn = document.getElementById('toggleEditor');
-if (toggleEditorBtn) {
-  const panel = document.getElementById('editorPanel');
-  toggleEditorBtn.addEventListener('click', () => {
-    const isShown = panel.style.display !== 'none';
-    panel.style.display = isShown ? 'none' : '';
-    toggleEditorBtn.textContent = isShown ? 'Show Editor' : 'Hide Editor';
-    toggleEditorBtn.setAttribute('aria-expanded', String(!isShown));
-    panel.setAttribute('aria-hidden', String(isShown));
-  });
-}


### PR DESCRIPTION
## Summary
- group bottom Adventure Kit controls into bordered sections
- drop hide/show editor and generate world buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e76d5eb083288db19a975177699a