### PR TITLE
docs: expand bios with project overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ Guidelines for contributors and automated agents working on Dustland CRT.
 - Update README files or inline comments when behavior or APIs change.
 - Extend this file whenever new best practices emerge during development.
 
+## Design documentation
+- Keep design docs in `docs/design`.
+- Each document should list its author and reflect the background and tone from `docs/team-bios.md`.
+
 ## UI style
 - Ensure any newly added buttons match the visual style of existing controls in both the game and editor.
 

--- a/docs/design/editor.md
+++ b/docs/design/editor.md
@@ -1,0 +1,5 @@
+# Editor Notes
+*By Priya "Gizmo" Sharma*
+
+Our editor should feel like a trusty pocket multitool. Drop-down menus for modules, drag-and-drop for NPC placement, and instant validation— no one should fight the tools. Every asset lives in a predictable folder, and the editor warns instead of crashing when someone forgets a comma. Let's keep the UI keyboard-friendly and expose hooks so modders can extend panels without forking the core.
+

--- a/docs/design/game-story.md
+++ b/docs/design/game-story.md
@@ -1,0 +1,5 @@
+# Game Story
+*By Alex "Echo" Johnson*
+
+The Dustland stretches beyond the horizon, a patchwork of forgotten highways and half-buried towns. Survivors cling to myths about a signal that can stitch the world back together. Our party rides into this mess not as heroes, but as witnesses. Every quest should show how people bend— or break— under the weight of dust and hope. Give me moments where a broken radio triggers an uprising, or a cracked photo frame becomes a plot twist. Keep the tone soulful, never cynical; we scrape the rust to find glimmers underneath.
+

--- a/docs/design/gameplay.md
+++ b/docs/design/gameplay.md
@@ -1,0 +1,5 @@
+# Gameplay Loop
+*By Mateo "Wing" Alvarez*
+
+Feel every encounter in your pulse. Combat should reward timing and positioning— dodge at the last frame, strike where it hurts, then sprint before the dust settles. I want mobs that telegraph clearly and punish greed, plus arenas with multiple routes for stylish escapes. Playtest with a stopwatch: if a fight drags past ninety seconds, trim the fat. Players chase mastery, so surface stats and replays to fuel that drive.
+

--- a/docs/design/project.md
+++ b/docs/design/project.md
@@ -1,0 +1,9 @@
+# Project Overview
+
+*By Riley "Clown" Morgan*
+
+We're building a hackable, no-build playground—a wasteland stitched with Planescape oddities and Nethack grit. The editor sits alongside the world, letting anyone pop the hood and rewrite reality mid-run.
+
+Every sprite and script is a mask waiting to be swapped. Players can spawn doppelgängers, twist tiles with arcane macros, and weave secret identities through the ruins. If you can imagine it, you can code it, no compile ceremony required.
+
+The goal is a living toolkit: part game, part open sketchbook. We keep the rules lean, the files plain, and the door wide open for mods, forks, and mischief.

--- a/docs/team-bios.md
+++ b/docs/team-bios.md
@@ -1,0 +1,22 @@
+# Team Bios
+
+## Riley "Clown" Morgan
+- **Background:** Hacker-artist steering our neon wasteland carnival.
+- **Skills:** Mod-friendly coding, quick sketches, collaborative worldbuilding.
+- **Interests:** Cyberpunk runs, doppelgängers, open-source mischief.
+
+## Alex "Echo" Johnson
+- **Background:** Former indie comics writer who migrated to games to build interactive stories.
+- **Skills:** World-building, character arcs, moody dialogue.
+- **Interests:** Dystopian caravans, synth music, dusty sunsets.
+
+## Priya "Gizmo" Sharma
+- **Background:** Tools engineer obsessed with clean pipelines and happy teammates.
+- **Skills:** Debugging, editor automation, modular architecture.
+- **Interests:** Accessible UIs, open-source gadgets, spicy snacks.
+
+## Mateo "Wing" Alvarez
+- **Background:** Ex-speedrunner who designs encounters with a stopwatch in hand.
+- **Skills:** Combat tuning, user testing, rapid iteration.
+- **Interests:** High-tempo action, fair challenges, retro mechs.
+


### PR DESCRIPTION
## Summary
- Add concise bio for project lead Riley "Clown" Morgan and list them first
- Introduce project overview design doc in Clown's voice alongside editor, story, and gameplay docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2b7aca8c83288c5bf271c6a43a9a