### PR TITLE
test: add progression test suite

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -72,7 +72,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] **Respec Vendor:** Create a special vendor NPC who sells "Memory Worm" tokens for a high price (e.g., 500 scrap). This vendor should be placed in a mid-to-late game area.
 
 #### **Phase 4: Testing and Balancing (The Stopwatch)**
-- [ ] **Progression Test Suite:** Write automated tests to verify:
+- [x] **Progression Test Suite:** Write automated tests to verify:
     - XP is awarded correctly.
     - Level-ups trigger at the right thresholds according to `xpCurve`.
     - HP and skill points are granted correctly.

--- a/test/progression.test.js
+++ b/test/progression.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import '../core/party.js';
+import '../core/npc.js';
+
+globalThis.log = () => {};
+globalThis.toast = () => {};
+globalThis.renderParty = () => {};
+globalThis.updateHUD = () => {};
+globalThis.hudBadge = () => {};
+globalThis.EventBus = { emit() {} };
+globalThis.hasItem = () => false;
+
+test('awardXP uses xpCurve thresholds', () => {
+  const c = new Character('t','Tester','Role');
+  c.awardXP(99);
+  assert.strictEqual(c.lvl, 1);
+  assert.strictEqual(c.xp, 99);
+  c.awardXP(1);
+  assert.strictEqual(c.lvl, 2);
+  assert.strictEqual(c.xp, 0);
+  assert.strictEqual(c.maxHp, 20);
+  assert.strictEqual(c.skillPoints, 1);
+});
+
+test('scaleEnemy grows stats and HP per level', () => {
+  const npc = {};
+  scaleEnemy(npc, 4, ['STR']);
+  assert.strictEqual(npc.maxHp, 40);
+  assert.strictEqual(npc.hp, 40);
+  assert.strictEqual(npc.lvl, 4);
+  assert.strictEqual(npc.stats.STR, 7);
+});


### PR DESCRIPTION
## Summary
- add tests covering XP thresholds and enemy scaling
- mark progression test suite as complete in design doc

## Testing
- `npm test` *(fails: Game balance tester, Game balance tester (Puppeteer))*

------
https://chatgpt.com/codex/tasks/task_e_68ab9c3c78f48328aa2fe3ce1281b11e