### PR TITLE
fix: remove redundant door actions

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -604,11 +604,7 @@ function renderTreeEditor() {
   Object.entries(treeData).forEach(([id, node]) => {
     const div = document.createElement('div');
     div.className = 'node';
-    const boardEff = (node.effects || []).find(e => e.effect === 'boardDoor');
-    const unboardEff = (node.effects || []).find(e => e.effect === 'unboardDoor');
-    const boardId = boardEff ? boardEff.interiorId || '' : '';
-    const unboardId = unboardEff ? unboardEff.interiorId || '' : '';
-    div.innerHTML = `<div class="nodeHeader"><button class="toggle" type="button">[-]</button><label>Node ID<input class="nodeId" value="${id}"></label><button class="delNode" type="button">Delete</button></div><div class="nodeBody"><label>Dialog Text<textarea class="nodeText" rows="2">${node.text || ''}</textarea></label><label>Board Door<select class="nodeBoard"></select></label><label>Unboard Door<select class="nodeUnboard"></select></label><fieldset class="choiceGroup"><legend>Choices</legend><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button></fieldset></div>`;
+    div.innerHTML = `<div class="nodeHeader"><button class="toggle" type="button">[-]</button><label>Node ID<input class="nodeId" value="${id}"></label><button class="delNode" type="button">Delete</button></div><div class="nodeBody"><label>Dialog Text<textarea class="nodeText" rows="2">${node.text || ''}</textarea></label><fieldset class="choiceGroup"><legend>Choices</legend><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button></fieldset></div>`;
     const choicesDiv = div.querySelector('.choices');
     (node.choices || []).forEach(ch => addChoiceRow(choicesDiv, ch));
     div.querySelector('.addChoice').onclick = () => addChoiceRow(choicesDiv);

--- a/test/dialog.effects.test.js
+++ b/test/dialog.effects.test.js
@@ -138,8 +138,6 @@ test('updateTreeData removes deleted nodes', () => {
       switch(sel){
         case '.nodeId': return { value: 'start' };
         case '.nodeText': return { value: '' };
-        case '.nodeBoard': return { value: '' };
-        case '.nodeUnboard': return { value: '' };
         default: return { value: '' };
       }
     },


### PR DESCRIPTION
## Summary
- drop unused board/unboard selectors from dialog node editor
- update dialog effects tests accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b279bd988328a0acc476e87419ea