### PR TITLE
fix: hook playtest button

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -2744,5 +2744,4 @@ if (document && typeof document.addEventListener === 'function') {
   });
 }
 
-document.getElementById('playtestFloat').onclick =
-  () => document.getElementById('playtest')?.click();
+document.getElementById('playtestFloat')?.addEventListener('click', playtestModule);


### PR DESCRIPTION
## Summary
- wire the floating playtest button to launch playtests directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac764368a88328ab3374585b0d63e8