### PR TITLE
fix: spawn Dustland player in test hall

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -684,10 +684,10 @@ const DUSTLAND_MODULE = (() => {
 })();
 
 startGame = function () {
-  applyModule(DUSTLAND_MODULE);
-  const s = DUSTLAND_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-  setPartyPos(s.x, s.y);
-  setMap(s.map, s.map === 'world' ? 'Wastes' : 'Test Hall');
+  const { start: s } = applyModule(DUSTLAND_MODULE) || {};
+  const loc = s || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
+  setMap(loc.map, loc.map === 'world' ? 'Wastes' : 'Test Hall');
+  setPartyPos(loc.x, loc.y);
   renderInv();
   renderQuests();
   renderParty();

--- a/test/dustland-start.test.js
+++ b/test/dustland-start.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+test('dustland module starts in test hall', () => {
+  const party = { map: 'creator', x: 0, y: 0 };
+  const state = { map: 'creator' };
+  function setPartyPos(x, y) { party.x = x; party.y = y; }
+  function setMap(map) { state.map = map; party.map = map; }
+  const context = {
+    CURRENCY: 'Scrap',
+    TILE: { WALL: 1, FLOOR: 2, DOOR: 3 },
+    WORLD_H: 90,
+    player: { scrap: 0 },
+    addToInv() {},
+    renderInv() {},
+    renderQuests() {},
+    renderParty() {},
+    updateHUD() {},
+    log() {},
+    toast() {},
+    party,
+    state,
+    setPartyPos,
+    setMap,
+    applyModule(data) { return data; },
+    DC: { TALK: 10 },
+    rand() { return 0; },
+    NPCS: [],
+    queueNanoDialogForNPCs() {}
+  };
+  context.global = context;
+  vm.createContext(context);
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const src = fs.readFileSync(path.join(__dirname, '..', 'modules', 'dustland.module.js'), 'utf8');
+  vm.runInContext(src, context);
+  context.startGame();
+  assert.strictEqual(state.map, 'hall');
+  assert.strictEqual(party.x, 15);
+  assert.strictEqual(party.y, 18);
+});


### PR DESCRIPTION
## Summary
- ensure startGame respects module start coordinates and sets map before positioning
- add regression test for Dustland start location

## Testing
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acbcb4ce888328990aac634768d368