### PR TITLE
fix: prevent combat overlay from overlapping sidebar

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -4,6 +4,7 @@
         --frame: #141614;
         --accent: #9ef7a0;
         --muted: #7a8a7a;
+        --panelW: 440px;
     }
 
     input::placeholder,
@@ -298,8 +299,8 @@
         .panel {
             width: 840px;
         }
-        #combatOverlay {
-            right: 840px;
+        :root {
+            --panelW: 840px;
         }
 
         .tabs {
@@ -330,8 +331,8 @@
             transform: translateX(100%);
             transition: transform .2s;
         }
-        #combatOverlay {
-            right: 0;
+        :root {
+            --panelW: 0;
         }
         .panel.show {
             transform: translateX(0);
@@ -442,7 +443,7 @@
     }
 
 /* Combat UI */
-#combatOverlay { background:rgba(0,0,0,.8); pointer-events:auto; z-index:10; right:440px; }
+#combatOverlay { background:rgba(0,0,0,.8); pointer-events:auto; z-index:10; right:var(--panelW); }
 #combatOverlay.warning { animation:bossWarn .3s steps(1) 4; }
 @keyframes bossWarn { 50% { background:rgba(80,0,0,.8); } }
 #combatOverlay .combat-window {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1173,7 +1173,8 @@ test('combat overlay sits behind the log panel', async () => {
 
 test('combat overlay leaves room for panel', async () => {
   const css = await fs.readFile(new URL('../dustland.css', import.meta.url), 'utf8');
-  assert.match(css, /#combatOverlay\s*{[\s\S]*right:\s*440px/);
+  assert.match(css, /#combatOverlay\s*{[\s\S]*right:\s*var\(--panelW\)/);
+  assert.match(css, /:root\s*{[\s\S]*--panelW:\s*440px/);
 });
 
 test('distance to road increases encounter chance', () => {


### PR DESCRIPTION
## Summary
- ensure combat overlay offsets dynamically with panel width via CSS variable
- update unit test to expect CSS variable and default panel width

## Testing
- `npm test`
- `./install-deps.sh`
- `node presubmit.js`
- `node balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68adb34915d08328a0d9d284a5a6f238