### PR TITLE
feat: gate shop behind dialog with keyboard nav

### DIFF
--- a/core/movement.js
+++ b/core/movement.js
@@ -271,11 +271,7 @@ function interactAt(x, y) {
   const info = queryTile(x, y);
   if (info.entities.length) {
     const npc = info.entities[0];
-    if (npc.shop) {
-      Actions.openShop(npc);
-    } else {
-      openDialog(npc);
-    }
+    openDialog(npc);
     EventBus.emit('sfx', 'confirm');
     return true;
   }

--- a/core/npc.js
+++ b/core/npc.js
@@ -11,6 +11,10 @@ class NPC {
         this.tree.sell.text = items.length ? 'What are you selling?' : 'Nothing to sell.';
         items.push({label: '(Back)', to: 'start'});
         this.tree.sell.choices = items;
+      } else if (this.shop && node === 'buy') {
+        closeDialog();
+        Actions.openShop(this);
+        return;
       }
     };
     const capChoice = (c) => {
@@ -61,7 +65,9 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
     tree = tree || {};
     tree.start = tree.start || {text: '', choices: []};
     tree.start.choices = tree.start.choices || [];
-    tree.start.choices.push({label: '(Sell items)', to: 'sell'});
+    if (!tree.start.choices.some(c => c.to === 'sell')) {
+      tree.start.choices.push({label: '(Sell items)', to: 'sell'});
+    }
     tree.sell = tree.sell || {text: 'What are you selling?', choices: []};
   }
   return new NPC({id,map,x,y,color,name,title,desc,tree,quest,processNode,processChoice, ...(opts || {})});

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -620,6 +620,16 @@ function openShop(npc) {
 
   shopName.textContent = npc.name;
 
+  let focusables = [];
+  let focusIdx = 0;
+  function refreshFocusables() {
+    focusables = Array.from(shopOverlay.querySelectorAll('button'));
+    if (focusIdx >= focusables.length) focusIdx = 0;
+  }
+  function focusCurrent() {
+    refreshFocusables();
+    if (focusables.length) focusables[focusIdx].focus();
+  }
   function renderShop() {
     shopBuy.innerHTML = '';
     shopSell.innerHTML = '';
@@ -669,13 +679,32 @@ function openShop(npc) {
       };
       shopSell.appendChild(row);
     });
+    focusCurrent();
+  }
+
+  function close() {
+    shopOverlay.classList.remove('shown');
+    shopOverlay.removeEventListener('keydown', handleKey);
+  }
+  function handleKey(e) {
+    if (e.key === 'Escape') { close(); return; }
+    if (e.key === 'ArrowDown') {
+      focusIdx = (focusIdx + 1) % focusables.length;
+      focusCurrent();
+      e.preventDefault();
+    } else if (e.key === 'ArrowUp') {
+      focusIdx = (focusIdx - 1 + focusables.length) % focusables.length;
+      focusCurrent();
+      e.preventDefault();
+    }
   }
 
   renderShop();
   shopOverlay.classList.add('shown');
-  closeShopBtn.onclick = () => {
-    shopOverlay.classList.remove('shown');
-  };
+  shopOverlay.tabIndex = -1;
+  shopOverlay.addEventListener('keydown', handleKey);
+  closeShopBtn.onclick = close;
+  shopOverlay.focus();
 }
 
 const engineExports = { log, updateHUD, renderInv, renderQuests, renderParty, footstepBump, pickupSparkle, openShop };

--- a/dustland.css
+++ b/dustland.css
@@ -602,11 +602,22 @@
 .shop-panels {
   display: flex;
   padding: 12px;
+  gap: 24px;
 }
 
 .shop-inv, .player-inv {
   flex: 1;
   padding: 0 12px;
+}
+
+.shop-window .slot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.shop-window .slot button {
+  margin-left: 8px;
 }
 
 .slot-list {

--- a/dustland.html
+++ b/dustland.html
@@ -190,7 +190,7 @@
     document.body.appendChild(modeScript);
   </script>
   <!-- Shop overlay -->
-  <div class="overlay" id="shopOverlay" role="dialog" aria-modal="true">
+  <div class="overlay" id="shopOverlay" role="dialog" aria-modal="true" tabindex="-1">
     <div class="shop-window">
       <header>
         <div id="shopName"></div>

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -448,7 +448,16 @@ const DUSTLAND_MODULE = (() => {
       title: 'Shopkeep',
       desc: 'A roving merchant weighing your wares.',
       portraitSheet: 'assets/portraits/cass_4.png',
-      tree: { start: { text: 'Got goods to sell? I pay in scrap.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      tree: {
+        start: {
+          text: 'Got goods to sell? I pay in scrap.',
+          choices: [
+            { label: 'Browse goods', to: 'buy' },
+            { label: '(Sell items)', to: 'sell' },
+            { label: '(Leave)', to: 'bye' }
+          ]
+        }
+      },
       shop: true
     },
     {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1403,3 +1403,19 @@ test('equipment modifiers apply at battle start', async () => {
   handleCombatKey({ key: 'Enter' });
   await resultPromise;
 });
+
+test('shop npc opens dialog before trading', () => {
+  NPCS.length = 0;
+  party.x = 0; party.y = 0;
+  const shopNpc = makeNPC('shop', 'world', 1, 0, '#fff', 'Shopkeep', '', '', {
+    start: { text: 'Trade?', choices: [ { label: '(Leave)', to: 'bye' } ] }
+  }, null, null, null, { shop: { inv: [] } });
+  NPCS.push(shopNpc);
+  let openedShop = 0;
+  const origOpenShop = global.openShop;
+  global.openShop = () => { openedShop++; };
+  interactAt(1, 0);
+  assert.strictEqual(openedShop, 0);
+  global.openShop = origOpenShop;
+  closeDialog();
+});


### PR DESCRIPTION
## Summary
- let shopkeepers talk before trade and add a buy node to NPC logic
- support keyboard navigation and escape-close for the shop overlay
- tidy shop layout and test that interaction no longer opens the store immediately

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68ade35cb56c8328b1235344493e6277