### PR TITLE
fix: health bars update during combat

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -301,6 +301,8 @@ function doAttack(dmg){
     combatState.enemies.shift();
     renderCombat();
     if(combatState.enemies.length===0){ log?.('Victory!'); closeCombat('loot'); return; }
+  } else {
+    renderCombat();
   }
   nextCombatant();
 }
@@ -334,6 +336,8 @@ function finishEnemyAttack(enemy, target){
     party.splice(0,1);
     renderCombat();
     if(party.length===0){ log?.('The party has fallen...'); closeCombat('bruise'); return; }
+  } else {
+    renderCombat();
   }
   player.hp = party[0] ? party[0].hp : player.hp;
   updateHUD?.();

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1066,6 +1066,29 @@ test('fallen party members are revived after combat', async () => {
   assert.ok(party[0].hp >= 1);
 });
 
+test('combat hp bars update after damage', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  m1.hp = 2;
+  m1.maxHp = 2;
+  party.addMember(m1);
+
+  const resultPromise = openCombat([
+    { name:'E1', hp:2, maxHp:2 }
+  ]);
+
+  handleCombatKey({ key:'Enter' });
+  const enemyHp = combatEnemies.children[0].children[1].children[0].style.width;
+  const memberHp = combatParty.children[0].children[1].children[0].style.width;
+  assert.strictEqual(enemyHp, '50%');
+  assert.strictEqual(memberHp, '50%');
+
+  handleCombatKey({ key:'Enter' });
+  const res = await resultPromise;
+  assert.strictEqual(res.result, 'loot');
+});
+
 test('combat menu can be clicked', async () => {
   party.length = 0;
   player.inv.length = 0;


### PR DESCRIPTION
## Summary
- rerender combat overlay after attacks so party and enemy health bars shrink correctly
- add regression test for combat health bar updates

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68adcbb8692c832890b108faf80a8a85