### PR TITLE
feat: bootstrap broadcast fragments through loader

### DIFF
--- a/broadcast-story.js
+++ b/broadcast-story.js
@@ -1,0 +1,35 @@
+const BROADCAST_FILES = [
+  'modules/broadcast-fragment-1.module.js',
+  'modules/broadcast-fragment-2.module.js',
+  'modules/broadcast-fragment-3.module.js'
+];
+
+let fragmentsReady;
+function loadFragments(){
+  fragmentsReady = new Promise(resolve => {
+    let loaded = 0;
+    BROADCAST_FILES.forEach(src => {
+      const s = document.createElement('script');
+      s.src = `${src}?_=${Date.now()}`;
+      s.onload = () => {
+        loaded++;
+        if(loaded === BROADCAST_FILES.length) resolve();
+      };
+      document.head.appendChild(s);
+    });
+  });
+}
+loadFragments();
+
+seedWorldContent = () => {};
+
+startGame = async function(){
+  await fragmentsReady;
+  startWorld();
+  applyModule(BROADCAST_FRAGMENT_1);
+  const map = BROADCAST_FRAGMENT_1.startMap || 'world';
+  const pt = BROADCAST_FRAGMENT_1.startPoint || { x: 2, y: Math.floor(WORLD_H/2) };
+  setPartyPos(pt.x, pt.y);
+  setMap(map, map === 'world' ? 'Wastes' : map);
+  refreshUI();
+};

--- a/docs/design/plot-draft.md
+++ b/docs/design/plot-draft.md
@@ -76,6 +76,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
   - The Silencers hunt with relentless, calculated precision. They deploy mobile signal jammers to create "dead zones," use EMP traps to disable caravan vehicles, and employ sonic weaponry to disorient their prey. They don't seek converts; they seek only to silence the signal and anyone who would amplify its "poisonous" message.
 - [x] **Modular Story Beats:** Design the first three "broadcast fragment" modules. Each should introduce a new location, a new set of characters, and a new piece of the central mystery.
   - We are going to need to be able to link multiple world maps together in single module, or let character/inventory carry state across modules to tell this story
+  - Broadcast fragments now load through script tags and each defines a `startMap` and `startPoint`. The module picker offers a single **Broadcast Story** option that bootstraps the sequence.
 
 #### **Phase 2: Character and Item Implementation**
 - [x] Detail Mara "Surveyor"—an ex-cartographer seeking the map she burned; arc: learns the signal isn't the only way home.

--- a/module-picker.js
+++ b/module-picker.js
@@ -4,9 +4,7 @@ const MODULES = [
   { id: 'dustland', name: 'Dustland', file: 'modules/dustland.module.js' },
   { id: 'echoes', name: 'Echoes', file: 'modules/echoes.module.js' },
   { id: 'office', name: 'Office', file: 'modules/office.module.js' },
-  { id: 'broadcast1', name: 'Broadcast Fragment 1', file: 'modules/broadcast-fragment-1.module.js' },
-  { id: 'broadcast2', name: 'Broadcast Fragment 2', file: 'modules/broadcast-fragment-2.module.js' },
-  { id: 'broadcast3', name: 'Broadcast Fragment 3', file: 'modules/broadcast-fragment-3.module.js' },
+  { id: 'broadcast', name: 'Broadcast Story', file: 'broadcast-story.js' },
   { id: 'mara', name: 'Mara Puzzle', file: 'modules/mara-puzzle.module.js' },
   { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' }
 ];

--- a/modules/broadcast-fragment-1.module.js
+++ b/modules/broadcast-fragment-1.module.js
@@ -1,6 +1,8 @@
 const BROADCAST_FRAGMENT_1 = {
   "seed": "broadcast-1",
   "name": "broadcast-fragment-1",
+  "startMap": "world",
+  "startPoint": { "x": 102, "y": 20 },
   "items": [
     { "id": "tuned_crystal", "name": "Tuned Crystal", "type": "quest" },
     { "id": "signal_fragment_1", "name": "Signal Fragment 1", "type": "quest", "desc": "A strange, humming piece of metal that seems to resonate with the radio waves." }
@@ -90,3 +92,4 @@ const BROADCAST_FRAGMENT_1 = {
     { "x": 100, "y": 20, "w": 1, "h": 1, "interiorId": "radio_shack", "boarded": false }
   ]
 };
+globalThis.BROADCAST_FRAGMENT_1 = BROADCAST_FRAGMENT_1;

--- a/modules/broadcast-fragment-2.module.js
+++ b/modules/broadcast-fragment-2.module.js
@@ -1,6 +1,8 @@
 const BROADCAST_FRAGMENT_2 = {
   "seed": "broadcast-2",
   "name": "broadcast-fragment-2",
+  "startMap": "world",
+  "startPoint": { "x": 140, "y": 22 },
   "items": [
     { "id": "power_cell", "name": "Power Cell", "type": "quest" },
     { "id": "signal_fragment_2", "name": "Signal Fragment 2", "type": "quest", "desc": "Another humming fragment. The resonance is stronger." }
@@ -73,3 +75,4 @@ const BROADCAST_FRAGMENT_2 = {
     { "x": 140, "y": 20, "w": 1, "h": 1, "interiorId": "comms_tower_base", "grid": [[8]] }
   ]
 };
+globalThis.BROADCAST_FRAGMENT_2 = BROADCAST_FRAGMENT_2;

--- a/modules/broadcast-fragment-3.module.js
+++ b/modules/broadcast-fragment-3.module.js
@@ -1,6 +1,8 @@
 const BROADCAST_FRAGMENT_3 = {
   "seed": "broadcast-3",
   "name": "broadcast-fragment-3",
+  "startMap": "world",
+  "startPoint": { "x": 140, "y": 12 },
   "items": [
     { "id": "signal_fragment_3", "name": "Signal Fragment 3", "type": "quest", "desc": "The final fragment. It hums with a powerful, clear energy." }
   ],
@@ -64,3 +66,4 @@ const BROADCAST_FRAGMENT_3 = {
     { "x": 140, "y": 10, "w": 1, "h": 1, "interiorId": "resonant_cave", "grid": [[8]] }
   ]
 };
+globalThis.BROADCAST_FRAGMENT_3 = BROADCAST_FRAGMENT_3;

--- a/test/broadcast-fragments.test.js
+++ b/test/broadcast-fragments.test.js
@@ -1,0 +1,22 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+test('broadcast fragment modules expose globals', async () => {
+  delete globalThis.BROADCAST_FRAGMENT_1;
+  delete globalThis.BROADCAST_FRAGMENT_2;
+  delete globalThis.BROADCAST_FRAGMENT_3;
+  await import('../modules/broadcast-fragment-1.module.js');
+  await import('../modules/broadcast-fragment-2.module.js');
+  await import('../modules/broadcast-fragment-3.module.js');
+  assert.ok(globalThis.BROADCAST_FRAGMENT_1);
+  assert.ok(globalThis.BROADCAST_FRAGMENT_2);
+  assert.ok(globalThis.BROADCAST_FRAGMENT_3);
+  [
+    globalThis.BROADCAST_FRAGMENT_1,
+    globalThis.BROADCAST_FRAGMENT_2,
+    globalThis.BROADCAST_FRAGMENT_3
+  ].forEach(f => {
+    assert.ok(f.startMap);
+    assert.ok(f.startPoint);
+  });
+});


### PR DESCRIPTION
## Summary
- Load all broadcast fragments through a new `Broadcast Story` loader that registers modules via script tags and starts from the first fragment
- Add `startMap` and `startPoint` fields to each fragment for automatic placement
- Update design docs and tests for broadcast fragment bootstrapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac7b88c8c4832899d8fffbad7b94c7