### PR TITLE
fix: adjust camera for small screens

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -186,6 +186,16 @@ function isWalkable(tile){ return !!walkable[tile]; }
 const VIEW_W=40, VIEW_H=30, TS=16;
 const WORLD_W=120, WORLD_H=90;
 
+function getViewSize(){
+  const iw = typeof window !== 'undefined' ? window.innerWidth : VIEW_W * TS;
+  const ih = typeof window !== 'undefined' ? window.innerHeight : VIEW_H * TS;
+  return {
+    w: Math.min(VIEW_W, Math.floor(iw / TS)),
+    h: Math.min(VIEW_H, Math.floor(ih / TS))
+  };
+}
+globalThis.getViewSize = getViewSize;
+
 // ===== Game state =====
 let world = [], interiors = {}, buildings = [], portals = [], npcTemplates = [];
 const tileEvents = [];

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -254,8 +254,9 @@ function centerCamera(x,y,map){
   if(map==='world'){ W=WORLD_W; H=WORLD_H; }
   else if(interiors[map]){ const I=interiors[map]; W=(I&&I.w)||VIEW_W; H=(I&&I.h)||VIEW_H; }
   else { W=VIEW_W; H=VIEW_H; }
-  camX = clamp(x - Math.floor(VIEW_W/2), 0, Math.max(0, (W||VIEW_W) - VIEW_W));
-  camY = clamp(y - Math.floor(VIEW_H/2), 0, Math.max(0, (H||VIEW_H) - VIEW_H));
+  const { w:vW, h:vH } = getViewSize();
+  camX = clamp(x - Math.floor(vW/2), 0, Math.max(0, (W||vW) - vW));
+  camY = clamp(y - Math.floor(vH/2), 0, Math.max(0, (H||vH) - vH));
 }
 
 // ===== Drawing Pipeline =====
@@ -265,11 +266,12 @@ function render(gameState=state, dt){
   const ctx = sctx;
   ctx.fillStyle='#000';
   ctx.fillRect(0,0,disp.width,disp.height);
-  
+
   const activeMap = gameState.map || mapIdForState();
   const { W, H } = mapWH(activeMap);
-  const offX = Math.max(0, Math.floor((VIEW_W - W) / 2));
-  const offY = Math.max(0, Math.floor((VIEW_H - H) / 2));
+  const { w:vW, h:vH } = getViewSize();
+  const offX = Math.max(0, Math.floor((vW - W) / 2));
+  const offY = Math.max(0, Math.floor((vH - H) / 2));
 
   const items = gameState.itemDrops || itemDrops;
   const entities = gameState.entities || NPCS;
@@ -310,7 +312,7 @@ function render(gameState=state, dt){
     else if(layer==='items'){
       for(const it of items){
         if(it.map!==activeMap) continue;
-        if(it.x>=camX&&it.y>=camY&&it.x<camX+VIEW_W&&it.y<camY+VIEW_H){
+        if(it.x>=camX&&it.y>=camY&&it.x<camX+vW&&it.y<camY+vH){
           const vx=(it.x-camX+offX)*TS, vy=(it.y-camY+offY)*TS;
           ctx.fillStyle='#c8ffbf'; ctx.fillRect(vx+4,vy+4,TS-8,TS-8);
         }
@@ -337,18 +339,19 @@ function render(gameState=state, dt){
 
   // UI border
   ctx.strokeStyle='#2a3b2a';
-  ctx.strokeRect(0.5,0.5,VIEW_W*TS-1,VIEW_H*TS-1);
+  ctx.strokeRect(0.5,0.5,vW*TS-1,vH*TS-1);
 }
 
 function drawEntities(ctx, list, offX, offY){
-    for(const n of list){
-      if(n.x>=camX&&n.y>=camY&&n.x<camX+VIEW_W&&n.y<camY+VIEW_H){
-        const vx=(n.x-camX+offX)*TS, vy=(n.y-camY+offY)*TS;
-        ctx.fillStyle=n.color; ctx.fillRect(vx,vy,TS,TS);
-        ctx.fillStyle='#000'; ctx.fillText('!',vx+5,vy+12);
-      }
+  const { w:vW, h:vH } = getViewSize();
+  for(const n of list){
+    if(n.x>=camX&&n.y>=camY&&n.x<camX+vW&&n.y<camY+vH){
+      const vx=(n.x-camX+offX)*TS, vy=(n.y-camY+offY)*TS;
+      ctx.fillStyle=n.color; ctx.fillRect(vx,vy,TS,TS);
+      ctx.fillStyle='#000'; ctx.fillText('!',vx+5,vy+12);
     }
   }
+}
 
 Object.assign(window, { renderOrderSystem: { order: renderOrder, render } });
 

--- a/test/view-size.test.js
+++ b/test/view-size.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function stubEl(){
+  return {
+    style:{},
+    classList:{ add(){}, remove(){}, toggle(){}, contains(){return false;} },
+    textContent:'',
+    appendChild(){},
+    prepend(){},
+    children:[],
+    parentElement:{ appendChild(){} },
+    getContext: () => ({ fillRect(){}, strokeRect(){}, fillText(){}, clearRect(){}, font:'' })
+  };
+}
+
+test('getViewSize reflects window bounds', async () => {
+  const document = {
+    body: stubEl(),
+    getElementById: () => stubEl(),
+    createElement: () => stubEl(),
+    querySelector: () => stubEl()
+  };
+  const context = {
+    window: { innerWidth:320, innerHeight:480, document },
+    document,
+    EventBus:{ on:()=>{}, emit:()=>{} },
+    registerItem:()=>{},
+    centerCamera:()=>{},
+    setGameState:()=>{},
+    incFlag:()=>{},
+    renderInv:()=>{},
+    renderParty:()=>{},
+    renderQuests:()=>{},
+    updateHUD:()=>{},
+    Audio: function(){},
+    console
+  };
+  vm.createContext(context);
+  const code = await fs.readFile(new URL('../dustland-core.js', import.meta.url), 'utf8');
+  vm.runInContext(code, context);
+  const small = context.getViewSize();
+  assert.strictEqual(small.w, 20);
+  assert.strictEqual(small.h, 30);
+  context.window.innerWidth = 2000;
+  context.window.innerHeight = 2000;
+  const big = context.getViewSize();
+  assert.strictEqual(big.w, 40);
+  assert.strictEqual(big.h, 30);
+});


### PR DESCRIPTION
## Summary
- compute visible tiles with `getViewSize`
- center and render camera based on viewport
- add tests for viewport sizing

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68adadb00d848328a6008f3541cc81b0