### PR TITLE
fix: prevent duplicate buildings when loading

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -2152,7 +2152,7 @@ function applyLoadedModule(data) {
     });
   }
   buildings.length = 0;
-  moduleData.buildings.forEach(b => buildings.push(placeHut(b.x, b.y, b)));
+  moduleData.buildings.forEach(b => placeHut(b.x, b.y, b));
   moduleData.buildings = [...buildings];
 
   drawWorld();

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -103,6 +103,17 @@ test('applyLoadedModule clears previous building tiles', () => {
   assert.strictEqual(globalThis.buildings.length, 0);
 });
 
+test('applyLoadedModule avoids duplicate buildings', () => {
+  genWorld(1);
+  const data = { seed: 1, buildings: [{ x:2, y:2, w:2, h:2 }] };
+  applyLoadedModule(data);
+  assert.strictEqual(globalThis.buildings.length, 1);
+  const saved = { seed: moduleData.seed, buildings: moduleData.buildings };
+  applyLoadedModule(saved);
+  assert.strictEqual(globalThis.buildings.length, 1);
+  applyLoadedModule({ seed: 1, buildings: [] });
+});
+
 test('saveModule uses module name for download', () => {
   const origValidateSpawns = globalThis.validateSpawns;
   globalThis.validateSpawns = () => true;


### PR DESCRIPTION
## Summary
- avoid pushing buildings twice when loading Adventure Kit modules
- test module loading to ensure buildings aren't duplicated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab574d0f7083288aaa0b3ea20fe9cd