### PR TITLE
feat: highlight palette selection and label color

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -209,6 +209,7 @@
             <button type="button" data-tile="5" style="background:#304326"></button>
             <button type="button" data-tile="6" style="background:#4d5f4d"></button>
           </div>
+          <div id="paletteLabel"></div>
           <button class="btn" id="noiseToggle">Noise: On</button>
           <button class="btn" id="clear">Clear Map</button>
         </div>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -10,6 +10,15 @@ window.seedWorldContent = () => { };
 const PLAYTEST_KEY = 'ack_playtest';
 
 const akColors = { 0: '#1e271d', 1: '#2c342c', 2: '#1573ff', 3: '#203320', 4: '#777777', 5: '#304326', 6: '#4d5f4d', 7: '#233223', 8: '#8bd98d', 9: '#000' };
+const tileNames = {
+  [TILE.SAND]: 'Sand',
+  [TILE.ROCK]: 'Rock',
+  [TILE.WATER]: 'Water',
+  [TILE.BRUSH]: 'Brush',
+  [TILE.ROAD]: 'Road',
+  [TILE.RUIN]: 'Ruin',
+  [TILE.WALL]: 'Wall'
+};
 const canvas = document.getElementById('map');
 const ctx = canvas.getContext('2d');
 
@@ -43,6 +52,7 @@ let bldgPainting = false;
 let bldgGrid = [];
 
 const worldPalette = document.getElementById('worldPalette');
+const paletteLabel = document.getElementById('paletteLabel');
 let worldPaint = null;
 let worldPainting = false;
 let didPaint = false;
@@ -1512,7 +1522,12 @@ if (worldPalette) {
       const isOn = btn.classList.contains('active');
       worldPalette.querySelectorAll('button').forEach(b => b.classList.remove('active'));
       worldPaint = isOn ? null : parseInt(btn.dataset.tile, 10);
-      if (!isOn) btn.classList.add('active');
+      if (!isOn) {
+        btn.classList.add('active');
+        if (paletteLabel) paletteLabel.textContent = tileNames[worldPaint] || '';
+      } else if (paletteLabel) {
+        paletteLabel.textContent = '';
+      }
       updateCursor();
     });
   });

--- a/dustland.css
+++ b/dustland.css
@@ -830,6 +830,9 @@
     }
 
 #intPalette button,
-#bldgPalette button { width:20px; height:20px; border:none; margin:2px; }
+#bldgPalette button,
+#worldPalette button { width:20px; height:20px; border:none; margin:2px; }
 #intPalette button.active,
-#bldgPalette button.active { outline:2px solid #fff; }
+#bldgPalette button.active,
+#worldPalette button.active { outline:2px solid #fff; }
+#paletteLabel { color:#fff; font-family:sans-serif; margin-top:4px; }

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -50,7 +50,15 @@ const canvasEl = stubEl();
 canvasEl.width = 120;
 canvasEl.height = 90;
 const moduleNameInput = stubEl();
-const elements = { map: canvasEl, moduleName: moduleNameInput  };
+const paletteLabel = stubEl();
+const worldButtons = Array.from({ length: 3 }, (_, i) => {
+  const b = stubEl();
+  b.dataset = { tile: String(i) };
+  return b;
+});
+const worldPalette = stubEl();
+worldPalette.querySelectorAll = () => worldButtons;
+const elements = { map: canvasEl, moduleName: moduleNameInput, worldPalette, paletteLabel };
 global.document = {
   body: bodyEl,
   getElementById: id => elements[id] || (elements[id] = stubEl()),
@@ -190,6 +198,17 @@ test('regenWorld creates empty map without buildings', () => {
   regenWorld();
   assert.strictEqual(globalThis.buildings.length, 0);
   assert.ok(world.every(row => row.every(t => t !== TILE.BUILDING)));
+});
+
+test('world palette selection stays highlighted and labels color', () => {
+  genWorld(1);
+  const btn = worldButtons[1];
+  btn._listeners.click[0]();
+  assert.strictEqual(btn.classList.contains('active'), true);
+  assert.strictEqual(paletteLabel.textContent, 'Rock');
+  canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0, button:0 });
+  canvasEl._listeners.mouseup[0]({ button:0 });
+  assert.strictEqual(btn.classList.contains('active'), true);
 });
 
 test('clearWorld wipes tiles and data', () => {


### PR DESCRIPTION
## Summary
- keep selected world palette color highlighted during painting
- show the name of the chosen color beneath the palette
- add tests for persistent highlight and color label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b4d675e48328957582128bafc1b0