### PR TITLE
feat: tune spoils cache drops

### DIFF
--- a/core/spoils-cache.js
+++ b/core/spoils-cache.js
@@ -22,7 +22,7 @@ const SpoilsCache = {
       icon: '💠'
     }
   },
-  baseRate: 0.1,
+  baseRate: 0.08,
   create(rank){
     const info = this.ranks[rank];
     if(!info) throw new Error('Unknown cache rank');
@@ -37,11 +37,11 @@ const SpoilsCache = {
     const c = Math.max(1, Math.min(10, challenge|0));
     const r = rng();
     if(c >= 9){
-      return r < 0.3 ? 'vaulted' : 'armored';
+      return r < 0.2 ? 'vaulted' : 'armored';
     }
     if(c >= 7){
-      if(r < 0.1) return 'vaulted';
-      if(r < 0.7) return 'armored';
+      if(r < 0.03) return 'vaulted';
+      if(r < 0.9) return 'armored';
       return 'sealed';
     }
     if(c >= 4){

--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -59,7 +59,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 
 #### Phase 3: Content & Balancing
 - [x] Populate adjective/noun pools for item names and tier stat tables.
-- [ ] Tune `baseRate` and tier weights for different enemy challenges.
+ - [x] Tune `baseRate` and tier weights for different enemy challenges.
 - [ ] Author lore snippets for oddity items.
 
 #### Phase 4: Testing

--- a/test/spoils-cache.test.js
+++ b/test/spoils-cache.test.js
@@ -27,6 +27,14 @@ test('create returns cache item', () => {
     assert.strictEqual(hit.type, 'spoils-cache');
   });
 
+test('pickRank tuned for challenge tiers', () => {
+  assert.strictEqual(SpoilsCache.pickRank(7, () => 0.02), 'vaulted');
+  assert.strictEqual(SpoilsCache.pickRank(7, () => 0.5), 'armored');
+  assert.strictEqual(SpoilsCache.pickRank(7, () => 0.95), 'sealed');
+  assert.strictEqual(SpoilsCache.pickRank(9, () => 0.05), 'vaulted');
+  assert.strictEqual(SpoilsCache.pickRank(9, () => 0.95), 'armored');
+});
+
   test('renderIcon creates element with rank class', () => {
     global.document = {
       createElement(tag){


### PR DESCRIPTION
## Summary
- balance spoils cache drop rates across challenge tiers
- cover new rank weights with unit tests
- check off tuning task in spoils cache design doc

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68aca99a5f3083288e7b1855d03b90e9