### PR TITLE
refactor: centralize event bus and flags

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -214,7 +214,7 @@ function advanceDialog(stateObj, choiceIdx){
     } else if (op === 'add') {
       incFlag(flag, value);
     } else if (op === 'clear') {
-      clearFlag(flag);
+      Dustland.eventFlags.clear(flag);
     }
   }
 

--- a/core/event-flags.js
+++ b/core/event-flags.js
@@ -1,13 +1,15 @@
 (function(){
-  function watchEventFlag(evt, flag){
-    if(!evt || !flag || !globalThis.EventBus?.on) return;
-    globalThis.EventBus.on(evt, () => incFlag?.(flag));
+  globalThis.Dustland = globalThis.Dustland || {};
+  function watch(evt, flag){
+    const bus = globalThis.Dustland.eventBus;
+    if(!evt || !flag || !bus?.on) return;
+    bus.on(evt, () => incFlag?.(flag));
   }
-  function clearFlag(flag){
+  function clear(flag){
     if(!flag) return;
     const v = typeof flagValue === 'function' ? flagValue(flag) : 0;
     if(v) incFlag?.(flag, -v);
     if(party?.flags) delete party.flags[flag];
   }
-  Object.assign(globalThis, { watchEventFlag, clearFlag });
+  globalThis.Dustland.eventFlags = { watch, clear };
 })();

--- a/docs/design/tech-debt-paydown.md
+++ b/docs/design/tech-debt-paydown.md
@@ -51,6 +51,8 @@ Our CRT playground is scrappy by design, but a few lingering habits slow our bui
 - [ ] **Phase 1: Namespace the world**
   - [x] Introduce `globalThis.Dustland = {}`.
   - [ ] Move module exports into `Dustland.*` buckets.
+    - [x] Namespace event bus under `Dustland.eventBus`.
+    - [x] Namespace event flag helpers under `Dustland.eventFlags`.
   - [ ] Update references and tests incrementally.
 - [ ] **Phase 2: Untangle UI from logic**
   - [ ] Replace direct DOM calls with event emissions.

--- a/event-bus.js
+++ b/event-bus.js
@@ -23,6 +23,8 @@ globalThis.Dustland = globalThis.Dustland || {};
   }
 
   const bus = { on, off, emit };
-  Object.assign(globalThis, bus, { EventBus: bus });
+  // Expose under Dustland namespace and keep a legacy shim
+  globalThis.Dustland.eventBus = bus;
+  globalThis.EventBus = bus;
 })();
 

--- a/modules/lootbox-demo.module.js
+++ b/modules/lootbox-demo.module.js
@@ -11,17 +11,17 @@ const LOOTBOX_DEMO_MODULE = (() => {
   const demoRoom = { id: 'demo_room', w: ROOM_W, h: ROOM_H, grid, entryX: 1, entryY: Math.floor(ROOM_H / 2) };
 
   let sawDrop = false;
-  watchEventFlag('spoils:opened', 'cache_opened');
-  EventBus.on('spoils:drop', () => { sawDrop = true; });
-  EventBus.on('combat:ended', ({ result }) => {
+  Dustland.eventFlags.watch('spoils:opened', 'cache_opened');
+  Dustland.eventBus.on('spoils:drop', () => { sawDrop = true; });
+  Dustland.eventBus.on('combat:ended', ({ result }) => {
     if(result === 'loot'){
       incFlag('dummy_defeated');
-      if(!sawDrop) EventBus.emit('mentor:bark', { text:'Better luck next time', sound:'mentor' });
+      if(!sawDrop) Dustland.eventBus.emit('mentor:bark', { text:'Better luck next time', sound:'mentor' });
       sawDrop = false;
     }
   });
-  EventBus.on('spoils:opened', () => {
-    EventBus.emit('mentor:bark', { text:'Good job', sound:'mentor' });
+  Dustland.eventBus.on('spoils:opened', () => {
+    Dustland.eventBus.emit('mentor:bark', { text:'Good job', sound:'mentor' });
   });
 
   const npcs = [
@@ -44,16 +44,16 @@ const LOOTBOX_DEMO_MODULE = (() => {
         opened: {
           text: 'Nice work. Want another dummy?',
           choices: [
-            { label: '(Same dummy)', to: 'spawn_same', effects: [() => clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') } },
-            { label: '(Tougher dummy)', to: 'spawn_tough', effects: [() => incFlag('dummy_challenge'), () => clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') + 1 } },
+            { label: '(Same dummy)', to: 'spawn_same', effects: [() => Dustland.eventFlags.clear('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') } },
+            { label: '(Tougher dummy)', to: 'spawn_tough', effects: [() => incFlag('dummy_challenge'), () => Dustland.eventFlags.clear('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') + 1 } },
             { label: '(Leave)', to: 'bye' }
           ]
         },
         fought: {
           text: 'No cache yet? Want to try again?',
           choices: [
-            { label: '(Same dummy)', to: 'spawn_same', effects: [() => clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') } },
-            { label: '(Tougher dummy)', to: 'spawn_tough', effects: [() => incFlag('dummy_challenge'), () => clearFlag('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') + 1 } },
+            { label: '(Same dummy)', to: 'spawn_same', effects: [() => Dustland.eventFlags.clear('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') } },
+            { label: '(Tougher dummy)', to: 'spawn_tough', effects: [() => incFlag('dummy_challenge'), () => Dustland.eventFlags.clear('cache_opened')], spawn: { templateId: 'training_dummy', x: 5, y: Math.floor(ROOM_H / 2), challenge: flagValue('dummy_challenge') + 1 } },
             { label: '(Leave)', to: 'bye' }
           ]
         },

--- a/test/event-bus.test.js
+++ b/test/event-bus.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('EventBus exposes Dustland namespace', async () => {
+  const code = await fs.readFile(new URL('../event-bus.js', import.meta.url), 'utf8');
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  assert.ok(context.Dustland?.eventBus);
+  assert.strictEqual(context.EventBus, context.Dustland.eventBus);
+  assert.strictEqual(typeof context.Dustland.EventBus, 'undefined');
+  assert.strictEqual(typeof context.on, 'undefined');
+});

--- a/test/event-flags.test.js
+++ b/test/event-flags.test.js
@@ -1,17 +1,17 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
 
-test('watchEventFlag increments and clearFlag resets', async () => {
+test('event flags watch and clear via Dustland namespace', async () => {
   const flags = {};
   const handlers = {};
-  globalThis.EventBus = { on: (evt, fn) => { handlers[evt] = fn; } };
+  globalThis.Dustland = { eventBus: { on: (evt, fn) => { handlers[evt] = fn; } } };
   globalThis.incFlag = (flag, amt = 1) => { flags[flag] = (flags[flag] || 0) + amt; };
   globalThis.flagValue = (flag) => flags[flag] || 0;
   globalThis.party = { flags: {} };
   await import('../core/event-flags.js');
-  watchEventFlag('demo', 'demo_flag');
+  Dustland.eventFlags.watch('demo', 'demo_flag');
   handlers.demo();
   assert.strictEqual(flagValue('demo_flag'), 1);
-  clearFlag('demo_flag');
+  Dustland.eventFlags.clear('demo_flag');
   assert.strictEqual(flagValue('demo_flag'), 0);
 });


### PR DESCRIPTION
## Summary
- expose event bus on the Dustland namespace while retaining legacy global shim
- move event flag helpers into Dustland.eventFlags and wire them to the namespaced bus
- update modules and dialog logic to consume the namespaced helpers

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68adb9c12c388328ab5eb147ebeeecb7