### PR TITLE
fix: remove default modules before module selection

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -165,6 +165,9 @@
   <script>
     const params = new URLSearchParams(location.search);
     const isAck = params.get('ack-player') === '1';
+    if (!isAck) {
+      document.querySelectorAll('script[src^="./modules/"]').forEach(s => s.remove());
+    }
     if (isAck) {
       document.getElementById('moduleLoader').style.display = 'flex';
       const btns = document.getElementById('mainButtons');


### PR DESCRIPTION
## Summary
- Drop preloaded module scripts when module picker runs so selection loads correctly

## Testing
- `npm test` *(fails: Failed to launch the browser process due to missing libcups.so.2)*

------
https://chatgpt.com/codex/tasks/task_e_68abed5b98d88328bdf9602b6076c59b