### PR TITLE
refactor: namespace event bus and flags

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -213,7 +213,7 @@ function advanceDialog(stateObj, choiceIdx){
     } else if (op === 'add') {
       incFlag(flag, value);
     } else if (op === 'clear') {
-      clearFlag(flag);
+      Dustland.eventFlags.clearFlag(flag);
     }
   }
 

--- a/core/event-flags.js
+++ b/core/event-flags.js
@@ -1,7 +1,9 @@
+globalThis.Dustland = globalThis.Dustland || {};
 (function(){
+  const bus = globalThis.Dustland.eventBus;
   function watchEventFlag(evt, flag){
-    if(!evt || !flag || !globalThis.EventBus?.on) return;
-    globalThis.EventBus.on(evt, () => incFlag?.(flag));
+    if(!evt || !flag || !bus?.on) return;
+    bus.on(evt, () => incFlag?.(flag));
   }
   function clearFlag(flag){
     if(!flag) return;
@@ -9,5 +11,5 @@
     if(v) incFlag?.(flag, -v);
     if(party?.flags) delete party.flags[flag];
   }
-  Object.assign(globalThis, { watchEventFlag, clearFlag });
+  globalThis.Dustland.eventFlags = { watchEventFlag, clearFlag };
 })();

--- a/event-bus.js
+++ b/event-bus.js
@@ -23,6 +23,7 @@ globalThis.Dustland = globalThis.Dustland || {};
   }
 
   const bus = { on, off, emit };
-  Object.assign(globalThis, bus, { EventBus: bus });
+  globalThis.Dustland.eventBus = bus;
+  globalThis.EventBus = bus; // legacy shim during migration
 })();
 

--- a/modules/lootbox-demo.module.js
+++ b/modules/lootbox-demo.module.js
@@ -11,7 +11,7 @@ const LOOTBOX_DEMO_MODULE = (() => {
   const demoRoom = { id: 'demo_room', w: ROOM_W, h: ROOM_H, grid, entryX: 1, entryY: Math.floor(ROOM_H / 2) };
 
   let sawDrop = false;
-  watchEventFlag('spoils:opened', 'cache_opened');
+  Dustland.eventFlags.watchEventFlag('spoils:opened', 'cache_opened');
   EventBus.on('spoils:drop', () => { sawDrop = true; });
   EventBus.on('combat:ended', ({ result }) => {
     if(result === 'loot'){
@@ -51,8 +51,8 @@ const LOOTBOX_DEMO_MODULE = (() => {
           }
           const choices = [];
           if(fought){
-            choices.push({ label:'(Same dummy)', to:'spawn_same', effects: [()=>clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') } });
-            choices.push({ label:'(Tougher dummy)', to:'spawn_tough', effects: [() => incFlag('dummy_challenge'), ()=>clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') + 1 } });
+            choices.push({ label:'(Same dummy)', to:'spawn_same', effects: [() => Dustland.eventFlags.clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') } });
+            choices.push({ label:'(Tougher dummy)', to:'spawn_tough', effects: [() => incFlag('dummy_challenge'), () => Dustland.eventFlags.clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') + 1 } });
           }
           choices.push({ label:'(Leave)', to:'bye' });
           this.tree.start.choices = choices;

--- a/test/event-flags.test.js
+++ b/test/event-flags.test.js
@@ -4,11 +4,12 @@ import { test } from 'node:test';
 test('watchEventFlag increments and clearFlag resets', async () => {
   const flags = {};
   const handlers = {};
-  globalThis.EventBus = { on: (evt, fn) => { handlers[evt] = fn; } };
+  globalThis.Dustland = { eventBus: { on: (evt, fn) => { handlers[evt] = fn; } } };
   globalThis.incFlag = (flag, amt = 1) => { flags[flag] = (flags[flag] || 0) + amt; };
   globalThis.flagValue = (flag) => flags[flag] || 0;
   globalThis.party = { flags: {} };
   await import('../core/event-flags.js');
+  const { watchEventFlag, clearFlag } = Dustland.eventFlags;
   watchEventFlag('demo', 'demo_flag');
   handlers.demo();
   assert.strictEqual(flagValue('demo_flag'), 1);


### PR DESCRIPTION
## Summary
- move event bus into `Dustland.eventBus` with legacy shim
- group flag helpers under `Dustland.eventFlags` and update usages

## Testing
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb88d3cd88328a57b8859d677758d