### PR TITLE
Add test for dust storm puzzle effects

### DIFF
--- a/docs/design/plot-draft.md
+++ b/docs/design/plot-draft.md
@@ -78,7 +78,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
 - [x] Detail Jax "Patch"—a scavenger mechanic hoarding tech; arc: opens his toolkit to the crew.
 - [x] Detail Nyx "Speaker"—a poet tuning radio static into verse; arc: chooses between broadcasting or listening.
 - [ ] **Implement Signature Encounters:**
-    - [ ] Design and build Mara's dust storm navigation puzzle.
+    - [x] Design and build Mara's dust storm navigation puzzle.
     - [ ] Script Jax's timed repair sequence under combat pressure.
     - [ ] Write the dialogue and branching paths for Nyx's "conversational tuning" encounter.
 - [ ] **Doppelgänger System:**

--- a/test/duststorm.effects.test.js
+++ b/test/duststorm.effects.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+const setup = async () => {
+  const dom = new JSDOM('<!doctype html><body></body>', { pretendToBeVisual: true });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.requestAnimationFrame = () => 0;
+  window.HTMLCanvasElement.prototype.getContext = () => ({
+    clearRect() {},
+    fillRect() {},
+  });
+  global.soundSources = [];
+  global.state = { map: 'dust_storm' };
+  await import(new URL('../core/effects.js', import.meta.url));
+  return dom;
+};
+
+test('dustStorm and addSoundSource effects', async () => {
+  const dom = await setup();
+  const { Effects } = globalThis;
+
+  Effects.apply([{ effect: 'dustStorm', active: true }]);
+  assert.ok(document.getElementById('dustStorm'));
+
+  Effects.apply([{ effect: 'addSoundSource', id: 'chime1', x: 2, y: 3 }]);
+  assert.deepStrictEqual(global.soundSources, [{ id: 'chime1', x: 2, y: 3, map: 'dust_storm' }]);
+
+  Effects.apply([{ effect: 'dustStorm', active: false }]);
+  assert.strictEqual(document.getElementById('dustStorm'), null);
+
+  dom.window.close();
+});


### PR DESCRIPTION
## Summary
- test dust storm overlay and sound source handling for Mara's navigation puzzle
- check off Mara dust storm puzzle in plot draft

## Testing
- `npm test`
- `node --test test/duststorm.effects.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abe4378ee483289316c80d5a359d39