### PR TITLE
docs: add trainer UI mockup design

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -60,7 +60,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] **Party Panel UI:** Add a compact XP bar below each character's health in the party panel. On hover, it should expand to show `currentXP / nextXP` values.
 - [x] **Skill Point Badge:** Create a small, glowing badge that appears over a character's portrait when they have unspent skill points. The badge should display the number of available points.
 - [x] **Mentor System:** Implement a simple event hook in the level-up function that can trigger a sound file and a brief on-screen text notification (a "bark"). This should be tied to a quest flag or a specific item to remain optional.
-- [ ] **Trainer UI Mockup:** Design the "Upgrade Skills" dialog. It needs a list of available upgrades (stats and abilities), their costs, and a clear "before and after" preview for any selected stat change.
+- [x] **Trainer UI Mockup:** Design the "Upgrade Skills" dialog. It needs a list of available upgrades (stats and abilities), their costs, and a clear "before and after" preview for any selected stat change. See `docs/design/trainer-ui-mockup.md`.
     > **Gizmo:** Let's make this UI data-driven. It should just read a list of available upgrades from the trainer NPC's data. That way, modders can add new trainers with unique skill trees just by editing a JSON file.
     > **Clown:** It can be a json blob, but keep in mind that all json lives inside the javascript to keep the "no builds no servers" running locally ethos.
 

--- a/docs/design/trainer-ui-mockup.md
+++ b/docs/design/trainer-ui-mockup.md
@@ -1,0 +1,46 @@
+# Trainer UI Mockup
+
+*By Priya "Gizmo" Sharma*
+
+The Upgrade Skills dialog is a lightweight overlay that pops up when a player talks to a trainer NPC and selects **Upgrade Skills**. It keeps the flow quick while showing exactly what each upgrade buys.
+
+### Layout
+
+```
++----------------------------+
+| Upgrade Skills      Points:1|
+|----------------------------|
+| STR 25 -> 30        Cost:1 |
+| END 20 -> 25        Cost:1 |
+| Dash (new)          Cost:1 |
+|                        [✓]|
+| [Confirm] [Cancel]        |
++----------------------------+
+```
+
+Selecting a row highlights it and fills the preview. The point total updates in real time.
+
+### Data Driven
+
+Each trainer owns a `tree` object that lists possible upgrades. The UI reads this object and renders rows automatically:
+
+```
+const trainerTrees = {
+  power: [
+    { id: 'str', label: 'Strength', cost: 1, before: 25, after: 30 },
+    { id: 'dash', label: 'Dash Attack', cost: 1, before: null, after: 'Unlocked' }
+  ]
+};
+```
+
+> **Clown:** Keep the data inline. No external JSON files, just plain objects so the game still runs out of a single HTML file.
+
+The dialog doesn't care how many entries exist; modders add new upgrades by extending the `tree` data. Stats show a `before ➜ after` preview. Abilities list an `Unlocked` tag.
+
+### Flow
+
+1. Player enters the dialog with one or more unspent points.
+2. Selecting an upgrade previews the change and grays out unaffordable options.
+3. Confirming applies the upgrade and deducts the points; cancel leaves everything untouched.
+
+Fast, clear, and hackable—exactly how our trainers like it.


### PR DESCRIPTION
## Summary
- outline Upgrade Skills dialog in new trainer UI mockup design doc
- mark Trainer UI mockup task complete in RPG progression roadmap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab3b5766e08328a1361c5a592860d2