### PR TITLE
fix: clear dialog preview for new NPC

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -428,7 +428,7 @@ function renderDialogPreview() {
   let tree = null;
   const txt = document.getElementById('npcTree').value.trim();
   if (txt) { try { tree = JSON.parse(txt); } catch (e) { tree = null; } }
-  if (!tree) { prev.innerHTML = ''; return; }
+  if (!tree || !tree.start) { prev.innerHTML = ''; return; }
   function show(id) {
     const node = tree[id]; if (!node) return;
     const html = (node.choices || [])

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -203,3 +203,14 @@ test('clearWorld wipes tiles and data', () => {
   assert.strictEqual(moduleData.npcs.length, 0);
   assert.strictEqual(globalThis.buildings.length, 0);
 });
+
+test('renderDialogPreview clears when no start node', () => {
+  const treeEl = document.getElementById('npcTree');
+  const prevEl = document.getElementById('dialogPreview');
+  treeEl.value = JSON.stringify({ start: { text: 'hi', choices: [] } });
+  renderDialogPreview();
+  assert.ok(prevEl.innerHTML.includes('hi'));
+  treeEl.value = '{}';
+  renderDialogPreview();
+  assert.strictEqual(prevEl.innerHTML, '');
+});


### PR DESCRIPTION
## Summary
- reset dialog preview when an NPC lacks a start node
- add regression test for dialog preview clearing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a98ecfc6888328b4b21b46a7c90401