### PR TITLE
fix: honor slot items and keep office castle

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -147,7 +147,9 @@ function advanceDialog(stateObj, choiceIdx){
 
   if(choice.reqItem || choice.reqSlot){
     const requiredCount = choice.reqCount || 1;
-    const hasEnough = choice.reqItem ? countItems(choice.reqItem) >= requiredCount : hasItem(choice.reqSlot);
+    const hasEnough = choice.reqItem
+      ? countItems(choice.reqItem) >= requiredCount
+      : player.inv.some(it => it.slot === choice.reqSlot);
 
     if(!hasEnough){
       return finalize(choice.failure || 'You lack the required item.', false);
@@ -165,7 +167,9 @@ function advanceDialog(stateObj, choiceIdx){
 
   if(choice.costItem || choice.costSlot){
     const costCount = choice.costCount || 1;
-    const hasEnough = choice.costItem ? countItems(choice.costItem) >= costCount : hasItem(choice.costSlot);
+    const hasEnough = choice.costItem
+      ? countItems(choice.costItem) >= costCount
+      : player.inv.some(it => it.slot === choice.costSlot);
 
     if(!hasEnough){
       return finalize(choice.failure || 'You lack the required item.', false);

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -573,7 +573,7 @@ const OFFICE_MODULE = (() => {
 startGame = function () {
   if (OFFICE_MODULE.worldGen) {
     const { castleId } = OFFICE_MODULE.worldGen();
-    applyModule(OFFICE_MODULE);
+    applyModule(OFFICE_MODULE, { fullReset: false });
     const charm = registerItem({
       id: 'forest_charm',
       name: 'Forest Charm',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -486,6 +486,39 @@ test('advanceDialog respects goto with costItem', () => {
   assert.ok(!player.inv.some(it => it.id === 'key'));
 });
 
+test('advanceDialog respects costSlot', () => {
+  player.inv.length = 0;
+  const trinket = registerItem({ id: 'river_trinket', name: 'Trinket', slot: 'trinket', type: 'trinket' });
+  addToInv(trinket);
+  const tree = {
+    start: { text: '', next: [ { label: 'Pay', costSlot: 'trinket', to: 'end' } ] },
+    end: { text: '' }
+  };
+  const dialog = { tree, node: 'start' };
+  const res = advanceDialog(dialog, 0);
+  assert.ok(res.success);
+  assert.ok(!player.inv.some(it => it.slot === 'trinket'));
+});
+
+test('advanceDialog honours reqSlot', () => {
+  player.inv.length = 0;
+  const token = registerItem({ id: 'fae_token', name: 'Fae Token', slot: 'trinket', type: 'trinket' });
+  const tree = {
+    start: { text: '', next: [ { label: 'Enter', reqSlot: 'trinket', success: 'ok', to: 'end' }, { label: 'Leave', to: 'end' } ] },
+    end: { text: '' }
+  };
+  let dialog = { tree, node: 'start' };
+  // Without item should fail
+  let res = advanceDialog(dialog, 0);
+  assert.ok(!res.success);
+  // With item should succeed
+  addToInv(token);
+  dialog = { tree, node: 'start' };
+  res = advanceDialog(dialog, 0);
+  assert.ok(res.success);
+  assert.ok(player.inv.some(it => it.slot === 'trinket'));
+});
+
 test('advanceDialog uses reqItem without consuming and allows goto', () => {
   player.inv.length = 0;
   const pass = registerItem({id:'pass',name:'Pass',type:'quest'});

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -15,3 +15,10 @@ test('office module boards castle and unboards via dialog', () => {
   assert.match(src, /start: [\s\S]*?effect: 'unboardDoor',\s*interiorId: 'castle'[\s\S]*?unlock:/);
   assert.match(src, /label: '\(Fight\)'/);
 });
+
+test('startGame preserves generated world when applying module', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /applyModule\(OFFICE_MODULE,\s*\{\s*fullReset: false\s*}\)/);
+});


### PR DESCRIPTION
## Summary
- honor `costSlot` and `reqSlot` by checking item slots instead of tags
- keep the castle hut generated in the office module when starting the game
- cover slot-based dialog costs and startGame call with tests

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acae5f436c8328bbb605b12d6b0adb