### PR TITLE
feat: show tile AI status

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -249,6 +249,10 @@
         <canvas id="map" width="640" height="480" aria-label="Map preview"></canvas>
         <div class="btn-group" id="paletteGroup">
           <div id="paletteWrap">
+            <div id="nanoStatus">
+              <div id="nanoProgress" class="nano-progress"></div>
+              <div id="nanoBadge" class="nano-badge off">✗</div>
+            </div>
             <div id="worldPalette">
               <button type="button" data-tile="0" style="background:#1e271d"></button>
               <button type="button" data-tile="1" style="background:#2c342c"></button>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1633,7 +1633,7 @@ bldgPalette.querySelectorAll('button').forEach(btn=>{
 bldgPalette.querySelector('button')?.classList.add('active');
 
 if (worldPalette) {
-  worldPalette.querySelectorAll('button').forEach(btn => {
+  function bindPaletteBtn(btn) {
     btn.addEventListener('click', () => {
       const isOn = btn.classList.contains('active');
       worldPalette.querySelectorAll('button').forEach(b => b.classList.remove('active'));
@@ -1641,13 +1641,39 @@ if (worldPalette) {
       worldStamp = null;
       if (!isOn) {
         btn.classList.add('active');
-        if (paletteLabel) paletteLabel.textContent = tileNames[worldPaint] || '';
+        if (paletteLabel) {
+          const label = btn.dataset.name || tileNames[worldPaint] || '';
+          paletteLabel.textContent = label;
+        }
       } else if (paletteLabel) {
         paletteLabel.textContent = '';
       }
       updateCursor();
     });
-  });
+  }
+  worldPalette.querySelectorAll('button').forEach(bindPaletteBtn);
+
+  if (window.NanoPalette) {
+    window.NanoPalette.init();
+    async function pumpAiTiles() {
+      const block = await window.NanoPalette.generate();
+      if (block) {
+        const btn = document.createElement('button');
+        btn.dataset.tile = '0';
+        btn.dataset.name = 'AI';
+        btn.textContent = block[0]?.[0] || '?';
+        const anchor = document.getElementById('stampsBtn');
+        if (worldPalette.insertBefore && anchor) {
+          worldPalette.insertBefore(btn, anchor);
+        } else {
+          worldPalette.appendChild(btn);
+        }
+        bindPaletteBtn(btn);
+      }
+      setTimeout(pumpAiTiles, 0);
+    }
+    pumpAiTiles();
+  }
 }
 
 const stampsBtn = document.getElementById('stampsBtn');

--- a/dustland-nano.js
+++ b/dustland-nano.js
@@ -23,7 +23,8 @@
     init,
     generate: generatePalette,
     isReady: ()=> _state.ready,
-    enabled: true
+    enabled: true,
+    refreshIndicator
   };
 
   const _state = {
@@ -55,7 +56,7 @@
   function _updateBadge(){
     _ensureUI();
     if(!_ui.badge) return;
-    const on=_state.ready && window.NanoDialog.enabled;
+    const on=_state.ready && (window.NanoDialog.enabled || window.NanoPalette.enabled);
     _ui.badge.textContent = on ? '✓' : (_state.failed ? '!' : '✗');
     _ui.badge.classList.toggle('on', on);
     _ui.badge.classList.toggle('off', !on && !_state.failed);
@@ -406,6 +407,7 @@ Choices:
 
   async function generatePalette(examples){
     if(!_state.ready || !window.NanoPalette.enabled) return null;
+    _setBusy(true);
     const prompt = _buildPalettePrompt(examples);
     try {
       const out = await _state.session.prompt(prompt);
@@ -414,6 +416,8 @@ Choices:
     } catch(err){
       console.error('[Nano] palette generation failed:', err);
       return null;
+    } finally {
+      _setBusy(false);
     }
   }
 

--- a/test/nano.test.js
+++ b/test/nano.test.js
@@ -33,7 +33,14 @@ global.toast = noop;
 global.LanguageModel = {
   availability: async () => 'available',
   create: async () => ({
-    prompt: async () => `Lines:\nRust bites every gear, but we endure.\nKeep your scrap dry.\nNever trade hope for rust.\nChoices:\nAsk about wares|Got anything rare?\nInspect the stall|INT|8|XP 5|You spot a hidden coil.|You find only dust.\n`
+    prompt: async (p) => {
+      if (p.includes('New 16x16 block')) {
+        const line = '🏝'.repeat(16);
+        const block = Array(16).fill(line).join('\n');
+        return { output: [{ content: [{ text: block }] }] };
+      }
+      return `Lines:\nRust bites every gear, but we endure.\nKeep your scrap dry.\nNever trade hope for rust.\nChoices:\nAsk about wares|Got anything rare?\nInspect the stall|INT|8|XP 5|You spot a hidden coil.|You find only dust.\n`;
+    }
   })
 };
 
@@ -64,4 +71,11 @@ test('NanoDialog skips missing dialog nodes', async () => {
   const choices = window.NanoDialog.choicesFor('npc1', 'bogus');
   assert.deepStrictEqual(lines, []);
   assert.deepStrictEqual(choices, []);
+});
+
+test('NanoPalette generates a block', async () => {
+  await import('../dustland-nano.js');
+  await window.NanoPalette.init();
+  const block = await window.NanoPalette.generate();
+  assert.ok(Array.isArray(block) && block.length === 16, 'block generated');
 });


### PR DESCRIPTION
## Summary
- show Gemini Nano tile generator status in the palette UI
- stream generated tiles into the palette as they arrive
- exercise NanoPalette generation in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9ec3ffb408328a66d51519d5241e0