### PR TITLE
feat: add oddity lore snippets

### DIFF
--- a/core/item-generator.js
+++ b/core/item-generator.js
@@ -25,6 +25,13 @@ const ItemGen = {
     'Emitter',
     'Engine'
   ],
+  oddityLore: [
+    'Whispers of a lost caravan.',
+    'Hums a tune no one remembers.',
+    'Its needle spins toward a buried vault.',
+    'Smells faintly of ozone after a storm.',
+    'Vibrates near old world tech.'
+  ],
   statRanges: {
     rusted: { min: 1, max: 4 },
     sealed: { min: 4, max: 7 },
@@ -43,13 +50,17 @@ const ItemGen = {
     const noun = this.pick(this.nouns, rng);
     const range = this.statRanges[rank] || this.statRanges.rusted;
     const power = this.randRange(range.min, range.max, rng);
-    return {
+    const item = {
       type,
       name: `${adj} ${noun}`,
       rank,
       stats: { power },
       scrap: Math.round(power / 2)
     };
+    if(type === 'oddity'){
+      item.lore = this.pick(this.oddityLore, rng);
+    }
+    return item;
   }
 };
 Object.assign(globalThis, { ItemGen });

--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -52,6 +52,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 - [x] Define `SpoilsCache` item type and rank data structure.
 - [x] Implement drop roll tied to enemy `challenge` rating.
 - [x] Create modular item generator for type, name, and stats.
+- [ ] Expose tier weight configuration for modding.
 
 #### Phase 2: UI/UX
 - [x] Add cache icons and quick-open animations.
@@ -60,7 +61,8 @@ Opening a cache triggers a generator that stitches gear on the fly:
 #### Phase 3: Content & Balancing
 - [x] Populate adjective/noun pools for item names and tier stat tables.
  - [x] Tune `baseRate` and tier weights for different enemy challenges.
-- [ ] Author lore snippets for oddity items.
+- [x] Author lore snippets for oddity items.
+- [ ] Add affix or mini-quest hooks for Vaulted caches.
 
 #### Phase 4: Testing
 - [ ] Write tests to verify drop odds and tier distribution across challenge levels.

--- a/test/item-generator.test.js
+++ b/test/item-generator.test.js
@@ -35,3 +35,11 @@ test('generate uses updated tables', () => {
   assert.strictEqual(item.stats.power, 9);
   assert.strictEqual(item.scrap, 5);
 });
+
+test('oddity items include lore snippet', () => {
+  const vals = [0.95,0,0,0];
+  const rng = () => vals.shift() ?? 0;
+  const item = ItemGen.generate('rusted', rng);
+  assert.strictEqual(item.type, 'oddity');
+  assert.ok(ItemGen.oddityLore.includes(item.lore));
+});


### PR DESCRIPTION
## Summary
- add lore snippets for oddity items
- test oddity lore generation
- document remaining spoils cache tasks

## Testing
- `npm test`
- `node presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68acc2aa8aa083288a91bfe0be5d6154