### PR TITLE
fix: include item generator for loot caches

### DIFF
--- a/core/spoils-cache.js
+++ b/core/spoils-cache.js
@@ -79,7 +79,7 @@ const SpoilsCache = {
     if(idx === -1) return null;
     player.inv.splice(idx,1);
     notifyInventoryChanged?.();
-    const item = ItemGen?.generate?.(rank, rng);
+    const item = globalThis.ItemGen?.generate?.(rank, rng);
     if(item){
       if(typeof addToInv === 'function'){
         if(!addToInv(item)){

--- a/dustland.html
+++ b/dustland.html
@@ -155,6 +155,7 @@
   </div>
 
     <script defer src="./event-bus.js"></script>
+    <script defer src="./core/item-generator.js"></script>
     <script defer src="./core/effects.js"></script>
     <script defer src="./core/spoils-cache.js"></script>
     <script defer src="./core/inventory.js"></script>

--- a/test/spoils-cache.test.js
+++ b/test/spoils-cache.test.js
@@ -109,3 +109,12 @@ test('registering cache preserves rank for inventory', () => {
   delete global.player;
   delete global.EventBus;
 });
+
+test('openAll handles missing ItemGen gracefully', () => {
+  delete global.ItemGen;
+  global.player = { inv: [SpoilsCache.create('sealed')] };
+  global.notifyInventoryChanged = () => {};
+  const opened = SpoilsCache.openAll('sealed');
+  assert.strictEqual(opened, 0);
+  delete global.player;
+});


### PR DESCRIPTION
## Summary
- load `item-generator.js` so loot caches can spawn items
- guard ItemGen access to avoid crashing when opening caches
- cover missing item generator scenario with a test

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68addb296d90832896cf95d118768198