### PR TITLE
feat: add modular item generator

### DIFF
--- a/core/item-generator.js
+++ b/core/item-generator.js
@@ -1,0 +1,33 @@
+// ===== Item Generator =====
+const ItemGen = {
+  types: ['weapon','armor','gadget','oddity'],
+  adjectives: ['Grit-Stitched','Rusty','Quantum','Crystal'],
+  nouns: ['Repeater','Shield','Gizmo','Compass'],
+  statRanges: {
+    rusted: { min: 1, max: 3 },
+    sealed: { min: 3, max: 5 },
+    armored: { min: 5, max: 8 },
+    vaulted: { min: 8, max: 12 }
+  },
+  pick(list, rng){
+    return list[Math.floor(rng() * list.length)];
+  },
+  randRange(min, max, rng){
+    return min + Math.floor(rng() * (max - min + 1));
+  },
+  generate(rank='rusted', rng=Math.random){
+    const type = this.pick(this.types, rng);
+    const adj = this.pick(this.adjectives, rng);
+    const noun = this.pick(this.nouns, rng);
+    const range = this.statRanges[rank] || this.statRanges.rusted;
+    const power = this.randRange(range.min, range.max, rng);
+    return {
+      type,
+      name: `${adj} ${noun}`,
+      rank,
+      stats: { power },
+      scrap: Math.round(power / 2)
+    };
+  }
+};
+Object.assign(globalThis, { ItemGen });

--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -51,7 +51,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 #### Phase 1: Core Systems
 - [x] Define `SpoilsCache` item type and rank data structure.
 - [x] Implement drop roll tied to enemy `challenge` rating.
-- [ ] Create modular item generator for type, name, and stats.
+- [x] Create modular item generator for type, name, and stats.
 
 #### Phase 2: UI/UX
 - [ ] Add cache icons and quick-open animations.

--- a/test/item-generator.test.js
+++ b/test/item-generator.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const code = await fs.readFile(new URL('../core/item-generator.js', import.meta.url), 'utf8');
+vm.runInThisContext(code, { filename: 'core/item-generator.js' });
+
+test('generator creates item with type, name, and stats', () => {
+  const vals = [0,0,0,0];
+  const rng = () => vals.shift() ?? 0;
+  const item = ItemGen.generate('sealed', rng);
+  assert.strictEqual(item.type, 'weapon');
+  assert.strictEqual(item.name, 'Grit-Stitched Repeater');
+  assert.strictEqual(item.rank, 'sealed');
+  assert.ok(item.stats.power >= 3 && item.stats.power <= 5);
+  assert.strictEqual(item.scrap, Math.round(item.stats.power / 2));
+});
+
+test('higher rank yields higher power', () => {
+  const rusted = ItemGen.generate('rusted', () => 0.99);
+  const armored = ItemGen.generate('armored', () => 0);
+  assert.ok(armored.stats.power > rusted.stats.power);
+});


### PR DESCRIPTION
## Summary
- add ItemGen to build cache loot with types, names, stats, and scrap values
- cover generator behavior with tests
- check off item generator task in Spoils Caches design doc

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68aca3b244ec8328bdf9341262da516f