### PR TITLE
feat: add respec vendor NPC

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -69,7 +69,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] **Enemy Presets:** Create a `presets.json` file to define enemy stat allocations per level. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
 - [x] **Zone Population:** Populate the "Scrap Wastes" (Levels 1-5) with 5-7 on-level enemies and one or two higher-level "challenge" enemies off the main path. Ensure the zone layout naturally funnels players back toward a trainer NPC.
 - [x] **Boss Mechanics:** Implement the first boss with a telegraphed special move. This involves creating a visual cue (e.g., a "charging up" animation or effect) and a corresponding high-damage attack that triggers after a short delay.
-- [ ] **Respec Vendor:** Create a special vendor NPC who sells "Memory Worm" tokens for a high price (e.g., 500 scrap). This vendor should be placed in a mid-to-late game area.
+- [x] **Respec Vendor:** Create a special vendor NPC who sells "Memory Worm" tokens for a high price (e.g., 500 scrap). This vendor should be placed in a mid-to-late game area.
 
 #### **Phase 4: Testing and Balancing (The Stopwatch)**
 - [ ] **Progression Test Suite:** Write automated tests to verify:

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -22,6 +22,17 @@ const DUSTLAND_MODULE = (() => {
   };
   const hall = makeHall();
 
+  function buyMemoryWorm() {
+    if (player.scrap < 500) {
+      log('Not enough scrap.');
+      return;
+    }
+    player.scrap -= 500;
+    addToInv('memory_worm');
+    renderInv?.(); updateHUD?.();
+    log('Purchased Memory Worm.');
+  }
+
   const events = [
     { map: 'hall', x: hall.entryX - 1, y: hall.entryY, events:[{ when:'enter', effect:'toast', msg:'You smell rot.' }] }
   ];
@@ -561,6 +572,32 @@ const DUSTLAND_MODULE = (() => {
           choices: [
             { label: 'PER +1', to: 'train', effects: [() => trainStat('PER')] },
             { label: 'LCK +1', to: 'train', effects: [() => trainStat('LCK')] },
+            { label: '(Back)', to: 'start' }
+          ]
+        }
+      }
+    },
+    {
+      id: 'respec_vendor',
+      map: 'world',
+      x: 94,
+      y: midY + 5,
+      color: '#ffee99',
+      name: 'Nora',
+      title: 'Worm Seller',
+      desc: 'She trades memory worms for scrap.',
+      tree: {
+        start: {
+          text: 'Fresh worms for fading sins.',
+          choices: [
+            { label: `Buy Memory Worm (500 ${CURRENCY})`, to: 'buy' },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        },
+        buy: {
+          text: 'One bite resets the mind.',
+          choices: [
+            { label: '(Buy)', to: 'start', effects: [buyMemoryWorm] },
             { label: '(Back)', to: 'start' }
           ]
         }

--- a/test/respec-vendor.test.js
+++ b/test/respec-vendor.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('dustland module includes respec vendor', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'dustland.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /id: 'respec_vendor'/);
+  assert.match(src, /Buy Memory Worm \(500/);
+});


### PR DESCRIPTION
## Summary
- add Nora, a respec vendor selling Memory Worm tokens for scrap
- document respec vendor in RPG progression design doc
- test includes verification of vendor presence

## Testing
- `npm test` *(fails: Game balance tester; Game balance tester (Puppeteer) missing library)*
- `npm run test:balance` *(fails: Cannot read properties of undefined (reading 'length'))*


------
https://chatgpt.com/codex/tasks/task_e_68ab9a39e5348328a6366d5f96f33ccb