### PR TITLE
fix: enable A button to pick combat action

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -102,7 +102,13 @@ function setMobileControls(on){
       mobileAB=document.createElement('div');
       mobileAB.style.cssText='position:fixed;bottom:20px;right:20px;display:flex;gap:10px;z-index:1000;user-select:none;';
       mobileAB.appendChild(mk('A',()=>{
-        if(overlay?.classList?.contains('shown')) handleDialogKey?.({ key:'Enter' }); else interact();
+        if(overlay?.classList?.contains('shown')){
+          handleDialogKey?.({ key:'Enter' });
+        } else if(document.getElementById('combatOverlay')?.classList?.contains('shown')){
+          handleCombatKey?.({ key:'Enter' });
+        } else {
+          interact();
+        }
       }));
       mobileAB.appendChild(mk('B',takeNearestItem));
       document.body.appendChild(mobileAB);

--- a/test/mobile-controls.test.js
+++ b/test/mobile-controls.test.js
@@ -83,3 +83,17 @@ test('mobile arrows navigate combat menu when in combat', async () => {
   down.onclick();
   assert.deepStrictEqual(keys, ['ArrowUp', 'ArrowDown']);
 });
+
+test('mobile A selects combat option when in combat', async () => {
+  const keys = [];
+  const html = '<body><div id="combatOverlay" class="shown"></div><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>';
+  const { context } = await setup(html, {
+    handleCombatKey: e => { keys.push(e.key); return true; },
+    interact: () => { keys.push('interact'); },
+    overlay: null
+  });
+  context.setMobileControls(true);
+  const a = [...context.document.querySelectorAll('button')].find(b => b.textContent === 'A');
+  a.onclick();
+  assert.deepStrictEqual(keys, ['Enter']);
+});


### PR DESCRIPTION
## Summary
- route mobile A button presses to combat menu when the combat overlay is visible
- test that mobile A button selects the current combat option

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: TypeError: Cannot set properties of null (setting 'innerHTML'))*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfe5e776083289d65cdcb4e5243f1