### PR TITLE
docs: convert plot draft to task list

### DIFF
--- a/docs/design/plot-draft.md
+++ b/docs/design/plot-draft.md
@@ -1,0 +1,40 @@
+# Plot Tasks
+*By Alex "Echo" Johnson*
+
+This checklist charts the caravan's chase after a fading broadcast. We'll cross off each beat as the signal sharpens.
+
+## Plot
+- [ ] Outline the caravan's pursuit of the fading broadcast across the Dustland.
+- [ ] Decide whether restoring the broadcast heals the wastes or silences their stories.
+- [ ] **Gizmo:** Keep broadcast fragments modular so new episodes slot in without rewiring tools.
+- [ ] **Wing:** Pace each stop with a ticking clock or rival crew so the caravan never stalls.
+- [ ] **Clown:** Paint each stop like a glitchy midway to keep the signal trail feeling like a rogue carnival ride.
+
+## Characters and Arcs
+- [ ] Detail Mara "Surveyor"—an ex-cartographer seeking the map she burned; arc: learns the signal isn't the only way home.
+- [ ] Detail Jax "Patch"—a scavenger mechanic hoarding tech; arc: opens his toolkit to the crew.
+- [ ] Detail Nyx "Speaker"—a poet tuning radio static into verse; arc: chooses between broadcasting or listening.
+- [ ] **Gizmo:** Flag each character's gear for editor hooks so we can test their arcs in isolation.
+- [ ] **Wing:** Give every arc a signature encounter that teaches their move set under fire.
+- [ ] **Clown:** Sketch alt personas and mask options; doppelgänger vibes fuel fan quests and cosplay.
+
+## Items
+- [ ] Flesh out the Signal Compass that spins toward the next fragment of the broadcast.
+- [ ] Flesh out the Glinting Key that opens an echo chamber hidden beneath the highway.
+- [ ] Flesh out the Memory Tape that captures choices to replay for other survivors.
+- [ ] **Gizmo:** Call out any custom UI needs for these items to keep the pipeline tidy.
+- [ ] **Wing:** Note upgrade paths or cooldowns so players can route runs around them.
+- [ ] **Clown:** Make sprites kitbash-friendly so modders can remix them into neon charms.
+
+## Puzzles
+- [ ] Design a radio tower alignment puzzle that tunes the broadcast.
+- [ ] Design a dust storm navigation puzzle using wind chimes along ruined billboards.
+- [ ] Design a layered graffiti decoding puzzle to reveal a safe route before the sun bleeds out.
+- [ ] **Gizmo:** Build puzzles from reusable widgets—modders will thank us.
+- [ ] **Wing:** Allow quick resets and split timers so practice runs feel fair and fast.
+- [ ] **Clown:** Drop in hooks for glitch filters; let the wasteland melt into art when players reroute.
+
+## Team Review
+- **Gizmo:** Modular breakdown checks out, though tagging task dependencies would keep the toolchain humming.
+- **Wing:** Detail level feels right; add rough time boxes so the caravan never idles.
+- **Clown:** Forethought's strong—save a flex slot in each list for carnival surprises.


### PR DESCRIPTION
## Summary
- replace Dustland plot draft with a checklist of tasks for plot beats, character arcs, items, and puzzles
- capture Gizmo, Wing, and Clown feedback as checkbox items for future iteration
- log each teammate's review of task breakdown and detail

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa33853fb883289b1fd50d3ec50980