### PR TITLE
feat: add NPC path editor

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -132,7 +132,7 @@ _______________________________________________________________________________
   - ACK player can fetch modules by URL, load local JSON, or auto-load via &module=URL (defaults to modules/golden.module.json).
   - World map editor supports mousewheel zoom and right-drag panning.
   - World map editor includes a stamp icon for 16x16 terrain chunks.
-  - NPCs can patrol between waypoints using async A* pathfinding.
+  - NPC patrol routes are visualized with draggable waypoints and add/remove controls.
 
 [ LICENSE ]
  MIT License

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -313,7 +313,9 @@
           <label>Map<input id="npcMap" value="world" /></label>
           <label>X<input id="npcX" type="number" min="0" /></label>
           <label>Y<input id="npcY" type="number" min="0" /></label>
-          <label>Loop<input id="npcLoop" placeholder="x1,y1;x2,y2" /></label>
+          <label>Patrol Waypoints</label>
+          <div id="npcLoopPts"></div>
+          <button class="btn" type="button" id="addLoopPt">+ Waypoint</button>
           <div class="portrait" id="npcPort"></div>
           <div class="row" style="margin:8px 0">
             <span class="pill" id="npcPrevP">&lt;</span>


### PR DESCRIPTION
## Summary
- show selected NPC patrol route with draggable waypoints
- allow adding/removing patrol points via hover buttons
- swap single loop field for individual waypoint inputs in NPC editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa077bf4688328a89eccab02407ade