### PR TITLE
refactor: namespace movement helpers

### DIFF
--- a/balance-tester-agent.js
+++ b/balance-tester-agent.js
@@ -166,12 +166,12 @@ async function runBalanceTest() {
           const step = agent.path.shift();
           const dx = step.x - px;
           const dy = step.y - py;
-          await move(dx, dy);
+          await Dustland.movement.move(dx, dy);
           stats.pathDistance += Math.abs(dx) + Math.abs(dy);
           return;
         }
         if (agent.job) {
-          const p = PathQueue.pathFor(agent.job);
+          const p = Dustland.path.pathFor(agent.job);
           if (p) {
             agent.path = p.slice(1);
             agent.job = null;
@@ -182,7 +182,7 @@ async function runBalanceTest() {
         const target = findRandomGoal(map, agent.goal);
         if (target) {
           agent.goal = target;
-          agent.job = PathQueue.queue(map, { x: px, y: py }, agent.goal, leader.id);
+          agent.job = Dustland.path.queue(map, { x: px, y: py }, agent.goal, leader.id);
         }
       }
     };

--- a/core/movement.js
+++ b/core/movement.js
@@ -179,7 +179,7 @@ function move(dx,dy){
         checkRandomEncounter();
         EventBus.emit('sfx','step');
         // NPCs advance along paths after the player steps
-        if(typeof tickPathAI==='function') tickPathAI();
+        if (Dustland.path?.tickPathAI) Dustland.path.tickPathAI();
         moveDelay = 0;
         resolve();
       }, moveDelay);
@@ -346,7 +346,7 @@ function interact(){
 const movementSystem = { canWalk, move };
 const collisionSystem = { queryTile, canWalk };
 const interactionSystem = { adjacentNPC, takeNearestItem, interact, interactAt };
-Object.assign(globalThis, {
+const movement = {
   movementSystem,
   collisionSystem,
   interactionSystem,
@@ -364,4 +364,7 @@ Object.assign(globalThis, {
   getMoveDelay: () => moveDelay,
   checkRandomEncounter,
   distanceToRoad
-});
+};
+globalThis.Dustland = globalThis.Dustland || {};
+globalThis.Dustland.movement = movement;
+Object.assign(globalThis, movement);

--- a/docs/design/tech-debt-paydown.md
+++ b/docs/design/tech-debt-paydown.md
@@ -53,6 +53,8 @@ Our CRT playground is scrappy by design, but a few lingering habits slow our bui
   - [ ] Move module exports into `Dustland.*` buckets.
     - [x] Namespace event bus under `Dustland.eventBus`.
     - [x] Namespace event flag helpers under `Dustland.eventFlags`.
+    - [x] Namespace path helpers under `Dustland.path`.
+    - [x] Namespace movement helpers under `Dustland.movement`.
   - [ ] Update references and tests incrementally.
 - [ ] **Phase 2: Untangle UI from logic**
   - [ ] Replace direct DOM calls with event emissions.

--- a/dustland-path.js
+++ b/dustland-path.js
@@ -2,7 +2,6 @@
 // Simple A* pathfinding with async queue for Dustland
 (function(){
   console.log('[Path] Script loaded');
-  const PathQueue = { queue, pathFor };
   const state = { queue: [], busy:false, cache:new Map() };
 
   function queue(map, start, goal, ignoreId){
@@ -115,7 +114,7 @@
         continue;
       }
       if(st.job){
-        const p=PathQueue.pathFor(st.job);
+        const p=pathFor(st.job);
         if(p){
           st.path=p.slice(1);
           st.job=null;
@@ -131,6 +130,6 @@
       st.job=queue(n.map,{x:n.x,y:n.y},target,n.id);
     }
   }
-
-  Object.assign(globalThis,{ PathQueue, tickPathAI });
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.path = { queue, pathFor, tickPathAI };
 })();

--- a/test/balance-tester.test.js
+++ b/test/balance-tester.test.js
@@ -148,7 +148,7 @@ test('Game balance tester', () => {
       const dirMap = { up:[0,-1], down:[0,1], left:[-1,0], right:[1,0] };
       const dir = directions[Math.floor(Math.random() * directions.length)];
       const [dx, dy] = dirMap[dir];
-      move(dx, dy);
+      Dustland.movement.move(dx, dy);
     }
   };
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -117,7 +117,8 @@ for (const f of files) {
   vm.runInThisContext(code, { filename: f });
 }
 
-const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, findFreeDropTile, canWalk, move, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey, uncurseItem, save, makeInteriorRoom, placeHut, TILE, getTile, calcMoveDelay, getMoveDelay, healParty, buildings, world } = globalThis;
+const { clamp, createRNG, addToInv, equipItem, unequipItem, normalizeItem, player, party, state, Character, advanceDialog, applyModule, createNpcFactory, openDialog, closeDialog, NPCS, itemDrops, setLeader, resolveCheck, queryTile, interactAt, registerItem, getItem, setRNGSeed, useItem, registerTileEvents, buffs, handleDialogKey, worldFlags, makeNPC, Effects, openCombat, handleCombatKey, uncurseItem, save, makeInteriorRoom, placeHut, TILE, getTile, healParty, buildings, world } = globalThis;
+const { findFreeDropTile, canWalk, move, calcMoveDelay, getMoveDelay } = globalThis.Dustland.movement;
 let interiors = globalThis.interiors;
 
 // Stub out globals used by equipment functions

--- a/test/movement-namespace.test.js
+++ b/test/movement-namespace.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('movement exposes Dustland namespace', async () => {
+  const code = await fs.readFile(new URL('../core/movement.js', import.meta.url), 'utf8');
+  const context = { Dustland: {}, Effects: {}, state: { map: 'world' } };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  assert.ok(context.Dustland?.movement);
+  assert.strictEqual(context.move, context.Dustland.movement.move);
+  assert.strictEqual(typeof context.Dustland.move, 'undefined');
+});

--- a/test/npc-path.test.js
+++ b/test/npc-path.test.js
@@ -25,18 +25,18 @@ global.party = { x:5, y:5 };
 
 test('NPC follows waypoints with capped speed and waits when close', async () => {
   await import('../dustland-path.js');
-  window.tickPathAI();
+  window.Dustland.path.tickPathAI();
   await new Promise(r => setTimeout(r,20));
-  window.tickPathAI();
+  window.Dustland.path.tickPathAI();
   assert.strictEqual(NPCS[0].x, 1);
   party.x = 1; party.y = 0;
-  window.tickPathAI();
+  window.Dustland.path.tickPathAI();
   assert.strictEqual(NPCS[0].x, 1);
   party.x = 5; party.y = 5;
-  window.tickPathAI();
+  window.Dustland.path.tickPathAI();
   assert.strictEqual(NPCS[0].x, 1);
   await new Promise(r => setTimeout(r,210));
-  window.tickPathAI();
+  window.Dustland.path.tickPathAI();
   assert.strictEqual(NPCS[0].x, 2);
 });
 
@@ -51,9 +51,9 @@ test('NPC re-pathfinds after being moved', async () => {
     createElement: () => ({ children: [], classList:{ toggle(){}, contains(){ return false; }, add(){}, remove(){} }, style:{}, appendChild(){}, remove(){}, innerHTML:'', textContent:'', onclick:null }),
   };
   await import('../core/dialog.js');
-  window.tickPathAI();
+  window.Dustland.path.tickPathAI();
   await new Promise(r => setTimeout(r,20));
-  window.tickPathAI();
+  window.Dustland.path.tickPathAI();
   assert.strictEqual(NPCS[0].x, 1);
   const stPre = NPCS[0]._loop;
   assert.ok(stPre && (stPre.path.length > 0 || stPre.job));

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -22,9 +22,9 @@ global.NPCS = [];
 
 test('PathQueue finds a path', async () => {
   await import('../dustland-path.js');
-  const key = window.PathQueue.queue('world',{x:0,y:0},{x:2,y:2});
+  const key = window.Dustland.path.queue('world',{x:0,y:0},{x:2,y:2});
   await new Promise(r => setTimeout(r,20));
-  const path = window.PathQueue.pathFor(key);
+  const path = window.Dustland.path.pathFor(key);
   assert.ok(path && path.length > 0, 'path exists');
   assert.deepStrictEqual(path[0], {x:0,y:0});
   assert.deepStrictEqual(path[path.length-1], {x:2,y:2});


### PR DESCRIPTION
## Summary
- expose pathfinding queue and AI tick under `Dustland.path`
- expose movement utilities under `Dustland.movement` and keep legacy globals
- update balance tester, tests, and tech-debt plan to use the new namespaces

## Testing
- `./install-deps.sh`
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68adeb0643ec83289724b780518339cf