### PR TITLE
fix: auto-scale Adventure Kit editor panel

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -2101,15 +2101,14 @@ animate();
   if (!panel) return;
   const tabs = Array.from(panel.querySelectorAll('.tab2'));
   const panes = Array.from(panel.querySelectorAll('[data-pane]'));
-  const mq = window.matchMedia('(min-width: 1600px)');
   let current = 'npc';
+  let wide = false;
 
   function setLayout() {
-    if (mq.matches) {
-      panel.classList.add('wide');
+    wide = panel.offsetWidth >= 960;
+    panel.classList.toggle('wide', wide);
+    if (wide) {
       panes.forEach(p => p.style.display = '');
-    } else {
-      panel.classList.remove('wide');
     }
     show(current);
   }
@@ -2121,15 +2120,22 @@ animate();
       t.classList.toggle('active', on);
       t.setAttribute('aria-selected', on ? 'true' : 'false');
     });
-    if (!mq.matches) {
+    if (!wide) {
       panes.forEach(p => p.style.display = (p.dataset.pane === tabName ? '' : 'none'));
     }
   }
 
   tabs.forEach(t => t.addEventListener('click', () => show(t.dataset.tab)));
-  mq.addEventListener('change', setLayout);
+  if (typeof ResizeObserver === 'function') {
+    const ro = new ResizeObserver(setLayout);
+    ro.observe(panel);
+  } else if (typeof window !== 'undefined' && window.addEventListener) {
+    window.addEventListener('resize', setLayout);
+  }
   setLayout();
-  window.showEditorTab = show;
+  if (typeof window !== 'undefined') {
+    window.showEditorTab = show;
+  }
 })();
 
 document.getElementById('playtestFloat').onclick =

--- a/dustland.css
+++ b/dustland.css
@@ -685,10 +685,11 @@
 
     .map-card {
         width: 640px;
+        flex: 0 0 auto;
     }
 
     .editor-panel {
-        width: 320px;
+        flex: 1 1 320px;
         background: #0b0d0b;
         border: 1px solid #273027;
         border-radius: 10px;
@@ -804,30 +805,28 @@
         overflow: auto;
     }
 
-    /* Show all editor panes side-by-side on wide screens */
-    @media (min-width: 1600px) {
-        .editor-panel {
-            width: auto;
-            flex: 1;
-            max-height: none;
-        }
+    /* Show all editor panes side-by-side when the panel is wide */
+    .editor-panel.wide {
+        width: auto;
+        flex: 1;
+        max-height: none;
+    }
 
-        .editor-panel.wide .tabs2 {
-            display: none;
-        }
+    .editor-panel.wide .tabs2 {
+        display: none;
+    }
 
-        .editor-panel.wide .tabpanes {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 16px;
-            padding: 16px;
-            overflow: visible;
-        }
+    .editor-panel.wide .tabpanes {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        padding: 16px;
+        overflow: visible;
+    }
 
-.editor-panel.wide .tabpanes .card {
-            flex: 1 1 320px;
-            margin: 0 8px 16px !important;
-        }
+    .editor-panel.wide .tabpanes .card {
+        flex: 1 1 320px;
+        margin: 0 8px 16px !important;
     }
 
 #intPalette button,


### PR DESCRIPTION
## Summary
- allow Adventure Kit editor panel to flex and fill remaining space
- expand to grid view and hide tabs when panel grows wide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a97dcb535083289b24a0781fdc702a