### PR TITLE
fix: yield during balance test loop

### DIFF
--- a/balance-tester-agent.js
+++ b/balance-tester-agent.js
@@ -131,6 +131,8 @@ async function runBalanceTest() {
     let lastPartySize = party.length;
     const maxSteps = 5000;
     let steps = 0;
+    // Allow queued pathfinding and other async tasks to run between steps.
+    const macroyield = () => new Promise(r => setTimeout(r, 0));
 
     while (party[0].level < 5 && steps < maxSteps) {
       await agent.think();
@@ -139,6 +141,7 @@ async function runBalanceTest() {
       }
       lastPartySize = party.length;
       steps++;
+      await macroyield();
     }
     console.log('Balance test checkpoint: loop end');
 


### PR DESCRIPTION
## Summary
- allow async tasks to run between balance tester steps to avoid busy waiting

## Testing
- `./install-deps.sh` *(failed: Invalid response from proxy: HTTP/1.1 403 Forbidden)*
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: ReferenceError: window is not defined)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb4d29d248328bac6db2ccf212cda