### PR TITLE
feat: add party XP bar

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -57,7 +57,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] **Respec Logic:** Implement the "Memory Worm" token item. Create a function in `core/party.js` that consumes a token to reset a character's spent skill points.
 
 #### **Phase 2: HUD and UX (The Dashboard)**
-- [ ] **Party Panel UI:** Add a compact XP bar below each character's health in the party panel. On hover, it should expand to show `currentXP / nextXP` values.
+- [x] **Party Panel UI:** Add a compact XP bar below each character's health in the party panel. On hover, it should expand to show `currentXP / nextXP` values.
 - [ ] **Skill Point Badge:** Create a small, glowing badge that appears over a character's portrait when they have unspent skill points. The badge should display the number of available points.
 - [ ] **Mentor System:** Implement a simple event hook in the level-up function that can trigger a sound file and a brief on-screen text notification (a "bark"). This should be tied to a quest flag or a specific item to remain optional.
 - [ ] **Trainer UI Mockup:** Design the "Upgrade Skills" dialog. It needs a list of available upgrades (stats and abilities), their costs, and a clear "before and after" preview for any selected stat change.

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -425,7 +425,37 @@ function renderQuests(){
     q.appendChild(div);
   });
 }
-function renderParty(){ const p=document.getElementById('party'); p.innerHTML=''; if(party.length===0){ p.innerHTML='<div class="pcard muted">(no party members yet)</div>'; return; } party.forEach((m,i)=>{ const c=document.createElement('div'); c.className='pcard'+(i===selectedMember?' selected':''); const bonus=m._bonus||{}; const fmt=v=> (v>0? '+'+v : v); const wLabel=m.equip.weapon?(m.equip.weapon.cursed&&m.equip.weapon.cursedKnown?m.equip.weapon.name+' (cursed)':m.equip.weapon.name):'—'; const aLabel=m.equip.armor?(m.equip.armor.cursed&&m.equip.armor.cursedKnown?m.equip.armor.name+' (cursed)':m.equip.armor.name):'—'; const tLabel=m.equip.trinket?(m.equip.trinket.cursed&&m.equip.trinket.cursedKnown?m.equip.trinket.name+' (cursed)':m.equip.trinket.name):'—'; c.innerHTML = `<div class='row'><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div><div class='row small'>${statLine(m.stats)}</div><div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div><div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div><div class='row small'>XP ${m.xp}/${xpToNext(m.lvl)}</div><div class='row'><label><input type='radio' name='selMember' ${i===selectedMember?'checked':''}> Selected</label></div>`; c.querySelector('input').onchange=()=>{ selectedMember=i; }; c.querySelectorAll('button[data-a="unequip"]').forEach(b=>{ const sl=b.dataset.slot; b.onclick=()=> unequipItem(i,sl); }); p.appendChild(c); }); }
+function renderParty(){
+  const p=document.getElementById('party');
+  p.innerHTML='';
+  if(party.length===0){
+    p.innerHTML='<div class="pcard muted">(no party members yet)</div>';
+    return;
+  }
+  party.forEach((m,i)=>{
+    const c=document.createElement('div');
+    c.className='pcard'+(i===selectedMember?' selected':'');
+    const bonus=m._bonus||{};
+    const fmt=v=> (v>0? '+'+v : v);
+    const wLabel=m.equip.weapon?(m.equip.weapon.cursed&&m.equip.weapon.cursedKnown?m.equip.weapon.name+' (cursed)':m.equip.weapon.name):'—';
+    const aLabel=m.equip.armor?(m.equip.armor.cursed&&m.equip.armor.cursedKnown?m.equip.armor.name+' (cursed)':m.equip.armor.name):'—';
+    const tLabel=m.equip.trinket?(m.equip.trinket.cursed&&m.equip.trinket.cursedKnown?m.equip.trinket.name+' (cursed)':m.equip.trinket.name):'—';
+    const nextXP=xpToNext(m.lvl);
+    const pct=Math.min(100,(m.xp/nextXP)*100);
+    c.innerHTML = `<div class='row'><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div>
+<div class='row small'>${statLine(m.stats)}</div>
+<div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div>
+<div class='row'><div class='xpbar' data-xp='${m.xp}/${nextXP}'><div class='fill' style='width:${pct}%'></div></div></div>
+<div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div>
+<div class='row'><label><input type='radio' name='selMember' ${i===selectedMember?'checked':''}> Selected</label></div>`;
+    c.querySelector('input').onchange=()=>{ selectedMember=i; };
+    c.querySelectorAll('button[data-a="unequip"]').forEach(b=>{
+      const sl=b.dataset.slot;
+      b.onclick=()=> unequipItem(i,sl);
+    });
+    p.appendChild(c);
+  });
+}
 
 const engineExports = { log, updateHUD, renderInv, renderQuests, renderParty, footstepBump, pickupSparkle };
 Object.assign(globalThis, engineExports);

--- a/dustland.css
+++ b/dustland.css
@@ -196,6 +196,33 @@
         box-shadow: 0 0 0 2px #8bd98d;
     }
 
+.xpbar {
+  position: relative;
+  width: 100%;
+  height: 4px;
+  background: #273027;
+  border-radius: 4px;
+  overflow: hidden;
+  transition: height .2s;
+}
+.xpbar .fill {
+  height: 100%;
+  background: #8bd98d;
+  transition: width .2s;
+}
+.xpbar:hover {
+  height: 16px;
+}
+.xpbar:hover::after {
+  content: attr(data-xp);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 10px;
+  color: #fff;
+}
+
     .row {
         display: flex;
         flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add compact XP progress bar to party panel with hover details
- style XP bar and hover expansion
- check off Party Panel UI design task

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab27d88d2c8328bcfbbdf343a20fba