### PR TITLE
fix: style stamp button with icon

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -131,7 +131,7 @@ _______________________________________________________________________________
 [ FEATURE LOG ]
   - ACK player can fetch modules by URL, load local JSON, or auto-load via &module=URL (defaults to modules/golden.module.json).
   - World map editor supports mousewheel zoom and right-drag panning.
-  - World map editor includes a Stamps button for 16x16 terrain chunks.
+  - World map editor includes a stamp icon for 16x16 terrain chunks.
 
 [ LICENSE ]
  MIT License

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -257,8 +257,8 @@
               <button type="button" data-tile="4" style="background:#777777"></button>
               <button type="button" data-tile="5" style="background:#304326"></button>
               <button type="button" data-tile="6" style="background:#4d5f4d"></button>
-              <button type="button" id="stampsBtn">Stamps</button>
             </div>
+            <button class="btn" type="button" id="stampsBtn" title="Stamps" aria-label="Stamps">🔖</button>
             <div id="stampWindow"></div>
             <div id="paletteLabel"></div>
           </div>


### PR DESCRIPTION
## Summary
- replace text "Stamps" button with a bookmark icon and apply editor button styling
- document stamp icon in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9ecbdc0c08328956cceeb21bcab70