### PR TITLE
fix: retain NPC portrait when joining party

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -88,7 +88,13 @@ function processQuestFlag(c){
 
 function joinParty(join){
   if(!join) return;
-  const m=makeMember(join.id, join.name, join.role);
+  const opts = {};
+  if(join.portraitSheet){
+    opts.portraitSheet = join.portraitSheet;
+  } else if(currentNPC?.portraitSheet){
+    opts.portraitSheet = currentNPC.portraitSheet;
+  }
+  const m=makeMember(join.id, join.name, join.role, opts);
   if(addPartyMember(m)){
     removeNPC(currentNPC);
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -689,6 +689,15 @@ test('setPortraitDiv uses full image when not sprite sheet', () => {
   assert.strictEqual(el.style.backgroundSize, '100% 100%');
 });
 
+test('joinParty copies current NPC portraitSheet', () => {
+  party.length = 0;
+  NPCS.length = 0;
+  currentNPC = { id: 'j', name: 'Joker', portraitSheet: 'assets/portraits/portrait_1000.png' };
+  joinParty({ id: 'j', name: 'Joker', role: 'Trickster' });
+  assert.strictEqual(party[0].portraitSheet, 'assets/portraits/portrait_1000.png');
+  currentNPC = null;
+});
+
 test('clamp swaps reversed bounds', () => {
   assert.strictEqual(clamp(5, 10, 0), 5);
 });


### PR DESCRIPTION
## Summary
- keep NPC portrait sheet when they join the party
- test that joinParty uses current NPC portrait

## Testing
- `npm test` *(fails: Game balance tester (Puppeteer) missing libcups.so.2)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6c7245b083288c899f3cf8ac5539