### PR TITLE
fix: align dialog editor checkboxes

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -204,11 +204,22 @@
       margin-top: 0;
     }
 
+    #treeEditor .choices label.inline,
+    #treeEditor .choices label.onceWrap {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
     #treeEditor .choices details input,
     #treeEditor .choices details select {
       width: 100%;
       flex: none;
       min-width: 0;
+    }
+
+    #treeEditor .choices details input[type=checkbox] {
+      width: auto;
     }
 
     #treeEditor .nodeHeader {


### PR DESCRIPTION
## Summary
- ensure checkbox labels in dialog editor align inline
- prevent advanced dialog editor checkboxes from stretching full width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab28f1d5a48328aa9821a47e929a1b