### PR TITLE
feat: add mentor level-up hook

### DIFF
--- a/core/party.js
+++ b/core/party.js
@@ -36,6 +36,9 @@ class Character {
     if(typeof hudBadge==='function') hudBadge('+1 Skill Point');
     EventBus.emit('sfx','tick');
     log(`${this.name} leveled up to ${this.lvl}! (+10 HP, +1 SP)`);
+    if((party.flags && party.flags.mentor) || (typeof hasItem==='function' && hasItem('mentor_token'))){
+      EventBus.emit('mentor:bark', { text:'Another scar, another lesson learned.', sound:'mentor' });
+    }
   }
   applyEquipmentStats(){
     this._bonus = {ATK:0, DEF:0, LCK:0};

--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -59,7 +59,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 #### **Phase 2: HUD and UX (The Dashboard)**
 - [x] **Party Panel UI:** Add a compact XP bar below each character's health in the party panel. On hover, it should expand to show `currentXP / nextXP` values.
 - [x] **Skill Point Badge:** Create a small, glowing badge that appears over a character's portrait when they have unspent skill points. The badge should display the number of available points.
-- [ ] **Mentor System:** Implement a simple event hook in the level-up function that can trigger a sound file and a brief on-screen text notification (a "bark"). This should be tied to a quest flag or a specific item to remain optional.
+- [x] **Mentor System:** Implement a simple event hook in the level-up function that can trigger a sound file and a brief on-screen text notification (a "bark"). This should be tied to a quest flag or a specific item to remain optional.
 - [ ] **Trainer UI Mockup:** Design the "Upgrade Skills" dialog. It needs a list of available upgrades (stats and abilities), their costs, and a clear "before and after" preview for any selected stat change.
     > **Gizmo:** Let's make this UI data-driven. It should just read a list of available upgrades from the trainer NPC's data. That way, modders can add new trainers with unique skill trees just by editing a JSON file.
 


### PR DESCRIPTION
## Summary
- add optional mentor bark hook when characters level up
- check off Mentor System task in rpg-progression doc

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab3a72bcd08328b6da1d440228cdb3