### PR TITLE
fix: clear random huts when modules define buildings

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -294,6 +294,13 @@ function applyModule(data, options = {}){
   if (fullReset) {
     // Reset and repopulate core collections without changing references
     Object.keys(interiors).forEach(k => delete interiors[k]);
+    buildings.forEach(b => {
+      for (let yy = 0; yy < b.h; yy++) {
+        for (let xx = 0; xx < b.w; xx++) {
+          setTile('world', b.x + xx, b.y + yy, b.under[yy][xx]);
+        }
+      }
+    });
     buildings.length = 0;
     portals.length = 0;
     tileEvents.length = 0;
@@ -304,7 +311,13 @@ function applyModule(data, options = {}){
     hiddenNPCs.length = 0;
   }
 
-  if (data.buildings) buildings.push(...data.buildings.filter(b => !buildings.some(eb => eb.x === b.x && eb.y === b.y)));
+  if (data.buildings) {
+    data.buildings.forEach(b => {
+      if (!buildings.some(eb => eb.x === b.x && eb.y === b.y)) {
+        placeHut(b.x, b.y, b);
+      }
+    });
+  }
   if (data.portals) portals.push(...data.portals);
   if (data.events) registerTileEvents(data.events);
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -116,7 +116,8 @@ for (const f of files) {
   vm.runInThisContext(code, { filename: f });
 }
 
-const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey, uncurseItem, save, makeInteriorRoom, placeHut, TILE, getTile, interiors, calcMoveDelay, getMoveDelay } = globalThis;
+const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey, uncurseItem, save, makeInteriorRoom, placeHut, TILE, getTile, calcMoveDelay, getMoveDelay, buildings, world } = globalThis;
+let interiors = globalThis.interiors;
 
 // Stub out globals used by equipment functions
 global.log = () => {};
@@ -266,6 +267,20 @@ test('applyModule assigns NPC loops', () => {
   const world = [[7,7]];
   applyModule({world, npcs:[{id:'n', map:'world', x:0, y:0, loop:[{x:0,y:0},{x:1,y:0}]}]});
   assert.deepStrictEqual(NPCS[0].loop, [{x:0,y:0},{x:1,y:0}]);
+});
+
+test('applyModule removes random huts when module supplies buildings', () => {
+  world.length = 0;
+  for (let y = 0; y < 10; y++) world.push(Array(10).fill(TILE.SAND));
+  buildings.length = 0;
+  placeHut(3, 3);
+  const prev = buildings.map(b => ({ x: b.x, y: b.y }));
+  applyModule({ seed: 42, buildings: [{ x: 1, y: 1, w: 1, h: 2 }] });
+  prev.forEach(p => {
+    assert.notStrictEqual(getTile('world', p.x, p.y), TILE.BUILDING);
+  });
+  assert.strictEqual(getTile('world', 1, 1), TILE.BUILDING);
+  assert.strictEqual(buildings.length, 1);
 });
 
 test('walking regenerates leader HP', async () => {


### PR DESCRIPTION
## Summary
- restore underlying tiles and replace huts when applying modules
- test that module building placement clears preexisting random huts

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac92620a008328a754412acbb0516c