### PR TITLE
fix: preserve spoils cache rank

### DIFF
--- a/core/inventory.js
+++ b/core/inventory.js
@@ -154,6 +154,7 @@ function normalizeItem(it){
     id: it.id || '',
     name: it.name || 'Unknown',
     type: it.type || 'misc',
+    rank: it.rank,
     tags: Array.isArray(it.tags) ? it.tags.map(t=>t.toLowerCase()) : [],
     slot: it.slot || null,
     mods: it.mods ? { ...it.mods } : {},


### PR DESCRIPTION
## Summary
- keep spoils cache rank when registering items so loot boxes enter inventory
- test that registered caches retain their rank and can be opened

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68adc2eb68b88328b529b375b62bf694