### PR TITLE
fix: click-to-edit path waypoints

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -132,7 +132,7 @@ _______________________________________________________________________________
   - ACK player can fetch modules by URL, load local JSON, or auto-load via &module=URL (defaults to modules/golden.module.json).
   - World map editor supports mousewheel zoom and right-drag panning.
   - World map editor includes a stamp icon for 16x16 terrain chunks.
-  - NPC patrol routes are visualized with draggable waypoints and add/remove controls.
+  - NPC patrol routes are visualized with draggable waypoints and click-to-add/remove controls.
 
 [ LICENSE ]
  MIT License


### PR DESCRIPTION
## Summary
- Show + and – controls when clicking NPC patrol waypoints
- Allow dragging waypoints while keeping controls visible until dismissed
- Document click-based path editing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2a73b0448328af11cae02886c691