### PR TITLE
feat: add special move framework

### DIFF
--- a/core/abilities.js
+++ b/core/abilities.js
@@ -1,5 +1,6 @@
 (function(){
   const Abilities = {};
+  const Specials = {};
 
   function defineAbility(id, data = {}){
     const ability = {
@@ -16,5 +17,17 @@
     return ability;
   }
 
-  Object.assign(globalThis, { Abilities, defineAbility });
+  function defineSpecial(id, data = {}){
+    const special = {
+      id,
+      adrenaline_cost: data.adrenaline_cost || 0,
+      target_type: data.target_type || 'single',
+      effect: data.effect || {},
+      wind_up_time: data.wind_up_time || 0
+    };
+    Specials[id] = special;
+    return special;
+  }
+
+  Object.assign(globalThis, { Abilities, defineAbility, Specials, defineSpecial });
 })();

--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -76,7 +76,7 @@ The challenge should grow as the player masters the system.
 #### Phase 1: Core Systems
 - [x] **Adrenaline Resource:** Implement the Adrenaline bar (`adr`) for all combatants in `core/party.js` and `core/combat.js`.
 - [x] **Adrenaline Generation:** Basic attacks now generate Adrenaline. This value is determined by weapon stats via the `ADR` modifier.
-- [ ] **Special Move Framework:** In `core/abilities.js`, create a data structure for Specials that includes `adrenaline_cost`, `target_type` (single, aoe), `effect` (damage, stun, etc.), and `wind_up_time`.
+- [x] **Special Move Framework:** In `core/abilities.js`, create a data structure for Specials that includes `adrenaline_cost`, `target_type` (single, aoe), `effect` (damage, stun, etc.), and `wind_up_time`.
 - [ ] **Equipment Modifiers:** Update the inventory system to apply combat modifiers from equipped items at the start of each battle.
 - [ ] **Adrenaline Prototype:** Script a small arena fight to validate Adrenaline gain pacing and HUD readability.
 

--- a/test/abilities.test.js
+++ b/test/abilities.test.js
@@ -27,3 +27,23 @@ test('defineAbility supports passive abilities', () => {
   assert.strictEqual(ability.prereq.level, 2);
   assert.deepStrictEqual(ability.prereq.abilities, []);
 });
+
+test('defineSpecial registers special with fields and defaults', () => {
+  const special = globalThis.defineSpecial('stunGrenade', {
+    adrenaline_cost: 20,
+    target_type: 'aoe',
+    effect: { stun: 2 },
+    wind_up_time: 1
+  });
+  assert.strictEqual(globalThis.Specials.stunGrenade, special);
+  assert.strictEqual(special.adrenaline_cost, 20);
+  assert.strictEqual(special.target_type, 'aoe');
+  assert.deepStrictEqual(special.effect, { stun: 2 });
+  assert.strictEqual(special.wind_up_time, 1);
+
+  const defaults = globalThis.defineSpecial('quickJab');
+  assert.strictEqual(defaults.adrenaline_cost, 0);
+  assert.strictEqual(defaults.target_type, 'single');
+  assert.deepStrictEqual(defaults.effect, {});
+  assert.strictEqual(defaults.wind_up_time, 0);
+});


### PR DESCRIPTION
## Summary
- add Specials registry and defineSpecial helper
- document completion of Special Move Framework in combat design
- test special move registration and defaults

## Testing
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js` (errors: TypeError: Cannot set properties of null (setting 'innerHTML'))

------
https://chatgpt.com/codex/tasks/task_e_68ad1b0c9d14832881c51b52ffbe8eba