### PR TITLE
refactor: namespace effects module

### DIFF
--- a/core/effects.js
+++ b/core/effects.js
@@ -129,6 +129,8 @@
     }
   };
 
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.effects = Effects;
   globalThis.Effects = Effects;
 })();
 

--- a/core/movement.js
+++ b/core/movement.js
@@ -1,4 +1,5 @@
-const { Effects } = globalThis;
+const { Dustland } = globalThis;
+const { effects: Effects } = Dustland || {};
 
 // active temporary stat modifiers
 const buffs = [];              // 2c342c / 313831

--- a/docs/design/tech-debt-paydown.md
+++ b/docs/design/tech-debt-paydown.md
@@ -55,6 +55,7 @@ Our CRT playground is scrappy by design, but a few lingering habits slow our bui
     - [x] Namespace event flag helpers under `Dustland.eventFlags`.
     - [x] Namespace path helpers under `Dustland.path`.
     - [x] Namespace movement helpers under `Dustland.movement`.
+    - [x] Namespace effects under `Dustland.effects`.
   - [ ] Update references and tests incrementally.
 - [ ] **Phase 2: Untangle UI from logic**
   - [ ] Replace direct DOM calls with event emissions.

--- a/test/duststorm.effects.test.js
+++ b/test/duststorm.effects.test.js
@@ -20,15 +20,16 @@ const setup = async () => {
 
 test('dustStorm and addSoundSource effects', async () => {
   const dom = await setup();
-  const { Effects } = globalThis;
+  const { effects } = globalThis.Dustland;
+  assert.strictEqual(globalThis.Effects, effects);
 
-  Effects.apply([{ effect: 'dustStorm', active: true }]);
+  effects.apply([{ effect: 'dustStorm', active: true }]);
   assert.ok(document.getElementById('dustStorm'));
 
-  Effects.apply([{ effect: 'addSoundSource', id: 'chime1', x: 2, y: 3 }]);
+  effects.apply([{ effect: 'addSoundSource', id: 'chime1', x: 2, y: 3 }]);
   assert.deepStrictEqual(global.soundSources, [{ id: 'chime1', x: 2, y: 3, map: 'dust_storm' }]);
 
-  Effects.apply([{ effect: 'dustStorm', active: false }]);
+  effects.apply([{ effect: 'dustStorm', active: false }]);
   assert.strictEqual(document.getElementById('dustStorm'), null);
 
   dom.window.close();

--- a/test/effects-namespace.test.js
+++ b/test/effects-namespace.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('effects exposes Dustland namespace', async () => {
+  const code = await fs.readFile(new URL('../core/effects.js', import.meta.url), 'utf8');
+  const context = { Dustland: {}, soundSources: [], state: { map: 'world' } };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  assert.ok(context.Dustland?.effects);
+  assert.strictEqual(context.Effects, context.Dustland.effects);
+  assert.strictEqual(typeof context.Dustland.Effects, 'undefined');
+});

--- a/test/movement-namespace.test.js
+++ b/test/movement-namespace.test.js
@@ -5,7 +5,7 @@ import vm from 'node:vm';
 
 test('movement exposes Dustland namespace', async () => {
   const code = await fs.readFile(new URL('../core/movement.js', import.meta.url), 'utf8');
-  const context = { Dustland: {}, Effects: {}, state: { map: 'world' } };
+  const context = { Dustland: { effects: {} }, state: { map: 'world' } };
   vm.createContext(context);
   vm.runInContext(code, context);
   assert.ok(context.Dustland?.movement);


### PR DESCRIPTION
## Summary
- namespace effects under `Dustland.effects`
- reference namespaced effects in movement helpers
- cover `Dustland.effects` with tests and docs

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68adee5e843483288e8cfd05e1fc097a