### PR TITLE
fix: force fresh game on module pick

### DIFF
--- a/module-picker.js
+++ b/module-picker.js
@@ -108,12 +108,8 @@ function loadModule(moduleInfo){
     if(picker) picker.remove();
     window.openCreator = realOpenCreator;
     window.showStart = realShowStart;
-    const savedGame = localStorage.getItem('dustland_crt');
-    if(savedGame){
-      showStart();
-    } else {
-      openCreator();
-    }
+    localStorage.removeItem('dustland_crt');
+    openCreator();
   };
   document.body.appendChild(script);
 }


### PR DESCRIPTION
## Summary
- always start a new game when a module is selected

## Testing
- `npm test` *(fails: Game balance tester, test/npc-scaling.test.js, test/puppeteer-runner.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68abd78c40ec8328ab44025fa68f8f4b