### PR TITLE
feat: add spoils cache drops

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -261,6 +261,14 @@ function doAttack(dmg){
   if(target.hp<=0){
     log?.(`${target.name} is defeated!`);
     if(target.loot) addToInv?.(target.loot);
+    if(typeof SpoilsCache !== 'undefined'){
+      const cache = SpoilsCache.rollDrop?.(target.challenge);
+      if(cache){
+        const registered = typeof registerItem === 'function' ? registerItem(cache) : cache;
+        itemDrops?.push({ id: registered.id, map: party.map, x: party.x, y: party.y });
+        log?.(`The ground coughs up a ${registered.name}.`);
+      }
+    }
     if(target.npc) removeNPC(target.npc);
     combatState.enemies.shift();
     renderCombat();

--- a/dustland.html
+++ b/dustland.html
@@ -143,20 +143,21 @@
     </div>
   </div>
 
-  <script defer src="./event-bus.js"></script>
-  <script defer src="./core/effects.js"></script>
-  <script defer src="./core/inventory.js"></script>
-  <script defer src="./core/actions.js"></script>
-  <script defer src="./core/movement.js"></script>
-  <script defer src="./core/dialog.js"></script>
-  <script defer src="./core/combat.js"></script>
-  <script defer src="./core/party.js"></script>
-  <script defer src="./core/quests.js"></script>
-  <script defer src="./core/npc.js"></script>
-  <script defer src="./dustland-core.js"></script>
-  <script defer src="./dustland-path.js"></script>
-  <script defer src="./dustland-nano.js"></script>
-  <script defer src="./dustland-engine.js"></script>
+    <script defer src="./event-bus.js"></script>
+    <script defer src="./core/effects.js"></script>
+    <script defer src="./core/spoils-cache.js"></script>
+    <script defer src="./core/inventory.js"></script>
+    <script defer src="./core/actions.js"></script>
+    <script defer src="./core/movement.js"></script>
+    <script defer src="./core/dialog.js"></script>
+    <script defer src="./core/combat.js"></script>
+    <script defer src="./core/party.js"></script>
+    <script defer src="./core/quests.js"></script>
+    <script defer src="./core/npc.js"></script>
+    <script defer src="./dustland-core.js"></script>
+    <script defer src="./dustland-path.js"></script>
+    <script defer src="./dustland-nano.js"></script>
+    <script defer src="./dustland-engine.js"></script>
   <script>
     const params = new URLSearchParams(location.search);
     const isAck = params.get('ack-player') === '1';


### PR DESCRIPTION
## Summary
- drop a spoils cache on victory with a chance roll and log message
- load spoils cache script in game
- test cache drop behavior

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68aca8f795a483288ed71d44088b74c3