### PR TITLE
feat: switch ACK to sans-serif typography

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -11,7 +11,9 @@
       margin: 0;
       background: #000;
       color: #c8f7c9;
-      font-family: ui-monospace;
+      font-family: system-ui, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
       position: relative;
       min-height: 100vh;
     }
@@ -42,7 +44,7 @@
     }
 
     .list {
-      font-size: 12px;
+      font-size: 13px;
     }
 
     .list div {
@@ -64,12 +66,22 @@
       border: 1px solid #2b3b2b;
       color: #c8f7c9;
       font-family: inherit;
-      font-size: 12px;
+      font-size: 13px;
       border-radius: 4px;
     }
 
     button.btn {
       margin-top: 6px;
+      font-size: 14px;
+    }
+
+    .btn-group .btn {
+      font-size: 13px;
+    }
+
+    legend {
+      font-size: 16px;
+      font-weight: 600;
     }
 
     .btn-group {

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -167,7 +167,7 @@ const scene = document.createElement('canvas'); scene.width=disp.width; scene.he
 const prev = document.createElement('canvas'); prev.width=disp.width; prev.height=disp.height; const pctx=prev.getContext('2d');
 
 // Font init (prevents invisible glyphs on some canvases)
-sctx.font = '12px ui-monospace';
+sctx.font = '12px system-ui, sans-serif';
 
 let camX=0, camY=0, showMini=true;
 let _lastTime=0;

--- a/dustland.css
+++ b/dustland.css
@@ -18,7 +18,7 @@
         margin: 0;
         background: radial-gradient(circle at top, #141614 0%, var(--bg) 70%);
         color: var(--ink);
-        font: 14px/1.35 ui-monospace, SFMono-Regular, Menlo, Consolas, Liberation Mono, monospace;
+        font: 14px/1.5 system-ui, sans-serif;
     }
 
     .wrap {
@@ -68,14 +68,14 @@
     }
 
     .panel h1 {
-        font-size: 16px;
+        font-size: 18px;
         margin: 0;
         padding: 10px 12px;
         background: #0f120f;
         border-bottom: 1px solid #1a1f1a;
         color: #c7ff9e;
         font-weight: 800;
-        letter-spacing: .6px
+        letter-spacing: .6px;
     }
 
     .panel .content {
@@ -131,6 +131,8 @@
         color: var(--ink);
         cursor: pointer;
         transition: background 0.2s ease, border-color 0.2s ease, transform 0.1s ease;
+        font-size: 14px;
+        font-family: inherit;
     }
 
     .btn:hover {
@@ -373,7 +375,8 @@
   padding:8px 16px;
   border-radius:6px;
   min-width:120px;
-  font-family:'Courier New', monospace;
+  font-family:system-ui, sans-serif;
+  font-size:14px;
   color:#fff;
   box-shadow:0 0 8px #000 inset;
 }
@@ -724,6 +727,8 @@
         border-radius: 6px;
         background: #121712;
         color: var(--ink);
+        font-size: 13px;
+        font-weight: 600;
     }
 
     .tab2:hover {
@@ -835,4 +840,4 @@
 #intPalette button.active,
 #bldgPalette button.active,
 #worldPalette button.active { outline:2px solid #fff; }
-#paletteLabel { color:#fff; font-family:sans-serif; margin-top:4px; }
+#paletteLabel { color:#fff; font-family:system-ui, sans-serif; margin-top:4px; }


### PR DESCRIPTION
## Summary
- adopt system sans-serif fonts for Adventure Kit and shared styles
- establish type hierarchy for headers, labels, inputs, and buttons
- ensure engine and overlays render text with sans-serif fonts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b6b64abc8328b2aa2d7a0fa28bcf