### PR TITLE
feat: define spoils cache item structure

### DIFF
--- a/core/spoils-cache.js
+++ b/core/spoils-cache.js
@@ -1,0 +1,32 @@
+// ===== Spoils Cache =====
+const SpoilsCache = {
+  ranks: {
+    rusted: {
+      name: 'Rusted Cache',
+      desc: 'Hinges squeal; expect scraps and makeshift tools.'
+    },
+    sealed: {
+      name: 'Sealed Cache',
+      desc: 'Intact plating and corporate wax. Solid baseline loot.'
+    },
+    armored: {
+      name: 'Armored Cache',
+      desc: 'Reinforced with ex-military alloy. High-grade hardware.'
+    },
+    vaulted: {
+      name: 'Vaulted Cache',
+      desc: 'Quantum locks and glowing seams. Legendary rarities.'
+    }
+  },
+  create(rank){
+    const info = this.ranks[rank];
+    if(!info) throw new Error('Unknown cache rank');
+    return {
+      id: `cache-${rank}`,
+      name: info.name,
+      type: 'spoils-cache',
+      rank
+    };
+  }
+};
+Object.assign(globalThis, { SpoilsCache });

--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -49,7 +49,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 ### Expanded Task List
 
 #### Phase 1: Core Systems
-- [ ] Define `SpoilsCache` item type and rank data structure.
+- [x] Define `SpoilsCache` item type and rank data structure.
 - [ ] Implement drop roll tied to enemy `challenge` rating.
 - [ ] Create modular item generator for type, name, and stats.
 

--- a/test/spoils-cache.test.js
+++ b/test/spoils-cache.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const code = await fs.readFile(new URL('../core/spoils-cache.js', import.meta.url), 'utf8');
+vm.runInThisContext(code, { filename: 'core/spoils-cache.js' });
+
+test('spoils cache ranks are defined', () => {
+  const ranks = Object.keys(SpoilsCache.ranks);
+  assert.deepStrictEqual(ranks, ['rusted','sealed','armored','vaulted']);
+});
+
+test('create returns cache item', () => {
+  const cache = SpoilsCache.create('rusted');
+  assert.strictEqual(cache.type, 'spoils-cache');
+  assert.strictEqual(cache.rank, 'rusted');
+  assert.strictEqual(cache.name, 'Rusted Cache');
+});


### PR DESCRIPTION
## Summary
- define SpoilsCache ranks and factory for cache items
- add unit tests for SpoilsCache
- mark design task as complete

## Testing
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9f04226083288d5cf56970dffaf0