### PR TITLE
fix: guard NPC start choices

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -106,6 +106,9 @@ _______________________________________________________________________________
       * Open Party tab and switch the Selected radio—this member becomes
         the leader for checks and XP.
 
+  - Starts in Creator map instead of your module?
+      * A module load error likely occurred. Check the console for exceptions.
+
 [ HACKING NOTES ]
   - Plain JS scripts with globals; no build step or framework.
   - Gameplay logic is split into tiny systems: movement, collisions,

--- a/core/npc.js
+++ b/core/npc.js
@@ -45,6 +45,7 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
   if (opts?.combat) {
     tree = tree || {};
     tree.start = tree.start || {text: '', choices: []};
+    tree.start.choices = tree.start.choices || [];
     let fightChoice = tree.start.choices.find(c => c.label === '(Fight)' || c.to === 'do_fight');
     if (fightChoice) {
       fightChoice.label = '(Fight)';
@@ -59,6 +60,7 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
   if (opts?.shop) {
     tree = tree || {};
     tree.start = tree.start || {text: '', choices: []};
+    tree.start.choices = tree.start.choices || [];
     tree.start.choices.push({label: '(Sell items)', to: 'sell'});
     tree.sell = tree.sell || {text: 'What are you selling?', choices: []};
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -761,6 +761,14 @@ test('clamp swaps reversed bounds', () => {
   assert.strictEqual(clamp(5, 10, 0), 5);
 });
 
+test('makeNPC tolerates start nodes without choices', () => {
+  const tree = { start: { text: 'growl' } };
+  const npc = makeNPC('beast', 'world', 0, 0, '#fff', 'Beast', '', '', tree, null, null, null, { combat: { DEF: 1 } });
+  assert.ok(Array.isArray(npc.tree.start.choices));
+  const fights = npc.tree.start.choices.filter(c => c.label === '(Fight)');
+  assert.strictEqual(fights.length, 1);
+});
+
 test('makeNPC normalizes existing fight choices', () => {
   const quest = new Quest('q_boss', 'Boss', '');
   quest.status = 'active';


### PR DESCRIPTION
## Summary
- avoid TypeError when NPC start nodes lack `choices`
- document Creator fallback when module load fails
- test NPC creation with missing start choices

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68acc6d9ba0c8328ac77d64df70074f5