### PR TITLE
feat: extend dialog goto options

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -122,6 +122,7 @@ _______________________________________________________________________________
       * applyModule(data), openCreator()
       * uncurseItem(id)
   - NPC trees can be functions for dynamic dialog.
+  - Dialog choices support `goto` targeting the player or NPC with optional relative coordinates.
   - Items support `equip.flag` and `unequip` teleport/message effects.
   - Tiles: see TILE enum + colors[] + walkable[].
   - Maps can be specified as arrays of emoji strings using `tileEmoji` (numeric grids still load).

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -172,6 +172,16 @@
       padding: 0 4px;
     }
 
+    #treeEditor .choiceAdv fieldset {
+      border: 1px solid #2b3b2b;
+      padding: 4px;
+      margin-top: 4px;
+    }
+
+    #treeEditor .choiceAdv fieldset legend {
+      padding: 0 4px;
+    }
+
     #treeEditor .choices details {
       flex-basis: 100%;
     }

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -580,6 +580,8 @@ function addChoiceRow(container, ch = {}) {
   const joinId = join?.id || '', joinName = join?.name || '', joinRole = join?.role || '';
   const goto = ch.goto || {};
   const gotoMap = goto.map || '', gotoX = goto.x != null ? goto.x : '', gotoY = goto.y != null ? goto.y : '';
+  const gotoTarget = goto.target === 'npc' ? 'npc' : 'player';
+  const gotoRel = !!goto.rel;
   const isXP = typeof reward === 'string' && /^xp\s*\d+/i.test(reward);
   const xpVal = isXP ? parseInt(reward.replace(/[^0-9]/g, ''), 10) : '';
   const isItem = reward && !isXP;
@@ -605,12 +607,18 @@ function addChoiceRow(container, ch = {}) {
       <label>Cost Slot<select class="choiceCostSlot"></select></label>
       <label>Req Item<select class="choiceReqItem"></select></label>
       <label>Req Slot<select class="choiceReqSlot"></select></label>
-      <label>Join ID<select class="choiceJoinId"></select></label>
-      <label>Join Name<input class="choiceJoinName" value="${joinName}"/><span class="small">Name shown after joining.</span></label>
-      <label>Join Role<select class="choiceJoinRole"></select></label>
-      <label>Goto Map<select class="choiceGotoMap"></select></label>
-      <label>Goto X<input type="number" class="choiceGotoX" value="${gotoX}"/><span class="small">X coordinate.</span></label>
-      <label>Goto Y<input type="number" class="choiceGotoY" value="${gotoY}"/><span class="small">Y coordinate.</span></label>
+      <fieldset class="choiceSubGroup"><legend>Join</legend>
+        <label>ID<select class="choiceJoinId"></select></label>
+        <label>Name<input class="choiceJoinName" value="${joinName}"/><span class="small">Name shown after joining.</span></label>
+        <label>Role<select class="choiceJoinRole"></select></label>
+      </fieldset>
+      <fieldset class="choiceSubGroup"><legend>Goto</legend>
+        <label>Target<select class="choiceGotoTarget"><option value="player" ${gotoTarget==='player'?'selected':''}>Player</option><option value="npc" ${gotoTarget==='npc'?'selected':''}>NPC</option></select></label>
+        <label>Map<select class="choiceGotoMap"></select></label>
+        <label>X<input type="number" class="choiceGotoX" value="${gotoX}"/><span class="small">X coordinate.</span></label>
+        <label>Y<input type="number" class="choiceGotoY" value="${gotoY}"/><span class="small">Y coordinate.</span></label>
+        <label class="inline"><input type="checkbox" class="choiceGotoRel" ${gotoRel?'checked':''}/> relative</label>
+      </fieldset>
       <label>Board Door<select class="choiceBoard"></select></label>
       <label>Unboard Door<select class="choiceUnboard"></select></label>
       <label>Quest<select class="choiceQ"><option value=""></option><option value="accept" ${q==='accept'?'selected':''}>accept</option><option value="turnin" ${q==='turnin'?'selected':''}>turnin</option></select></label>
@@ -803,6 +811,8 @@ function updateTreeData() {
       const gotoMap = chEl.querySelector('.choiceGotoMap').value.trim();
       const gotoXTxt = chEl.querySelector('.choiceGotoX').value.trim();
       const gotoYTxt = chEl.querySelector('.choiceGotoY').value.trim();
+      const gotoTarget = chEl.querySelector('.choiceGotoTarget').value;
+      const gotoRel = chEl.querySelector('.choiceGotoRel').checked;
       const q = chEl.querySelector('.choiceQ').value.trim();
       const once = chEl.querySelector('.choiceOnce').checked;
       const flag = chEl.querySelector('.choiceFlag').value.trim();
@@ -825,12 +835,16 @@ function updateTreeData() {
         if (reqItem) c.reqItem = reqItem;
         if (reqSlot) c.reqSlot = reqSlot;
         if (joinId || joinName || joinRole) c.join = { id: joinId, name: joinName, role: joinRole };
-        if (gotoMap) {
-          c.goto = { map: gotoMap };
+        if (gotoMap || gotoXTxt || gotoYTxt || gotoTarget === 'npc' || gotoRel) {
+          const go = {};
+          if (gotoMap) go.map = gotoMap;
           const gx = gotoXTxt ? parseInt(gotoXTxt, 10) : undefined;
           const gy = gotoYTxt ? parseInt(gotoYTxt, 10) : undefined;
-          if (gx != null && !Number.isNaN(gx)) c.goto.x = gx;
-          if (gy != null && !Number.isNaN(gy)) c.goto.y = gy;
+          if (gx != null && !Number.isNaN(gx)) go.x = gx;
+          if (gy != null && !Number.isNaN(gy)) go.y = gy;
+          if (gotoTarget === 'npc') go.target = 'npc';
+          if (gotoRel) go.rel = true;
+          c.goto = go;
         }
         if (q) c.q = q;
         if (once) c.once = true;

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -91,15 +91,29 @@ function joinParty(join){
   }
 }
 
+// Teleport actor to a new position.
+// g: { map?, x?, y?, target?:'npc'|'player', rel?:true }
+//   target defaults to player (party).
+//   rel=true offsets from current position.
 function handleGoto(g){
   if(!g) return;
-  if(g.map==='world'){
-    startWorld();
-    setPartyPos(g.x, g.y);
-    setMap('world');
+  const tgtNPC = g.target === 'npc' ? currentNPC : null;
+  const base = tgtNPC || party;
+  const x = g.rel ? base.x + (g.x || 0) : (g.x != null ? g.x : base.x);
+  const y = g.rel ? base.y + (g.y || 0) : (g.y != null ? g.y : base.y);
+  if(tgtNPC){
+    if(g.map) tgtNPC.map = g.map;
+    tgtNPC.x = x;
+    tgtNPC.y = y;
   }else{
-    setPartyPos(g.x, g.y);
-    if(g.map) setMap(g.map); else if(typeof centerCamera==='function') centerCamera(party.x,party.y,state.map);
+    if(g.map==='world'){
+      startWorld();
+      setPartyPos(x, y);
+      setMap('world');
+    }else{
+      setPartyPos(x, y);
+      if(g.map) setMap(g.map); else if(typeof centerCamera==='function') centerCamera(party.x,party.y,state.map);
+    }
   }
   updateHUD?.();
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -460,6 +460,29 @@ test('advanceDialog matches reqItem case-insensitively', () => {
   assert.strictEqual(party.y, 8);
 });
 
+test('advanceDialog goto can target NPC', () => {
+  NPCS.length = 0;
+  const tree = { start: { text: '', choices: [ { label: 'Move', goto: { target: 'npc', x: 1, y: 2 } } ] } };
+  const npc = makeNPC('m', 'world', 0, 0, '#fff', 'Mover', '', '', tree);
+  NPCS.push(npc);
+  openDialog(npc);
+  choicesEl.children[0].onclick();
+  assert.strictEqual(npc.x, 1);
+  assert.strictEqual(npc.y, 2);
+  closeDialog();
+  NPCS.length = 0;
+});
+
+test('advanceDialog goto supports relative movement', () => {
+  state.map = 'world';
+  party.x = 4; party.y = 5;
+  const tree = { start: { text: '', next: [ { label: 'Step', goto: { rel: true, x: 2, y: -1 } } ] } };
+  const dialog = { tree, node: 'start' };
+  advanceDialog(dialog, 0);
+  assert.strictEqual(party.x, 6);
+  assert.strictEqual(party.y, 4);
+});
+
 test('advanceDialog returns success flag on failure', () => {
   const tree = {
     start: { text: '', next: [{ label: 'Fail', check: { stat: 'str', dc: 999 } }] }


### PR DESCRIPTION
## Summary
- allow dialog goto to target the player or NPC and use relative coordinates
- group join and goto widgets in Adventure Kit
- document goto targeting support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2878803883288e69a40df13309c4