### PR TITLE
feat: allow custom module filename

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -28,7 +28,7 @@ _______________________________________________________________________________
     https://weatheredclown.github.io/dustland/dustland.html
   - Just open:  dustland.html  (double-click or serve from any static server).
   - Pick a module on startup (e.g. Dustland or Echoes).
-  - Build a module with: adventure-kit.html  (save to JSON).
+  - Build a module with: adventure-kit.html  (set a module name to save as custom-name.json).
   - Play a module with: dustland.html?ack-player=1 (fetch a module URL, load a local JSON, or pass &module=URL to auto-load; defaults to modules/golden.module.json).
   - No build step. No dependencies. Works offline.
   - Tip: Use a modern Chromium, Firefox, or Safari.

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -211,6 +211,8 @@
           <button class="btn" id="noiseToggle">Noise: On</button>
           <button class="btn" id="clear">Clear Map</button>
         </div>
+        <label for="moduleName">Module Name</label>
+        <input type="text" id="moduleName" />
         <div class="btn-group">
           <button class="btn btn--primary" id="save">Download Module</button>
           <button class="btn" id="load">Load Module</button>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -18,7 +18,7 @@ let placingType = null, placingPos = null;
 let hoverTile = null;
 let coordTarget = null;
 
-const moduleData = { seed: Date.now(), npcs: [], items: [], quests: [], buildings: [], interiors: [], portals: [], events: [], start: { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) } };
+const moduleData = { seed: Date.now(), name: 'adventure-module', npcs: [], items: [], quests: [], buildings: [], interiors: [], portals: [], events: [], start: { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) } };
 const STAT_OPTS = ['ATK', 'DEF', 'LCK', 'INT', 'PER', 'CHA'];
 let editNPCIdx = -1, editItemIdx = -1, editQuestIdx = -1, editBldgIdx = -1, editInteriorIdx = -1, editEventIdx = -1, editPortalIdx = -1;
 let treeData = {};
@@ -1628,6 +1628,7 @@ function deleteQuest() {
 
 function applyLoadedModule(data) {
   moduleData.seed = data.seed || Date.now();
+  moduleData.name = data.name || 'adventure-module';
   moduleData.npcs = data.npcs || [];
   moduleData.items = data.items || [];
   moduleData.quests = data.quests || [];
@@ -1636,6 +1637,7 @@ function applyLoadedModule(data) {
   moduleData.portals = data.portals || [];
   moduleData.events = data.events || [];
   moduleData.start = data.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
+  document.getElementById('moduleName').value = moduleData.name;
   globalThis.interiors = {};
   interiors = globalThis.interiors;
   moduleData.interiors.forEach(I => { interiors[I.id] = I; });
@@ -1686,17 +1688,19 @@ function validateSpawns(){
 
 function saveModule() {
   if(!validateSpawns()) return;
+  moduleData.name = document.getElementById('moduleName').value.trim() || 'adventure-module';
   const bldgs = buildings.map(({ under, ...rest }) => rest);
   const data = { ...moduleData, world, buildings: bldgs };
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
   const a = document.createElement('a');
   a.href = URL.createObjectURL(blob);
-  a.download = 'adventure-module.json';
+  a.download = moduleData.name + '.json';
   a.click();
   URL.revokeObjectURL(a.href);
 }
 
 function playtestModule() {
+  moduleData.name = document.getElementById('moduleName').value.trim() || 'adventure-module';
   const bldgs = buildings.map(({ under, ...rest }) => rest);
   const data = { ...moduleData, world, buildings: bldgs };
   localStorage.setItem(PLAYTEST_KEY, JSON.stringify(data));
@@ -1742,6 +1746,7 @@ document.getElementById('eventEffect').addEventListener('change', updateEventEff
 document.getElementById('eventPick').onclick = () => { coordTarget = { x: 'eventX', y: 'eventY' }; };
 document.getElementById('npcFlagType').addEventListener('change', updateFlagBuilder);
 document.getElementById('npcEditor').addEventListener('input', applyNPCChanges);
+document.getElementById('moduleName').value = moduleData.name;
 document.getElementById('npcEditor').addEventListener('change', applyNPCChanges);
 document.getElementById('bldgEditor').addEventListener('input', applyBldgChanges);
 document.getElementById('bldgEditor').addEventListener('change', applyBldgChanges);


### PR DESCRIPTION
## Summary
- add module name field to Adventure Construction Kit
- use module name for downloaded JSON filename

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a971ad71388328a1b6ad799aad42d0