### PR TITLE
feat: show critical health feedback in HUD

### DIFF
--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -100,7 +100,7 @@ The prototype doesn't spend Adrenaline yet; it's a pacing probe. Once the gain c
 
 #### Phase 2: Content & UI
 - [x] **New HUD:** Redesign the combat UI to include the Adrenaline bar, status effect icons, and improved health bar feedback.
-- [ ] **Player Health Panel:** Update the right-side player health panel to show damage being taken in real-time, with visual effects for critical health and passing out.
+- [x] **Player Health Panel:** Update the right-side player health panel to show damage being taken in real-time, with visual effects for critical health and passing out.
 - [ ] **Implement 5-10 Specials:** Create a starter set of special moves (e.g., "Power Strike," "Stun Grenade," "First Aid").
 - [ ] **Implement Equipment:** Create a set of weapons and armor with varied combat modifiers.
 - [ ] **Enemy Design:** Create 3-5 new enemy types that require tactical use of specials (e.g., a "Shielded Guard" that is resistant to basic attacks).

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -6,6 +6,7 @@ const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');
 const scrEl = document.getElementById('scrap');
+const hpBar = document.getElementById('hpBar');
 const hpFill = document.getElementById('hpFill');
 const hpGhost = document.getElementById('hpGhost');
 const adrFill = document.getElementById('adrFill');
@@ -364,10 +365,16 @@ const TAB_BREAKPOINT = 1600;
 let activeTab = 'inv';
 
 function updateHUD(){
+  const prevHp = updateHUD._lastHpVal ?? player.hp;
   hpEl.textContent = player.hp;
   apEl.textContent = player.ap;
   if(scrEl) scrEl.textContent = player.scrap;
   const lead = typeof leader === 'function' ? leader() : null;
+  if(hpBar && player.hp < prevHp){
+    hpBar.classList.add('hurt');
+    clearTimeout(updateHUD._hurtTimer);
+    updateHUD._hurtTimer = setTimeout(()=>hpBar.classList.remove('hurt'), 300);
+  }
   if(hpFill && lead){
     const pct = Math.max(0, Math.min(100, (player.hp / (lead.maxHp || 1)) * 100));
     hpFill.style.width = pct + '%';
@@ -376,6 +383,11 @@ function updateHUD(){
       requestAnimationFrame(()=>{ hpGhost.style.width = pct + '%'; });
     }
     updateHUD._lastHpPct = pct;
+    if(lead){
+      const crit = player.hp > 0 && player.hp <= (lead.maxHp || 1) * 0.25;
+      document.body.classList.toggle('hp-critical', crit);
+      document.body.classList.toggle('hp-out', player.hp <= 0);
+    }
   }
   if(adrFill && lead){
     const apct = Math.max(0, Math.min(100, (lead.adr / (lead.maxAdr || 1)) * 100));
@@ -392,6 +404,7 @@ function updateHUD(){
       }
     }
   }
+  updateHUD._lastHpVal = player.hp;
 }
 
 function showTab(which){

--- a/dustland.css
+++ b/dustland.css
@@ -130,6 +130,10 @@
         background: #d98b8b
     }
 
+    .hudbar.hurt .fill {
+        background: #f55
+    }
+
     .status-row {
         display: flex;
         gap: 2px;
@@ -142,6 +146,37 @@
         height: 8px;
         background: #8bd98d;
         border-radius: 2px
+    }
+
+    body.hp-critical #game {
+        filter: grayscale(.8)
+    }
+
+    body.hp-critical::after {
+        content: '';
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        pointer-events: none;
+        box-shadow: inset 0 0 40px 20px rgba(0, 0, 0, .6)
+    }
+
+    body.hp-out #game {
+        filter: grayscale(1) brightness(.5)
+    }
+
+    body.hp-out::after {
+        content: '';
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        pointer-events: none;
+        background: #000;
+        opacity: .8
     }
 
     .hudBadge {

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const full = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
+const code = full.split('// ===== Boot =====')[0];
+
+class AudioCtx {
+  createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
+  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
+  get destination(){ return {}; }
+  get currentTime(){ return 0; }
+}
+
+const AudioStub = class { constructor(){ this.addEventListener = () => {}; } cloneNode(){ return new AudioStub(); } };
+
+function setup(html){
+  const dom = new JSDOM(html);
+  dom.window.AudioContext = AudioCtx;
+  dom.window.webkitAudioContext = AudioCtx;
+  const dummyCtx = new Proxy({}, { get: () => () => {}, set: () => true });
+  dom.window.HTMLCanvasElement.prototype.getContext = () => dummyCtx;
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    requestAnimationFrame: fn => fn(),
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    Audio: AudioStub,
+    EventBus: { on: () => {}, emit: () => {} },
+    NanoDialog: { enabled: true },
+    location: { hash: '' },
+    move: () => {},
+    interact: () => {},
+    takeNearestItem: () => {},
+    save: () => {},
+    load: () => {},
+    resetAll: () => {},
+    setTimeout,
+    clearTimeout,
+    console,
+    player: { hp: 10, ap: 2, scrap: 0 },
+    leader: () => ({ maxHp: 10, adr: 0, maxAdr: 100 }),
+    buffs: []
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  return context;
+}
+
+test('hp bar flashes and body gains critical/out classes', async () => {
+  const html = `<body><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div><div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrFill"></div><div id="statusIcons"></div></body>`;
+  const ctx = setup(html);
+  ctx.updateHUD();
+  assert.ok(!ctx.document.body.classList.contains('hp-critical'));
+  ctx.player.hp = 2;
+  ctx.updateHUD();
+  assert.ok(ctx.document.body.classList.contains('hp-critical'));
+  const bar = ctx.document.getElementById('hpBar');
+  assert.ok(bar.classList.contains('hurt'));
+  ctx.player.hp = 0;
+  ctx.updateHUD();
+  assert.ok(ctx.document.body.classList.contains('hp-out'));
+});


### PR DESCRIPTION
## Summary
- flash HP bar and apply visual filters when low or downed
- style HUD for hurt, critical, and pass-out states
- add test covering HUD damage and critical effects

## Testing
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68adb0e5d8b4832895b561dd6dcb4e19