### PR TITLE
feat: apply equipment combat modifiers

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -77,7 +77,7 @@ function openCombat(enemies){
     combatState.choice=0;
     combatState.onComplete=resolve;
     combatState.fallen = [];
-    (party||[]).forEach(m => { m.maxAdr = m.maxAdr || 100; m.adr = 0; });
+    (party||[]).forEach(m => { m.maxAdr = m.maxAdr || 100; m.adr = 0; m.applyCombatMods?.(); });
     renderCombat();
     combatOverlay.classList.add('shown');
     openCommand();
@@ -123,7 +123,7 @@ function openCommand(){
   ['Attack','Special','Item','Flee'].forEach((opt)=>{
     const d=document.createElement('div');
     d.textContent=opt;
-    if(opt==='Special' && !m?.special) d.classList.add('disabled');
+    if(opt==='Special' && !(m?.special?.length>0)) d.classList.add('disabled');
     if(opt==='Item' && (!(player?.inv?.length>0))) d.classList.add('disabled');
     cmdMenu.appendChild(d);
   });
@@ -260,7 +260,8 @@ function doAttack(dmg){
   const target=combatState.enemies[0];
   target.hp-=dmg;
   const weapon=attacker.equip?.weapon;
-  const gain=weapon?.mods?.ADR ?? 10;
+  const baseGain=weapon?.mods?.ADR ?? 10;
+  const gain=Math.round(baseGain * (attacker.adrGenMod || 1));
   attacker.adr=Math.min(attacker.maxAdr||100, attacker.adr+gain);
   log?.(`${attacker.name} hits ${target.name} for ${dmg} damage.`);
   if(target.hp<=0){

--- a/core/party.js
+++ b/core/party.js
@@ -16,7 +16,8 @@ class Character {
     this.maxAdr=100;
     this.adr=0;
     this._bonus={ATK:0, DEF:0, LCK:0};
-    this.special = opts.special || null;
+    this.special = Array.isArray(opts.special) ? [...opts.special] : [];
+    this.adrGenMod = 1;
   }
   xpToNext(){ return xpToNext(this.lvl); }
   awardXP(amt){
@@ -51,6 +52,26 @@ class Character {
       if(it&&it.mods){
         for(const stat in it.mods){
           this._bonus[stat]=(this._bonus[stat]||0)+it.mods[stat];
+        }
+      }
+    }
+  }
+  applyCombatMods(){
+    this.adrGenMod = 1;
+    if(!Array.isArray(this._baseSpecial)){
+      this._baseSpecial = [...this.special];
+    }
+    this.special = [...(this._baseSpecial||[])];
+    for(const k of ['weapon','armor','trinket']){
+      const it=this.equip[k];
+      if(it&&it.mods){
+        if(typeof it.mods.adrenaline_gen_mod === 'number'){
+          this.adrGenMod *= it.mods.adrenaline_gen_mod;
+        }
+        const grant = it.mods.granted_special;
+        if(grant){
+          if(Array.isArray(grant)) this.special.push(...grant);
+          else this.special.push(grant);
         }
       }
     }
@@ -109,6 +130,7 @@ function xpToNext(lvl){
 }
 function awardXP(who, amt){ who.awardXP(amt); }
 function applyEquipmentStats(m){ m.applyEquipmentStats(); }
+function applyCombatMods(m){ m.applyCombatMods(); }
 function leader(){ return party.leader(); }
 function setLeader(idx){ selectedMember = idx; }
 
@@ -148,5 +170,5 @@ function trainStat(stat, memberIndex = selectedMember){
   return true;
 }
 
-const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, leader, setLeader, respec, trainStat, selectedMember, xpCurve };
+const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, applyCombatMods, leader, setLeader, respec, trainStat, selectedMember, xpCurve };
 Object.assign(globalThis, partyExports);

--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -77,7 +77,7 @@ The challenge should grow as the player masters the system.
 - [x] **Adrenaline Resource:** Implement the Adrenaline bar (`adr`) for all combatants in `core/party.js` and `core/combat.js`.
 - [x] **Adrenaline Generation:** Basic attacks now generate Adrenaline. This value is determined by weapon stats via the `ADR` modifier.
 - [x] **Special Move Framework:** In `core/abilities.js`, create a data structure for Specials that includes `adrenaline_cost`, `target_type` (single, aoe), `effect` (damage, stun, etc.), and `wind_up_time`.
-- [ ] **Equipment Modifiers:** Update the inventory system to apply combat modifiers from equipped items at the start of each battle.
+- [x] **Equipment Modifiers:** Update the inventory system to apply combat modifiers from equipped items at the start of each battle.
 - [ ] **Adrenaline Prototype:** Script a small arena fight to validate Adrenaline gain pacing and HUD readability.
 
 #### Phase 2: Content & UI

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -707,7 +707,7 @@ function finalizeCurrentMember(){
   if(!building.name || !building.name.trim()) building.name = defaultDrifterName(built.length+1);
   const m=makeMember(building.id, building.name, building.spec||'Wanderer', {permanent:true, portraitSheet: building.portraitSheet});
   m.stats=building.stats; m.origin=building.origin; m.quirk=building.quirk;
-  m.special = classSpecials[building.spec||'Wanderer'] || null;
+  m.special = classSpecials[building.spec||'Wanderer'] || [];
   addPartyMember(m);
   const spec = specializations[building.spec]; if(spec){ spec.gear.forEach(g=> addToInv(g)); }
   built.push(m);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1288,3 +1288,18 @@ test('basic attacks generate adrenaline from weapon stats', async () => {
   const res = await resultPromise;
   assert.strictEqual(res.result, 'loot');
 });
+
+test('equipment modifiers apply at battle start', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  m1.equip.weapon = { mods: { ADR: 10 } };
+  m1.equip.trinket = { mods: { adrenaline_gen_mod: 2, granted_special: { label: 'Power Hit', dmg: 2 } } };
+  party.addMember(m1);
+  const resultPromise = openCombat([{ name: 'E1', hp: 2 }]);
+  assert.strictEqual(m1.special.length, 1);
+  handleCombatKey({ key: 'Enter' });
+  assert.strictEqual(m1.adr, 20);
+  handleCombatKey({ key: 'Enter' });
+  await resultPromise;
+});


### PR DESCRIPTION
## Summary
- apply equipment-based combat modifiers each battle start
- scale adrenaline gains and grant specials from equipped items
- note completion of equipment modifiers in combat design doc

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad1c96e79c8328819f24fb10a6f492