### PR TITLE
docs: detail barrel dimension

### DIFF
--- a/docs/design/game-story.md
+++ b/docs/design/game-story.md
@@ -3,3 +3,5 @@
 
 The Dustland stretches beyond the horizon, a patchwork of forgotten highways and half-buried towns. Survivors cling to myths about a signal that can stitch the world back together. Our party rides into this mess not as heroes, but as witnesses. Every quest should show how people bend— or break— under the weight of dust and hope. Give me moments where a broken radio triggers an uprising, or a cracked photo frame becomes a plot twist. Keep the tone soulful, never cynical; we scrape the rust to find glimmers underneath.
 
+Reality here sits in a barrel-shaped pocket dimension. Relics slide in from Earth's timeline starting in the 1950s, and the further a thing has traveled into tomorrow, the more shattered it lands. Transistor radios arrive almost whole; smartphones are glittering dust. The people who've been stranded here patch these scraps with mid-century know-how and stubborn hope. They've lived in the Dustland so long their memories of Earth smear like fog on glass.
+

--- a/docs/design/plot-draft.md
+++ b/docs/design/plot-draft.md
@@ -10,6 +10,10 @@ Let's rectify that. Here is a properly expanded and improved version of `plot-dr
 
 > **Clown:** The first draft was a good skeleton. Now we flesh it out. Let's give this carnival ride some more loops and twists. The goal isn't just to chase a signal; it's to make the caravan's journey feel like a living, breathing story that the player can bend and break.
 
+### **Setting: The Barrel**
+
+Dustland sits in a barrel-shaped pocket dimension where debris from Earth's timeline slips in starting in the 1950s. The further into the future an object originates, the more mangled it is when it lands. A vinyl jukebox might arrive with only a few scratches while a late-century drone smashes down in sparks and shards. The people trapped here patch these fragments with mid-century tools and grit, but years in the Dustland have smeared their memories of Earth to static.
+
 ### **The Grand Narrative: The Ghost Signal**
 
 The core of our story remains the caravan's desperate pursuit of a fading broadcast, a ghost signal that whispers promises of a world not yet lost to rust and dust. But what is this signal? Is it a pre-Fall AI, a loop of a forgotten artist's last words, or something stranger? We need to build this mystery, layer by layer. Each stop on the journey shouldn't just be a point on a map; it should be a fresh breadcrumb, a new piece of the puzzle.


### PR DESCRIPTION
## Summary
- integrate barrel-dimension setting into plot draft
- expand game story with falling relics and faded memories

## Testing
- `npm test` *(fails: Failed to launch the browser process! Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68abe8f08794832894d4e534059b8564