### PR TITLE
fix: make mara puzzle playable

### DIFF
--- a/modules/mara-puzzle.module.js
+++ b/modules/mara-puzzle.module.js
@@ -1,3 +1,5 @@
+function seedWorldContent() {}
+
 const MARA_PUZZLE = {
   "seed": "mara-puzzle",
   "name": "mara-puzzle",
@@ -44,5 +46,16 @@ const MARA_PUZZLE = {
   "portals": [
     { "map": "dust_storm", "x": 10, "y": 6, "toMap": "world", "toX": 10, "toY": 10, "desc": "You emerge from the dust storm." }
   ],
-  "buildings": []
+  "buildings": [],
+  "start": { "map": "dust_storm", "x": 10, "y": 18 }
+};
+
+startGame = function () {
+  startWorld();
+  applyModule(MARA_PUZZLE);
+  const s = MARA_PUZZLE.start;
+  setPartyPos(s.x, s.y);
+  setMap(s.map, 'Dust Storm');
+  refreshUI();
+  log('You are lost in a dust storm.');
 };

--- a/test/mara-puzzle.module.test.js
+++ b/test/mara-puzzle.module.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('mara puzzle module defines startGame to launch dust storm', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'mara-puzzle.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /startGame\s*=\s*function/);
+  assert.match(src, /applyModule\(MARA_PUZZLE\)/);
+  assert.match(src, /setPartyPos\(s\.x, s\.y\)/);
+  assert.match(src, /setMap\(s\.map/);
+});


### PR DESCRIPTION
## Summary
- add start position and startGame for Mara Puzzle so it can launch
- provide unit test ensuring module defines startGame

## Testing
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acaa6e0fe48328a368de41b3c5bdb7