### PR TITLE
Keep NPC selected when adding path waypoints

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -548,6 +548,7 @@
   <script defer src="./core/quests.js"></script>
     <script defer src="./core/npc.js"></script>
     <script defer src="./dustland-core.js"></script>
+    <script defer src="./core/loop.js"></script>
     <script defer src="./dustland-path.js"></script>
     <script defer src="./dustland-nano.js"></script>
     <script defer src="./dustland-engine.js"></script>

--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -171,10 +171,13 @@ loopPlus.addEventListener('click', () => {
   if (!selectedObj || selectedObj.type !== 'npc' || !loopHover) return;
   const npc = selectedObj.obj;
   npc.loop = npc.loop || [{ x: npc.x, y: npc.y }];
-  npc.loop.splice(loopHover.idx + 1, 0, { x: loopHover.x, y: loopHover.y });
+  const newIdx = loopHover.idx + 1;
+  const pos = nextLoopPoint(npc.loop[loopHover.idx], npc);
+  npc.loop.splice(newIdx, 0, pos);
   renderLoopFields(npc.loop);
   drawWorld();
-  showLoopControls(null);
+  // Keep NPC selected and highlight the new point for easy dragging
+  showLoopControls({ idx: newIdx, x: pos.x, y: pos.y });
 });
 
 loopMinus.addEventListener('click', () => {

--- a/core/loop.js
+++ b/core/loop.js
@@ -1,0 +1,15 @@
+(function(){
+  function nextLoopPoint(prev, npc){
+    if(!prev) return { x:npc.x, y:npc.y };
+    const maxDist = 10;
+    let x = prev.x + 1;
+    let y = prev.y;
+    if (typeof WORLD_W === 'number' && x >= WORLD_W) x = prev.x - 1;
+    x = clamp(x, prev.x - maxDist, prev.x + maxDist);
+    y = clamp(y, prev.y - maxDist, prev.y + maxDist);
+    if (typeof WORLD_W === 'number') x = clamp(x, 0, WORLD_W - 1);
+    if (typeof WORLD_H === 'number') y = clamp(y, 0, WORLD_H - 1);
+    return { x, y };
+  }
+  Object.assign(globalThis, { nextLoopPoint });
+})();

--- a/test/loop-utils.test.js
+++ b/test/loop-utils.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+global.WORLD_W = 100;
+global.WORLD_H = 100;
+global.clamp = (v,a,b)=>{ if(a>b) [a,b]=[b,a]; return Math.max(a, Math.min(b, v)); };
+
+await import('../core/loop.js');
+
+test('nextLoopPoint defaults to NPC position when no previous', () => {
+  const npc = { x: 5, y: 7 };
+  const pt = nextLoopPoint(null, npc);
+  assert.deepStrictEqual(pt, { x: 5, y: 7 });
+});
+
+test('nextLoopPoint stays within 10 squares of previous', () => {
+  const npc = { x: 5, y: 5 };
+  const prev = { x: 5, y: 5 };
+  const pt = nextLoopPoint(prev, npc);
+  const dx = Math.abs(pt.x - prev.x);
+  const dy = Math.abs(pt.y - prev.y);
+  assert.ok(dx <= 10 && dy <= 10);
+});


### PR DESCRIPTION
## Summary
- generate next waypoint within 10 tiles of the prior or NPC position
- highlight newly added waypoint so NPC remains active for editing
- load loop utility and add tests for waypoint placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4b87ca7c832893c28affba798acd