### PR TITLE
feat: add adrenaline resource

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -71,12 +71,13 @@ function renderCombat(){
 function openCombat(enemies){
   if(!combatOverlay) return Promise.resolve({ result:'flee' });
   return new Promise((resolve)=>{
-    combatState.enemies = enemies.map(e=>({...e}));
+    combatState.enemies = enemies.map(e=>({ ...e, maxAdr: e.maxAdr || 100, adr: 0 }));
     combatState.phase='party';
     combatState.active=0;
     combatState.choice=0;
     combatState.onComplete=resolve;
     combatState.fallen = [];
+    (party||[]).forEach(m => { m.maxAdr = m.maxAdr || 100; m.adr = 0; });
     renderCombat();
     combatOverlay.classList.add('shown');
     openCommand();

--- a/core/party.js
+++ b/core/party.js
@@ -13,6 +13,8 @@ class Character {
     this.maxHp=10;
     this.hp=this.maxHp;
     this.ap=2;
+    this.maxAdr=100;
+    this.adr=0;
     this._bonus={ATK:0, DEF:0, LCK:0};
     this.special = opts.special || null;
   }

--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -74,7 +74,7 @@ The challenge should grow as the player masters the system.
 ### Expanded Task List
 
 #### Phase 1: Core Systems
-- [ ] **Adrenaline Resource:** Implement the Adrenaline bar (`adr`) for all combatants in `core/party.js` and `core/combat.js`.
+- [x] **Adrenaline Resource:** Implement the Adrenaline bar (`adr`) for all combatants in `core/party.js` and `core/combat.js`.
 - [ ] **Adrenaline Generation:** Basic attacks now generate Adrenaline. This value should be determined by weapon stats.
 - [ ] **Special Move Framework:** In `core/abilities.js`, create a data structure for Specials that includes `adrenaline_cost`, `target_type` (single, aoe), `effect` (damage, stun, etc.), and `wind_up_time`.
 - [ ] **Equipment Modifiers:** Update the inventory system to apply combat modifiers from equipped items at the start of each battle.

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1091,6 +1091,20 @@ test('special menu lists class ability', async () => {
   await resultPromise;
 });
 
+test('openCombat resets adrenaline for party members', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  m1.adr = 50;
+  m1.maxAdr = 150;
+  party.addMember(m1);
+  const resultPromise = openCombat([{ name:'E1', hp:1 }]);
+  assert.strictEqual(party[0].adr, 0);
+  handleCombatKey({ key:'Enter' });
+  const res = await resultPromise;
+  assert.strictEqual(res.result, 'loot');
+});
+
 test('startCombat forwards portraitSheet', async () => {
   let captured;
   const orig = global.openCombat;


### PR DESCRIPTION
## Summary
- track adrenaline (`adr`) and maximum (`maxAdr`) on characters
- initialize adrenaline stats for combatants when combat starts
- document the adrenaline resource in combat design and add regression test

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68ad100322a08328933c9797454e75e3