### PR TITLE
feat: add enemy stat presets

### DIFF
--- a/core/npc.js
+++ b/core/npc.js
@@ -135,5 +135,10 @@ function scaleEnemy(npc, lvl = 1, build = []) {
   npc.lvl = lvl;
 }
 
-const npcExports = { NPC, makeNPC, resolveNode, NPCS, npcsOnMap, queueNanoDialogForNPCs, removeNPC, createNpcFactory, scaleEnemy };
+function scaleEnemyWithPreset(npc, lvl = 1, preset = '') {
+  const build = enemyPresets?.[preset] || [];
+  scaleEnemy(npc, lvl, build);
+}
+
+const npcExports = { NPC, makeNPC, resolveNode, NPCS, npcsOnMap, queueNanoDialogForNPCs, removeNPC, createNpcFactory, scaleEnemy, scaleEnemyWithPreset };
 Object.assign(globalThis, npcExports);

--- a/core/presets.js
+++ b/core/presets.js
@@ -1,0 +1,3 @@
+import presets from './presets.json' assert { type: 'json' };
+const enemyPresets = presets;
+Object.assign(globalThis, { enemyPresets });

--- a/core/presets.json
+++ b/core/presets.json
@@ -1,0 +1,4 @@
+{
+  "Scrapper": ["STR", "AGI"],
+  "Bulwark": ["DEF", "DEF"]
+}

--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -66,7 +66,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 
 #### **Phase 3: Content Implementation (The World)**
  - [x] **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer's `tree` object should include the **Upgrade Skills** dialog option and their unique list of available upgrades.
-- [ ] **Enemy Presets:** Create a `presets.json` file to define enemy stat allocations per level. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
+- [x] **Enemy Presets:** Create a `presets.json` file to define enemy stat allocations per level. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
 - [ ] **Zone Population:** Populate the "Scrap Wastes" (Levels 1-5) with 5-7 on-level enemies and one or two higher-level "challenge" enemies off the main path. Ensure the zone layout naturally funnels players back toward a trainer NPC.
 - [ ] **Boss Mechanics:** Implement the first boss with a telegraphed special move. This involves creating a visual cue (e.g., a "charging up" animation or effect) and a corresponding high-damage attack that triggers after a short delay.
 - [ ] **Respec Vendor:** Create a special vendor NPC who sells "Memory Worm" tokens for a high price (e.g., 500 scrap). This vendor should be placed in a mid-to-late game area.

--- a/test/npc-scaling.test.js
+++ b/test/npc-scaling.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
 import '../core/party.js';
+import '../core/presets.js';
 import '../core/npc.js';
 
 test('scaleEnemy applies level-based scaling', () => {
@@ -12,4 +13,11 @@ test('scaleEnemy applies level-based scaling', () => {
   assert.strictEqual(npc.stats.STR, 5);
   assert.strictEqual(npc.stats.AGI, 5);
   assert.strictEqual(npc.stats.INT, 4);
+});
+
+test('scaleEnemyWithPreset uses named build', () => {
+  const npc = {};
+  scaleEnemyWithPreset(npc, 3, 'Scrapper');
+  assert.strictEqual(npc.stats.STR, 5);
+  assert.strictEqual(npc.stats.AGI, 5);
 });


### PR DESCRIPTION
## Summary
- add core/presets.json defining Scrapper and Bulwark stat builds
- expose enemyPresets globally and helper to scale enemies by preset
- verify preset-based scaling in tests and mark doc task complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab7bdd7ea483289873b10a4eed7099