### PR TITLE
fix: drop import.meta from balance tester

### DIFF
--- a/balance-tester-agent.js
+++ b/balance-tester-agent.js
@@ -8,8 +8,7 @@ if (typeof window === 'undefined') {
     const { JSDOM } = await import('jsdom');
     const fs = await import('node:fs');
     const path = await import('node:path');
-    const { fileURLToPath } = await import('node:url');
-    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const baseDir = process.cwd();
 
     const html = `<!DOCTYPE html><body>
       <div id="log"></div>
@@ -89,7 +88,7 @@ if (typeof window === 'undefined') {
       'dustland-engine.js'
     ];
     for (const file of scripts) {
-      w.eval(fs.readFileSync(path.join(__dirname, file), 'utf8'));
+      w.eval(fs.readFileSync(path.join(baseDir, file), 'utf8'));
     }
     await runBalanceTest();
   })().catch(err => {
@@ -114,9 +113,7 @@ async function runBalanceTest() {
     } else {
       const fs = await import('node:fs/promises');
       const path = await import('node:path');
-      const { fileURLToPath } = await import('node:url');
-      const __dirname = path.dirname(fileURLToPath(import.meta.url));
-      const json = await fs.readFile(path.join(__dirname, modulePath), 'utf8');
+      const json = await fs.readFile(path.join(process.cwd(), modulePath), 'utf8');
       moduleData = JSON.parse(json);
     }
     applyModule(moduleData);


### PR DESCRIPTION
## Summary
- load balance tester agent with classic script tag again
- stop using `import.meta` in balance tester agent so it runs without module support
- adjust balance tester test to match the classic script tag

## Testing
- `node presubmit.js`
- `npm test`
- `npm run test:puppeteer` *(fails: Puppeteer launch failed: Failed to launch the browser process! libatk-1.0.so.0: cannot open shared object file: No such file or directory)*
- `node balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68acc61cf0c083289dd29d305f39b543