### PR TITLE
fix: skip painting when selecting map

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1853,7 +1853,7 @@ canvas.addEventListener('mousedown', ev => {
   const overStart = moduleData.start && moduleData.start.map === 'world' && moduleData.start.x === x && moduleData.start.y === y;
   const overEvent = moduleData.events.some(ev => ev.map === 'world' && ev.x === x && ev.y === y);
   const overPortal = moduleData.portals.some(p => p.map === 'world' && p.x === x && p.y === y);
-  if (worldPaint != null && !(overNpc || overItem || overBldg || overStart || overEvent || overPortal)) {
+  if (worldPaint != null && !coordTarget && !(overNpc || overItem || overBldg || overStart || overEvent || overPortal)) {
     worldPainting = true;
     hoverTile = { x, y };
     addTerrainFeature(x, y, worldPaint);

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -133,6 +133,18 @@ test('dragging building ignores paint', () => {
   assert.strictEqual(worldPainting, false);
 });
 
+test('select on map does not paint', () => {
+  genWorld(1);
+  worldPaint = TILE.ROCK;
+  const before = world[2][3];
+  coordTarget = { x: 'eventX', y: 'eventY' };
+  canvasEl._listeners.mousedown[0]({ clientX:3, clientY:2 });
+  assert.strictEqual(world[2][3], before);
+  assert.strictEqual(worldPainting, false);
+  assert.strictEqual(document.getElementById('eventX').value, 3);
+  assert.strictEqual(document.getElementById('eventY').value, 2);
+});
+
 test('clicking building while paint palette active still edits', () => {
   genWorld(1);
   moduleData.buildings = [{ x:5, y:5, w:1, h:1 }];


### PR DESCRIPTION
## Summary
- avoid painting terrain when choosing coordinates on the map
- test selecting on map does not paint tiles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9831c29388328a4fce2088bd98726