### PR TITLE
fix: cap NPC patrol speed

### DIFF
--- a/dustland-path.js
+++ b/dustland-path.js
@@ -92,18 +92,22 @@
 
   function key(x,y){ return x+','+y; }
 
+  const NPC_MOVE_DELAY = globalThis.NPC_MOVE_DELAY || 200; // min ms between NPC patrol steps
+
   // Step NPCs along their waypoint loops. Invoked after player moves.
   function tickPathAI(){
+    const now = Date.now();
     for(const n of NPCS){
       const pts=n.loop;
       if(!Array.isArray(pts) || pts.length<2) continue;
       n._loop = n._loop || { idx:1, path:[], job:null };
+      if(n._lastMove && now - n._lastMove < NPC_MOVE_DELAY) continue;
       const st=n._loop;
       const near=party && Math.abs(n.x-party.x)+Math.abs(n.y-party.y) <= 2;
       if(near) continue;
       if(st.path.length){
         const step=st.path.shift();
-        if(step){ n.x=step.x; n.y=step.y; }
+        if(step){ n.x=step.x; n.y=step.y; n._lastMove=now; }
         if(!st.path.length){ st.idx=(st.idx+1)%pts.length; }
         continue;
       }
@@ -114,7 +118,7 @@
           st.job=null;
           if(st.path.length){
             const step=st.path.shift();
-            if(step){ n.x=step.x; n.y=step.y; }
+            if(step){ n.x=step.x; n.y=step.y; n._lastMove=now; }
             if(!st.path.length){ st.idx=(st.idx+1)%pts.length; }
           }
         }

--- a/test/npc-path.test.js
+++ b/test/npc-path.test.js
@@ -23,7 +23,7 @@ global.NPCS = [
 
 global.party = { x:5, y:5 };
 
-test('NPC follows waypoints per player move and waits when close', async () => {
+test('NPC follows waypoints with capped speed and waits when close', async () => {
   await import('../dustland-path.js');
   window.tickPathAI();
   await new Promise(r => setTimeout(r,20));
@@ -33,6 +33,9 @@ test('NPC follows waypoints per player move and waits when close', async () => {
   window.tickPathAI();
   assert.strictEqual(NPCS[0].x, 1);
   party.x = 5; party.y = 5;
+  window.tickPathAI();
+  assert.strictEqual(NPCS[0].x, 1);
+  await new Promise(r => setTimeout(r,210));
   window.tickPathAI();
   assert.strictEqual(NPCS[0].x, 2);
 });


### PR DESCRIPTION
## Summary
- limit NPC patrol steps to once every 200ms
- adjust NPC path test for new capped speed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4c7803d08328a4fafedb993f0d73