### PR TITLE
fix: harden install-deps and presubmit

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -166,6 +166,12 @@ _______________________________________________________________________________
   - ASCII/NFO: generated in classic BBS spirit.
   - Inspirations: Wasteland (DOS), Planescape-like dialog energy, 90s P&P.
 
+[ INSTALL TROUBLESHOOTING ]
+  - install-deps.sh fails with '403 Forbidden' from mise.jdx.dev?
+      * install-deps.sh now disables the mise repo and retries automatically.
+      * If the repo is required, ensure your proxy allows access or update the URL.
+      * You can re-enable it by editing /etc/apt/sources.list.d/mise.list.
+
 [ CONTACT ]
   - GitHub issues preferred. Paste console logs & steps to reproduce.
   - Include browser/version and whether a save existed when it happened.

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,6 +1,21 @@
 #!/bin/sh
 set -e
-apt-get update
+if ! apt-get update 2>&1 | tee /tmp/apt-update.log; then
+  update_status=$?
+else
+  update_status=0
+fi
+if grep -q "mise.jdx.dev" /tmp/apt-update.log; then
+  echo "mise.jdx.dev repo unreachable; disabling and retrying..."
+  grep -Rl "mise.jdx.dev" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | \
+    xargs -r sed -i.bak '/mise\.jdx\.dev/s/^/#/'
+  apt-get update
+elif [ "$update_status" -ne 0 ]; then
+  echo "apt-get update failed"
+  exit 1
+fi
+rm /tmp/apt-update.log
+
 apt-get install -y \
   libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
   libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \

--- a/presubmit.js
+++ b/presubmit.js
@@ -26,3 +26,4 @@ if (failed) {
   console.error('Presubmit failed: remove unsupported patterns from HTML files.');
   process.exit(1);
 }
+console.log('Presubmit passed: no forbidden patterns found.');


### PR DESCRIPTION
## Summary
- retry `apt-get update` without the `mise.jdx.dev` repo when it returns 403
- log successful `presubmit.js` runs
- document automatic handling of the failing repo

## Testing
- `npm test`
- `node presubmit.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68acb699fad48328b379f9fa0fd8fef6