### PR TITLE
fix: reload selected module before new game

### DIFF
--- a/module-picker.js
+++ b/module-picker.js
@@ -114,7 +114,12 @@ function loadModule(moduleInfo){
     if(picker) picker.remove();
     window.openCreator = realOpenCreator;
     window.showStart = realShowStart;
-    window.resetAll = () => { realResetAll(); loadModule(moduleInfo); };
+    window.resetAll = () => {
+      // Prevent stale modules from launching before the new one loads
+      window.openCreator = () => {};
+      realResetAll();
+      loadModule(moduleInfo);
+    };
     localStorage.removeItem('dustland_crt');
     openCreator();
   };


### PR DESCRIPTION
## Summary
- Prevent stale modules from launching by stubbing `openCreator` during New Game resets.

## Testing
- `npm test` *(fails: Failed to launch the browser process; libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abe990f2ec8328a0c89fba0f87d9bf