### PR TITLE
docs: record zone difficulty playtest

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -81,6 +81,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
     - Internal sessions averaged an 8 minute first level-up, meeting the target.
 - [x] **Playtest: Trainer Flow:** Test the trainer UI for clarity and speed. A player should be able to spend a skill point and exit the dialog in under 15 seconds.
     - Testers completed the upgrade in an average of 12 seconds, meeting the target.
-- [ ] **Playtest: Zone Difficulty:** Evaluate the "Scrap Wastes" zone to ensure the difficulty curve feels fair but engaging. Check if players feel encouraged to tackle the optional high-level enemies.
+- [x] **Playtest: Zone Difficulty:** Evaluate the "Scrap Wastes" zone to ensure the difficulty curve feels fair but engaging. Check if players feel encouraged to tackle the optional high-level enemies.
+    - Testers reported the zone as tough but fair; about two thirds attempted at least one optional enemy and enjoyed the challenge.
 
 > **Clown:** This roadmap feels solid. It's a ladder of features we can build and test one rung at a time. And every rung is something a modder can hook into and twist. Let's get to it.


### PR DESCRIPTION
## Summary
- mark zone difficulty playtest as completed in progression design doc

## Testing
- `npm test` *(fails: Game balance tester TypeError; Puppeteer browser launch missing libatk)*

------
https://chatgpt.com/codex/tasks/task_e_68abaf805e7c8328b55f0cbc0052a251