### PR TITLE
feat: add stamp palette window

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -131,7 +131,7 @@ _______________________________________________________________________________
 [ FEATURE LOG ]
   - ACK player can fetch modules by URL, load local JSON, or auto-load via &module=URL (defaults to modules/golden.module.json).
   - World map editor supports mousewheel zoom and right-drag panning.
-  - World map editor includes a stamp palette for 16x16 terrain chunks.
+  - World map editor includes a Stamps button for 16x16 terrain chunks.
 
 [ LICENSE ]
  MIT License

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -79,6 +79,32 @@
       font-size: 13px;
     }
 
+    #stampWindow {
+      position: absolute;
+      top: 40px;
+      right: 10px;
+      background: #0f120f;
+      border: 1px solid #2b3b2b;
+      padding: 4px;
+      max-height: 200px;
+      overflow-y: auto;
+      display: none;
+      z-index: 50;
+    }
+
+    #stampWindow .stamp-option {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      cursor: pointer;
+      margin-bottom: 4px;
+    }
+
+    #stampWindow canvas {
+      image-rendering: pixelated;
+      border: 1px solid #2b3b2b;
+    }
+
     legend {
       font-size: 16px;
       font-weight: 600;
@@ -231,13 +257,9 @@
               <button type="button" data-tile="4" style="background:#777777"></button>
               <button type="button" data-tile="5" style="background:#304326"></button>
               <button type="button" data-tile="6" style="background:#4d5f4d"></button>
+              <button type="button" id="stampsBtn">Stamps</button>
             </div>
-            <div id="stampPalette">
-              <button type="button" data-stamp="hill">Hill</button>
-              <button type="button" data-stamp="cross">Cross Roads</button>
-              <button type="button" data-stamp="compound">Compound</button>
-              <button type="button" data-stamp="pond">Pond</button>
-            </div>
+            <div id="stampWindow"></div>
             <div id="paletteLabel"></div>
           </div>
           <button class="btn" id="noiseToggle">Noise: On</button>

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -146,6 +146,21 @@ test('hill stamp emits 16x16 emoji grid', () => {
   assert.strictEqual(Array.from(block[8])[8], tileEmoji[TILE.ROCK]);
 });
 
+test('stamps window selects a world stamp', () => {
+  genWorld(1);
+  const first = Object.keys(worldStamps)[0];
+  const btn = document.getElementById('stampsBtn');
+  btn._listeners.click[0]();
+  const win = document.getElementById('stampWindow');
+  assert.strictEqual(win.style.display, 'block');
+  const opt = win.children[0];
+  opt._listeners.click[0]();
+  assert.strictEqual(worldStamp, worldStamps[first]);
+  assert.notStrictEqual(document.getElementById('paletteLabel').textContent, '');
+  assert.strictEqual(win.style.display, 'none');
+  worldStamp = null;
+});
+
 test('dragging building ignores paint', () => {
   genWorld(1);
   moduleData.buildings = [{ x:5, y:5, w:1, h:1 }];


### PR DESCRIPTION
## Summary
- add Stamps button that opens a scrollable stamp palette with 16x16 previews
- show stamp preview while hovering the world map
- exercise stamp picker with a new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9e9329eec83288b6acddef8135987