### PR TITLE
feat: randomize default portrait

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -578,7 +578,7 @@ function randomName(){
   return avail.length? avail[Math.floor(Math.random()*avail.length)] : 'Drifter '+(built.length+1);
 }
 function newBuilding(){
-  portraitIndex = 0;
+  portraitIndex = Math.floor(Math.random()*portraits.length);
   return { id:'pc'+(built.length+1), name:randomName(), role:'Wanderer', stats:baseStats(), quirk:null, spec:null, origin:null, portraitSheet: portraits[portraitIndex] };
 }
 

--- a/test/ack-player.param.test.js
+++ b/test/ack-player.param.test.js
@@ -24,6 +24,7 @@ test('ack-player auto-loads module from URL param', async () => {
   global.openCreator = window.openCreator;
   global.applyModule = window.applyModule;
   global.location = window.location;
+  global.params = new URLSearchParams(window.location.search);
   global.alert = () => {};
   window.fetch = () => Promise.resolve({ json: () => Promise.resolve({}) });
   global.fetch = window.fetch;

--- a/test/portraits.test.js
+++ b/test/portraits.test.js
@@ -56,3 +56,11 @@ test('combat uses member portrait', () => {
   context.setPortraitDiv(el, context.party[0]);
   assert.ok(el.style.backgroundImage.includes('assets/portraits/portrait_1000.png'));
 });
+
+test('creator picks random default portrait', () => {
+  const {context} = setup();
+  context.Math.random = () => 0.5;
+  context.openCreator();
+  const sheet = vm.runInContext('building.portraitSheet', context);
+  assert.strictEqual(sheet, 'assets/portraits/portrait_1045.png');
+});


### PR DESCRIPTION
## Summary
- pick a random portrait when starting character creation
- cover portrait randomization with a new test
- fix ack-player param test setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a97a461fdc83288b614f3882e692bf