### PR TITLE
fix: ensure enemy HP bars scale during combat

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -87,7 +87,7 @@ function renderCombat(){
 function openCombat(enemies){
   if(!combatOverlay) return Promise.resolve({ result:'flee' });
   return new Promise((resolve)=>{
-    combatState.enemies = enemies.map(e=>({ ...e, maxAdr: e.maxAdr || 100, adr: 0 }));
+    combatState.enemies = enemies.map(e=>({ ...e, maxHp: e.maxHp || e.hp, maxAdr: e.maxAdr || 100, adr: 0 }));
     combatState.phase='party';
     combatState.active=0;
     combatState.choice=0;

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1089,6 +1089,27 @@ test('combat hp bars update after damage', async () => {
   assert.strictEqual(res.result, 'loot');
 });
 
+test('enemy hp bar defaults maxHp to hp', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  m1.hp = 2;
+  m1.maxHp = 2;
+  party.addMember(m1);
+
+  const resultPromise = openCombat([
+    { name:'E1', hp:2 }
+  ]);
+
+  handleCombatKey({ key:'Enter' });
+  const enemyHp = combatEnemies.children[0].children[1].children[0].style.width;
+  assert.strictEqual(enemyHp, '50%');
+
+  handleCombatKey({ key:'Enter' });
+  const res = await resultPromise;
+  assert.strictEqual(res.result, 'loot');
+});
+
 test('combat menu can be clicked', async () => {
   party.length = 0;
   player.inv.length = 0;


### PR DESCRIPTION
## Summary
- default enemy maxHp to current hp when combat starts so HP bars scale properly
- add regression test for enemy health bars without explicit maxHp

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js`

------
https://chatgpt.com/codex/tasks/task_e_68add0bbc4ac8328852232268ba3f2ba