### PR TITLE
feat: move NPCs with player steps

### DIFF
--- a/core/movement.js
+++ b/core/movement.js
@@ -160,6 +160,8 @@ function move(dx,dy){
         centerCamera(party.x,party.y,state.map); updateHUD();
         checkAggro();
         EventBus.emit('sfx','step');
+        // NPCs advance along paths after the player steps
+        if(typeof tickPathAI==='function') tickPathAI();
         moveDelay = 0;
         resolve();
       }, moveDelay);

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -189,7 +189,6 @@ function draw(t){
     return;
   }
   const dt=(t-_lastTime)||0; _lastTime=t;
-  if (typeof tickPathAI === 'function') tickPathAI(dt);
   render(state, dt/1000);
   const bx = bumpEnd > performance.now() ? bumpX : 0;
   const by = bumpEnd > performance.now() ? bumpY : 0;

--- a/dustland-path.js
+++ b/dustland-path.js
@@ -92,24 +92,32 @@
 
   function key(x,y){ return x+','+y; }
 
+  // Step NPCs along their waypoint loops. Invoked after player moves.
   function tickPathAI(){
-    const now=Date.now();
     for(const n of NPCS){
       const pts=n.loop;
       if(!Array.isArray(pts) || pts.length<2) continue;
-      n._loop = n._loop || { idx:1, path:[], job:null, next:0 };
+      n._loop = n._loop || { idx:1, path:[], job:null };
       const st=n._loop;
+      const near=party && Math.abs(n.x-party.x)+Math.abs(n.y-party.y) <= 2;
+      if(near) continue;
       if(st.path.length){
-        if(now<st.next) continue;
         const step=st.path.shift();
         if(step){ n.x=step.x; n.y=step.y; }
-        st.next=now+400;
         if(!st.path.length){ st.idx=(st.idx+1)%pts.length; }
         continue;
       }
       if(st.job){
         const p=PathQueue.pathFor(st.job);
-        if(p){ st.path=p.slice(1); st.job=null; }
+        if(p){
+          st.path=p.slice(1);
+          st.job=null;
+          if(st.path.length){
+            const step=st.path.shift();
+            if(step){ n.x=step.x; n.y=step.y; }
+            if(!st.path.length){ st.idx=(st.idx+1)%pts.length; }
+          }
+        }
         continue;
       }
       const target=pts[st.idx];

--- a/test/npc-path.test.js
+++ b/test/npc-path.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+global.window = globalThis;
+
+global.TILE = { FLOOR:0, WALL:1 };
+global.walkable = { 0:true };
+
+global.world = [
+  [0,0,0],
+  [0,0,0],
+  [0,0,0]
+];
+
+global.queryTile = (x,y,map='world') => {
+  const tile = world[y] && world[y][x];
+  return { tile, walkable: tile===0, entities: [] };
+};
+
+global.NPCS = [
+  { id:'n1', map:'world', x:0, y:0, loop:[{x:0,y:0},{x:2,y:0}] }
+];
+
+global.party = { x:5, y:5 };
+
+test('NPC follows waypoints per player move and waits when close', async () => {
+  await import('../dustland-path.js');
+  window.tickPathAI();
+  await new Promise(r => setTimeout(r,20));
+  window.tickPathAI();
+  assert.strictEqual(NPCS[0].x, 1);
+  party.x = 1; party.y = 0;
+  window.tickPathAI();
+  assert.strictEqual(NPCS[0].x, 1);
+  party.x = 5; party.y = 5;
+  window.tickPathAI();
+  assert.strictEqual(NPCS[0].x, 2);
+});


### PR DESCRIPTION
## Summary
- drive NPC waypoint movement via player steps instead of frame ticks
- pause NPCs when the party is within two tiles
- test waypoint following and proximity pause logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa3cebbb3483288ab8879aa7ff4af5