### PR TITLE
fix: reset module hooks before loading new module

### DIFF
--- a/module-picker.js
+++ b/module-picker.js
@@ -102,6 +102,8 @@ function startDust(canvas){
 function loadModule(moduleInfo){
   const existingScript = document.getElementById('activeModuleScript');
   if (existingScript) existingScript.remove();
+  window.seedWorldContent = () => {};
+  window.startGame = () => {};
   if (moduleInfo.file.endsWith('.json')) {
     window.location.href = `dustland.html?ack-player=1&module=${encodeURIComponent(moduleInfo.file)}`;
     return;


### PR DESCRIPTION
## Summary
- reset global `seedWorldContent` and `startGame` when swapping modules to avoid leftover Dustland content

## Testing
- `npm test` *(fails: Failed to launch the browser process: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac56e7ff048328b1b1829ea69bb428