### PR TITLE
feat: allow selecting party members via panel click or Tab

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -463,9 +463,16 @@ function renderParty(){
     p.innerHTML='<div class="pcard muted">(no party members yet)</div>';
     return;
   }
+  const selectMember=idx=>{
+    selectedMember=idx;
+    p.querySelectorAll('.pcard').forEach((card,j)=>{
+      card.classList.toggle('selected', j===selectedMember);
+    });
+  };
   party.forEach((m,i)=>{
     const c=document.createElement('div');
     c.className='pcard'+(i===selectedMember?' selected':'');
+    c.tabIndex=0;
     const bonus=m._bonus||{};
     const fmt=v=> (v>0? '+'+v : v);
     const wLabel=m.equip.weapon?(m.equip.weapon.cursed&&m.equip.weapon.cursedKnown?m.equip.weapon.name+' (cursed)':m.equip.weapon.name):'—';
@@ -479,9 +486,9 @@ function renderParty(){
 <div class='row small'>${statLine(m.stats)}</div>
 <div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div>
 <div class='row'><div class='xpbar' data-xp='${m.xp}/${nextXP}'><div class='fill' style='width:${pct}%'></div></div></div>
-<div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div>
-<div class='row'><label><input type='radio' name='selMember' ${i===selectedMember?'checked':''}> Selected</label></div>`;
-    c.querySelector('input').onchange=()=>{ selectedMember=i; };
+<div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div>`;
+    c.onclick=()=>selectMember(i);
+    c.onfocus=()=>selectMember(i);
     c.querySelectorAll('button[data-a="unequip"]').forEach(b=>{
       const sl=b.dataset.slot;
       b.onclick=()=> unequipItem(i,sl);

--- a/dustland.css
+++ b/dustland.css
@@ -190,7 +190,8 @@
         border: 1px solid #273027;
         border-radius: 8px;
         background: #0f120f;
-        padding: 8px
+        padding: 8px;
+        cursor: pointer
     }
     .pcard.selected {
         box-shadow: 0 0 0 2px #8bd98d;

--- a/test/party-selection.test.js
+++ b/test/party-selection.test.js
@@ -1,0 +1,121 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const full = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
+
+class AudioCtx {
+  createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
+  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
+  get destination(){ return {}; }
+  resume(){}
+  suspend(){}
+  get currentTime(){ return 0; }
+}
+
+class Audio {
+  constructor(){ this.addEventListener = () => {}; }
+  cloneNode(){ return new Audio(); }
+  play(){ return Promise.resolve(); }
+  pause(){}
+}
+
+test('party panels handle click and focus selection', async () => {
+  const html = `<body>
+  <div id="log"></div>
+  <div id="hp"></div>
+  <div id="ap"></div>
+  <div id="scrap"></div>
+  <canvas id="game"></canvas>
+  <button id="saveBtn"></button>
+  <button id="loadBtn"></button>
+  <button id="resetBtn"></button>
+  <button id="nanoToggle"></button>
+  <button id="audioToggle"></button>
+  <button id="mobileToggle"></button>
+  <button id="settingsBtn"></button>
+  <div id="settings"><button id="settingsClose"></button></div>
+  <div id="panelToggle"></div>
+  <div class="panel"></div>
+  <div class="tabs"></div>
+  <div id="tabInv"></div>
+  <div id="tabParty"></div>
+  <div id="tabQuests"></div>
+  <div id="inv"></div>
+  <div id="party"></div>
+  <div id="quests"></div>
+  <div id="overlay"></div>
+  <div id="combatOverlay"></div>
+  <div id="moduleLoader"></div>
+  </body>`;
+  const dom = new JSDOM(html, { url:'https://example.com' });
+  Object.defineProperty(dom.window.HTMLCanvasElement.prototype, 'getContext', { value: () => ({ fillRect(){}, strokeRect(){}, drawImage(){}, clearRect(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){}, save(){}, restore(){}, translate(){}, fillText(){}, globalAlpha:1, font:'' }) });
+  dom.window.AudioContext = AudioCtx;
+  dom.window.webkitAudioContext = AudioCtx;
+  dom.window.Audio = Audio;
+
+  const party = [
+    { name:'A', role:'Hero', lvl:1, hp:5, maxHp:5, ap:2, skillPoints:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null }, _bonus:{}, portraitSheet:null, xp:0 },
+    { name:'B', role:'Mage', lvl:1, hp:5, maxHp:5, ap:2, skillPoints:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null }, _bonus:{}, portraitSheet:null, xp:0 }
+  ];
+  party.flags = {};
+
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    navigator: { userAgent: 'Test' },
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    Audio: Audio,
+    EventBus: { on: () => {}, emit: () => {} },
+    requestAnimationFrame: () => 0,
+    move: () => {},
+    interact: () => {},
+    showTab: () => {},
+    takeNearestItem: () => {},
+    toast: () => {},
+    NPCS: [],
+    party,
+    selectedMember: 0,
+    state: { map: 'world' },
+    player: { hp:10, ap:2, scrap:0 },
+    save: () => {},
+    load: () => {},
+    resetAll: () => {},
+    genWorld: () => {},
+    buildings: [],
+    interiors: {},
+    assert: () => {},
+    openCreator: () => {},
+    closeCreator: () => {},
+    startGame: () => {},
+    overlay: null,
+    handleDialogKey: () => false,
+    handleCombatKey: () => false,
+    showMini: false,
+    console,
+    URLSearchParams,
+    location: { search:'', hash:'' },
+    statLine: () => '',
+    xpToNext: () => 100,
+    unequipItem: () => {}
+  };
+  vm.createContext(context);
+  vm.runInContext(full, context);
+
+  context.renderParty();
+  const partyDiv = dom.window.document.getElementById('party');
+  assert.strictEqual(partyDiv.querySelectorAll('.pcard').length, 2);
+  assert.strictEqual(partyDiv.querySelector('input[type="radio"]'), null);
+
+  partyDiv.children[1].dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  assert.strictEqual(context.selectedMember, 1);
+  assert(partyDiv.children[1].classList.contains('selected'));
+
+  partyDiv.children[0].focus();
+  assert.strictEqual(context.selectedMember, 0);
+  assert(partyDiv.children[0].classList.contains('selected'));
+});
+


### PR DESCRIPTION
## Summary
- allow selecting party members by clicking or focusing their panel
- hide radio buttons and style cards as clickable
- add tests for panel selection behavior

## Testing
- `npm test` *(fails: Game balance tester (Puppeteer) - missing libXcomposite.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6cf47970832882cefff4e6f3d15f