### PR TITLE
feat: add spoils cache icons with quick-open animation

### DIFF
--- a/core/spoils-cache.js
+++ b/core/spoils-cache.js
@@ -3,20 +3,24 @@ const SpoilsCache = {
   ranks: {
     rusted: {
       name: 'Rusted Cache',
-      desc: 'Hinges squeal; expect scraps and makeshift tools.'
+      desc: 'Hinges squeal; expect scraps and makeshift tools.',
+      icon: '🥫'
     },
     sealed: {
       name: 'Sealed Cache',
-      desc: 'Intact plating and corporate wax. Solid baseline loot.'
+      desc: 'Intact plating and corporate wax. Solid baseline loot.',
+      icon: '📦'
     },
     armored: {
       name: 'Armored Cache',
-      desc: 'Reinforced with ex-military alloy. High-grade hardware.'
+      desc: 'Reinforced with ex-military alloy. High-grade hardware.',
+      icon: '🛡️'
     },
     vaulted: {
       name: 'Vaulted Cache',
-      desc: 'Quantum locks and glowing seams. Legendary rarities.'
-    } 
+      desc: 'Quantum locks and glowing seams. Legendary rarities.',
+      icon: '💠'
+    }
   },
   baseRate: 0.1,
   create(rank){
@@ -53,6 +57,21 @@ const SpoilsCache = {
     if(rng() >= chance) return null;
     const rank = this.pickRank(c, rng);
     return this.create(rank);
+  },
+  renderIcon(rank, onOpen){
+    const info = this.ranks[rank];
+    if(!info || typeof document === 'undefined') return null;
+    const el = document.createElement('div');
+    el.className = `cache-icon ${rank}`;
+    el.textContent = info.icon || '';
+    el.addEventListener('click', () => {
+      el.classList.add('open');
+      setTimeout(() => {
+        el.remove();
+        onOpen?.();
+      }, 200);
+    }, { once: true });
+    return el;
   }
 };
 Object.assign(globalThis, { SpoilsCache });

--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -54,7 +54,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 - [x] Create modular item generator for type, name, and stats.
 
 #### Phase 2: UI/UX
-- [ ] Add cache icons and quick-open animations.
+- [x] Add cache icons and quick-open animations.
 - [ ] Implement inventory UI for cache stacking and "Open All".
 
 #### Phase 3: Content & Balancing

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -398,6 +398,18 @@ function renderInv(){
     return;
   }
   player.inv.forEach((it,idx)=>{
+    if(it.type === 'spoils-cache'){
+      const row=document.createElement('div');
+      row.className='slot cache-slot';
+      const icon = SpoilsCache.renderIcon(it.rank, () => {
+        const index = player.inv.indexOf(it);
+        if(index !== -1) removeFromInv(index);
+        log?.(`${it.name} opened.`);
+      });
+      if(icon) row.appendChild(icon);
+      inv.appendChild(row);
+      return;
+    }
     const row=document.createElement('div');
     row.className='slot';
     const baseLabel = it.name + (it.slot?` [${it.slot}]`:'');

--- a/dustland.css
+++ b/dustland.css
@@ -918,3 +918,31 @@
 #worldPalette button.active { outline:2px solid #fff; }
 #paletteWrap { display:flex; flex-direction:column; align-items:center; }
 #paletteLabel { color:#fff; font-family:system-ui, sans-serif; margin-top:4px; }
+
+.cache-slot {
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  height:40px;
+}
+.cache-icon {
+  width:24px;
+  height:24px;
+  border:1px solid #283228;
+  border-radius:4px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+}
+.cache-icon.rusted { background:#5a3a2e; }
+.cache-icon.sealed { background:#3e4a5a; }
+.cache-icon.armored { background:#4a545a; }
+.cache-icon.vaulted { background:#563e5a; }
+.cache-icon.open { animation: cachePop .2s forwards; }
+@keyframes cachePop {
+  to {
+    transform: scale(1.4) rotate(10deg);
+    opacity:0;
+  }
+}

--- a/test/spoils-cache.test.js
+++ b/test/spoils-cache.test.js
@@ -18,11 +18,32 @@ test('create returns cache item', () => {
   assert.strictEqual(cache.name, 'Rusted Cache');
 });
 
-test('drop roll tied to challenge rating', () => {
-  SpoilsCache.baseRate = 0.1;
-  const fail = SpoilsCache.rollDrop(1, () => 0.2);
-  assert.strictEqual(fail, null);
-  const hit = SpoilsCache.rollDrop(5, () => 0.2);
-  assert.ok(hit);
-  assert.strictEqual(hit.type, 'spoils-cache');
-});
+  test('drop roll tied to challenge rating', () => {
+    SpoilsCache.baseRate = 0.1;
+    const fail = SpoilsCache.rollDrop(1, () => 0.2);
+    assert.strictEqual(fail, null);
+    const hit = SpoilsCache.rollDrop(5, () => 0.2);
+    assert.ok(hit);
+    assert.strictEqual(hit.type, 'spoils-cache');
+  });
+
+  test('renderIcon creates element with rank class', () => {
+    global.document = {
+      createElement(tag){
+        const el = {
+          tagName: tag.toUpperCase(),
+          className: '',
+          classList: {
+            add(cls){ el.className += (el.className ? ' ' : '') + cls; }
+          },
+          addEventListener(){},
+          remove(){}
+        };
+        return el;
+      }
+    };
+    const el = SpoilsCache.renderIcon('sealed');
+    assert.ok(el.className.includes('cache-icon'));
+    assert.ok(el.className.includes('sealed'));
+    delete global.document;
+  });


### PR DESCRIPTION
## Summary
- render spoils caches with rank icons
- animate caches popping open in inventory
- mark design task done and cover renderIcon in tests

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68aca4b0602483288576e24f1d764b24