### PR TITLE
refactor: unify world and module init

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -74,9 +74,8 @@ fileBtn.onclick = () => {
 
 // After party creation, start the loaded module
 window.startGame = async function () {
-  const seed = moduleData && moduleData.seed ? moduleData.seed : Date.now();
-  genWorld(seed);
   if (moduleData) applyModule(moduleData);
+  else applyModule({});
   const start = moduleData && moduleData.start ? moduleData.start : { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   setPartyPos(start.x, start.y);
   setMap(start.map || 'world', 'Module');

--- a/balance-tester-agent.js
+++ b/balance-tester-agent.js
@@ -9,9 +9,6 @@ window.addEventListener('load', () => {
 async function runBalanceTest() {
   try {
     console.log('Running balance test...');
-    // Boot world and load the golden module
-    startWorld();
-    console.log('Balance test checkpoint: world started');
     const modulePath = 'modules/golden.module.json';
     const res = await fetch(modulePath);
     const moduleData = await res.json();

--- a/broadcast-story.js
+++ b/broadcast-story.js
@@ -25,7 +25,6 @@ seedWorldContent = () => {};
 
 startGame = async function(){
   await fragmentsReady;
-  startWorld();
   applyModule(BROADCAST_FRAGMENT_1);
   const map = BROADCAST_FRAGMENT_1.startMap || 'world';
   const pt = BROADCAST_FRAGMENT_1.startPoint || { x: 2, y: Math.floor(WORLD_H/2) };

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -120,7 +120,7 @@ function handleGoto(g){
     }
   }else{
     if(g.map==='world'){
-      startWorld();
+      if(!world.length) applyModule({});
       setPartyPos(x, y);
       setMap('world');
     }else{

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -684,7 +684,6 @@ const DUSTLAND_MODULE = (() => {
 })();
 
 startGame = function () {
-  startWorld();
   applyModule(DUSTLAND_MODULE);
   const s = DUSTLAND_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   setPartyPos(s.x, s.y);

--- a/modules/echoes.module.js
+++ b/modules/echoes.module.js
@@ -177,7 +177,6 @@ const ECHOES_MODULE = (() => {
 })();
 
 startGame = function () {
-  startWorld();
   applyModule(ECHOES_MODULE);
   const s = ECHOES_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   setPartyPos(s.x, s.y);

--- a/modules/mara-puzzle.module.js
+++ b/modules/mara-puzzle.module.js
@@ -51,7 +51,6 @@ const MARA_PUZZLE = {
 };
 
 startGame = function () {
-  startWorld();
   applyModule(MARA_PUZZLE);
   const s = MARA_PUZZLE.start;
   setPartyPos(s.x, s.y);

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -572,8 +572,7 @@ const OFFICE_MODULE = (() => {
 
 startGame = function () {
   if (OFFICE_MODULE.worldGen) {
-    const { castleId } = OFFICE_MODULE.worldGen();
-    applyModule(OFFICE_MODULE, { fullReset: false });
+    const { castleId } = applyModule(OFFICE_MODULE);
     const charm = registerItem({
       id: 'forest_charm',
       name: 'Forest Charm',

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -20,5 +20,5 @@ test('startGame preserves generated world when applying module', () => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const file = path.join(__dirname, '..', 'modules', 'office.module.js');
   const src = fs.readFileSync(file, 'utf8');
-  assert.match(src, /applyModule\(OFFICE_MODULE,\s*\{\s*fullReset: false\s*}\)/);
+  assert.match(src, /applyModule\(OFFICE_MODULE\)/);
 });


### PR DESCRIPTION
## Summary
- centralize world generation and module application in applyModule
- remove startWorld wiring and auto-init world from dialog teleport
- simplify module start functions to rely on unified initializer

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acb5f2c7bc8328a98ab41a4300cf8e