### PR TITLE
feat: namespace actions under Dustland

### DIFF
--- a/core/actions.js
+++ b/core/actions.js
@@ -35,5 +35,7 @@
       if(typeof globalThis.openShop==='function') return globalThis.openShop(npc);
     }
   };
-  Object.assign(globalThis, { Actions });
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.actions = Actions;
+  globalThis.Actions = Actions;
 })();

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -9,6 +9,7 @@ let currentNPC=null;
 Object.defineProperty(globalThis,'currentNPC',{get:()=>currentNPC,set:v=>{currentNPC=v;}});
 const dialogState={ tree:null, node:null };
 let selectedChoice=0;
+const { Dustland } = globalThis;
 
 function dlgHighlightChoice(){
   [...choicesEl.children].forEach((c,i)=>{
@@ -156,7 +157,7 @@ function advanceDialog(stateObj, choiceIdx){
     if(!hasEnough){
       return finalize(choice.failure || 'You lack the required item.', false, true);
     }
-    Actions.applyQuestReward(choice.reward);
+    Dustland.actions.applyQuestReward(choice.reward);
     joinParty(choice.join);
     processQuestFlag(choice);
     runEffects(choice.effects);
@@ -187,7 +188,7 @@ function advanceDialog(stateObj, choiceIdx){
       if (itemIdx > -1) removeFromInv(itemIdx);
     }
 
-    Actions.applyQuestReward(choice.reward);
+    Dustland.actions.applyQuestReward(choice.reward);
     joinParty(choice.join);
     processQuestFlag(choice);
     runEffects(choice.effects);
@@ -206,7 +207,7 @@ function advanceDialog(stateObj, choiceIdx){
     }
   }
 
-  Actions.applyQuestReward(choice.reward);
+  Dustland.actions.applyQuestReward(choice.reward);
   joinParty(choice.join);
   processQuestFlag(choice);
   runEffects(choice.effects);

--- a/core/movement.js
+++ b/core/movement.js
@@ -197,7 +197,7 @@ function checkAggro(){
     if(n.map!==state.map) continue;
     const d = Math.abs(n.x - party.x) + Math.abs(n.y - party.y);
     if(d<=3){
-      Actions.startCombat({ ...n.combat, npc:n, name:n.name });
+      Dustland.actions.startCombat({ ...n.combat, npc:n, name:n.name });
       break;
     }
   }
@@ -229,7 +229,7 @@ function checkRandomEncounter(){
   const chance = Math.min(dist * 0.02, 0.5);
   if(Math.random() < chance){
     const def = bank[Math.floor(Math.random()*bank.length)];
-    Actions.startCombat(def);
+    Dustland.actions.startCombat(def);
   }
 }
 function adjacentNPC(){

--- a/core/npc.js
+++ b/core/npc.js
@@ -1,11 +1,12 @@
 // ===== NPCs =====
+const { Dustland } = globalThis;
 class NPC {
   constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null}) {
     Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet});
     const capNode = (node) => {
       if (this.combat && node === 'do_fight') {
         closeDialog();
-        Actions.startCombat({ ...this.combat, npc: this, name: this.name });
+        Dustland.actions.startCombat({ ...this.combat, npc: this, name: this.name });
       } else if (this.shop && node === 'sell') {
         const items = player.inv.map((it, idx) => ({label: `Sell ${it.name} (${Math.max(1, it.value || 0)} ${CURRENCY})`, to: 'sell', sellIndex: idx}));
         this.tree.sell.text = items.length ? 'What are you selling?' : 'Nothing to sell.';
@@ -13,7 +14,7 @@ class NPC {
         this.tree.sell.choices = items;
       } else if (this.shop && node === 'buy') {
         closeDialog();
-        Actions.openShop(this);
+        Dustland.actions.openShop(this);
         return;
       }
     };

--- a/docs/design/tech-debt-paydown.md
+++ b/docs/design/tech-debt-paydown.md
@@ -55,7 +55,8 @@ Our CRT playground is scrappy by design, but a few lingering habits slow our bui
     - [x] Namespace event flag helpers under `Dustland.eventFlags`.
     - [x] Namespace path helpers under `Dustland.path`.
     - [x] Namespace movement helpers under `Dustland.movement`.
-    - [x] Namespace effects under `Dustland.effects`.
+  - [x] Namespace effects under `Dustland.effects`.
+    - [x] Namespace actions under `Dustland.actions`.
   - [ ] Update references and tests incrementally.
 - [ ] **Phase 2: Untangle UI from logic**
   - [ ] Replace direct DOM calls with event emissions.

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -796,16 +796,16 @@ test('makeNPC normalizes existing fight choices', () => {
 
 test('fight choice triggers combat', () => {
   NPCS.length = 0;
-  const orig = Actions.startCombat;
+  const orig = globalThis.Dustland.actions.startCombat;
   let triggered = false;
-  Actions.startCombat = () => { triggered = true; };
+  globalThis.Dustland.actions.startCombat = () => { triggered = true; };
   const npc = makeNPC('rival', 'world', 0, 0, '#fff', 'Rival', '', '', null, null, null, null, { combat: { DEF: 1 } });
   NPCS.push(npc);
   openDialog(npc);
   const fightBtn = choicesEl.children.find(c => c.textContent === '(Fight)');
   fightBtn.onclick();
   assert.ok(triggered);
-  Actions.startCombat = orig;
+  globalThis.Dustland.actions.startCombat = orig;
 });
 
 test('boss special telegraphs before striking', async () => {
@@ -1253,7 +1253,7 @@ test('distance to road increases encounter chance', () => {
   let started = false;
   const origRand = Math.random;
   Math.random = () => 0;
-  Actions.startCombat = () => { started = true; };
+  globalThis.Dustland.actions.startCombat = () => { started = true; };
   checkRandomEncounter();
   Math.random = origRand;
   assert.ok(started);
@@ -1268,7 +1268,7 @@ test('no encounters occur on roads', () => {
   let started = false;
   const origRand = Math.random;
   Math.random = () => 0;
-  Actions.startCombat = () => { started = true; };
+  globalThis.Dustland.actions.startCombat = () => { started = true; };
   checkRandomEncounter();
   Math.random = origRand;
   assert.ok(!started);

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -52,7 +52,7 @@ test('office worker lends scrap when low', () => {
   const tree = worker.tree();
   const loanChoice = tree.start.choices.find((c) => c.label === 'Borrow 2 scrap');
   assert(loanChoice);
-  Actions.applyQuestReward(loanChoice.reward);
+  globalThis.Dustland.actions.applyQuestReward(loanChoice.reward);
   assert.equal(player.scrap, 3);
   assert(hudCalled);
 });


### PR DESCRIPTION
## Summary
- scope Actions module under globalThis.Dustland
- update dialog, movement, and NPC logic to use Dustland.actions
- tick off actions namespacing in tech debt plan

## Testing
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js` *(fails: TypeError: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68adf377ec188328b442c95247895964