### PR TITLE
feat: add rotwalker test in hall

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -125,6 +125,14 @@ const DUSTLAND_MODULE = (() => {
           text: 'Kesh unlocks the chain. “Off you go.”',
           choices: [ { label: '(Continue)', to: 'bye', goto: { map: 'world', x: 2, y: midY } } ]
         }
+      },
+      processNode(node) {
+        if (node === 'start') {
+          const monsterAlive = NPCS.some(n => n.id === 'hall_rotwalker');
+          this.tree.start.text = monsterAlive
+            ? 'Caretaker Kesh eyes the chained exit. "There\'s a rotwalker at the top of the hall. Killing it would be a good test."'
+            : 'Caretaker Kesh eyes the chained exit.';
+        }
       }
     },
     {
@@ -163,6 +171,18 @@ const DUSTLAND_MODULE = (() => {
       desc: 'A drifter muttering to themselves.',
       portraitSheet: 'assets/portraits/drifter_4.png',
       tree: { start: { text: '"Dust gets in everything."', choices: [ { label: '(Nod)', to: 'bye' } ] } }
+    },
+    {
+      id: 'hall_rotwalker',
+      map: 'hall',
+      x: hall.entryX,
+      y: 2,
+      color: '#f88',
+      name: 'Rotwalker',
+      title: 'Test Monster',
+      desc: 'A shambler posted here for practice.',
+      tree: { start: { text: 'A rotwalker lurches at you.' } },
+      combat: { HP: 6, ATK: 1, loot: 'water_flask', auto: true }
     },
     {
       id: 'road_sign',

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -22,3 +22,11 @@ test('dustland module includes plot improvements', () => {
   assert.match(src, /hall sheltered survivors/);
   assert.match(src, /Radio crackles from the north; idol whispers from the south/);
 });
+
+test('dustland module warns about hall monster', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'dustland.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /id: 'hall_rotwalker'/);
+  assert.match(src, /rotwalker at the top of the hall/);
+});


### PR DESCRIPTION
## Summary
- add rotwalker enemy to the hall for combat testing
- have Kesh warn about the hall's rotwalker when it's alive
- cover hall warning with a new module test

## Testing
- `npm test`
- `node presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68aca97fa150832896a8e60207750d1a