### PR TITLE
fix: skip start flow in ACK playtest

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -545,13 +545,18 @@ requestAnimationFrame(draw);
 log('v0.6.7 — Stable boot; items/NPCs visible; E/T to take; selected member rolls.');
 if (window.NanoDialog) NanoDialog.init();
 
-if(location.hash.includes('test')){ runTests(); }
-else {
-const saveStr = globalThis.localStorage?.getItem('dustland_crt');
-  if(saveStr){
-    showStart();
-  } else {
-    openCreator();
+{ // skip normal boot flow in ACK player mode
+  const params = new URLSearchParams(location.search);
+  const isAck = params.get('ack-player') === '1';
+  if (location.hash.includes('test')) {
+    runTests();
+  } else if (!isAck) {
+    const saveStr = globalThis.localStorage?.getItem('dustland_crt');
+    if (saveStr) {
+      showStart();
+    } else {
+      openCreator();
+    }
   }
 }
 

--- a/test/ack-player.playtest.test.js
+++ b/test/ack-player.playtest.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+test('engine skips start when ack-player param present', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const html = `<!DOCTYPE html><body>
+    <div id="log"></div>
+    <div id="hp"></div>
+    <div id="ap"></div>
+    <div id="scrap"></div>
+    <canvas id="game"></canvas>
+  </body>`;
+  const dom = new JSDOM(html, { url: 'http://localhost/dustland.html?ack-player=1' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.location = window.location;
+  window.requestAnimationFrame = () => {};
+  global.requestAnimationFrame = window.requestAnimationFrame;
+  window.NanoDialog = { init: () => {} };
+  global.NanoDialog = window.NanoDialog;
+  window.AudioContext = function() {};
+  window.webkitAudioContext = window.AudioContext;
+  window.Audio = function(){ return { cloneNode: () => ({ play: () => {} }) }; };
+  global.Audio = window.Audio;
+  global.EventBus = { on: () => {}, emit: () => {} };
+  global.TS = 16;
+  global.camX = 0;
+  global.camY = 0;
+  global.interactAt = () => {};
+  window.HTMLCanvasElement.prototype.getContext = () => ({
+    drawImage: () => {},
+    clearRect: () => {},
+    getImageData: () => ({ data: [] }),
+    putImageData: () => {}
+  });
+  const store = { dustland_crt: '{}' };
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k) => store[k],
+      setItem: (k, v) => { store[k] = String(v); },
+      removeItem: (k) => { delete store[k]; }
+    }
+  });
+  global.localStorage = window.localStorage;
+  let startShown = false;
+  let creatorOpened = false;
+  global.showStart = () => { startShown = true; };
+  global.openCreator = () => { creatorOpened = true; };
+  global.bootMap = () => {};
+  global.draw = () => {};
+  global.runTests = () => {};
+  const enginePath = path.join(__dirname, '..', 'dustland-engine.js');
+  window.eval(fs.readFileSync(enginePath, 'utf8'));
+  assert.ok(!startShown && !creatorOpened, 'engine should not boot when ack-player param present');
+});


### PR DESCRIPTION
## Summary
- skip normal boot flow when adventure kit player is used so playtests start immediately
- add regression test for ACK playtest boot

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8ef22f7b883288569ef5cba3f6825