### PR TITLE
fix: use mobile arrows for combat

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -80,6 +80,8 @@ function setMobileControls(on){
       const mobileMove=(dx,dy,key)=>{
         if(overlay?.classList?.contains('shown')){
           handleDialogKey?.({ key });
+        }else if(document.getElementById('combatOverlay')?.classList?.contains('shown')){
+          handleCombatKey?.({ key });
         }else{
           move(dx,dy);
         }

--- a/test/mobile-controls.test.js
+++ b/test/mobile-controls.test.js
@@ -67,3 +67,19 @@ test('mobile arrows navigate dialog when overlay shown', async () => {
   down.onclick();
   assert.deepStrictEqual(keys, ['ArrowUp', 'ArrowDown']);
 });
+
+test('mobile arrows navigate combat menu when in combat', async () => {
+  const keys=[];
+  const html = '<body><div id="combatOverlay" class="shown"></div><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>';
+  const { context } = await setup(html, {
+    handleCombatKey: e => { keys.push(e.key); return true; },
+    move: () => { keys.push('move'); },
+    overlay: null
+  });
+  context.setMobileControls(true);
+  const up = [...context.document.querySelectorAll('button')].find(b => b.textContent === '↑');
+  up.onclick();
+  const down = [...context.document.querySelectorAll('button')].find(b => b.textContent === '↓');
+  down.onclick();
+  assert.deepStrictEqual(keys, ['ArrowUp', 'ArrowDown']);
+});


### PR DESCRIPTION
## Summary
- allow mobile arrow keys to navigate combat menu when combat overlay is active
- cover mobile combat navigation with unit tests

## Testing
- `npm test` *(fails: Game balance tester (Puppeteer): libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6d6aa59c83288aa24d9dbb73b653