### PR TITLE
feat: show skill point badge on party portraits

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -58,7 +58,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 
 #### **Phase 2: HUD and UX (The Dashboard)**
 - [x] **Party Panel UI:** Add a compact XP bar below each character's health in the party panel. On hover, it should expand to show `currentXP / nextXP` values.
-- [ ] **Skill Point Badge:** Create a small, glowing badge that appears over a character's portrait when they have unspent skill points. The badge should display the number of available points.
+- [x] **Skill Point Badge:** Create a small, glowing badge that appears over a character's portrait when they have unspent skill points. The badge should display the number of available points.
 - [ ] **Mentor System:** Implement a simple event hook in the level-up function that can trigger a sound file and a brief on-screen text notification (a "bark"). This should be tied to a quest flag or a specific item to remain optional.
 - [ ] **Trainer UI Mockup:** Design the "Upgrade Skills" dialog. It needs a list of available upgrades (stats and abilities), their costs, and a clear "before and after" preview for any selected stat change.
     > **Gizmo:** Let's make this UI data-driven. It should just read a list of available upgrades from the trainer NPC's data. That way, modders can add new trainers with unique skill trees just by editing a JSON file.

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -442,7 +442,9 @@ function renderParty(){
     const tLabel=m.equip.trinket?(m.equip.trinket.cursed&&m.equip.trinket.cursedKnown?m.equip.trinket.name+' (cursed)':m.equip.trinket.name):'—';
     const nextXP=xpToNext(m.lvl);
     const pct=Math.min(100,(m.xp/nextXP)*100);
-    c.innerHTML = `<div class='row'><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div>
+    const badge = m.skillPoints>0?`<div class="spbadge">${m.skillPoints}</div>`:'';
+    const portrait = `<div class='portrait' ${m.portraitSheet?`style="background-image:url(${m.portraitSheet})"`:''}>${badge}</div>`;
+    c.innerHTML = `<div class='row'>${portrait}<div><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div></div>
 <div class='row small'>${statLine(m.stats)}</div>
 <div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div>
 <div class='row'><div class='xpbar' data-xp='${m.xp}/${nextXP}'><div class='fill' style='width:${pct}%'></div></div></div>

--- a/dustland.css
+++ b/dustland.css
@@ -333,6 +333,19 @@
   image-rendering: pixelated;      /* preserve chunky pixels */
   background-repeat:no-repeat;
   background-size:100% 100%;       /* 2×2 grid */
+  position:relative;
+}
+
+.spbadge{
+  position:absolute;
+  top:-4px; right:-4px;
+  background:#8bd98d;
+  color:#0f120f;
+  border-radius:8px;
+  padding:2px 4px;
+  font-size:10px;
+  line-height:1;
+  box-shadow:0 0 4px #8bd98d;
 }
 
     .dialog main {

--- a/test/skill-badge.test.js
+++ b/test/skill-badge.test.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const partyCode = await fs.readFile(new URL('../core/party.js', import.meta.url), 'utf8');
+const engineCode = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
+
+function setup(){
+  const html = `<body><div id="log"></div><span id="hp"></span><span id="ap"></span><span id="scrap"></span><canvas id="game"></canvas><div class="tabs"></div><div id="inv"></div><div id="party"></div><div id="quests"></div><div id="tabInv"></div><div id="tabParty"></div><div id="tabQuests"></div></body>`;
+  const dom = new JSDOM(html);
+  const AudioCtx = class { resume(){} suspend(){} };
+  dom.window.AudioContext = AudioCtx;
+  dom.window.webkitAudioContext = AudioCtx;
+  dom.window.Audio = class { constructor(){ } cloneNode(){ return new dom.window.Audio(); } play(){} pause(){} };
+  dom.window.HTMLCanvasElement.prototype.getContext = () => ({});
+  dom.window.NanoDialog = { enabled: true, init: () => {} };
+  dom.window.requestAnimationFrame = () => 0;
+  dom.window.cancelAnimationFrame = () => {};
+  dom.window.URLSearchParams = class { constructor(){ } get(){ return null; } };
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    player: { hp:10, ap:2, scrap:0 },
+    EventBus: { emit: () => {}, on: () => {} },
+    unequipItem: () => {},
+    log: () => {},
+    localStorage: { getItem: () => null, setItem() {}, removeItem() {}, clear() {} },
+    showStart: () => {},
+    openCreator: () => {},
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    Audio: dom.window.Audio,
+    NanoDialog: dom.window.NanoDialog,
+    requestAnimationFrame: dom.window.requestAnimationFrame,
+    cancelAnimationFrame: dom.window.cancelAnimationFrame,
+    URLSearchParams: dom.window.URLSearchParams,
+    location: dom.window.location,
+  };
+  vm.createContext(context);
+  vm.runInContext(partyCode, context);
+  vm.runInContext(engineCode, context);
+  return { context, dom };
+}
+
+test('renders skill point badge when points available', () => {
+  const { context, dom } = setup();
+  const m = context.makeMember('id','Name','Role');
+  m.skillPoints = 2;
+  context.party.push(m);
+  context.renderParty();
+  const badge = dom.window.document.querySelector('.spbadge');
+  assert.ok(badge, 'badge exists');
+  assert.strictEqual(badge.textContent, '2');
+});
+
+test('no badge when no skill points', () => {
+  const { context, dom } = setup();
+  const m = context.makeMember('id','Name','Role');
+  context.party.push(m);
+  context.renderParty();
+  const badge = dom.window.document.querySelector('.spbadge');
+  assert.strictEqual(badge, null);
+});


### PR DESCRIPTION
## Summary
- highlight unspent skill points with a glowing badge on party portraits
- style badge overlay and make portraits badge-friendly
- document and test skill point badge behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab2980affc8328b39ee033de3896b0