### PR TITLE
Enrich Dustland plot with new sign and dialogue

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -77,7 +77,7 @@ const DUSTLAND_MODULE = (() => {
             { label: '(Leave)', to: 'bye' }
           ]
         },
-        accept: { text: 'Try the crates. And don’t scuff the floor.', choices: [ { label: '(Okay)', to: 'bye' } ] },
+        accept: { text: 'Try the crates. This hall sheltered survivors once. Don’t scuff the floor.', choices: [ { label: '(Okay)', to: 'bye' } ] },
         do_turnin: {
           text: 'Kesh unlocks the chain. “Off you go.”',
           choices: [ { label: '(Continue)', to: 'bye', goto: { map: 'world', x: 2, y: midY } } ]
@@ -120,6 +120,17 @@ const DUSTLAND_MODULE = (() => {
       desc: 'A drifter muttering to themselves.',
       portraitSheet: 'assets/portraits/drifter_4.png',
       tree: { start: { text: '"Dust gets in everything."', choices: [ { label: '(Nod)', to: 'bye' } ] } }
+    },
+    {
+      id: 'road_sign',
+      map: 'world',
+      x: 6,
+      y: midY,
+      color: '#caffc6',
+      name: 'Worn Sign',
+      title: 'Warning',
+      desc: 'Faded letters warn travelers.',
+      tree: { start: { text: 'Rust storms east. Shelter west.', choices: [ { label: '(Leave)', to: 'bye' } ] } }
     },
     {
       id: 'pump',
@@ -303,11 +314,13 @@ const DUSTLAND_MODULE = (() => {
           choices: [
             { label: '(Pay) Nod and pass', to: 'pay', q: 'turnin' },
             { label: '(Refuse)', to: 'ref', q: 'turnin' },
+            { label: '(Rumors)', to: 'rumors' },
             { label: '(Leave)', to: 'bye' }
           ]
         },
         pay: { text: 'Wise. Move along.', choices: [ { label: '(Ok)', to: 'bye' } ] },
-        ref: { text: 'Brave. Or foolish.', choices: [ { label: '(Ok)', to: 'bye' } ] }
+        ref: { text: 'Brave. Or foolish.', choices: [ { label: '(Ok)', to: 'bye' } ] },
+        rumors: { text: 'Radio crackles from the north; idol whispers from the south.', choices: [ { label: '(Thanks)', to: 'bye' } ] }
       }
     },
     {

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('dustland module includes plot improvements', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'dustland.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /id: 'road_sign'/);
+  assert.match(src, /hall sheltered survivors/);
+  assert.match(src, /Radio crackles from the north; idol whispers from the south/);
+});


### PR DESCRIPTION
## Summary
- Expand Kesh's guidance with a nod to the hall's survivor past
- Add a worn sign on the road warning of rust storms
- Let the Scrap Duchess share rumors about the wastes
- Cover the new plot beats with a simple module test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2abd0de0832886166be9ef577985