### PR TITLE
feat: add keyboard navigation to module picker

### DIFF
--- a/module-picker.js
+++ b/module-picker.js
@@ -132,7 +132,7 @@ function showModulePicker(){
   overlay.id = 'modulePicker';
   overlay.style = 'position:fixed;inset:0;background:#000;display:flex;flex-direction:column;align-items:center;justify-content:center;overflow:hidden;z-index:40';
   const styleTag = document.createElement('style');
-  styleTag.textContent = '@keyframes pulse{0%,100%{opacity:.8}50%{opacity:1}}';
+  styleTag.textContent = '@keyframes pulse{0%,100%{opacity:.8}50%{opacity:1}}.btn.selected{border-color:#4f6b4f;background:#151b15}';
   document.head.appendChild(styleTag);
 
   const ackBtn = document.createElement('div');
@@ -163,15 +163,48 @@ function showModulePicker(){
   overlay.appendChild(win);
   document.body.appendChild(overlay);
   const buttonContainer = overlay.querySelector('#moduleButtons');
-  MODULES.forEach(moduleInfo => {
+  const buttons = [];
+  let selectedIndex = 0;
+  function updateSelected() {
+    buttons.forEach((btn, i) => {
+      if (i === selectedIndex) {
+        btn.className = 'btn selected';
+        if (btn.focus) btn.focus();
+      } else {
+        btn.className = 'btn';
+      }
+    });
+  }
+  MODULES.forEach((moduleInfo, i) => {
     const btn = document.createElement('button');
     btn.className = 'btn';
     btn.textContent = moduleInfo.name;
     btn.style.display = 'block';
     btn.style.margin = '4px 0';
     btn.onclick = () => loadModule(moduleInfo);
+    btn.onfocus = () => { selectedIndex = i; updateSelected(); };
+    buttons.push(btn);
     buttonContainer.appendChild(btn);
   });
+  updateSelected();
+
+  overlay.tabIndex = 0;
+  if (overlay.focus) overlay.focus();
+  const keyHandler = (e) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      selectedIndex = (selectedIndex + 1) % buttons.length;
+      updateSelected();
+    } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      selectedIndex = (selectedIndex - 1 + buttons.length) % buttons.length;
+      updateSelected();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      loadModule(MODULES[selectedIndex]);
+    }
+  };
+  if (overlay.addEventListener) overlay.addEventListener('keydown', keyHandler);
 }
 
 showModulePicker();

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -5,18 +5,45 @@ import vm from 'node:vm';
 
 function stubEl(){
   const ctx = { clearRect(){}, fillRect(){ ctx.count++; }, fillStyle:'', count:0 };
+  let inner = '';
   const el = {
     id: '',
     style: {},
     children: [],
     textContent: '',
     className: '',
+    listeners: {},
     appendChild(child){ this.children.push(child); child.parentElement = this; },
-    querySelector: () => stubEl(),
-    querySelectorAll: () => [],
+    querySelector(sel){
+      if (sel.startsWith('#')) {
+        const id = sel.slice(1);
+        return find(this, id) || stubEl();
+      }
+      return stubEl();
+    },
+    querySelectorAll(){ return []; },
+    addEventListener(type, fn){ this.listeners[type] = fn; },
+    dispatchEvent(evt){ const fn = this.listeners[evt.type]; if (fn) fn(evt); },
     ctx,
-    getContext: () => ctx
+    getContext: () => ctx,
+    set innerHTML(html){
+      inner = html;
+      if (html.includes('id="moduleButtons"')) {
+        const main = stubEl();
+        main.id = 'moduleButtons';
+        this.children.push(main);
+      }
+    },
+    get innerHTML(){ return inner; }
   };
+  function find(node, id){
+    if (node.id === id) return node;
+    for (const child of node.children){
+      const res = find(child, id);
+      if (res) return res;
+    }
+    return null;
+  }
   return el;
 }
 
@@ -74,4 +101,22 @@ test('particles respawn at edges after aging', () => {
   assert.ok(allAtEdges);
   const moving = dust.particles.some(p => p.vx !== 0 || p.vy !== 0);
   assert.ok(moving);
+});
+
+test('arrow keys cycle module selection', () => {
+  const overlay = bodyEl.children.find(c => c.id === 'modulePicker');
+  const buttons = overlay.querySelector('#moduleButtons').children;
+  assert.ok(buttons[0].className.includes('selected'));
+  overlay.dispatchEvent({ type: 'keydown', key: 'ArrowDown', preventDefault(){} });
+  assert.ok(buttons[1].className.includes('selected'));
+});
+
+test('enter key loads selected module', () => {
+  const overlay = bodyEl.children.find(c => c.id === 'modulePicker');
+  overlay.dispatchEvent({ type: 'keydown', key: 'ArrowUp', preventDefault(){} });
+  for (let i = 0; i < 6; i++) {
+    overlay.dispatchEvent({ type: 'keydown', key: 'ArrowDown', preventDefault(){} });
+  }
+  overlay.dispatchEvent({ type: 'keydown', key: 'Enter', preventDefault(){} });
+  assert.ok(global.location.href.includes('golden.module.json'));
 });


### PR DESCRIPTION
## Summary
- enable navigating module picker with arrow keys and Enter
- highlight selected module button
- add tests for keyboard navigation

## Testing
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade381c4988328bfaaa7e0ecd06061