### PR TITLE
fix: replace duplicate interiors when applying modules

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -322,10 +322,6 @@ function applyModule(data, options = {}){
   if (data.events) registerTileEvents(data.events);
 
   (data.interiors || []).forEach(I => {
-    if (!fullReset && interiors[I.id]) {
-      console.warn('Interior already exists: ' + I.id);
-      return;
-    }
     const { id, grid, ...rest } = I;
     const g = grid && typeof grid[0] === 'string' ? gridFromEmoji(grid) : grid;
     interiors[id] = { ...rest, grid: g };

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -570,6 +570,13 @@ test('door portals link interiors', () => {
   assert.strictEqual(state.map, 'forest');
 });
 
+test('applyModule overwrites existing interiors', () => {
+  applyModule({ interiors: [{ id: 'dup', w: 1, h: 1, grid: [[7]], entryX: 0, entryY: 0 }] });
+  applyModule({ interiors: [{ id: 'dup', w: 2, h: 2, grid: [[7,7],[7,7]], entryX: 1, entryY: 1 }] });
+  assert.strictEqual(interiors.dup.w, 2);
+  assert.strictEqual(interiors.dup.h, 2);
+});
+
 test('makeInteriorRoom supports custom size', () => {
   const id = makeInteriorRoom('big', 20, 15);
   const I = interiors[id];


### PR DESCRIPTION
## Summary
- allow modules to overwrite existing interiors instead of aborting
- add test confirming interior overwrite support

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac9fb1d3e883288cdea44a344543e4