### PR TITLE
feat: support emoji map grids

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -128,6 +128,7 @@ _______________________________________________________________________________
   - NPC trees can be functions for dynamic dialog.
   - Items support `equip.flag` and `unequip` teleport/message effects.
   - Tiles: see TILE enum + colors[] + walkable[].
+  - Maps can be specified as arrays of emoji strings using `tileEmoji` (numeric grids still load).
   - Tests: run `npm install` to fetch dev deps like jsdom, then `npm test` for basic checks.
     The main game still runs from the repo download alone.
 

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1699,7 +1699,10 @@ function applyLoadedModule(data) {
   moduleData.items = data.items || [];
   moduleData.quests = data.quests || [];
   moduleData.buildings = data.buildings || [];
-  moduleData.interiors = data.interiors || [];
+  moduleData.interiors = (data.interiors || []).map(I => {
+    const g = I.grid && typeof I.grid[0] === 'string' ? gridFromEmoji(I.grid) : I.grid;
+    return { ...I, grid: g };
+  });
   moduleData.portals = data.portals || [];
   moduleData.events = data.events || [];
   moduleData.start = data.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
@@ -1709,7 +1712,8 @@ function applyLoadedModule(data) {
   moduleData.interiors.forEach(I => { interiors[I.id] = I; });
 
   if (data.world) {
-    globalThis.world = data.world;
+    const w = typeof data.world[0] === 'string' ? gridFromEmoji(data.world) : data.world;
+    globalThis.world = w;
     world = globalThis.world;
   } else {
     buildings.forEach(b => {
@@ -1756,7 +1760,8 @@ function saveModule() {
   if(!validateSpawns()) return;
   moduleData.name = document.getElementById('moduleName').value.trim() || 'adventure-module';
   const bldgs = buildings.map(({ under, ...rest }) => rest);
-  const data = { ...moduleData, world, buildings: bldgs };
+  const ints = moduleData.interiors.map(I => ({...I, grid: gridToEmoji(I.grid)}));
+  const data = { ...moduleData, world: gridToEmoji(world), buildings: bldgs, interiors: ints };
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
   const a = document.createElement('a');
   a.href = URL.createObjectURL(blob);
@@ -1768,7 +1773,8 @@ function saveModule() {
 function playtestModule() {
   moduleData.name = document.getElementById('moduleName').value.trim() || 'adventure-module';
   const bldgs = buildings.map(({ under, ...rest }) => rest);
-  const data = { ...moduleData, world, buildings: bldgs };
+  const ints = moduleData.interiors.map(I => ({...I, grid: gridToEmoji(I.grid)}));
+  const data = { ...moduleData, world: gridToEmoji(world), buildings: bldgs, interiors: ints };
   localStorage.setItem(PLAYTEST_KEY, JSON.stringify(data));
   window.open('dustland.html?ack-player=1#play', '_blank');
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -249,6 +249,15 @@ test('pathfinding blocks on NPCs', () => {
   assert.strictEqual(party.x,0);
 });
 
+test('applyModule parses emoji world grid', () => {
+  const worldRows = ['\u{1F3DD}\u{1FAA8}', '\u{1F30A}\u{1F33F}'];
+  applyModule({world: worldRows});
+  assert.strictEqual(world[0][0], TILE.SAND);
+  assert.strictEqual(world[0][1], TILE.ROCK);
+  assert.strictEqual(world[1][0], TILE.WATER);
+  assert.strictEqual(world[1][1], TILE.BRUSH);
+});
+
 test('walking regenerates leader HP', async () => {
   const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
   applyModule({world});


### PR DESCRIPTION
## Summary
- allow modules to define world and interior maps as emoji strings
- export module maps to emoji grids in Adventure Kit
- document emoji map format and add regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9ca26ff2883289b3923ee6897c202