### PR TITLE
fix: keep party cards compact

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -266,7 +266,9 @@
     #party {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-        gap: 8px
+        gap: 8px;
+        align-content: start;
+        align-items: start;
     }
 
     .pcard {


### PR DESCRIPTION
## Summary
- stop party grid from stretching member cards to full height, removing excess whitespace

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68adddbcf56883288cc02bed46ecea61