### PR TITLE
feat: expand item generator pools

### DIFF
--- a/core/item-generator.js
+++ b/core/item-generator.js
@@ -1,13 +1,35 @@
 // ===== Item Generator =====
 const ItemGen = {
   types: ['weapon','armor','gadget','oddity'],
-  adjectives: ['Grit-Stitched','Rusty','Quantum','Crystal'],
-  nouns: ['Repeater','Shield','Gizmo','Compass'],
+  adjectives: [
+    'Grit-Stitched',
+    'Rusty',
+    'Quantum',
+    'Crystal',
+    'Welded',
+    'Scrap-Bound',
+    'Solar-Forged',
+    'Echoing',
+    'Harmonic',
+    'Nova-Etched'
+  ],
+  nouns: [
+    'Repeater',
+    'Shield',
+    'Gizmo',
+    'Compass',
+    'Blade',
+    'Injector',
+    'Mask',
+    'Harmonica',
+    'Emitter',
+    'Engine'
+  ],
   statRanges: {
-    rusted: { min: 1, max: 3 },
-    sealed: { min: 3, max: 5 },
-    armored: { min: 5, max: 8 },
-    vaulted: { min: 8, max: 12 }
+    rusted: { min: 1, max: 4 },
+    sealed: { min: 4, max: 7 },
+    armored: { min: 7, max: 10 },
+    vaulted: { min: 10, max: 15 }
   },
   pick(list, rng){
     return list[Math.floor(rng() * list.length)];

--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -58,7 +58,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 - [x] Implement inventory UI for cache stacking and "Open All".
 
 #### Phase 3: Content & Balancing
-- [ ] Populate adjective/noun pools for item names and tier stat tables.
+- [x] Populate adjective/noun pools for item names and tier stat tables.
 - [ ] Tune `baseRate` and tier weights for different enemy challenges.
 - [ ] Author lore snippets for oddity items.
 

--- a/test/item-generator.test.js
+++ b/test/item-generator.test.js
@@ -22,3 +22,16 @@ test('higher rank yields higher power', () => {
   const armored = ItemGen.generate('armored', () => 0);
   assert.ok(armored.stats.power > rusted.stats.power);
 });
+
+test('pools and stat tables populated', () => {
+  assert.ok(ItemGen.adjectives.includes('Solar-Forged'));
+  assert.ok(ItemGen.nouns.includes('Harmonica'));
+  assert.deepStrictEqual(ItemGen.statRanges.vaulted, { min: 10, max: 15 });
+});
+
+test('generate uses updated tables', () => {
+  const item = ItemGen.generate('armored', () => 0.5);
+  assert.strictEqual(item.name, 'Scrap-Bound Injector');
+  assert.strictEqual(item.stats.power, 9);
+  assert.strictEqual(item.scrap, 5);
+});


### PR DESCRIPTION
## Summary
- expand item generator with richer adjective/noun pools and tier stat ranges
- document completion of spoils cache content task
- test item generator against updated tables

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68aca7a444788328afc292389de2e47e