### PR TITLE
fix: enable Grin recruitment options

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -261,16 +261,14 @@ const DUSTLAND_MODULE = (() => {
               check: { stat: 'CHA', dc: DC.TALK },
               success: 'Grin smirks: "Alright."',
               failure: 'Grin shrugs: "Not buying it."',
-              join: { id: 'grin', name: 'Grin', role: 'Scavenger' },
-              q: 'turnin'
+              join: { id: 'grin', name: 'Grin', role: 'Scavenger' }
             },
             {
               label: '(Pay) Give 1 trinket as hire bonus',
               costSlot: 'trinket',
               success: 'Deal.',
               failure: 'You have no trinket to pay with.',
-              join: { id: 'grin', name: 'Grin', role: 'Scavenger' },
-              q: 'turnin'
+              join: { id: 'grin', name: 'Grin', role: 'Scavenger' }
             },
             { label: '(Back)', to: 'start' }
           ]

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1232,3 +1232,32 @@ test('grin recruitment can be retried after failure', () => {
   openDialog(grin);
   assert.strictEqual(choicesEl.children[0].textContent, '(Recruit) Join me.');
 });
+
+test('grin recruitment offers persuade or pay options after recruiting', () => {
+  NPCS.length = 0;
+  party.length = 0;
+  player.inv.length = 0;
+  const hero = new Character('h', 'Hero', 'Leader');
+  party.push(hero);
+  const tree = {
+    start: { text: '', choices: [ { label: '(Recruit) Join me.', to: 'rec' }, { label: '(Leave)', to: 'bye' } ] },
+    rec: {
+      text: 'Convince me. Or pay me.',
+      choices: [
+        { label: '(CHA) Talk up the score', check: { stat: 'CHA', dc: DC.TALK }, join: { id: 'grin', name: 'Grin', role: 'Scavenger' } },
+        { label: '(Pay) Give 1 trinket as hire bonus', costSlot: 'trinket', join: { id: 'grin', name: 'Grin', role: 'Scavenger' } },
+        { label: '(Back)', to: 'start' }
+      ]
+    },
+    bye: { text: '' }
+  };
+  const grin = makeNPC('grin', 'world', 0, 0, '#fff', 'Grin', '', '', tree);
+  NPCS.push(grin);
+  openDialog(grin);
+  // start -> rec
+  choicesEl.children[0].onclick();
+  const labels = choicesEl.children.map(c => c.textContent);
+  assert.ok(labels.includes('(CHA) Talk up the score'));
+  assert.ok(labels.includes('(Pay) Give 1 trinket as hire bonus'));
+  closeDialog();
+});


### PR DESCRIPTION
## Summary
- ensure Grin's dialog includes persuasion and payment choices
- test Grin recruitment options are visible

## Testing
- `DEBIAN_FRONTEND=noninteractive ./install-deps.sh`
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js` *(fails: TypeError: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68acff2d56588328829bb4a2793f923b