### PR TITLE
refactor: streamline core helpers

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -78,10 +78,7 @@ window.startGame = async function () {
   const start = moduleData && moduleData.start ? moduleData.start : { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   setPartyPos(start.x, start.y);
   setMap(start.map || 'world', 'Module');
-  renderInv();
-  renderQuests();
-  renderParty();
-  updateHUD();
+  refreshUI();
   log('Adventure begins.');
 };
 


### PR DESCRIPTION
## Summary
- remove redundant type docs in core
- add `refreshUI` helper and reuse across engine and ACK player
- centralize default drifter name generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2ad3bc288328bff4d520797f367c