### PR TITLE
feat: refresh quest turn-in option

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -132,6 +132,7 @@ function handleGoto(g){
 }
 
 function advanceDialog(stateObj, choiceIdx){
+  const prevNode = stateObj.node;
   const node=stateObj.tree[stateObj.node];
   const choice=node.next[choiceIdx];
   if(!choice){ stateObj.node=null; return {next:null, text:null, close:true, success:false}; }
@@ -204,6 +205,18 @@ function advanceDialog(stateObj, choiceIdx){
   joinParty(choice.join);
   processQuestFlag(choice);
   runEffects(choice.effects);
+
+  if (choice.q === 'accept' && currentNPC?.quest) {
+    const meta = currentNPC.quest;
+    const requiredCount = meta.count || 1;
+    const hasItems = !meta.item || countItems(meta.item) >= requiredCount;
+    const hasFlag = !meta.reqFlag || (typeof flagValue === 'function' && flagValue(meta.reqFlag));
+    if (meta.status === 'active' && hasItems && hasFlag) {
+      res.next = prevNode;
+      stateObj.node = prevNode;
+      return res;
+    }
+  }
 
   if (choice.applyModule) {
     const moduleData = globalThis[choice.applyModule];

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -629,7 +629,7 @@ test('quest turn-in awards XP once', () => {
   assert.strictEqual(char.xp, 4);
 });
 
-test('turn-in choice hidden until quest accepted', () => {
+test('turn-in choice appears immediately after accepting', () => {
   player.inv.length = 0;
   NPCS.length = 0;
   const quest = new Quest('q_hidden', 'Quest', '');
@@ -649,12 +649,11 @@ test('turn-in choice hidden until quest accepted', () => {
   assert.ok(!labels.includes('turn in'));
 
   // accept quest
-  choicesEl.children[0].onclick(); // accept
-  choicesEl.children[0].onclick(); // bye
+  choicesEl.children[0].onclick();
 
-  openDialog(npc);
   labels = choicesEl.children.map(c => c.textContent);
   assert.ok(labels.includes('turn in'));
+  closeDialog();
 });
 
 test('createNpcFactory builds NPCs from definitions', () => {


### PR DESCRIPTION
## Summary
- refresh dialog after accepting a quest so "turn in" appears if requirements already met
- test quest acceptance flow to ensure immediate turn-in option

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acae3123e48328b6f8bccfeeaae0e1