### PR TITLE
feat: add spoils cache drop roll

### DIFF
--- a/core/spoils-cache.js
+++ b/core/spoils-cache.js
@@ -16,8 +16,9 @@ const SpoilsCache = {
     vaulted: {
       name: 'Vaulted Cache',
       desc: 'Quantum locks and glowing seams. Legendary rarities.'
-    }
+    } 
   },
+  baseRate: 0.1,
   create(rank){
     const info = this.ranks[rank];
     if(!info) throw new Error('Unknown cache rank');
@@ -27,6 +28,31 @@ const SpoilsCache = {
       type: 'spoils-cache',
       rank
     };
+  },
+  pickRank(challenge, rng=Math.random){
+    const c = Math.max(1, Math.min(10, challenge|0));
+    const r = rng();
+    if(c >= 9){
+      return r < 0.3 ? 'vaulted' : 'armored';
+    }
+    if(c >= 7){
+      if(r < 0.1) return 'vaulted';
+      if(r < 0.7) return 'armored';
+      return 'sealed';
+    }
+    if(c >= 4){
+      if(r < 0.1) return 'armored';
+      if(r < 0.7) return 'sealed';
+      return 'rusted';
+    }
+    return r < 0.2 ? 'sealed' : 'rusted';
+  },
+  rollDrop(challenge, rng=Math.random){
+    const c = Math.max(1, challenge||1);
+    const chance = Math.min(1, this.baseRate * c);
+    if(rng() >= chance) return null;
+    const rank = this.pickRank(c, rng);
+    return this.create(rank);
   }
 };
 Object.assign(globalThis, { SpoilsCache });

--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -50,7 +50,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 
 #### Phase 1: Core Systems
 - [x] Define `SpoilsCache` item type and rank data structure.
-- [ ] Implement drop roll tied to enemy `challenge` rating.
+- [x] Implement drop roll tied to enemy `challenge` rating.
 - [ ] Create modular item generator for type, name, and stats.
 
 #### Phase 2: UI/UX

--- a/test/spoils-cache.test.js
+++ b/test/spoils-cache.test.js
@@ -17,3 +17,12 @@ test('create returns cache item', () => {
   assert.strictEqual(cache.rank, 'rusted');
   assert.strictEqual(cache.name, 'Rusted Cache');
 });
+
+test('drop roll tied to challenge rating', () => {
+  SpoilsCache.baseRate = 0.1;
+  const fail = SpoilsCache.rollDrop(1, () => 0.2);
+  assert.strictEqual(fail, null);
+  const hit = SpoilsCache.rollDrop(5, () => 0.2);
+  assert.ok(hit);
+  assert.strictEqual(hit.type, 'spoils-cache');
+});


### PR DESCRIPTION
## Summary
- add challenge-based Spoils Cache drop mechanics
- cover drop roll with tests
- check off design doc task

## Testing
- `npm test`
- `node presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68ac9fd6c8b48328b0aeef6673cb4282