### PR TITLE
fix: ensure NPC dialog tree defaults populate

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -934,7 +934,7 @@ function collectNPCFromForm() {
   let tree = null;
   const treeTxt = document.getElementById('npcTree').value.trim();
   if (treeTxt) { try { tree = JSON.parse(treeTxt); } catch (e) { tree = null; } }
-  if (!tree) {
+  if (!tree || !Object.keys(tree).length) {
     if (questId) {
       tree = {
         start: { text: dialog, choices: [{ label: 'Accept quest', to: 'accept', q: 'accept' }, { label: 'Turn in', to: 'do_turnin', q: 'turnin' }, { label: '(Leave)', to: 'bye' }] },

--- a/core/npc.js
+++ b/core/npc.js
@@ -93,7 +93,7 @@ function createNpcFactory(defs) {
     npcFactory[n.id] = (x = n.x, y = n.y) => {
       let tree = n.tree;
       if (typeof tree === 'string') { try { tree = JSON.parse(tree); } catch (e) { tree = null; } }
-      if (!tree) {
+      if (!tree || !Object.keys(tree).length) {
         tree = { start: { text: n.dialog || '', choices: [{label: '(Leave)', to: 'bye'}] } };
       }
       const opts = {};

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -138,7 +138,7 @@ test('select on map does not paint', () => {
   worldPaint = TILE.ROCK;
   const before = world[2][3];
   coordTarget = { x: 'eventX', y: 'eventY' };
-  canvasEl._listeners.mousedown[0]({ clientX:3, clientY:2 });
+  canvasEl._listeners.mousedown[0]({ clientX:3, clientY:2, button:0 });
   assert.strictEqual(world[2][3], before);
   assert.strictEqual(worldPainting, false);
   assert.strictEqual(document.getElementById('eventX').value, 3);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -579,6 +579,14 @@ test('createNpcFactory builds NPCs from definitions', () => {
   assert.strictEqual(npc.portraitSheet, 'assets/portraits/portrait_1000.png');
 });
 
+test('createNpcFactory defaults empty tree to dialog', () => {
+  const defs = [{ id: 'n', map: 'world', dialog: 'Hi', tree: {} }];
+  const factory = createNpcFactory(defs);
+  const npc = factory.n();
+  assert.strictEqual(npc.tree.start.text, 'Hi');
+  assert.ok(npc.tree.start.choices.some(c => c.label === '(Leave)'));
+});
+
 test('openDialog displays portrait when sheet provided', () => {
   NPCS.length = 0;
   const tree = { start: { text: '', choices: [] } };


### PR DESCRIPTION
## Summary
- generate a starter dialog tree when NPC trees are missing or empty in Adventure Kit
- fall back to dialog text when loading NPCs with an empty tree
- cover empty-tree behavior and adjust ACK coordinate selection test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9894156cc8328a8db66c4bdbb632e