### PR TITLE
Fix module reset and expand picker

### DIFF
--- a/module-picker.js
+++ b/module-picker.js
@@ -4,13 +4,19 @@ const MODULES = [
   { id: 'dustland', name: 'Dustland', file: 'modules/dustland.module.js' },
   { id: 'echoes', name: 'Echoes', file: 'modules/echoes.module.js' },
   { id: 'office', name: 'Office', file: 'modules/office.module.js' },
+  { id: 'broadcast1', name: 'Broadcast Fragment 1', file: 'modules/broadcast-fragment-1.module.js' },
+  { id: 'broadcast2', name: 'Broadcast Fragment 2', file: 'modules/broadcast-fragment-2.module.js' },
+  { id: 'broadcast3', name: 'Broadcast Fragment 3', file: 'modules/broadcast-fragment-3.module.js' },
+  { id: 'mara', name: 'Mara Puzzle', file: 'modules/mara-puzzle.module.js' },
   { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' }
 ];
 
 const realOpenCreator = window.openCreator;
 const realShowStart = window.showStart;
+const realResetAll = window.resetAll;
 window.openCreator = () => {};
 window.showStart = () => {};
+window.resetAll = () => {};
 
 function startDust(canvas){
   const ctx = canvas.getContext('2d');
@@ -108,6 +114,7 @@ function loadModule(moduleInfo){
     if(picker) picker.remove();
     window.openCreator = realOpenCreator;
     window.showStart = realShowStart;
+    window.resetAll = () => { realResetAll(); loadModule(moduleInfo); };
     localStorage.removeItem('dustland_crt');
     openCreator();
   };

--- a/test/module-reload.test.js
+++ b/test/module-reload.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function stubEl(){
+  const ctx = { clearRect(){}, fillRect(){}, fillStyle: '', count:0 };
+  const el = {
+    id: '',
+    style: {},
+    children: [],
+    appendChild(child){
+      this.children.push(child);
+      child.parentElement = this;
+      if(child.onload) child.onload();
+    },
+    remove(){},
+    querySelector: () => stubEl(),
+    querySelectorAll: () => [],
+    textContent: '',
+    className: '',
+    ctx,
+    getContext: () => ctx
+  };
+  return el;
+}
+
+global.requestAnimationFrame = () => {};
+Object.assign(global, {
+  window: global,
+  innerWidth: 800,
+  innerHeight: 600,
+  addEventListener(){},
+  localStorage: { getItem: () => null, removeItem: () => {} },
+  location: { href: '' }
+});
+
+const bodyEl = stubEl();
+const headEl = stubEl();
+
+global.document = {
+  body: bodyEl,
+  head: headEl,
+  createElement: () => stubEl(),
+  getElementById: () => null
+};
+
+let openCalls = 0;
+let resetCalls = 0;
+
+global.openCreator = () => { openCalls++; };
+global.showStart = () => {};
+global.resetAll = () => { resetCalls++; };
+
+const code = await fs.readFile(new URL('../module-picker.js', import.meta.url), 'utf8');
+vm.runInThisContext(code, { filename: '../module-picker.js' });
+
+function getModule(){ return { id:'fake', name:'Fake', file:'fake.js' }; }
+
+await test('resetAll reloads current module', () => {
+  loadModule(getModule());
+  assert.strictEqual(openCalls, 1);
+  resetAll();
+  assert.strictEqual(resetCalls, 1);
+  assert.strictEqual(openCalls, 2);
+});
+


### PR DESCRIPTION
## Summary
- Reload currently selected module when starting a new game to avoid falling back to Dustland tutorial
- Offer additional built-in adventures in module picker, including Broadcast Fragments and Mara Puzzle
- Add test ensuring module reload on reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abe3e1de60832886c76c07efcd8e78