### PR TITLE
feat: expose watchEventFlag globally

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -592,6 +592,7 @@
   <script defer src="./core/quests.js"></script>
     <script defer src="./core/npc.js"></script>
     <script defer src="./dustland-core.js"></script>
+    <script defer src="./core/event-flags.js"></script>
     <script defer src="./core/loop.js"></script>
     <script defer src="./dustland-path.js"></script>
     <script defer src="./dustland-nano.js"></script>

--- a/balance-tester.html
+++ b/balance-tester.html
@@ -154,6 +154,7 @@
   <script defer src="./core/quests.js"></script>
   <script defer src="./core/npc.js"></script>
   <script defer src="./dustland-core.js"></script>
+  <script defer src="./core/event-flags.js"></script>
   <script defer src="./dustland-path.js"></script>
   <script defer src="./dustland-nano.js"></script>
   <script defer src="./dustland-engine.js"></script>

--- a/dustland.html
+++ b/dustland.html
@@ -155,6 +155,7 @@
     <script defer src="./core/quests.js"></script>
     <script defer src="./core/npc.js"></script>
     <script defer src="./dustland-core.js"></script>
+    <script defer src="./core/event-flags.js"></script>
     <script defer src="./dustland-path.js"></script>
     <script defer src="./dustland-nano.js"></script>
     <script defer src="./dustland-engine.js"></script>

--- a/modules/lootbox-demo.module.js
+++ b/modules/lootbox-demo.module.js
@@ -11,7 +11,7 @@ const LOOTBOX_DEMO_MODULE = (() => {
   const demoRoom = { id: 'demo_room', w: ROOM_W, h: ROOM_H, grid, entryX: 1, entryY: Math.floor(ROOM_H / 2) };
 
   let sawDrop = false;
-  watchEventFlag?.('spoils:opened', 'cache_opened');
+  watchEventFlag('spoils:opened', 'cache_opened');
   EventBus.on('spoils:drop', () => { sawDrop = true; });
   EventBus.on('combat:ended', ({ result }) => {
     if(result === 'loot'){


### PR DESCRIPTION
## Summary
- enable lootbox demo to set flags on spoils events via `watchEventFlag`
- load core/event-flags in Dustland, balance tester, and Adventure Kit HTML shells

## Testing
- `npm test` *(fails: SyntaxError: Unexpected end of input in test/core.test.js)*
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68acee99fc508328b52554cc41623984