### PR TITLE
feat: separate mobile controls from map

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
   <title>Dustland: CRT Edition</title>
   <link rel="stylesheet" href="dustland.css" />
 </head>
@@ -129,7 +129,7 @@
   </div>
 
   <!-- Module Loader -->
-  <div id="moduleLoader" style="position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;z-index:40">
+  <div id="moduleLoader" style="position:fixed;top:0;left:0;right:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;z-index:40">
     <div class="win" style="width:min(420px,92vw);background:#0b0d0b;border:1px solid #2a382a;border-radius:12px;box-shadow:0 20px 80px rgba(0,0,0,.7);overflow:hidden">
       <header style="padding:10px 12px;border-bottom:1px solid #223022;font-weight:700">Load Adventure Module</header>
       <main style="padding:12px">

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -49,19 +49,22 @@ function toggleAudio(){ setAudio(!audioEnabled); }
 globalThis.toggleAudio = toggleAudio;
 const isMobileUA = typeof navigator !== 'undefined' && /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 let mobileControlsEnabled = isMobileUA;
-let mobilePad = null, mobileAB = null;
+let mobileWrap = null, mobilePad = null, mobileAB = null;
 function setMobileControls(on){
   mobileControlsEnabled = on;
   const btn=document.getElementById('mobileToggle');
   if(btn) btn.textContent = `Mobile Controls: ${on ? 'On' : 'Off'}`;
+  document.body.classList.toggle('mobile-on', on);
   if(on){
-    if(!mobilePad){
-      mobilePad=document.createElement('div');
-      mobilePad.style.cssText='position:fixed;bottom:20px;left:20px;display:grid;grid-template-columns:repeat(3,48px);grid-template-rows:repeat(3,48px);gap:6px;z-index:1000;user-select:none;';
+    if(!mobileWrap){
+      mobileWrap=document.createElement('div');
+      mobileWrap.id='mobileControls';
+      mobileWrap.style.cssText='position:fixed;left:0;right:0;bottom:0;height:180px;display:flex;justify-content:space-between;padding:20px;z-index:1000;touch-action:manipulation;';
+      document.body.appendChild(mobileWrap);
       const mk=(t,fn)=>{
         const b=document.createElement('button');
         b.textContent=t;
-        b.style.cssText='width:48px;height:48px;border:2px solid #0f0;border-radius:8px;background:#000;color:#0f0;font-size:20px;user-select:none;outline:none;';
+        b.style.cssText='width:48px;height:48px;border:2px solid #0f0;border-radius:8px;background:#000;color:#0f0;font-size:20px;user-select:none;outline:none;touch-action:manipulation;';
         b.onclick=fn;
         b.onpointerdown=()=>{
           b.style.background='#0f0';
@@ -86,6 +89,8 @@ function setMobileControls(on){
           move(dx,dy);
         }
       };
+      mobilePad=document.createElement('div');
+      mobilePad.style.cssText='display:grid;grid-template-columns:repeat(3,48px);grid-template-rows:repeat(3,48px);gap:6px;user-select:none;';
       const cells=[
         document.createElement('div'),
         mk("↑",()=>mobileMove(0,-1,'ArrowUp')),
@@ -98,9 +103,9 @@ function setMobileControls(on){
         document.createElement('div')
       ];
       cells.forEach(c=>mobilePad.appendChild(c));
-      document.body.appendChild(mobilePad);
+      mobileWrap.appendChild(mobilePad);
       mobileAB=document.createElement('div');
-      mobileAB.style.cssText='position:fixed;bottom:20px;right:20px;display:flex;gap:10px;z-index:1000;user-select:none;';
+      mobileAB.style.cssText='display:flex;gap:10px;user-select:none;';
       mobileAB.appendChild(mk('A',()=>{
         if(overlay?.classList?.contains('shown')){
           handleDialogKey?.({ key:'Enter' });
@@ -111,11 +116,11 @@ function setMobileControls(on){
         }
       }));
       mobileAB.appendChild(mk('B',takeNearestItem));
-      document.body.appendChild(mobileAB);
+      mobileWrap.appendChild(mobileAB);
     }
   } else {
-    if(mobilePad) { mobilePad.remove(); mobilePad=null; }
-    if(mobileAB) { mobileAB.remove(); mobileAB=null; }
+    if(mobileWrap){ mobileWrap.remove(); mobileWrap=null; }
+    mobilePad=null; mobileAB=null;
   }
 }
 function toggleMobileControls(){ setMobileControls(!mobileControlsEnabled); }

--- a/dustland.css
+++ b/dustland.css
@@ -294,6 +294,12 @@
             padding: 12px;
             font-size: 24px;
         }
+        :root { --ctrlH: 180px; }
+        body.mobile-on .wrap { height: calc(100% - var(--ctrlH)); }
+        body.mobile-on .crt-wrap { align-items: flex-start; }
+        body.mobile-on .panel { height: calc(100% - var(--ctrlH)); }
+        #mobileControls { touch-action: manipulation; }
+        #mobileControls button { touch-action: manipulation; }
     }
 
     .overlay {
@@ -308,6 +314,18 @@
 
     .overlay.shown {
         display: flex
+    }
+
+    @media (max-width: 900px) {
+        body.mobile-on .overlay,
+        body.mobile-on #settings,
+        body.mobile-on #start,
+        body.mobile-on #creator,
+        body.mobile-on #moduleLoader,
+        body.mobile-on #shopOverlay {
+            bottom: var(--ctrlH);
+            height: calc(100% - var(--ctrlH));
+        }
     }
 
     .dialog {

--- a/dustland.html
+++ b/dustland.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
   <title>Dustland: CRT Edition</title>
   <link rel="stylesheet" href="dustland.css" />
 </head>
@@ -129,7 +129,7 @@
   </div>
 
   <!-- Module Loader -->
-  <div id="moduleLoader" style="position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;z-index:40">
+  <div id="moduleLoader" style="position:fixed;top:0;left:0;right:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;z-index:40">
     <div class="win" style="width:min(420px,92vw);background:#0b0d0b;border:1px solid #2a382a;border-radius:12px;box-shadow:0 20px 80px rgba(0,0,0,.7);overflow:hidden">
       <header style="padding:10px 12px;border-bottom:1px solid #223022;font-weight:700">Load Adventure Module</header>
       <main style="padding:12px">


### PR DESCRIPTION
## Summary
- reserve a dedicated bottom zone for mobile controls and keep the map at the top
- prevent double-tap zoom and adjust module loader positioning on small screens

## Testing
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada2494f088328ac6a04dc05684d6f