### PR TITLE
Refactor lootbox module to config-driven dialog

### DIFF
--- a/modules/lootbox-demo.module.js
+++ b/modules/lootbox-demo.module.js
@@ -34,29 +34,35 @@ const LOOTBOX_DEMO_MODULE = (() => {
       name: 'Cache Guide',
       desc: 'An eager scavenger itching to teach you about spoils caches.',
       tree: {
-        start: { text: '', choices: [] },
-        spawn_same: { text: 'Another dummy ready.', choices:[{ label:'(Back)', to:'start' }] },
-        spawn_tough: { text: 'Tougher dummy coming up.', choices:[{ label:'(Back)', to:'start' }] }
-      },
-      processNode(node){
-        if(node === 'start'){
-          const opened = flagValue('cache_opened') >= 1;
-          const fought = flagValue('dummy_defeated') >= 1;
-          if(opened){
-            this.tree.start.text = 'Nice work. Want another dummy?';
-          } else if(fought){
-            this.tree.start.text = 'No cache yet? Want to try again?';
-          } else {
-            this.tree.start.text = 'Defeat the dummy and open the spoils cache it drops. The higher the challenge, the better the loot.';
-          }
-          const choices = [];
-          if(fought){
-            choices.push({ label:'(Same dummy)', to:'spawn_same', effects: [()=>clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') } });
-            choices.push({ label:'(Tougher dummy)', to:'spawn_tough', effects: [() => incFlag('dummy_challenge'), ()=>clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') + 1 } });
-          }
-          choices.push({ label:'(Leave)', to:'bye' });
-          this.tree.start.choices = choices;
-        }
+        start: {
+          jump: [
+            { if: { flag: 'cache_opened', op: '>=', value: 1 }, to: 'opened' },
+            { if: { flag: 'dummy_defeated', op: '>=', value: 1 }, to: 'fought' },
+            { to: 'intro' }
+          ]
+        },
+        opened: {
+          text: 'Nice work. Want another dummy?',
+          choices: [
+            { label: '(Same dummy)', to: 'spawn_same', effects: [() => clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') } },
+            { label: '(Tougher dummy)', to: 'spawn_tough', effects: [() => incFlag('dummy_challenge'), () => clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') + 1 } },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        },
+        fought: {
+          text: 'No cache yet? Want to try again?',
+          choices: [
+            { label: '(Same dummy)', to: 'spawn_same', effects: [() => clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') } },
+            { label: '(Tougher dummy)', to: 'spawn_tough', effects: [() => incFlag('dummy_challenge'), () => clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') + 1 } },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        },
+        intro: {
+          text: 'Defeat the dummy and open the spoils cache it drops. The higher the challenge, the better the loot.',
+          choices: [ { label: '(Leave)', to: 'bye' } ]
+        },
+        spawn_same: { text: 'Another dummy ready.', choices: [ { label: '(Back)', to: 'start' } ] },
+        spawn_tough: { text: 'Tougher dummy coming up.', choices: [ { label: '(Back)', to: 'start' } ] }
       }
     }
   ];

--- a/test/dialog.jump.test.js
+++ b/test/dialog.jump.test.js
@@ -1,0 +1,81 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function stubEl(){
+  const el = {
+    style:{},
+    classList:{ _set:new Set(), contains(){return false;}, add(){}, remove(){}, toggle(){} },
+    textContent:'',
+    onclick:null,
+    value:'',
+    _innerHTML:'',
+    children:[],
+    appendChild(child){ this.children.push(child); child.parentElement=this; },
+    querySelector(){ return stubEl(); },
+    querySelectorAll(){ return []; },
+    addEventListener(){},
+    removeEventListener(){},
+    parentElement:{ appendChild(){}, querySelectorAll(){ return []; } },
+    setAttribute(){},
+    click(){},
+  };
+  Object.defineProperty(el,'innerHTML',{ get(){return this._innerHTML;}, set(v){ this._innerHTML=v; this.children=[]; }});
+  return el;
+}
+
+const elements = {};
+
+global.requestAnimationFrame = () => {};
+global.alert = () => {};
+global.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+global.window = global;
+window.matchMedia = () => ({ matches:false, addEventListener(){}, removeEventListener(){} });
+
+global.document = {
+  body: stubEl(),
+  getElementById(id){ if(!elements[id]) elements[id]=stubEl(); return elements[id]; },
+  createElement: () => stubEl(),
+  querySelector: () => stubEl(),
+  querySelectorAll: () => []
+};
+
+const files = [
+  '../event-bus.js',
+  '../dustland-core.js',
+  '../core/npc.js',
+  '../core/dialog.js'
+];
+for(const f of files){
+  const code = await fs.readFile(new URL(f, import.meta.url), 'utf8');
+  vm.runInThisContext(code, { filename: f });
+}
+
+global.setPortrait = () => {};
+global.setGameState = () => {};
+global.updateHUD = () => {};
+global.centerCamera = () => {};
+global.refreshUI = () => {};
+global.log = () => {};
+global.player = { inv: [] };
+global.party = {};
+global.state = { map: 'world' };
+
+test('dialog jump redirects based on flags', () => {
+  const tree = {
+    start:{ jump:[ { if:{ flag:'a', op:'>=', value:1 }, to:'one' }, { to:'zero' } ] },
+    zero:{ text:'zero', choices:[ { label:'(Leave)', to:'bye' } ] },
+    one:{ text:'one', choices:[ { label:'(Leave)', to:'bye' } ] }
+  };
+  const npc = makeNPC('npc1','world',0,0,'#fff','NPC','', '', tree, null, null, null, {});
+
+  setFlag('a',0);
+  openDialog(npc, 'start');
+  assert.equal(elements.dialogText.textContent, 'zero');
+  closeDialog();
+
+  setFlag('a',1);
+  openDialog(npc, 'start');
+  assert.equal(elements.dialogText.textContent, 'one');
+});


### PR DESCRIPTION
## Summary
- add `jump` support for dialog nodes to redirect based on flags
- refactor lootbox demo to use config-driven dialog tree
- cover dialog jumping with tests

## Testing
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68adb59fd15c83289692c03d5edcb159