### PR TITLE
feat: add ability registry

### DIFF
--- a/core/abilities.js
+++ b/core/abilities.js
@@ -1,0 +1,20 @@
+(function(){
+  const Abilities = {};
+
+  function defineAbility(id, data = {}){
+    const ability = {
+      id,
+      type: data.type || 'active',
+      cost: data.cost || 0,
+      prereq: {
+        level: data.prereq && data.prereq.level || 0,
+        abilities: data.prereq && data.prereq.abilities || []
+      },
+      effect: data.effect || {}
+    };
+    Abilities[id] = ability;
+    return ability;
+  }
+
+  Object.assign(globalThis, { Abilities, defineAbility });
+})();

--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -52,7 +52,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 #### **Phase 1: Core Progression Mechanics (The Engine)**
 - [x] Embed `xpCurve` array in `core/party.js` with sane defaults and expose it globally for mods.
 - [x] Implement XP tracking and level-up logic in the `Character` class. Automatically apply +10 max HP and grant one skill point upon level-up.
-- [ ] **Data Structure:** Define the data structure for active and passive abilities. This should include cost, prerequisites (level, other abilities), and the actual effect (e.g., `damage_boost`, `aoe_attack`).
+- [x] **Data Structure:** Define the data structure for active and passive abilities. This should include cost, prerequisites (level, other abilities), and the actual effect (e.g., `damage_boost`, `aoe_attack`).
 - [ ] **Enemy Scaling:** Create a function in `core/npc.js` that applies level-up logic to enemy NPCs based on their level. This should include the standard +10 max HP and a method for allocating points into predefined stat builds.
 - [ ] **Respec Logic:** Implement the "Memory Worm" token item. Create a function in `core/party.js` that consumes a token to reset a character's spent skill points.
 

--- a/test/abilities.test.js
+++ b/test/abilities.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import '../core/abilities.js';
+
+test('defineAbility stores ability with cost and prereqs', () => {
+  const ability = globalThis.defineAbility('powerStrike', {
+    type: 'active',
+    cost: 2,
+    prereq: { level: 5, abilities: ['basicSlash'] },
+    effect: { damageBoost: 3 }
+  });
+  assert.strictEqual(globalThis.Abilities.powerStrike, ability);
+  assert.strictEqual(ability.cost, 2);
+  assert.strictEqual(ability.prereq.level, 5);
+  assert.deepStrictEqual(ability.prereq.abilities, ['basicSlash']);
+  assert.deepStrictEqual(ability.effect, { damageBoost: 3 });
+});
+
+test('defineAbility supports passive abilities', () => {
+  const ability = globalThis.defineAbility('ironSkin', {
+    type: 'passive',
+    cost: 1,
+    prereq: { level: 2 },
+    effect: { defBoost: 1 }
+  });
+  assert.strictEqual(ability.type, 'passive');
+  assert.strictEqual(ability.prereq.level, 2);
+  assert.deepStrictEqual(ability.prereq.abilities, []);
+});


### PR DESCRIPTION
## Summary
- define global ability registry with cost, prerequisites, and effect fields
- mark ability data structure task as complete in RPG progression design doc
- test ability registration for active and passive abilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab1ac4d53c8328914b20fadd542feb