### PR TITLE
feat: generate adrenaline on basic attacks

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -259,6 +259,9 @@ function doAttack(dmg){
   const attacker=party[combatState.active];
   const target=combatState.enemies[0];
   target.hp-=dmg;
+  const weapon=attacker.equip?.weapon;
+  const gain=weapon?.mods?.ADR ?? 10;
+  attacker.adr=Math.min(attacker.maxAdr||100, attacker.adr+gain);
   log?.(`${attacker.name} hits ${target.name} for ${dmg} damage.`);
   if(target.hp<=0){
     log?.(`${target.name} is defeated!`);

--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -75,7 +75,7 @@ The challenge should grow as the player masters the system.
 
 #### Phase 1: Core Systems
 - [x] **Adrenaline Resource:** Implement the Adrenaline bar (`adr`) for all combatants in `core/party.js` and `core/combat.js`.
-- [ ] **Adrenaline Generation:** Basic attacks now generate Adrenaline. This value should be determined by weapon stats.
+- [x] **Adrenaline Generation:** Basic attacks now generate Adrenaline. This value is determined by weapon stats via the `ADR` modifier.
 - [ ] **Special Move Framework:** In `core/abilities.js`, create a data structure for Specials that includes `adrenaline_cost`, `target_type` (single, aoe), `effect` (damage, stun, etc.), and `wind_up_time`.
 - [ ] **Equipment Modifiers:** Update the inventory system to apply combat modifiers from equipped items at the start of each battle.
 - [ ] **Adrenaline Prototype:** Script a small arena fight to validate Adrenaline gain pacing and HUD readability.

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -47,11 +47,11 @@ const DUSTLAND_MODULE = (() => {
   const items = [
     { id: 'rusted_key', name: 'Rusted Key', type: 'quest', tags: ['key'] },
     { id: 'toolkit', name: 'Toolkit', type: 'quest', tags: ['tool'] },
-    { map: 'world', x: 8, y: midY, id: 'pipe_rifle', name: 'Pipe Rifle', type: 'weapon', slot: 'weapon', mods: { ATK: 2 } },
+    { map: 'world', x: 8, y: midY, id: 'pipe_rifle', name: 'Pipe Rifle', type: 'weapon', slot: 'weapon', mods: { ATK: 2, ADR: 15 } },
     { map: 'world', x: 10, y: midY, id: 'leather_jacket', name: 'Leather Jacket', type: 'armor', slot: 'armor', mods: { DEF: 1 } },
     { map: 'world', x: 12, y: midY, id: 'lucky_bottlecap', name: 'Lucky Bottlecap', type: 'trinket', slot: 'trinket', mods: { LCK: 1 } },
-    { map: 'world', x: 28, y: midY - 4, id: 'crowbar', name: 'Crowbar', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } },
-    { map: 'world', x: 35, y: midY + 6, id: 'rebar_club', name: 'Rebar Club', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } },
+    { map: 'world', x: 28, y: midY - 4, id: 'crowbar', name: 'Crowbar', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } },
+    { map: 'world', x: 35, y: midY + 6, id: 'rebar_club', name: 'Rebar Club', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } },
     { map: 'world', x: 52, y: midY - 3, id: 'kevlar_scrap_vest', name: 'Kevlar Scrap Vest', type: 'armor', slot: 'armor', mods: { DEF: 2 } },
     { map: 'world', x: 67, y: midY + 5, id: 'goggles', name: 'Goggles', type: 'trinket', slot: 'trinket', mods: { PER: 1 } },
     { map: 'world', x: 83, y: midY - 2, id: 'wrench', name: 'Wrench', type: 'trinket', slot: 'trinket', mods: { INT: 1 } },
@@ -61,7 +61,7 @@ const DUSTLAND_MODULE = (() => {
     { map: 'world', x: 18, y: midY - 2, id: 'valve', name: 'Valve', type: 'quest' },
     { map: 'world', x: 26, y: midY + 3, id: 'lost_satchel', name: 'Lost Satchel', type: 'quest' },
     { map: 'world', x: 60, y: midY - 1, id: 'rust_idol', name: 'Rust Idol', type: 'quest', tags: ['idol'] },
-    { id: 'raider_knife', name: 'Raider Knife', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } }
+    { id: 'raider_knife', name: 'Raider Knife', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } }
   ];
 
   const quests = [

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -557,9 +557,9 @@ const OFFICE_MODULE = (() => {
         { map: 'world', x: WORLD_MID - 6, y: WORLD_MIDY + 5, id: 'healing_potion3', name: 'Healing Potion', type: 'consumable', use: { type: 'heal', amount: 5 } },
         { id: 'fae_token', name: 'Fae Token', type: 'trinket', slot: 'trinket', mods: { LCK: 1 } },
         { id: 'rat_tail', name: 'Rat Tail', type: 'quest' },
-        { id: 'rusty_dagger', name: 'Rusty Dagger', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } },
+        { id: 'rusty_dagger', name: 'Rusty Dagger', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } },
         { id: 'ogre_tooth', name: 'Ogre Tooth', type: 'quest' },
-        { id: 'rusty_mop', name: 'Rusty Mop', type: 'weapon', slot: 'weapon', mods: { ATK: 1 } },
+        { id: 'rusty_mop', name: 'Rusty Mop', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } },
       ],
       quests: [
         {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1275,3 +1275,16 @@ test('grin recruitment offers persuade or pay options after recruiting', () => {
   assert.ok(labels.includes('(Pay) Give 1 trinket as hire bonus'));
   closeDialog();
 });
+test('basic attacks generate adrenaline from weapon stats', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  m1.equip.weapon = { mods: { ADR: 20 } };
+  party.addMember(m1);
+  const resultPromise = openCombat([{ name:'E1', hp:2 }]);
+  handleCombatKey({ key:'Enter' });
+  assert.strictEqual(party[0].adr, 20);
+  handleCombatKey({ key:'Enter' });
+  const res = await resultPromise;
+  assert.strictEqual(res.result, 'loot');
+});


### PR DESCRIPTION
## Summary
- Generate Adrenaline on basic attacks based on weapon `ADR` modifier
- Add `ADR` values to starter weapons
- Document and test Adrenaline generation

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad1389320883289c7452e32df2651f