### PR TITLE
fix: separate start tile from NPC

### DIFF
--- a/modules/golden.module.json
+++ b/modules/golden.module.json
@@ -15,7 +15,7 @@
       "id": "villager",
       "map": "world",
       "x": 7,
-      "y": 7,
+      "y": 8,
       "color": "#cfa",
       "name": "Worried Villager",
       "desc": "Lost a coin in the cabin.",

--- a/test/golden.module.json.test.js
+++ b/test/golden.module.json.test.js
@@ -57,6 +57,11 @@ test('golden module json exposes core features', () => {
   );
   assert.ok(!overlaps, 'npcs avoid building area');
 
+  const startClear = !mod.npcs.some(
+    (n) => n.map === mod.start.map && n.x === mod.start.x && n.y === mod.start.y
+  );
+  assert.ok(startClear, 'start tile is not occupied by NPC');
+
   const bandit = mod.npcs.find((n) => n.id === 'bandit');
   const dist = Math.abs(bandit.x - mod.start.x) + Math.abs(bandit.y - mod.start.y);
   assert.ok(dist > 2, 'bandit is spaced away from start');


### PR DESCRIPTION
## Summary
- move villager away from player spawn in golden module
- ensure tests verify start tile isn't occupied by NPCs

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acbc951bd483288f3f8ad6da982011