### PR TITLE
fix: guard palette insert

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1663,7 +1663,7 @@ if (worldPalette) {
         btn.dataset.name = 'AI';
         btn.textContent = block[0]?.[0] || '?';
         const anchor = document.getElementById('stampsBtn');
-        if (worldPalette.insertBefore && anchor) {
+        if (worldPalette.insertBefore && anchor && worldPalette.contains(anchor)) {
           worldPalette.insertBefore(btn, anchor);
         } else {
           worldPalette.appendChild(btn);


### PR DESCRIPTION
## Summary
- prevent AI tile generator from inserting relative to a node outside of the world palette

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9f7b80e948328afc0c0f81af8c3d8