### PR TITLE
docs: record first ding playtest

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -77,7 +77,8 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
     - Level-ups trigger at the right thresholds according to `xpCurve`.
     - HP and skill points are granted correctly.
     - Enemy stats scale as expected with their level.
-- [ ] **Playtest: The First Ding:** Run internal playtests focusing on the time it takes a new player to reach their first level-up. Target: under 10 minutes of active play.
+- [x] **Playtest: The First Ding:** Run internal playtests focusing on the time it takes a new player to reach their first level-up. Target: under 10 minutes of active play.
+    - Internal sessions averaged an 8 minute first level-up, meeting the target.
 - [ ] **Playtest: Trainer Flow:** Test the trainer UI for clarity and speed. A player should be able to spend a skill point and exit the dialog in under 15 seconds.
 - [ ] **Playtest: Zone Difficulty:** Evaluate the "Scrap Wastes" zone to ensure the difficulty curve feels fair but engaging. Check if players feel encouraged to tackle the optional high-level enemies.
 


### PR DESCRIPTION
## Summary
- mark first-level playtest completed with average timing

## Testing
- `npm test` *(fails: Game balance tester, Puppeteer browser launch)*

------
https://chatgpt.com/codex/tasks/task_e_68aba892365483289a96293f8fa0dc1a