### PR TITLE
feat: add presubmit check for html patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Guidelines for contributors and automated agents working on Dustland CRT.
 
 ## Testing
 - Run `npm test` after making changes; it invokes Node's built-in test runner.
+- Run `node presubmit.js` to check HTML files for unsupported fetch/import patterns.
 - Ensure the working tree is clean and tests pass before committing.
 - Before adding new tests, check for existing coverage and extend or modify tests instead of duplicating cases.
 

--- a/presubmit.js
+++ b/presubmit.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const files = ['dustland.html', 'adventure-kit.html'];
+const patterns = [
+  {regex: /\bfetch\s*\(/, message: 'fetch() usage'},
+  {regex: /\brequire\s*\(/, message: 'require() usage'},
+  {regex: /<script[^>]*src=["'][^"']+\.json["'][^>]*>/i, message: 'script tag loading JSON file'},
+  {regex: /import[^;"'`]*\.json/, message: 'import of JSON file'},
+  {regex: /<script[^>]*src=["']https?:\/\//i, message: 'remote script URL may be blocked by CORS'}
+];
+
+let failed = false;
+for (const file of files) {
+  if (!fs.existsSync(file)) continue;
+  const text = fs.readFileSync(file, 'utf8');
+  for (const {regex, message} of patterns) {
+    if (regex.test(text)) {
+      console.error(`${file} contains forbidden pattern: ${message}`);
+      failed = true;
+    }
+  }
+}
+
+if (failed) {
+  console.error('Presubmit failed: remove unsupported patterns from HTML files.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add presubmit script to block fetch/import/require/CORS violations in main HTML files
- document presubmit in AGENTS guidelines

## Testing
- `node presubmit.js`
- `npm test` *(fails: libatk-1.0.so.0 missing for Puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8292c678832884f3b504e24feef2