### PR TITLE
Add enemy scaling helper

### DIFF
--- a/core/npc.js
+++ b/core/npc.js
@@ -122,5 +122,18 @@ function createNpcFactory(defs) {
   return npcFactory;
 }
 
-const npcExports = { NPC, makeNPC, resolveNode, NPCS, npcsOnMap, queueNanoDialogForNPCs, removeNPC, createNpcFactory };
+function scaleEnemy(npc, lvl = 1, build = []) {
+  npc.stats = npc.stats || (typeof baseStats === 'function' ? baseStats() : {});
+  npc.maxHp = npc.maxHp ?? npc.hp ?? 10;
+  npc.hp = npc.maxHp;
+  for (let i = 1; i < lvl; i++) {
+    npc.maxHp += 10;
+    npc.hp = npc.maxHp;
+    const stat = Array.isArray(build) && build.length ? build[(i - 1) % build.length] : null;
+    if (stat) npc.stats[stat] = (npc.stats[stat] || 0) + 1;
+  }
+  npc.lvl = lvl;
+}
+
+const npcExports = { NPC, makeNPC, resolveNode, NPCS, npcsOnMap, queueNanoDialogForNPCs, removeNPC, createNpcFactory, scaleEnemy };
 Object.assign(globalThis, npcExports);

--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -53,7 +53,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] Embed `xpCurve` array in `core/party.js` with sane defaults and expose it globally for mods.
 - [x] Implement XP tracking and level-up logic in the `Character` class. Automatically apply +10 max HP and grant one skill point upon level-up.
 - [x] **Data Structure:** Define the data structure for active and passive abilities. This should include cost, prerequisites (level, other abilities), and the actual effect (e.g., `damage_boost`, `aoe_attack`).
-- [ ] **Enemy Scaling:** Create a function in `core/npc.js` that applies level-up logic to enemy NPCs based on their level. This should include the standard +10 max HP and a method for allocating points into predefined stat builds.
+- [x] **Enemy Scaling:** Create a function in `core/npc.js` that applies level-up logic to enemy NPCs based on their level. This should include the standard +10 max HP and a method for allocating points into predefined stat builds.
 - [ ] **Respec Logic:** Implement the "Memory Worm" token item. Create a function in `core/party.js` that consumes a token to reset a character's spent skill points.
 
 #### **Phase 2: HUD and UX (The Dashboard)**

--- a/test/npc-scaling.test.js
+++ b/test/npc-scaling.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import '../core/party.js';
+import '../core/npc.js';
+
+test('scaleEnemy applies level-based scaling', () => {
+  const npc = {};
+  scaleEnemy(npc, 3, ['STR', 'AGI']);
+  assert.strictEqual(npc.maxHp, 30);
+  assert.strictEqual(npc.hp, 30);
+  assert.strictEqual(npc.lvl, 3);
+  assert.strictEqual(npc.stats.STR, 5);
+  assert.strictEqual(npc.stats.AGI, 5);
+  assert.strictEqual(npc.stats.INT, 4);
+});


### PR DESCRIPTION
## Summary
- add `scaleEnemy` helper to level NPC enemies and allocate stat points
- cover enemy scaling with unit test
- check off enemy scaling task in design doc

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab1f760cc883289241c4624e372507