### PR TITLE
feat: slow adrenaline gain and add boosting items

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -260,7 +260,7 @@ function doAttack(dmg){
   const target=combatState.enemies[0];
   target.hp-=dmg;
   const weapon=attacker.equip?.weapon;
-  const baseGain=weapon?.mods?.ADR ?? 10;
+  const baseGain=(weapon?.mods?.ADR ?? 10) / 4;
   const gain=Math.round(baseGain * (attacker.adrGenMod || 1));
   attacker.adr=Math.min(attacker.maxAdr||100, attacker.adr+gain);
   log?.(`${attacker.name} hits ${target.name} for ${dmg} damage.`);

--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -40,7 +40,7 @@ Equipment isn't just about bigger numbers. It's about changing *how* you fight.
 
 *   **Weapons:** Determine your basic attack speed, damage, and Adrenaline generation rate. A heavy hammer might generate more Adrenaline per hit, but a quick knife lets you build it faster with rapid strikes. Some rare weapons might even come with a unique Special move.
 *   **Armor:** Provides damage resistance, but can also have passive combat effects. A "Scavenger's Rig" might grant a small amount of Adrenaline at the start of combat. A "Juggernaut Plate" could make you immune to being interrupted while using a Special.
-*   **Gadgets (Accessories):** This is where things get wild. A "Stim-Pack" gadget could allow you to convert HP into Adrenaline in an emergency. A "Targeting Visor" could increase the critical hit chance of your specials.
+*   **Gadgets (Accessories):** This is where things get wild. A "Stim-Pack" gadget could allow you to convert HP into Adrenaline in an emergency. A "Targeting Visor" could increase the critical hit chance of your specials. An "Adrenaline Charm" might double the rate at which Adrenaline builds.
 
 > **Gizmo:** The data structures for this need to be clean. An item should just have a `modifiers` object. For example: `{"adrenaline_gen_mod": 1.2, "granted_special": "CLEAVE"}`. The combat system just iterates through the equipped items and applies the modifiers at the start of a fight. This makes it incredibly easy for us, and for modders, to add new gear, but we'll need profiling to ensure modifier checks stay cheap.
 
@@ -83,7 +83,7 @@ The script pits a lone hero against a dummy and logs `Adrenaline: <value>` whene
 
 **Evaluate**
 
-- **Fill rate:** The bar should reach 100 in roughly four to six basic attacks. If it spikes or crawls, tweak `hero.equip.weapon.mods.ADR` or the dummy's `hp` in the script.
+- **Fill rate:** Without gear bonuses the bar should reach 100 in roughly sixteen to twenty-four basic attacks. Items like an Adrenaline Charm can speed this up. If it spikes or crawls, tweak `hero.equip.weapon.mods.ADR` or the dummy's `hp` in the script.
 - **Stability:** Watch for unexpected jumps or stalls in the numbers.
 - **Log clarity:** Ensure the output is readable enough to guide tuning.
 

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -590,11 +590,19 @@ startGame = function () {
       slot: 'trinket',
       mods: { LCK: 1 }
     });
+    const stim = registerItem({
+      id: 'adrenaline_charm',
+      name: 'Adrenaline Charm',
+      type: 'trinket',
+      slot: 'trinket',
+      mods: { adrenaline_gen_mod: 2 }
+    });
     if (castleId && interiors[castleId]) {
       const interior = interiors[castleId];
       const ix = Math.floor(interior.w / 2);
       const iy = Math.floor(interior.h / 2);
       itemDrops.push({ id: charm.id, map: castleId, x: ix, y: iy });
+      itemDrops.push({ id: stim.id, map: castleId, x: ix + 1, y: iy });
     }
     const s = OFFICE_MODULE.start;
     setPartyPos(s.x, s.y);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1316,7 +1316,7 @@ test('basic attacks generate adrenaline from weapon stats', async () => {
   party.addMember(m1);
   const resultPromise = openCombat([{ name:'E1', hp:2 }]);
   handleCombatKey({ key:'Enter' });
-  assert.strictEqual(party[0].adr, 20);
+  assert.strictEqual(party[0].adr, 5);
   handleCombatKey({ key:'Enter' });
   const res = await resultPromise;
   assert.strictEqual(res.result, 'loot');
@@ -1332,7 +1332,7 @@ test('equipment modifiers apply at battle start', async () => {
   const resultPromise = openCombat([{ name: 'E1', hp: 2 }]);
   assert.strictEqual(m1.special.length, 1);
   handleCombatKey({ key: 'Enter' });
-  assert.strictEqual(m1.adr, 20);
+  assert.strictEqual(m1.adr, 5);
   handleCombatKey({ key: 'Enter' });
   await resultPromise;
 });


### PR DESCRIPTION
## Summary
- Slow adrenaline gain to 25% of previous rate
- Add Adrenaline Charm trinket that doubles adrenaline build
- Document slower adrenaline pacing and gear bonus

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68adad1c77d8832891c720fcdec3fdee