### PR TITLE
fix: generate world before applying module

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -74,6 +74,8 @@ fileBtn.onclick = () => {
 
 // After party creation, start the loaded module
 window.startGame = async function () {
+  const seed = moduleData && moduleData.seed ? moduleData.seed : Date.now();
+  genWorld(seed);
   if (moduleData) applyModule(moduleData);
   const start = moduleData && moduleData.start ? moduleData.start : { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   setPartyPos(start.x, start.y);


### PR DESCRIPTION
## Summary
- ensure ack-player generates a world before applying a module

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac9776b7d08328b47ec6915261e9ae