### PR TITLE
fix: add ids to generated loot

### DIFF
--- a/core/item-generator.js
+++ b/core/item-generator.js
@@ -1,4 +1,5 @@
 // ===== Item Generator =====
+let nextItemId = 1;
 const ItemGen = {
   types: ['weapon','armor','gadget','oddity'],
   adjectives: [
@@ -51,6 +52,7 @@ const ItemGen = {
     const range = this.statRanges[rank] || this.statRanges.rusted;
     const power = this.randRange(range.min, range.max, rng);
     const item = {
+      id: `gen_${nextItemId++}`,
       type,
       name: `${adj} ${noun}`,
       rank,

--- a/test/item-generator.test.js
+++ b/test/item-generator.test.js
@@ -10,11 +10,18 @@ test('generator creates item with type, name, and stats', () => {
   const vals = [0,0,0,0];
   const rng = () => vals.shift() ?? 0;
   const item = ItemGen.generate('sealed', rng);
+  assert.ok(item.id);
   assert.strictEqual(item.type, 'weapon');
   assert.strictEqual(item.name, 'Grit-Stitched Repeater');
   assert.strictEqual(item.rank, 'sealed');
   assert.ok(item.stats.power >= 3 && item.stats.power <= 5);
   assert.strictEqual(item.scrap, Math.round(item.stats.power / 2));
+});
+
+test('generated items have unique ids', () => {
+  const a = ItemGen.generate('rusted', () => 0);
+  const b = ItemGen.generate('rusted', () => 0);
+  assert.notStrictEqual(a.id, b.id);
 });
 
 test('higher rank yields higher power', () => {


### PR DESCRIPTION
## Summary
- ensure item generator assigns unique IDs so loot can be added to inventory
- test generated items include IDs and are unique

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ade31cd07c8328a9c58cba5c101808