### PR TITLE
feat: establish Dustland namespace

### DIFF
--- a/docs/design/tech-debt-paydown.md
+++ b/docs/design/tech-debt-paydown.md
@@ -49,7 +49,7 @@ Our CRT playground is scrappy by design, but a few lingering habits slow our bui
 ## Tasks
 
 - [ ] **Phase 1: Namespace the world**
-  - [ ] Introduce `globalThis.Dustland = {}`.
+  - [x] Introduce `globalThis.Dustland = {}`.
   - [ ] Move module exports into `Dustland.*` buckets.
   - [ ] Update references and tests incrementally.
 - [ ] **Phase 2: Untangle UI from logic**

--- a/event-bus.js
+++ b/event-bus.js
@@ -1,4 +1,7 @@
 // Tiny event bus for pub/sub communication
+
+// Global namespace for game modules
+globalThis.Dustland = globalThis.Dustland || {};
 /**
  * Simple pub/sub bus.
  * @typedef {(payload:any)=>void} EventHandler

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1201,6 +1201,8 @@ test('applyModule from dialog adds next fragment', async () => {
   assert.ok(tower);
   assert.ok(tower.x < WORLD_W && tower.y < WORLD_H);
 
+});
+
 test('grin recruitment can be retried after failure', () => {
   NPCS.length = 0;
   party.length = 0;


### PR DESCRIPTION
## Summary
- introduce a global `Dustland` namespace for future modularization
- mark namespace task complete in tech-debt plan
- close unclosed broadcast fragment test block

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68aceda708348328b2dac58391384dfb