### PR TITLE
feat: persist adrenaline and show combat bars

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -50,6 +50,14 @@ function renderCombat(){
     const p=document.createElement('div'); p.className='portrait';
     setPortraitDiv(p,e);
     wrap.appendChild(p);
+    const hp=document.createElement('div'); hp.className='hudbar'; hp.style.width='48px';
+    const hpf=document.createElement('div'); hpf.className='fill';
+    hpf.style.width=Math.max(0,Math.min(100,(e.hp/(e.maxHp||1))*100))+'%';
+    hp.appendChild(hpf); wrap.appendChild(hp);
+    const adr=document.createElement('div'); adr.className='hudbar adr'; adr.style.width='48px';
+    const adrf=document.createElement('div'); adrf.className='fill';
+    adrf.style.width=Math.max(0,Math.min(100,(e.adr/(e.maxAdr||1))*100))+'%';
+    adr.appendChild(adrf); wrap.appendChild(adr);
     const lab=document.createElement('div'); lab.className='label'; lab.textContent=e.name||'';
     wrap.appendChild(lab);
     enemyRow.appendChild(wrap);
@@ -61,6 +69,14 @@ function renderCombat(){
     const p=document.createElement('div'); p.className='portrait';
     setPortraitDiv(p,m);
     wrap.appendChild(p);
+    const hp=document.createElement('div'); hp.className='hudbar'; hp.style.width='48px';
+    const hpf=document.createElement('div'); hpf.className='fill';
+    hpf.style.width=Math.max(0,Math.min(100,(m.hp/(m.maxHp||1))*100))+'%';
+    hp.appendChild(hpf); wrap.appendChild(hp);
+    const adr=document.createElement('div'); adr.className='hudbar adr'; adr.style.width='48px';
+    const adrf=document.createElement('div'); adrf.className='fill';
+    adrf.style.width=Math.max(0,Math.min(100,(m.adr/(m.maxAdr||1))*100))+'%';
+    adr.appendChild(adrf); wrap.appendChild(adr);
     const lab=document.createElement('div'); lab.className='label'; lab.textContent=m.name||'';
     wrap.appendChild(lab);
     partyRow.appendChild(wrap);
@@ -77,7 +93,7 @@ function openCombat(enemies){
     combatState.choice=0;
     combatState.onComplete=resolve;
     combatState.fallen = [];
-    (party||[]).forEach(m => { m.maxAdr = m.maxAdr || 100; m.adr = 0; m.applyCombatMods?.(); });
+    (party||[]).forEach(m => { m.maxAdr = m.maxAdr || 100; m.applyCombatMods?.(); });
     renderCombat();
     updateHUD?.();
     combatOverlay.classList.add('shown');

--- a/core/movement.js
+++ b/core/movement.js
@@ -166,6 +166,11 @@ function move(dx,dy){
           actor.hp = Math.min(actor.hp + 1, actor.maxHp);
           player.hp = actor.hp;
         }
+        (party||[]).forEach(m=>{
+          if(m.hp >= m.maxHp){
+            m.adr = Math.max(0, (m.adr||0) - 2);
+          }
+        });
         setPartyPos(nx, ny);
         if(typeof footstepBump==='function') footstepBump();
         onEnter(state.map, nx, ny, { player, party, state, actor, buffs });

--- a/core/party.js
+++ b/core/party.js
@@ -170,5 +170,11 @@ function trainStat(stat, memberIndex = selectedMember){
   return true;
 }
 
-const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, applyCombatMods, leader, setLeader, respec, trainStat, selectedMember, xpCurve };
+function healParty(){
+  (party||[]).forEach(m=>{ m.hp = m.maxHp; m.adr = 0; });
+  player.hp = party[0] ? party[0].hp : player.hp;
+  renderParty?.(); updateHUD?.();
+}
+
+const partyExports = { baseStats, Character, Party, party, makeMember, addPartyMember, removePartyMember, statLine, xpToNext, awardXP, applyEquipmentStats, applyCombatMods, leader, setLeader, respec, trainStat, healParty, selectedMember, xpCurve };
 Object.assign(globalThis, partyExports);

--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -15,6 +15,8 @@ This creates a simple, aggressive loop:
 
 Sitting back and playing defensively is a losing strategy. The player who isn't actively generating Adrenaline is a player who isn't using their best tools.
 
+Adrenaline persists between encounters, gently cooling when a character is at full health. A full rest that restores the whole party immediately clears any stored Adrenaline.
+
 > **Clown:** I'm into the forward momentum, but we should confirm the Adrenaline bar doesn't crowd the HUD. Let's prototype it with placeholder art before committing. When it's full, it could arc with energy. When you use a Special, it slams down, then starts building again. The UI itself should feel energetic.
 
 ### Specials: High Risk, High Reward

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -578,7 +578,7 @@ party.forEach((m,i)=>{
   const pct=Math.min(100,(m.xp/nextXP)*100);
   c.innerHTML = `<div class='row'><div class='portrait'></div><div><b>${m.name}</b> — ${m.role} (Lv ${m.lvl})</div></div>`+
 `<div class='row small'>${statLine(m.stats)}</div>`+
-`<div class='row'>HP ${m.hp}/${m.maxHp}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div>`+
+`<div class='row'>HP ${m.hp}/${m.maxHp}  ADR ${m.adr}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div>`+
 `<div class='row'><div class='xpbar' data-xp='${m.xp}/${nextXP}'><div class='fill' style='width:${pct}%'></div></div></div>`+
 `<div class='row small'>WPN: ${wLabel}${m.equip.weapon?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${m.equip.armor?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${m.equip.trinket?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div>`;
   const portrait=c.querySelector('.portrait');

--- a/dustland.css
+++ b/dustland.css
@@ -508,6 +508,7 @@
 #combatOverlay .enemy-row { align-items:flex-start; }
 #combatOverlay .party-row { align-items:flex-end; }
 #combatOverlay .member { position:relative; display:flex; flex-direction:column; align-items:center; }
+#combatOverlay .enemy .hudbar, #combatOverlay .member .hudbar { width:48px; margin-top:2px; }
 #combatOverlay .label { margin-top:4px; text-align:center; }
 #combatOverlay .enemy.active .portrait, #combatOverlay .member.active .portrait { border-color:#5c8a5c; }
 #combatOverlay .turn { text-align:center; margin-bottom:4px; }


### PR DESCRIPTION
## Summary
- show each combatant's HP and adrenaline beneath their portrait
- keep adrenaline between fights and let full party heals clear it
- slowly cool adrenaline for healthy members and display it in the party panel

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68adb91eb9ac83288984e31014947e2a