### PR TITLE
fix: render exit choices last in dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Guidelines for contributors and automated agents working on Dustland CRT.
 ## Testing
 - Run `npm test` after making changes; it invokes Node's built-in test runner.
 - Ensure the working tree is clean and tests pass before committing.
+- Before adding new tests, check for existing coverage and extend or modify tests instead of duplicating cases.
 
 ## Commit conventions
 - Use concise messages with prefixes such as `feat:`, `fix:`, or `docs:`.

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -56,7 +56,9 @@ function normalizeDialogTree(tree){
     const next=(n.next||n.choices||[]).map(c=>{
       if(typeof c==='string') return {id:c,label:c};
       const {to,id:cid,label,text,checks=[],effects=[],...rest}=c;
-      return {id:to||cid,label:label||text||'(Continue)',checks,effects,...rest};
+      const obj={id:to||cid,label:label||text||'(Continue)',checks,effects,...rest};
+      if(to) obj.to=to;
+      return obj;
     });
     out[id]={text:n.text||'',checks:n.checks||[],effects:n.effects||[],next};
   }
@@ -286,10 +288,11 @@ function renderDialog(){
     return !onceChoices.has(key);
   });
 
+  const isExit=opt=> opt.to==='bye';
   choices.sort((a,b)=>{
-    const aLeave=(a.opt.label||'').toLowerCase()==='leave';
-    const bLeave=(b.opt.label||'').toLowerCase()==='leave';
-    return aLeave===bLeave?0:(aLeave?1:-1);
+    const aExit=isExit(a.opt);
+    const bExit=isExit(b.opt);
+    return aExit===bExit?0:(aExit?1:-1);
   });
 
   choices.forEach(({opt,idx})=>{

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -642,14 +642,27 @@ test('fight choice triggers combat', () => {
   Actions.startCombat = orig;
 });
 
-test('leave choice is rendered last', () => {
+test('choices pointing to bye are rendered last', () => {
   NPCS.length = 0;
-  const tree = { start: { text: '', choices: [ { label: 'Leave', to: 'bye' }, { label: 'Talk', to: 'talk' } ] }, talk: { text: '', choices: [] }, bye: { text: '', choices: [] } };
-  const npc = makeNPC('l', 'world', 0, 0, '#fff', 'L', '', '', tree);
+  const tree = {
+    start: {
+      text: '',
+      choices: [
+        { label: '(Leave)', to: 'bye' },
+        { label: 'Later', to: 'bye' },
+        { label: 'Talk', to: 'talk' }
+      ]
+    },
+    talk: { text: '', choices: [] },
+    bye: { text: '', choices: [] }
+  };
+  const npc = makeNPC('b', 'world', 0, 0, '#fff', 'B', '', '', tree);
   NPCS.push(npc);
   openDialog(npc);
   const labels = choicesEl.children.map(c => c.textContent);
-  assert.strictEqual(labels[labels.length - 1], 'Leave');
+  assert.strictEqual(labels[0], 'Talk');
+  const tail = labels.slice(1).sort();
+  assert.deepStrictEqual(tail, ['(Leave)', 'Later'].sort());
 });
 
 test('hidden NPC reveals after visit condition met', () => {


### PR DESCRIPTION
## Summary
- retain `to` destinations when normalizing dialog trees
- sort dialog choices using `to: 'bye'` so exit options render last
- test rendering of exit choices independent of label
- document avoiding duplicate tests in guidelines
- verify exit choice reordering in dialog tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9c1cbef648328a1bcdbe8c2dd2e52