### PR TITLE
feat: add boots of speed near forest entrance

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -534,6 +534,16 @@ const OFFICE_MODULE = (() => {
         },
         {
           map: 'world',
+          x: 3,
+          y: WORLD_MIDY,
+          id: 'boots_of_speed',
+          name: 'Boots of Speed',
+          type: 'trinket',
+          slot: 'trinket',
+          mods: { AGI: 5 }
+        },
+        {
+          map: 'world',
           x: WORLD_MID - 2,
           y: WORLD_MIDY,
           id: 'river_trinket',

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -22,3 +22,12 @@ test('startGame preserves generated world when applying module', () => {
   const src = fs.readFileSync(file, 'utf8');
   assert.match(src, /applyModule\(OFFICE_MODULE\)/);
 });
+
+test('office module places Boots of Speed near forest entry', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /id: 'boots_of_speed'/);
+  assert.match(src, /x: 3,\s*y: WORLD_MIDY/);
+  assert.match(src, /mods: \{ AGI: 5 \}/);
+});


### PR DESCRIPTION
## Summary
- add Boots of Speed item near forest entry in the office module
- verify placement with tests

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: window is not defined)*
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68acbdd102a08328b1270d4cedc3b688