### PR TITLE
feat: add zoom and pan to ACK map editor

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -29,6 +29,7 @@ _______________________________________________________________________________
   - Just open:  dustland.html  (double-click or serve from any static server).
   - Pick a module on startup (e.g. Dustland or Echoes).
   - Build a module with: adventure-kit.html  (set a module name to save as custom-name.json).
+  - The world map editor supports mousewheel zoom and right-drag panning.
   - Play a module with: dustland.html?ack-player=1 (fetch a module URL, load a local JSON, or pass &module=URL to auto-load; defaults to modules/golden.module.json).
   - No build step. No dependencies. Works offline.
   - Tip: Use a modern Chromium, Firefox, or Safari.

--- a/test/ack-player.param.test.js
+++ b/test/ack-player.param.test.js
@@ -25,6 +25,8 @@ test('ack-player auto-loads module from URL param', async () => {
   global.applyModule = window.applyModule;
   global.location = window.location;
   global.alert = () => {};
+  window.params = new URLSearchParams(window.location.search);
+  global.params = window.params;
   window.fetch = () => Promise.resolve({ json: () => Promise.resolve({}) });
   global.fetch = window.fetch;
   const store = {};

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -128,7 +128,7 @@ test('dragging building ignores paint', () => {
   setTile('world',5,5,TILE.BUILDING);
   worldPaint = TILE.ROCK;
   const before = world[5][5];
-  canvasEl._listeners.mousedown[0]({ clientX:5, clientY:5 });
+  canvasEl._listeners.mousedown[0]({ clientX:5, clientY:5, button:0 });
   assert.strictEqual(world[5][5], before);
   assert.strictEqual(worldPainting, false);
 });
@@ -141,9 +141,9 @@ test('clicking building while paint palette active still edits', () => {
   let edited = false;
   const orig = globalThis.editBldg;
   globalThis.editBldg = () => { edited = true; };
-  canvasEl._listeners.mousedown[0]({ clientX:5, clientY:5 });
-  canvasEl._listeners.mouseup[0]({});
-  canvasEl._listeners.click[0]({ clientX:5, clientY:5 });
+  canvasEl._listeners.mousedown[0]({ clientX:5, clientY:5, button:0 });
+  canvasEl._listeners.mouseup[0]({ button:0 });
+  canvasEl._listeners.click[0]({ clientX:5, clientY:5, button:0 });
   globalThis.editBldg = orig;
   assert.strictEqual(edited, true);
 });
@@ -153,14 +153,14 @@ test('painting then leaving map keeps next click', () => {
   moduleData.buildings = [{ x:5, y:5, w:1, h:1 }];
   setTile('world',5,5,TILE.BUILDING);
   worldPaint = TILE.ROCK;
-  canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0 });
+  canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0, button:0 });
   canvasEl._listeners.mouseleave[0]({});
   let edited = false;
   const orig = globalThis.editBldg;
   globalThis.editBldg = () => { edited = true; };
-  canvasEl._listeners.mousedown[0]({ clientX:5, clientY:5 });
-  canvasEl._listeners.mouseup[0]({});
-  canvasEl._listeners.click[0]({ clientX:5, clientY:5 });
+  canvasEl._listeners.mousedown[0]({ clientX:5, clientY:5, button:0 });
+  canvasEl._listeners.mouseup[0]({ button:0 });
+  canvasEl._listeners.click[0]({ clientX:5, clientY:5, button:0 });
   globalThis.editBldg = orig;
   assert.strictEqual(edited, true);
 });
@@ -170,9 +170,9 @@ test('painting over building restores tiles', () => {
   moduleData.buildings = [{ x:5, y:5, w:1, h:1 }];
   setTile('world',5,5,TILE.BUILDING);
   worldPaint = TILE.ROCK;
-  canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0 });
+  canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0, button:0 });
   canvasEl._listeners.mousemove[0]({ clientX:5, clientY:5 });
-  canvasEl._listeners.mouseup[0]({});
+  canvasEl._listeners.mouseup[0]({ button:0 });
   assert.strictEqual(world[5][5], TILE.BUILDING);
 });
 


### PR DESCRIPTION
## Summary
- enable scroll-wheel zoom and right-drag panning on the Adventure Kit world map
- document new map editor navigation
- update tests to simulate left-button events and URL param parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a97bafba5883288c367ede9b80de4d