### PR TITLE
feat: open spoils caches

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -472,9 +472,7 @@ function renderInv(){
     const row=document.createElement('div');
     row.className='slot cache-slot';
     const icon = SpoilsCache.renderIcon(rank, () => {
-      const index = player.inv.findIndex(c => c.type==='spoils-cache' && c.rank===rank);
-      if(index !== -1) removeFromInv(index);
-      log?.(`${SpoilsCache.ranks[rank].name} opened.`);
+      SpoilsCache.open(rank);
     });
     if(icon){
       const wrap=document.createElement('div');

--- a/test/spoils-cache.test.js
+++ b/test/spoils-cache.test.js
@@ -3,8 +3,10 @@ import { test } from 'node:test';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
 
-const code = await fs.readFile(new URL('../core/spoils-cache.js', import.meta.url), 'utf8');
-vm.runInThisContext(code, { filename: 'core/spoils-cache.js' });
+const genCode = await fs.readFile(new URL('../core/item-generator.js', import.meta.url), 'utf8');
+const cacheCode = await fs.readFile(new URL('../core/spoils-cache.js', import.meta.url), 'utf8');
+vm.runInThisContext(genCode, { filename: 'core/item-generator.js' });
+vm.runInThisContext(cacheCode, { filename: 'core/spoils-cache.js' });
 
 test('spoils cache ranks are defined', () => {
   const ranks = Object.keys(SpoilsCache.ranks);
@@ -18,14 +20,14 @@ test('create returns cache item', () => {
   assert.strictEqual(cache.name, 'Rusted Cache');
 });
 
-  test('drop roll tied to challenge rating', () => {
-    SpoilsCache.baseRate = 0.1;
-    const fail = SpoilsCache.rollDrop(1, () => 0.2);
-    assert.strictEqual(fail, null);
-    const hit = SpoilsCache.rollDrop(5, () => 0.2);
-    assert.ok(hit);
-    assert.strictEqual(hit.type, 'spoils-cache');
-  });
+test('drop roll tied to challenge rating', () => {
+  SpoilsCache.baseRate = 0.1;
+  const fail = SpoilsCache.rollDrop(1, () => 0.2);
+  assert.strictEqual(fail, null);
+  const hit = SpoilsCache.rollDrop(5, () => 0.2);
+  assert.ok(hit);
+  assert.strictEqual(hit.type, 'spoils-cache');
+});
 
 test('pickRank tuned for challenge tiers', () => {
   assert.strictEqual(SpoilsCache.pickRank(7, () => 0.02), 'vaulted');
@@ -35,39 +37,61 @@ test('pickRank tuned for challenge tiers', () => {
   assert.strictEqual(SpoilsCache.pickRank(9, () => 0.95), 'armored');
 });
 
-  test('renderIcon creates element with rank class', () => {
-    global.document = {
-      createElement(tag){
-        const el = {
-          tagName: tag.toUpperCase(),
-          className: '',
-          classList: {
-            add(cls){ el.className += (el.className ? ' ' : '') + cls; }
-          },
-          addEventListener(){},
-          remove(){}
-        };
-        return el;
-      }
-    };
-    const el = SpoilsCache.renderIcon('sealed');
-    assert.ok(el.className.includes('cache-icon'));
-    assert.ok(el.className.includes('sealed'));
-    delete global.document;
-  });
+test('renderIcon creates element with rank class', () => {
+  global.document = {
+    createElement(tag){
+      const el = {
+        tagName: tag.toUpperCase(),
+        className: '',
+        classList: {
+          add(cls){ el.className += (el.className ? ' ' : '') + cls; }
+        },
+        addEventListener(){},
+        remove(){}
+      };
+      return el;
+    }
+  };
+  const el = SpoilsCache.renderIcon('sealed');
+  assert.ok(el.className.includes('cache-icon'));
+  assert.ok(el.className.includes('sealed'));
+  delete global.document;
+});
 
-test('openAll removes caches of specified rank', () => {
-  global.player = { inv: [SpoilsCache.create('sealed'), SpoilsCache.create('sealed'), {id:'x',type:'misc'}] };
-  let notified = 0;
-  global.notifyInventoryChanged = () => { notified++; };
-  const logs = [];
-  global.log = (msg) => logs.push(msg);
-  const opened = SpoilsCache.openAll('sealed');
-  assert.strictEqual(opened, 2);
+test('open generates loot and removes one cache', () => {
+  const loot = { id: 'loot', name: 'Test Loot', type: 'misc' };
+  global.player = { inv: [SpoilsCache.create('sealed')] };
+  global.notifyInventoryChanged = () => {};
+  global.addToInv = it => { player.inv.push(it); return true; };
+  ItemGen.generate = () => loot;
+  const events = [];
+  global.EventBus = { emit:(e,d)=>events.push({e,d}) };
+  const out = SpoilsCache.open('sealed');
+  assert.strictEqual(out, loot);
   assert.strictEqual(player.inv.length, 1);
-  assert.strictEqual(notified, 1);
-  assert.ok(logs[0].includes('Opened 2'));
+  assert.strictEqual(events[0].e, 'spoils:opened');
+  assert.strictEqual(events[0].d.item, loot);
   delete global.player;
   delete global.notifyInventoryChanged;
+  delete global.addToInv;
+  delete global.EventBus;
+});
+
+test('openAll opens caches and adds loot', () => {
+  global.player = { inv: [SpoilsCache.create('sealed'), SpoilsCache.create('sealed'), {id:'x',type:'misc'}] };
+  global.notifyInventoryChanged = () => {};
+  const logs = [];
+  global.log = m => logs.push(m);
+  const drops = [{id:'a',name:'A',type:'misc'},{id:'b',name:'B',type:'misc'}];
+  let i = 0;
+  ItemGen.generate = () => drops[i++];
+  global.addToInv = it => { player.inv.push(it); return true; };
+  const opened = SpoilsCache.openAll('sealed');
+  assert.strictEqual(opened, 2);
+  assert.strictEqual(player.inv.length, 3);
+  assert.ok(logs.some(m => m.includes('Opened 2')));
+  delete global.player;
+  delete global.notifyInventoryChanged;
+  delete global.addToInv;
   delete global.log;
 });


### PR DESCRIPTION
## Summary
- generate loot when opening a Spoils Cache and add it to inventory
- wire inventory UI to open caches
- cover cache opening with new tests

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68adbdd2635c8328b51a63b6307fede8