### PR TITLE
feat: allow deleting dialog nodes

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -597,7 +597,7 @@ function renderTreeEditor() {
     const unboardEff = (node.effects || []).find(e => e.effect === 'unboardDoor');
     const boardId = boardEff ? boardEff.interiorId || '' : '';
     const unboardId = unboardEff ? unboardEff.interiorId || '' : '';
-    div.innerHTML = `<div class="nodeHeader"><button class="toggle" type="button">[-]</button><label>Node ID<input class="nodeId" value="${id}"></label></div><div class="nodeBody"><label>Dialog Text<textarea class="nodeText" rows="2">${node.text || ''}</textarea></label><label>Board Door<select class="nodeBoard"></select></label><label>Unboard Door<select class="nodeUnboard"></select></label><fieldset class="choiceGroup"><legend>Choices</legend><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button></fieldset></div>`;
+    div.innerHTML = `<div class="nodeHeader"><button class="toggle" type="button">[-]</button><label>Node ID<input class="nodeId" value="${id}"></label><button class="delNode" type="button">Delete</button></div><div class="nodeBody"><label>Dialog Text<textarea class="nodeText" rows="2">${node.text || ''}</textarea></label><label>Board Door<select class="nodeBoard"></select></label><label>Unboard Door<select class="nodeUnboard"></select></label><fieldset class="choiceGroup"><legend>Choices</legend><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button></fieldset></div>`;
     const choicesDiv = div.querySelector('.choices');
     (node.choices || []).forEach(ch => addChoiceRow(choicesDiv, ch));
     div.querySelector('.addChoice').onclick = () => addChoiceRow(choicesDiv);
@@ -607,6 +607,11 @@ function renderTreeEditor() {
     toggleBtn.addEventListener('click', () => {
       div.classList.toggle('collapsed');
       toggleBtn.textContent = div.classList.contains('collapsed') ? '[+]' : '[-]';
+      updateTreeData();
+    });
+    const delBtn = div.querySelector('.delNode');
+    delBtn.addEventListener('click', () => {
+      div.remove();
       updateTreeData();
     });
     wrap.appendChild(div);

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -138,7 +138,7 @@ test('select on map does not paint', () => {
   worldPaint = TILE.ROCK;
   const before = world[2][3];
   coordTarget = { x: 'eventX', y: 'eventY' };
-  canvasEl._listeners.mousedown[0]({ clientX:3, clientY:2 });
+  canvasEl._listeners.mousedown[0]({ clientX:3, clientY:2, button:0 });
   assert.strictEqual(world[2][3], before);
   assert.strictEqual(worldPainting, false);
   assert.strictEqual(document.getElementById('eventX').value, 3);

--- a/test/dialog.effects.test.js
+++ b/test/dialog.effects.test.js
@@ -94,3 +94,28 @@ test('updateTreeData captures door board/unboard effects', () => {
   updateTreeData();
   assert.deepStrictEqual(treeData.start.effects, [ { effect: 'unboardDoor', interiorId: 'castle' } ]);
 });
+
+test('updateTreeData removes deleted nodes', () => {
+  treeData = { start: { text: '', choices: [] }, node1: { text: '', choices: [] } };
+  const nodeEl = {
+    querySelector(sel){
+      switch(sel){
+        case '.nodeId': return { value: 'start' };
+        case '.nodeText': return { value: '' };
+        case '.nodeBoard': return { value: '' };
+        case '.nodeUnboard': return { value: '' };
+        default: return { value: '' };
+      }
+    },
+    querySelectorAll(){ return []; },
+    classList:{ contains(){ return false; } },
+    style:{}
+  };
+  elements['treeEditor'] = {
+    querySelectorAll(sel){ return sel === '.node' ? [nodeEl] : []; }
+  };
+  elements['npcTree'] = { value: '' };
+  elements['treeWarning'] = { textContent: '' };
+  updateTreeData();
+  assert.deepStrictEqual(treeData, { start: { text: '', choices: [] } });
+});


### PR DESCRIPTION
## Summary
- allow removing dialog nodes in the Adventure Kit editor
- test tree updates when nodes are removed
- clarify map coordinate selection test by specifying left-click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a98821b2688328b80c6031cdcc29a3