### PR TITLE
feat: add trainer NPCs with stat training

### DIFF
--- a/core/party.js
+++ b/core/party.js
@@ -125,5 +125,24 @@ function respec(memberIndex=selectedMember){
   return true;
 }
 
-const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, leader, setLeader, respec, selectedMember, xpCurve };
+function trainStat(stat, memberIndex = selectedMember){
+  const m = party[memberIndex];
+  if(!m) return false;
+  if(m.skillPoints <= 0){
+    log('No skill points to spend.');
+    return false;
+  }
+  m.skillPoints -= 1;
+  if(stat === 'HP'){
+    m.maxHp += 5;
+    m.hp = m.maxHp;
+  }else{
+    m.stats[stat] = (m.stats[stat] || 0) + 1;
+  }
+  renderParty(); updateHUD();
+  log(`${m.name} trains ${stat}.`);
+  return true;
+}
+
+const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, leader, setLeader, respec, trainStat, selectedMember, xpCurve };
 Object.assign(globalThis, partyExports);

--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -65,7 +65,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
     > **Clown:** It can be a json blob, but keep in mind that all json lives inside the javascript to keep the "no builds no servers" running locally ethos.
 
 #### **Phase 3: Content Implementation (The World)**
-- [ ] **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer's `tree` object should include the **Upgrade Skills** dialog option and their unique list of available upgrades.
+ - [x] **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer's `tree` object should include the **Upgrade Skills** dialog option and their unique list of available upgrades.
 - [ ] **Enemy Presets:** Create a `presets.json` file to define enemy stat allocations per level. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
 - [ ] **Zone Population:** Populate the "Scrap Wastes" (Levels 1-5) with 5-7 on-level enemies and one or two higher-level "challenge" enemies off the main path. Ensure the zone layout naturally funnels players back toward a trainer NPC.
 - [ ] **Boss Mechanics:** Implement the first boss with a telegraphed special move. This involves creating a visual cue (e.g., a "charging up" animation or effect) and a corresponding high-damage attack that triggers after a short delay.

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -406,6 +406,87 @@ const DUSTLAND_MODULE = (() => {
         { x: 90, y: midY - 6 }
       ],
       combat: { HP: 7, ATK: 2, DEF: 1, loot: 'raider_knife', auto: true }
+    },
+    {
+      id: 'trainer_power',
+      map: 'world',
+      x: 6,
+      y: midY - 1,
+      color: '#ffcc99',
+      name: 'Brakk',
+      title: 'Power Trainer',
+      desc: 'A former arena champ teaching raw strength.',
+      tree: {
+        start: {
+          text: 'Brakk cracks his knuckles.',
+          choices: [
+            { label: '(Upgrade Skills)', to: 'train' },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        },
+        train: {
+          text: 'Push your limits.',
+          choices: [
+            { label: 'STR +1', to: 'train', effects: [() => trainStat('STR')] },
+            { label: 'AGI +1', to: 'train', effects: [() => trainStat('AGI')] },
+            { label: '(Back)', to: 'start' }
+          ]
+        }
+      }
+    },
+    {
+      id: 'trainer_endurance',
+      map: 'world',
+      x: 6,
+      y: midY + 1,
+      color: '#99ccff',
+      name: 'Rusty',
+      title: 'Endurance Trainer',
+      desc: 'A grizzled scavenger preaching survival.',
+      tree: {
+        start: {
+          text: 'Rusty studies your stance.',
+          choices: [
+            { label: '(Upgrade Skills)', to: 'train' },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        },
+        train: {
+          text: 'Breathe deep and endure.',
+          choices: [
+            { label: 'Max HP +5', to: 'train', effects: [() => trainStat('HP')] },
+            { label: 'DEF +1', to: 'train', effects: [() => trainStat('DEF')] },
+            { label: '(Back)', to: 'start' }
+          ]
+        }
+      }
+    },
+    {
+      id: 'trainer_tricks',
+      map: 'world',
+      x: 6,
+      y: midY + 3,
+      color: '#cc99ff',
+      name: 'Mira',
+      title: 'Tricks Trainer',
+      desc: 'A nimble tinkerer teaching odd moves.',
+      tree: {
+        start: {
+          text: 'Mira twirls a coin.',
+          choices: [
+            { label: '(Upgrade Skills)', to: 'train' },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        },
+        train: {
+          text: 'Learn a new trick.',
+          choices: [
+            { label: 'PER +1', to: 'train', effects: [() => trainStat('PER')] },
+            { label: 'LCK +1', to: 'train', effects: [() => trainStat('LCK')] },
+            { label: '(Back)', to: 'start' }
+          ]
+        }
+      }
     }
   ];
 

--- a/test/trainer-npcs.test.js
+++ b/test/trainer-npcs.test.js
@@ -1,0 +1,37 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const partyCode = await fs.readFile(new URL('../core/party.js', import.meta.url), 'utf8');
+
+function setupParty(){
+  const context = {
+    log: () => {},
+    renderParty: () => {},
+    updateHUD: () => {},
+    EventBus: { emit: () => {} }
+  };
+  vm.createContext(context);
+  vm.runInContext(partyCode, context);
+  return context;
+}
+
+test('trainStat spends a point and raises stat', () => {
+  const ctx = setupParty();
+  const m = ctx.makeMember('id', 'Name', 'Role');
+  m.skillPoints = 1;
+  ctx.party.push(m);
+  assert.strictEqual(ctx.trainStat('STR'), true);
+  assert.strictEqual(m.stats.STR, 5);
+  assert.strictEqual(m.skillPoints, 0);
+});
+
+const moduleCode = await fs.readFile(new URL('../modules/dustland.module.js', import.meta.url), 'utf8');
+
+test('dustland module includes trainer NPCs', () => {
+  const trainerIds = moduleCode.match(/id: 'trainer_[^']+'/g) || [];
+  assert.ok(trainerIds.length >= 3);
+  const upgradeOpts = moduleCode.match(/\(Upgrade Skills\)/g) || [];
+  assert.ok(upgradeOpts.length >= 3);
+});


### PR DESCRIPTION
## Summary
- add trainStat helper for spending skill points
- introduce Power, Endurance, and Tricks trainers with Upgrade Skills dialog
- document trainer NPC completion and add regression tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab3fd026e48328b503d84c85d9350b