### PR TITLE
fix: retain dialog text from editor

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -775,6 +775,8 @@ function openDialogEditor() {
 
 function closeDialogEditor() {
   document.getElementById('dialogModal').classList.remove('shown');
+  const dlgEl = document.getElementById('npcDialog');
+  if (!dlgEl.value.trim()) dlgEl.value = treeData.start?.text || '';
   applyNPCChanges();
 }
 

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -231,3 +231,21 @@ test('closing dialog editor persists dialog changes', () => {
   closeNPCEditor();
   assert.strictEqual(moduleData.npcs[0].tree.start.text, 'bye');
 });
+
+test('dialog text edited in tree editor is preserved', () => {
+  moduleData.npcs = [{
+    id: 'npc1', name: 'NPC', color: '#fff', map: 'world', x: 0, y: 0,
+    tree: { start: { text: 'hi', choices: [{ label: '(Leave)', to: 'bye' }] } }
+  }];
+  editNPC(0);
+  const newTree = { start: { text: 'welcome', choices: [{ label: '(Leave)', to: 'bye' }] } };
+  treeData = newTree;
+  document.getElementById('npcTree').value = JSON.stringify(newTree);
+  document.getElementById('npcDialog').value = '';
+  const origUpdate = globalThis.updateTreeData;
+  globalThis.updateTreeData = () => {};
+  closeDialogEditor();
+  globalThis.updateTreeData = origUpdate;
+  closeNPCEditor();
+  assert.strictEqual(moduleData.npcs[0].tree.start.text, 'welcome');
+});


### PR DESCRIPTION
## Summary
- sync NPC dialog field with tree editor on close
- test dialog edits persist when only tree editor used

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b18ee4808328b9b8a82e527cd4c5