### PR TITLE
feat: add scrap loan option in office

### DIFF
--- a/core/actions.js
+++ b/core/actions.js
@@ -8,6 +8,13 @@
           awardXP(leader(), amt);
         }
         if(typeof toast==='function') toast(`+${amt} XP`);
+      } else if (typeof reward==='string' && /^scrap\s*\d+/i.test(reward)) {
+        const amt = parseInt(reward.replace(/[^0-9]/g,''),10)||0;
+        if (typeof player === 'object') {
+          player.scrap = (player.scrap || 0) + amt;
+        }
+        if(typeof updateHUD==='function') updateHUD();
+        if(typeof toast==='function') toast(`+${amt} ${CURRENCY||'Scrap'}`);
       } else {
         const item = typeof resolveItem === 'function' ? resolveItem(reward) : null;
         if (item) {

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -235,10 +235,23 @@ const OFFICE_MODULE = (() => {
       name: 'Office Worker',
       desc: 'Busy typing at their desk.',
       portraitSheet: portraits.worker,
-      tree: () =>
-        flagValue('visited_forest')
-          ? { start: { text: 'Back from the forest already?', choices: [ { label: '(Leave)', to: 'bye' } ] } }
-          : { start: { text: 'Too busy to chat.', choices: [ { label: '(Leave)', to: 'bye' } ] } }
+      tree: () => {
+        const baseText = flagValue('visited_forest')
+          ? 'Back from the forest already?'
+          : 'Too busy to chat.';
+        const choices = [];
+        if (player.scrap < 2)
+          choices.push({ label: 'Borrow 2 scrap', to: 'borrow', reward: 'SCRAP 2' });
+        choices.push({ label: '(Leave)', to: 'bye' });
+        const nodes = { start: { text: baseText, choices } };
+        if (player.scrap < 2) {
+          nodes.borrow = {
+            text: 'Here, just bring it back.',
+            choices: [ { label: '(Thanks)', to: 'bye' } ]
+          };
+        }
+        return nodes;
+      }
     },
     {
       id: 'worker2',

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
 
 test('office module boards castle and unboards via dialog', () => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -30,4 +31,44 @@ test('office module places Boots of Speed near forest entry', () => {
   assert.match(src, /id: 'boots_of_speed'/);
   assert.match(src, /x: 3,\s*y: WORLD_MIDY/);
   assert.match(src, /mods: \{ AGI: 5 \}/);
+});
+
+test('office worker lends scrap when low', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const match = src.match(/\{\s*id: 'worker1',[\s\S]*?\n\s*\},\n\s*\{\s*id: 'worker2'/);
+  assert(match);
+  const objSrc = match[0].replace(/,\n\s*\{\s*id: 'worker2'.*/, '');
+  let hudCalled = false;
+  global.flagValue = () => 0;
+  global.player = { scrap: 1 };
+  global.updateHUD = () => { hudCalled = true; };
+  global.portraits = { worker: '' };
+  vm.runInThisContext(
+    fs.readFileSync(path.join(__dirname, '..', 'core', 'actions.js'), 'utf8')
+  );
+  const worker = vm.runInThisContext('(' + objSrc + ')');
+  const tree = worker.tree();
+  const loanChoice = tree.start.choices.find((c) => c.label === 'Borrow 2 scrap');
+  assert(loanChoice);
+  Actions.applyQuestReward(loanChoice.reward);
+  assert.equal(player.scrap, 3);
+  assert(hudCalled);
+});
+
+test('office worker hides loan if you have enough scrap', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const match = src.match(/\{\s*id: 'worker1',[\s\S]*?\n\s*\},\n\s*\{\s*id: 'worker2'/);
+  assert(match);
+  const objSrc = match[0].replace(/,\n\s*\{\s*id: 'worker2'.*/, '');
+  global.flagValue = () => 0;
+  global.player = { scrap: 5 };
+  global.updateHUD = () => {};
+  global.portraits = { worker: '' };
+  const worker = vm.runInThisContext('(' + objSrc + ')');
+  const tree = worker.tree();
+  assert(!tree.start.choices.some((c) => c.label === 'Borrow 2 scrap'));
 });


### PR DESCRIPTION
## Summary
- add core scrap reward to dialog actions
- let office worker lend scrap using reward instead of custom script
- adjust loan tests for new ability

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68ade3ec40f883288f551db4617cb59e