### PR TITLE
fix: persist NPC dialog edits after closing editor

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -775,6 +775,7 @@ function openDialogEditor() {
 
 function closeDialogEditor() {
   document.getElementById('dialogModal').classList.remove('shown');
+  applyNPCChanges();
 }
 
 function toggleQuestDialogBtn() {

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -214,3 +214,20 @@ test('renderDialogPreview clears when no start node', () => {
   renderDialogPreview();
   assert.strictEqual(prevEl.innerHTML, '');
 });
+
+test('closing dialog editor persists dialog changes', () => {
+  moduleData.npcs = [{
+    id: 'npc1', name: 'NPC', color: '#fff', map: 'world', x: 0, y: 0,
+    tree: { start: { text: 'hi', choices: [{ label: '(Leave)', to: 'bye' }] } }
+  }];
+  editNPC(0);
+  const newTree = { start: { text: 'bye', choices: [{ label: '(Leave)', to: 'bye' }] } };
+  document.getElementById('npcTree').value = JSON.stringify(newTree);
+  document.getElementById('npcDialog').value = 'bye';
+  const origUpdate = globalThis.updateTreeData;
+  globalThis.updateTreeData = () => {};
+  closeDialogEditor();
+  globalThis.updateTreeData = origUpdate;
+  closeNPCEditor();
+  assert.strictEqual(moduleData.npcs[0].tree.start.text, 'bye');
+});


### PR DESCRIPTION
## Summary
- ensure closing the dialog editor saves NPC dialog changes
- test dialog editor persistence in ACK

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9909b5fcc832898813c8c20d1d5a1