### PR TITLE
fix: reset NPC patrol after manual move

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -6,6 +6,7 @@ const nameEl=document.getElementById('npcName');
 const titleEl=document.getElementById('npcTitle');
 const portEl=document.getElementById('port');
 let currentNPC=null;
+Object.defineProperty(globalThis,'currentNPC',{get:()=>currentNPC,set:v=>{currentNPC=v;}});
 const dialogState={ tree:null, node:null };
 let selectedChoice=0;
 
@@ -107,6 +108,10 @@ function handleGoto(g){
     if(g.map) tgtNPC.map = g.map;
     tgtNPC.x = x;
     tgtNPC.y = y;
+    if(tgtNPC._loop){
+      tgtNPC._loop.path = [];
+      tgtNPC._loop.job = null;
+    }
   }else{
     if(g.map==='world'){
       startWorld();
@@ -355,5 +360,5 @@ function renderDialog(){
   dlgHighlightChoice();
 }
 
-const dialogExports = { overlay, choicesEl, textEl, nameEl, titleEl, portEl, openDialog, closeDialog, renderDialog, advanceDialog, resolveCheck, handleDialogKey };
+const dialogExports = { overlay, choicesEl, textEl, nameEl, titleEl, portEl, openDialog, closeDialog, renderDialog, advanceDialog, resolveCheck, handleDialogKey, handleGoto };
 Object.assign(globalThis, dialogExports);

--- a/test/npc-path.test.js
+++ b/test/npc-path.test.js
@@ -39,3 +39,28 @@ test('NPC follows waypoints with capped speed and waits when close', async () =>
   window.tickPathAI();
   assert.strictEqual(NPCS[0].x, 2);
 });
+
+test('NPC re-pathfinds after being moved', async () => {
+  NPCS.length = 0;
+  NPCS.push({ id:'n2', map:'world', x:0, y:0, loop:[{x:0,y:0},{x:2,y:0}] });
+  party.x = 5; party.y = 5;
+  await import('../dustland-path.js');
+  global.updateHUD = () => {};
+  global.document = {
+    getElementById: () => ({ children: [], classList:{ toggle(){}, contains(){ return false; }, add(){}, remove(){} }, style:{}, appendChild(){}, remove(){}, innerHTML:'', textContent:'' }),
+    createElement: () => ({ children: [], classList:{ toggle(){}, contains(){ return false; }, add(){}, remove(){} }, style:{}, appendChild(){}, remove(){}, innerHTML:'', textContent:'', onclick:null }),
+  };
+  await import('../core/dialog.js');
+  window.tickPathAI();
+  await new Promise(r => setTimeout(r,20));
+  window.tickPathAI();
+  assert.strictEqual(NPCS[0].x, 1);
+  const stPre = NPCS[0]._loop;
+  assert.ok(stPre && (stPre.path.length > 0 || stPre.job));
+  global.currentNPC = NPCS[0];
+  window.handleGoto({target:'npc', x:0, y:1, rel:false});
+  assert.deepStrictEqual({x:NPCS[0].x, y:NPCS[0].y}, {x:0, y:1});
+  const st = NPCS[0]._loop;
+  assert.deepStrictEqual(st.path, []);
+  assert.strictEqual(st.job, null);
+});


### PR DESCRIPTION
## Summary
- clear NPC patrol path and pending job when moved via dialog so they re-pathfind from the new location
- expose `currentNPC` via getter/setter for tests
- add regression test for NPC path reset after relocation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab412c63248328abc6ec44a2fd8a3a