### PR TITLE
feat: add async pathfinding and patrol loops

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -132,6 +132,7 @@ _______________________________________________________________________________
   - ACK player can fetch modules by URL, load local JSON, or auto-load via &module=URL (defaults to modules/golden.module.json).
   - World map editor supports mousewheel zoom and right-drag panning.
   - World map editor includes a stamp icon for 16x16 terrain chunks.
+  - NPCs can patrol between waypoints using async A* pathfinding.
 
 [ LICENSE ]
  MIT License

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -313,6 +313,7 @@
           <label>Map<input id="npcMap" value="world" /></label>
           <label>X<input id="npcX" type="number" min="0" /></label>
           <label>Y<input id="npcY" type="number" min="0" /></label>
+          <label>Loop<input id="npcLoop" placeholder="x1,y1;x2,y2" /></label>
           <div class="portrait" id="npcPort"></div>
           <div class="row" style="margin:8px 0">
             <span class="pill" id="npcPrevP">&lt;</span>
@@ -535,11 +536,12 @@
   <script defer src="./core/combat.js"></script>
   <script defer src="./core/party.js"></script>
   <script defer src="./core/quests.js"></script>
-  <script defer src="./core/npc.js"></script>
-  <script defer src="./dustland-core.js"></script>
-  <script defer src="./dustland-nano.js"></script>
-  <script defer src="./dustland-engine.js"></script>
-  <script defer src="./adventure-kit.js"></script>
-</body>
+    <script defer src="./core/npc.js"></script>
+    <script defer src="./dustland-core.js"></script>
+    <script defer src="./dustland-path.js"></script>
+    <script defer src="./dustland-nano.js"></script>
+    <script defer src="./dustland-engine.js"></script>
+    <script defer src="./adventure-kit.js"></script>
+  </body>
 
 </html>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1022,6 +1022,7 @@ function startNewNPC() {
   document.getElementById('npcMap').value = 'world';
   document.getElementById('npcX').value = 0;
   document.getElementById('npcY').value = 0;
+  document.getElementById('npcLoop').value = '';
   npcPortraitIndex = 0;
   setNpcPortrait();
   document.getElementById('npcHidden').checked = false;
@@ -1073,6 +1074,7 @@ function collectNPCFromForm() {
   const map = document.getElementById('npcMap').value.trim() || 'world';
   const x = parseInt(document.getElementById('npcX').value, 10) || 0;
   const y = parseInt(document.getElementById('npcY').value, 10) || 0;
+  const loopStr = document.getElementById('npcLoop').value.trim();
   const dialog = document.getElementById('npcDialog').value.trim();
   const questId = document.getElementById('npcQuest').value.trim();
   const accept = document.getElementById('npcAccept').value.trim();
@@ -1107,6 +1109,13 @@ function collectNPCFromForm() {
   loadTreeEditor();
 
   const npc = { id, name, desc, color, map, x, y, tree, questId };
+  if (loopStr) {
+    const pts = loopStr.split(';').map(p => {
+      const [px, py] = p.split(',').map(n => parseInt(n, 10) || 0);
+      return { x: px, y: py };
+    }).filter(p => !isNaN(p.x) && !isNaN(p.y));
+    if (pts.length >= 2) npc.loop = pts;
+  }
   if (combat) npc.combat = { DEF: 5 };
   if (shop) npc.shop = true;
   if (hidden && flag) npc.hidden = true, npc.reveal = { flag, op, value: val };
@@ -1155,6 +1164,7 @@ function editNPC(i) {
   document.getElementById('npcMap').value = n.map;
   document.getElementById('npcX').value = n.x;
   document.getElementById('npcY').value = n.y;
+  document.getElementById('npcLoop').value = (n.loop || []).map(p => `${p.x},${p.y}`).join(';');
   npcPortraitIndex = npcPortraits.indexOf(n.portraitSheet);
   if (npcPortraitIndex < 0) npcPortraitIndex = 0;
   setNpcPortrait();

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -189,6 +189,7 @@ function draw(t){
     return;
   }
   const dt=(t-_lastTime)||0; _lastTime=t;
+  if (typeof tickPathAI === 'function') tickPathAI(dt);
   render(state, dt/1000);
   const bx = bumpEnd > performance.now() ? bumpX : 0;
   const by = bumpEnd > performance.now() ? bumpY : 0;

--- a/dustland-path.js
+++ b/dustland-path.js
@@ -1,0 +1,121 @@
+// dustland-path.js
+// Simple A* pathfinding with async queue for Dustland
+(function(){
+  console.log('[Path] Script loaded');
+  const PathQueue = { queue, pathFor };
+  const state = { queue: [], busy:false, cache:new Map() };
+
+  function queue(map, start, goal, ignoreId){
+    const key = `${map}@${start.x},${start.y}->${goal.x},${goal.y}`;
+    if(state.cache.has(key) || state.queue.find(j=>j.key===key)) return key;
+    state.queue.push({map,start,goal,key,ignoreId});
+    process();
+    return key;
+  }
+
+  function pathFor(key){
+    return state.cache.get(key) || null;
+  }
+
+  function process(){
+    if(state.busy || !state.queue.length) return;
+    state.busy=true;
+    const job=state.queue.shift();
+    setTimeout(()=>{
+      const p=aStar(job.map, job.start, job.goal, job.ignoreId);
+      state.cache.set(job.key, p);
+      state.busy=false;
+      process();
+    },0);
+  }
+
+  function aStar(map, start, goal, ignoreId){
+    const open=[{x:start.x,y:start.y}];
+    const came={};
+    const g={};
+    const f={};
+    const startKey=key(start.x,start.y);
+    g[startKey]=0;
+    f[startKey]=heuristic(start,goal);
+    while(open.length){
+      open.sort((a,b)=>f[key(a.x,a.y)]-f[key(b.x,b.y)]);
+      const current=open.shift();
+      const ck=key(current.x,current.y);
+      if(current.x===goal.x && current.y===goal.y){
+        return reconstruct(came, ck);
+      }
+      for(const nb of neighbors(current.x,current.y,map,ignoreId)){
+        const nk=key(nb.x,nb.y);
+        const tentative=g[ck]+1;
+        if(tentative < (g[nk]??Infinity)){
+          came[nk]=ck;
+          g[nk]=tentative;
+          f[nk]=tentative+heuristic(nb,goal);
+          if(!open.find(p=>p.x===nb.x && p.y===nb.y)) open.push(nb);
+        }
+      }
+    }
+    return [];
+  }
+
+  function neighbors(x,y,map,ignoreId){
+    const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
+    const out=[];
+    for(const [dx,dy] of dirs){
+      const nx=x+dx, ny=y+dy;
+      if(isWalkableAt(map,nx,ny,ignoreId)) out.push({x:nx,y:ny});
+    }
+    return out;
+  }
+
+  function isWalkableAt(map,x,y,ignoreId){
+    const info=queryTile(x,y,map);
+    if(info.tile===null) return false;
+    if(!walkable[info.tile]) return false;
+    return info.entities.every(e=>e.id===ignoreId);
+  }
+
+  function heuristic(a,b){
+    return Math.abs(a.x-b.x)+Math.abs(a.y-b.y);
+  }
+
+  function reconstruct(came, endKey){
+    const path=[];
+    let k=endKey;
+    while(k){
+      const [x,y]=k.split(',').map(Number);
+      path.push({x,y});
+      k=came[k];
+    }
+    return path.reverse();
+  }
+
+  function key(x,y){ return x+','+y; }
+
+  function tickPathAI(){
+    const now=Date.now();
+    for(const n of NPCS){
+      const pts=n.loop;
+      if(!Array.isArray(pts) || pts.length<2) continue;
+      n._loop = n._loop || { idx:1, path:[], job:null, next:0 };
+      const st=n._loop;
+      if(st.path.length){
+        if(now<st.next) continue;
+        const step=st.path.shift();
+        if(step){ n.x=step.x; n.y=step.y; }
+        st.next=now+400;
+        if(!st.path.length){ st.idx=(st.idx+1)%pts.length; }
+        continue;
+      }
+      if(st.job){
+        const p=PathQueue.pathFor(st.job);
+        if(p){ st.path=p.slice(1); st.job=null; }
+        continue;
+      }
+      const target=pts[st.idx];
+      st.job=queue(n.map,{x:n.x,y:n.y},target,n.id);
+    }
+  }
+
+  Object.assign(globalThis,{ PathQueue, tickPathAI });
+})();

--- a/dustland.html
+++ b/dustland.html
@@ -154,6 +154,7 @@
   <script defer src="./core/quests.js"></script>
   <script defer src="./core/npc.js"></script>
   <script defer src="./dustland-core.js"></script>
+  <script defer src="./dustland-path.js"></script>
   <script defer src="./dustland-nano.js"></script>
   <script defer src="./dustland-engine.js"></script>
   <script>

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -362,6 +362,18 @@ const DUSTLAND_MODULE = (() => {
       portraitSheet: 'assets/portraits/cass_4.png',
       tree: { start: { text: 'Got goods to sell? I pay in scrap.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
       shop: true
+    },
+    {
+      id: 'mara_patrol',
+      map: 'world',
+      x: 14,
+      y: midY - 1,
+      color: '#9ef7a0',
+      name: 'Mara the Scout',
+      title: 'Water Runner',
+      desc: 'She checks the pump then the far ridge.',
+      tree: { start: { text: 'Mara strides past on her rounds.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      loop: [ { x: 14, y: midY - 1 }, { x: 80, y: midY + 4 } ]
     }
   ];
 

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+// minimal globals
+global.window = globalThis;
+
+global.TILE = { FLOOR:0, WALL:1 };
+global.walkable = { 0:true };
+
+global.world = [
+  [0,0,0],
+  [1,1,0],
+  [0,0,0]
+];
+
+global.queryTile = (x,y,map='world') => {
+  const tile = world[y] && world[y][x];
+  return { tile, walkable: tile === 0, entities: [] };
+};
+
+global.NPCS = [];
+
+test('PathQueue finds a path', async () => {
+  await import('../dustland-path.js');
+  const key = window.PathQueue.queue('world',{x:0,y:0},{x:2,y:2});
+  await new Promise(r => setTimeout(r,20));
+  const path = window.PathQueue.pathFor(key);
+  assert.ok(path && path.length > 0, 'path exists');
+  assert.deepStrictEqual(path[0], {x:0,y:0});
+  assert.deepStrictEqual(path[path.length-1], {x:2,y:2});
+});


### PR DESCRIPTION
## Summary
- add async A* pathfinding service with a single-task queue
- allow NPCs to patrol between waypoints using the new pathfinder
- expose loop field in Adventure Kit so modules can define patrol circuits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa015fa8588328b4b6cc6055b6a3ce