### PR TITLE
feat: populate Scrap Wastes with enemies

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -67,7 +67,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 #### **Phase 3: Content Implementation (The World)**
  - [x] **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer's `tree` object should include the **Upgrade Skills** dialog option and their unique list of available upgrades.
 - [x] **Enemy Presets:** Create a `presets.json` file to define enemy stat allocations per level. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
-- [ ] **Zone Population:** Populate the "Scrap Wastes" (Levels 1-5) with 5-7 on-level enemies and one or two higher-level "challenge" enemies off the main path. Ensure the zone layout naturally funnels players back toward a trainer NPC.
+- [x] **Zone Population:** Populate the "Scrap Wastes" (Levels 1-5) with 5-7 on-level enemies and one or two higher-level "challenge" enemies off the main path. Ensure the zone layout naturally funnels players back toward a trainer NPC.
 - [ ] **Boss Mechanics:** Implement the first boss with a telegraphed special move. This involves creating a visual cue (e.g., a "charging up" animation or effect) and a corresponding high-damage attack that triggers after a short delay.
 - [ ] **Respec Vendor:** Create a special vendor NPC who sells "Memory Worm" tokens for a high price (e.g., 500 scrap). This vendor should be placed in a mid-to-late game area.
 

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -389,6 +389,84 @@ const DUSTLAND_MODULE = (() => {
       loop: [ { x: 14, y: midY - 1 }, { x: 80, y: midY + 4 } ]
     },
     {
+      id: 'scrap_mutt',
+      map: 'world',
+      x: 18,
+      y: midY - 2,
+      color: '#d88',
+      name: 'Scrap Mutt',
+      title: 'Mangy Hound',
+      desc: 'A feral mutt snarling over junk.',
+      tree: { start: { text: 'The mutt bares its teeth.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      combat: { HP: 5, ATK: 1, loot: 'water_flask', auto: true }
+    },
+    {
+      id: 'scavenger_rat',
+      map: 'world',
+      x: 32,
+      y: midY + 3,
+      color: '#c66',
+      name: 'Scavenger Rat',
+      title: 'Vermin',
+      desc: 'A giant rat rooting through scraps.',
+      tree: { start: { text: 'It hisses.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      combat: { HP: 4, ATK: 1, loot: 'water_flask', auto: true }
+    },
+    {
+      id: 'rust_bandit',
+      map: 'world',
+      x: 44,
+      y: midY - 3,
+      color: '#f88',
+      name: 'Rust Bandit',
+      title: 'Scav Raider',
+      desc: 'A bandit prowling for easy loot.',
+      tree: { start: { text: 'The bandit sizes you up.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      combat: { HP: 6, ATK: 1, loot: 'raider_knife', auto: true }
+    },
+    {
+      id: 'feral_nomad',
+      map: 'world',
+      x: 68,
+      y: midY + 2,
+      color: '#f77',
+      name: 'Feral Nomad',
+      title: 'Mad Drifter',
+      desc: 'A wild-eyed drifter muttering to himself.',
+      tree: { start: { text: 'He lunges without warning.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      combat: { HP: 6, ATK: 2, loot: 'medkit', auto: true }
+    },
+    {
+      id: 'waste_ghoul',
+      map: 'world',
+      x: 82,
+      y: midY - 4,
+      color: '#aa8',
+      name: 'Waste Ghoul',
+      title: 'Rotwalker',
+      desc: 'A decayed wanderer hungry for flesh.',
+      tree: { start: { text: 'It shambles toward you.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      combat: { HP: 7, ATK: 2, loot: 'goggles', auto: true }
+    },
+    {
+      id: 'iron_brute',
+      map: 'world',
+      x: 120,
+      y: midY - 8,
+      color: '#f33',
+      name: 'Iron Brute',
+      title: 'Challenge',
+      desc: 'A hulking brute plated in scrap.',
+      tree: { start: { text: 'The brute roars.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      loop: [
+        { x: 120, y: midY - 8 },
+        { x: 124, y: midY - 8 },
+        { x: 124, y: midY - 12 },
+        { x: 120, y: midY - 12 }
+      ],
+      combat: { HP: 15, ATK: 3, DEF: 2, loot: 'raider_knife', auto: true }
+    },
+    {
       id: 'stalker_patrol',
       map: 'world',
       x: 90,


### PR DESCRIPTION
## Summary
- Populate the Scrap Wastes with new hostile NPCs and a roaming iron brute challenge
- Mark zone population as complete in RPG progression roadmap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab920e79f483289a5e19c52bea4322