### PR TITLE
feat: add adrenaline and status to hud

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -22,7 +22,18 @@
       <div class="content" id="log"></div>
       <div class="content">
         <div class="hud">
-          <div class="badge">HP: <span id="hp">10</span></div>
+          <div class="badge">
+            <div class="label">HP <span id="hp">10</span></div>
+            <div class="hudbar" id="hpBar">
+              <div class="ghost" id="hpGhost"></div>
+              <div class="fill" id="hpFill"></div>
+            </div>
+            <div class="status-row" id="statusIcons"></div>
+          </div>
+          <div class="badge">
+            <div class="label">Adrenaline</div>
+            <div class="hudbar adr" id="adrBar"><div class="fill" id="adrFill"></div></div>
+          </div>
           <div class="badge">AP: <span id="ap">2</span></div>
           <div class="badge">Scrap: <span id="scrap">0</span></div>
           <div class="badge">Map: <span id="mapname">—</span></div>

--- a/core/combat.js
+++ b/core/combat.js
@@ -79,6 +79,7 @@ function openCombat(enemies){
     combatState.fallen = [];
     (party||[]).forEach(m => { m.maxAdr = m.maxAdr || 100; m.adr = 0; m.applyCombatMods?.(); });
     renderCombat();
+    updateHUD?.();
     combatOverlay.classList.add('shown');
     openCommand();
   });
@@ -94,6 +95,8 @@ function closeCombat(result='flee'){
   globalThis.EventBus?.emit?.('combat:ended', { result });
   combatState.onComplete?.({ result });
   combatState.onComplete=null;
+  player.hp = party[0] ? party[0].hp : player.hp;
+  updateHUD?.();
 }
 
 function highlightActive(){
@@ -263,6 +266,7 @@ function doAttack(dmg){
   const baseGain=weapon?.mods?.ADR ?? 10;
   const gain=Math.round(baseGain * (attacker.adrGenMod || 1));
   attacker.adr=Math.min(attacker.maxAdr||100, attacker.adr+gain);
+  updateHUD?.();
   log?.(`${attacker.name} hits ${target.name} for ${dmg} damage.`);
   if(target.hp<=0){
     log?.(`${target.name} is defeated!`);
@@ -315,6 +319,8 @@ function finishEnemyAttack(enemy, target){
     renderCombat();
     if(party.length===0){ log?.('The party has fallen...'); closeCombat('bruise'); return; }
   }
+  player.hp = party[0] ? party[0].hp : player.hp;
+  updateHUD?.();
   combatState.active++;
   if(combatState.active<combatState.enemies.length){
     highlightActive();

--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -99,7 +99,7 @@ The prototype doesn't spend Adrenaline yet; it's a pacing probe. Once the gain c
 - [x] **Adrenaline Prototype:** Script a small arena fight to validate Adrenaline gain pacing and HUD readability.
 
 #### Phase 2: Content & UI
-- [ ] **New HUD:** Redesign the combat UI to include the Adrenaline bar, status effect icons, and improved health bar feedback.
+- [x] **New HUD:** Redesign the combat UI to include the Adrenaline bar, status effect icons, and improved health bar feedback.
 - [ ] **Player Health Panel:** Update the right-side player health panel to show damage being taken in real-time, with visual effects for critical health and passing out.
 - [ ] **Implement 5-10 Specials:** Create a starter set of special moves (e.g., "Power Strike," "Stun Grenade," "First Aid").
 - [ ] **Implement Equipment:** Create a set of weapons and armor with varied combat modifiers.

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -6,6 +6,10 @@ const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');
 const scrEl = document.getElementById('scrap');
+const hpFill = document.getElementById('hpFill');
+const hpGhost = document.getElementById('hpGhost');
+const adrFill = document.getElementById('adrFill');
+const statusIcons = document.getElementById('statusIcons');
 
 function log(msg){
   if (logEl) {
@@ -357,9 +361,34 @@ const TAB_BREAKPOINT = 1600;
 let activeTab = 'inv';
 
 function updateHUD(){
-  hpEl.textContent=player.hp;
-  apEl.textContent=player.ap;
+  hpEl.textContent = player.hp;
+  apEl.textContent = player.ap;
   if(scrEl) scrEl.textContent = player.scrap;
+  const lead = typeof leader === 'function' ? leader() : null;
+  if(hpFill && lead){
+    const pct = Math.max(0, Math.min(100, (player.hp / (lead.maxHp || 1)) * 100));
+    hpFill.style.width = pct + '%';
+    if(hpGhost){
+      hpGhost.style.width = (updateHUD._lastHpPct ?? pct) + '%';
+      requestAnimationFrame(()=>{ hpGhost.style.width = pct + '%'; });
+    }
+    updateHUD._lastHpPct = pct;
+  }
+  if(adrFill && lead){
+    const apct = Math.max(0, Math.min(100, (lead.adr / (lead.maxAdr || 1)) * 100));
+    adrFill.style.width = apct + '%';
+  }
+  if(statusIcons){
+    statusIcons.innerHTML='';
+    if(typeof buffs !== 'undefined' && lead){
+      for(const b of buffs){
+        if(b.target===lead){
+          const s=document.createElement('span');
+          statusIcons.appendChild(s);
+        }
+      }
+    }
+  }
 }
 
 function showTab(which){

--- a/dustland.css
+++ b/dustland.css
@@ -86,7 +86,7 @@
 
     .hud {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(4, 1fr);
         gap: 8px
     }
 
@@ -95,6 +95,53 @@
         padding: 6px 8px;
         border-radius: 8px;
         background: #0e110e
+    }
+
+    .hud .label {
+        font-weight: 700;
+        margin-bottom: 4px
+    }
+
+    .hudbar {
+        position: relative;
+        width: 100%;
+        height: 6px;
+        background: #273027;
+        border-radius: 4px;
+        overflow: hidden
+    }
+
+    .hudbar .fill {
+        height: 100%;
+        background: #8bd98d;
+        transition: width .2s
+    }
+
+    .hudbar .ghost {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        background: #3a493a;
+        transition: width .4s
+    }
+
+    .hudbar.adr .fill {
+        background: #d98b8b
+    }
+
+    .status-row {
+        display: flex;
+        gap: 2px;
+        margin-top: 4px;
+        min-height: 8px
+    }
+
+    .status-row span {
+        width: 8px;
+        height: 8px;
+        background: #8bd98d;
+        border-radius: 2px
     }
 
     .hudBadge {

--- a/dustland.html
+++ b/dustland.html
@@ -22,7 +22,18 @@
       <div class="content" id="log"></div>
       <div class="content">
         <div class="hud">
-          <div class="badge">HP: <span id="hp">10</span></div>
+          <div class="badge">
+            <div class="label">HP <span id="hp">10</span></div>
+            <div class="hudbar" id="hpBar">
+              <div class="ghost" id="hpGhost"></div>
+              <div class="fill" id="hpFill"></div>
+            </div>
+            <div class="status-row" id="statusIcons"></div>
+          </div>
+          <div class="badge">
+            <div class="label">Adrenaline</div>
+            <div class="hudbar adr" id="adrBar"><div class="fill" id="adrFill"></div></div>
+          </div>
           <div class="badge">AP: <span id="ap">2</span></div>
           <div class="badge">Scrap: <span id="scrap">0</span></div>
           <div class="badge">Map: <span id="mapname">—</span></div>


### PR DESCRIPTION
## Summary
- add health and adrenaline bars with status slots to HUD
- update engine and combat flow to refresh new HUD
- document HUD design progress

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `node balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adac0824d88328934b611320986650