### PR TITLE
fix: dedupe quest and map typedefs

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -52,48 +52,6 @@ const { on } = globalThis.EventBus;
  */
 
 /**
- * @typedef {Object} Quest
- * @property {string} id
- * @property {string} name
- * @property {'available'|'active'|'completed'} status
- * @property {string} [desc]
- * @property {Function} [onStart]
- * @property {Function} [onComplete]
- */
-
-/**
- * @typedef {Object} Map
- * @property {string} id
- * @property {number} w
- * @property {number} h
- * @property {number[][]} grid
- * @property {number} [entryX]
- * @property {number} [entryY]
- * @property {string} [name]
- */
-
-/**
- * @typedef {Object} Quest
- * @property {string} id
- * @property {string} name
- * @property {'available'|'active'|'completed'} status
- * @property {string} [desc]
- * @property {Function} [onStart]
- * @property {Function} [onComplete]
- */
-
-/**
- * @typedef {Object} Map
- * @property {string} id
- * @property {number} w
- * @property {number} h
- * @property {number[][]} grid
- * @property {number} [entryX]
- * @property {number} [entryY]
- * @property {string} [name]
- */
-
-/**
  * @typedef {Object} Check
  * @property {string} stat
  * @property {number} dc


### PR DESCRIPTION
## Summary
- remove duplicate Quest and Map typedefs in `dustland-core.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2b00bde08328ad159690037be191