### PR TITLE
feat: add respec via memory worm

### DIFF
--- a/core/party.js
+++ b/core/party.js
@@ -105,5 +105,22 @@ function applyEquipmentStats(m){ m.applyEquipmentStats(); }
 function leader(){ return party.leader(); }
 function setLeader(idx){ selectedMember = idx; }
 
-const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, leader, setLeader, selectedMember, xpCurve };
+function respec(memberIndex=selectedMember){
+  const m = party[memberIndex];
+  if(!m) return false;
+  const tokenIdx = typeof findItemIndex==='function' ? findItemIndex('memory_worm') : -1;
+  if(tokenIdx===-1){
+    log('Need a Memory Worm token.');
+    return false;
+  }
+  removeFromInv(tokenIdx);
+  m.stats = baseStats();
+  m.skillPoints = m.lvl - 1;
+  m.applyEquipmentStats();
+  renderParty(); updateHUD();
+  log(`${m.name} respecs their skills.`);
+  return true;
+}
+
+const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, leader, setLeader, respec, selectedMember, xpCurve };
 Object.assign(globalThis, partyExports);

--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -54,7 +54,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] Implement XP tracking and level-up logic in the `Character` class. Automatically apply +10 max HP and grant one skill point upon level-up.
 - [x] **Data Structure:** Define the data structure for active and passive abilities. This should include cost, prerequisites (level, other abilities), and the actual effect (e.g., `damage_boost`, `aoe_attack`).
 - [x] **Enemy Scaling:** Create a function in `core/npc.js` that applies level-up logic to enemy NPCs based on their level. This should include the standard +10 max HP and a method for allocating points into predefined stat builds.
-- [ ] **Respec Logic:** Implement the "Memory Worm" token item. Create a function in `core/party.js` that consumes a token to reset a character's spent skill points.
+- [x] **Respec Logic:** Implement the "Memory Worm" token item. Create a function in `core/party.js` that consumes a token to reset a character's spent skill points.
 
 #### **Phase 2: HUD and UX (The Dashboard)**
 - [ ] **Party Panel UI:** Add a compact XP bar below each character's health in the party panel. On hover, it should expand to show `currentXP / nextXP` values.

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -187,6 +187,14 @@ const tileEvents = [];
 function registerTileEvents(list){ (list||[]).forEach(e => tileEvents.push(e)); }
 const state = { map:'world' }; // default map
 const player = { hp:10, ap:2, inv:[], scrap:0 };
+if (typeof registerItem === 'function') {
+  registerItem({
+    id: 'memory_worm',
+    name: 'Memory Worm',
+    type: 'token',
+    desc: 'Resets a character\'s spent skill points.'
+  });
+}
 function setPartyPos(x, y){
   if(typeof x === 'number') party.x = x;
   if(typeof y === 'number') party.y = y;

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -404,6 +404,26 @@ test('level up grants +10 max HP and a skill point', () => {
   assert.strictEqual(c.skillPoints, 1);
 });
 
+test('respec consumes memory worm and restores skill points', () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const c = new Character('m','M','Role');
+  c.lvl = 3;
+  c.skillPoints = 0;
+  c.stats.STR += 2;
+  party.addMember(c);
+  setLeader(0);
+  registerItem({ id:'memory_worm', name:'Memory Worm', type:'token' });
+  addToInv('memory_worm');
+  const idx = findItemIndex('memory_worm');
+  assert.ok(idx !== -1);
+  const ok = respec();
+  assert.ok(ok);
+  assert.strictEqual(findItemIndex('memory_worm'), -1);
+  assert.deepStrictEqual(c.stats, baseStats());
+  assert.strictEqual(c.skillPoints, 2);
+});
+
 test('advanceDialog moves to next node', () => {
   const tree = {
     start: { text: 'hi', next: [{ id: 'bye', label: 'Bye' }] },


### PR DESCRIPTION
## Summary
- add Memory Worm token item to enable respec
- allow party members to reset stats and skill points by consuming Memory Worm
- document progress and cover respec logic with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab22038c3c8328888c8d4f16b0fde8