### PR TITLE
test: verify balance tester pathfinding progress

### DIFF
--- a/test/puppeteer-runner.test.js
+++ b/test/puppeteer-runner.test.js
@@ -52,9 +52,11 @@ if (puppeteer) {
       await page.waitForSelector('#results', { timeout: 60000 });
       lastCheckpoint = 'results';
       const results = await page.$eval('#results', el => el.textContent);
+      const stats = JSON.parse(results);
       console.log('Balance Test Results:');
-      console.log(JSON.parse(results));
+      console.log(stats);
       assert.ok(results, 'Should have results');
+      assert.ok(stats.pathDistance > 0, 'Pathfinding made no progress');
     } catch {
       const errorText = errors.length ? ` Errors: ${errors.join(' | ')}` : '';
       assert.fail(`Balance test failed after 60s (last checkpoint: ${lastCheckpoint}).${errorText}`);


### PR DESCRIPTION
## Summary
- track total pathfinding distance in balance tester agent
- seek random NPCs, items, or building doors instead of nearest NPC
- fail Puppeteer end-to-end test when pathfinding makes no progress

## Testing
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: window is not defined)*
- `npm test` *(Puppeteer launch failed: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68acbbd6dab483289ba9c67d4eafb8a2