### PR TITLE
fix: place stamp palette near button

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -81,8 +81,6 @@
 
     #stampWindow {
       position: absolute;
-      top: 40px;
-      right: 10px;
       background: #0f120f;
       border: 1px solid #2b3b2b;
       padding: 4px;

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1788,7 +1788,15 @@ if (stampsBtn && stampWindow) {
   }
   renderStampWindow();
   stampsBtn.addEventListener('click', () => {
-    stampWindow.style.display = stampWindow.style.display === 'block' ? 'none' : 'block';
+    if (stampWindow.style.display === 'block') {
+      stampWindow.style.display = 'none';
+      return;
+    }
+    const rect = stampsBtn.getBoundingClientRect();
+    stampWindow.style.left = rect.left + window.scrollX + 'px';
+    stampWindow.style.top = rect.bottom + window.scrollY + 'px';
+    stampWindow.style.right = 'auto';
+    stampWindow.style.display = 'block';
   });
 }
 

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -18,7 +18,7 @@ function stubEl(){
     prepend(child){ this.children.unshift(child); child.parentElement=this; },
     querySelector: () => stubEl(),
     querySelectorAll: () => [],
-    getBoundingClientRect: () => ({ left:0, top:0 }),
+    getBoundingClientRect: () => ({ left:0, top:0, bottom:0 }),
     getContext: () => ({
       clearRect(){}, drawImage(){}, fillRect(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){}, strokeRect(){},
       save(){}, restore(){}, translate(){}, font:'', fillText(){}, globalAlpha:1
@@ -165,6 +165,16 @@ test('stamps window selects a world stamp', () => {
   assert.notStrictEqual(document.getElementById('paletteLabel').textContent, '');
   assert.strictEqual(win.style.display, 'none');
   worldStamp = null;
+});
+
+test('stamps window positions near button', () => {
+  genWorld(1);
+  const btn = document.getElementById('stampsBtn');
+  btn._listeners.click[0]();
+  const win = document.getElementById('stampWindow');
+  assert.notStrictEqual(win.style.left, '');
+  assert.notStrictEqual(win.style.top, '');
+  win.style.display = 'none';
 });
 
 test('nano button generates a stamp', async () => {


### PR DESCRIPTION
## Summary
- position stamp palette window next to stamp button for easier access
- adjust tests and stubs to account for new dynamic placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa065729388328a5d8ffc049fbfa70