### PR TITLE
feat: add nano stamp button

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -105,6 +105,13 @@
       border: 1px solid #2b3b2b;
     }
 
+    #stampWindow #nanoStampBtn {
+      font-size: 12px;
+      margin: 4px auto 0;
+      display: block;
+      padding: 2px 4px;
+    }
+
     legend {
       font-size: 16px;
       font-weight: 600;

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1654,28 +1654,10 @@ if (worldPalette) {
     });
   }
   worldPalette.querySelectorAll('button').forEach(bindPaletteBtn);
+}
 
-  if (window.NanoPalette) {
-    window.NanoPalette.init();
-    async function pumpAiTiles() {
-      const block = await window.NanoPalette.generate();
-      if (block) {
-        const btn = document.createElement('button');
-        btn.dataset.tile = '0';
-        btn.dataset.name = 'AI';
-        btn.textContent = block[0]?.[0] || '?';
-        const anchor = document.getElementById('stampsBtn');
-        if (worldPalette.insertBefore && anchor && worldPalette.contains(anchor)) {
-          worldPalette.insertBefore(btn, anchor);
-        } else {
-          worldPalette.appendChild(btn);
-        }
-        bindPaletteBtn(btn);
-      }
-      setTimeout(pumpAiTiles, 0);
-    }
-    pumpAiTiles();
-  }
+if (window.NanoPalette) {
+  window.NanoPalette.init();
 }
 
 const stampsBtn = document.getElementById('stampsBtn');
@@ -1709,6 +1691,30 @@ if (stampsBtn && stampWindow) {
         drawWorld();
       });
       stampWindow.appendChild(opt);
+    }
+    if (window.NanoPalette) {
+      const aiBtn = document.createElement('button');
+      aiBtn.id = 'nanoStampBtn';
+      aiBtn.className = 'btn';
+      aiBtn.textContent = '🤖';
+      aiBtn.addEventListener('click', async () => {
+        const block = await window.NanoPalette.generate();
+        if (block) {
+          const grid = gridFromEmoji(block);
+          worldStamps.nano = grid;
+          worldStampEmoji.nano = block;
+          stampNames.nano = 'Nano';
+          renderStampWindow();
+          worldStamp = worldStamps.nano;
+          worldPaint = null;
+          if (worldPalette) worldPalette.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+          if (paletteLabel) paletteLabel.textContent = stampNames.nano || '';
+          stampWindow.style.display = 'none';
+          updateCursor();
+          drawWorld();
+        }
+      });
+      stampWindow.appendChild(aiBtn);
     }
   }
   renderStampWindow();

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -67,6 +67,12 @@ global.document = {
   querySelectorAll: () => []
 };
 
+global.NanoPalette = {
+  init: () => {},
+  generate: async () => Array(16).fill('🏝'.repeat(16)),
+  enabled: true
+};
+
 const files = [
   '../event-bus.js',
   '../core/movement.js',
@@ -158,6 +164,20 @@ test('stamps window selects a world stamp', () => {
   assert.strictEqual(worldStamp, worldStamps[first]);
   assert.notStrictEqual(document.getElementById('paletteLabel').textContent, '');
   assert.strictEqual(win.style.display, 'none');
+  worldStamp = null;
+});
+
+test('nano button generates a stamp', async () => {
+  genWorld(1);
+  const btn = document.getElementById('stampsBtn');
+  btn._listeners.click[0]();
+  const win = document.getElementById('stampWindow');
+  const nanoBtn = win.children[win.children.length - 1];
+  let called = 0;
+  NanoPalette.generate = async () => { called++; return Array(16).fill('🏝'.repeat(16)); };
+  await nanoBtn._listeners.click[0]();
+  assert.strictEqual(called, 1);
+  assert.ok(Array.isArray(worldStamp) && worldStamp.length === 16);
   worldStamp = null;
 });
 

--- a/test/nano.test.js
+++ b/test/nano.test.js
@@ -39,7 +39,7 @@ global.LanguageModel = {
       if (p.includes('New 16x16 block')) {
         const line = '🏝'.repeat(16);
         const block = Array(16).fill(line).join('\n');
-        return { output: [{ content: [{ text: block }] }] };
+        return block;
       }
       return `Lines:\nRust bites every gear, but we endure.\nKeep your scrap dry.\nNever trade hope for rust.\nChoices:\nAsk about wares|Got anything rare?\nInspect the stall|INT|8|XP 5|You spot a hidden coil.|You find only dust.\n`;
     }


### PR DESCRIPTION
## Summary
- add manual Nano stamp generation button in stamp palette
- style new Nano button for compact appearance
- parse Nano palette responses as plain text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9f9f753848328a6d6705bb3e34dbf