### PR TITLE
fix: skip module picker in balance tester

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -170,10 +170,12 @@
       const settingsBtn = document.getElementById('settingsBtn');
       if (settingsBtn) settingsBtn.style.display = 'none';
     }
-    const modeScript = document.createElement('script');
-    modeScript.defer = true;
-    modeScript.src = isAck ? './ack-player.js' : './module-picker.js';
-    document.body.appendChild(modeScript);
+    if (isAck) {
+      const modeScript = document.createElement('script');
+      modeScript.defer = true;
+      modeScript.src = './ack-player.js';
+      document.body.appendChild(modeScript);
+    }
   </script>
   <script defer src="./balance-tester-agent.js"></script>
 </body>

--- a/test/balance-tester.nopicker.test.js
+++ b/test/balance-tester.nopicker.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('balance tester does not load module picker', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const htmlPath = path.join(__dirname, '..', 'balance-tester.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const match = html.match(/<script>([\s\S]*?)<\/script>\s*<script defer src="\.\/balance-tester-agent.js"><\/script>/);
+  assert.ok(match, 'inline script not found');
+  const script = match[1];
+  const appended = [];
+  const document = {
+    body: { appendChild: (el) => appended.push(el) },
+    getElementById: () => ({ style: {}, appendChild: () => {} }),
+    createElement: () => ({})
+  };
+  const location = { search: '' };
+  new Function('document', 'location', script)(document, location);
+  const hasModulePicker = appended.some((el) => (el.src || '').includes('module-picker.js'));
+  assert.strictEqual(hasModulePicker, false, 'module picker script should not be appended');
+});


### PR DESCRIPTION
## Summary
- skip module picker in balance tester
- ensure balance tester never appends module picker script

## Testing
- `npm test` *(fails: Failed to launch the browser process! libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac70f9962483289f5d40a0ae55b4ab