### PR TITLE
fix: guard NPC references when absent

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -226,7 +226,7 @@ function advanceDialog(stateObj, choiceIdx){
   if (choice.spawn) {
     const template = npcTemplates.find(t => t.id === choice.spawn.templateId);
     if (template) {
-      const id = getNextId(template.id, NPCS);
+      const id = getNextId(template.id, typeof NPCS !== 'undefined' ? NPCS : []);
       const x = choice.spawn.x;
       const y = choice.spawn.y;
       const combat = template.combat ? {...template.combat} : {};
@@ -235,7 +235,7 @@ function advanceDialog(stateObj, choiceIdx){
         combat.challenge = choice.spawn.challenge;
       }
       const npc = makeNPC(id, state.map, x, y, template.color, template.name, '', template.desc, {}, null, null, null, { combat });
-      NPCS.push(npc);
+      if (typeof NPCS !== 'undefined') NPCS.push(npc);
     }
   }
 

--- a/core/movement.js
+++ b/core/movement.js
@@ -101,7 +101,7 @@ function currentGrid(){ return gridFor(mapIdForState()); }
 function queryTile(x,y,map=mapIdForState()){
   const tile=getTile(map,x,y);
   if(tile===null) return {tile:null, walkable:false, entities:[], items:[]};
-  const entities=NPCS.filter(n=> n.map===map && n.x===x && n.y===y);
+  const entities=(typeof NPCS !== 'undefined' ? NPCS : []).filter(n=> n.map===map && n.x===x && n.y===y);
   const items=itemDrops.filter(it=> it.map===map && it.x===x && it.y===y);
   const walkableFlag=!!(walkable[tile] && entities.length===0 && items.length===0);
   return {tile, walkable:walkableFlag, entities, items};
@@ -192,7 +192,7 @@ function move(dx,dy){
 
 function checkAggro(){
   if(typeof document !== 'undefined' && document.getElementById('combatOverlay')?.classList?.contains?.('shown')) return;
-  for(const n of NPCS){
+  for(const n of (typeof NPCS !== 'undefined' ? NPCS : [])){
     if(!n.combat || !n.combat.auto) continue;
     if(n.map!==state.map) continue;
     const d = Math.abs(n.x - party.x) + Math.abs(n.y - party.y);

--- a/core/party.js
+++ b/core/party.js
@@ -106,7 +106,7 @@ class Character {
     }
     this.splice(idx,1);
     renderParty(); updateHUD();
-    if(typeof makeNPC==='function' && Array.isArray(NPCS)){
+    if(typeof makeNPC==='function' && typeof NPCS !== 'undefined' && Array.isArray(NPCS)){
       const tree={ start:{ text:'', choices:[{label:'(Leave)', to:'bye'}] }, bye:{ text:'' } };
       const npc=makeNPC(member.id, this.map, this.x, this.y, '#fff', member.name, '', '', tree);
       NPCS.push(npc);

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -274,7 +274,7 @@ function revealHiddenNPCs(){
       if(n.portraitSheet) opts.portraitSheet=n.portraitSheet;
       const npc=makeNPC(n.id, n.map||'world', n.x, n.y, n.color||'#9ef7a0', n.name||n.id, n.title||'', n.desc||'', n.tree, quest, null, null, opts);
       if (Array.isArray(n.loop)) npc.loop = n.loop;
-      NPCS.push(npc);
+      if (typeof NPCS !== 'undefined') NPCS.push(npc);
       hiddenNPCs.splice(i,1);
     }
   }
@@ -312,7 +312,7 @@ function applyModule(data = {}, options = {}) {
     itemDrops.length = 0;
     if (typeof ITEMS !== 'undefined') Object.keys(ITEMS).forEach(k => delete ITEMS[k]);
     if (typeof quests !== 'undefined') Object.keys(quests).forEach(k => delete quests[k]);
-    NPCS.length = 0;
+    if (typeof NPCS !== 'undefined') NPCS.length = 0;
     hiddenNPCs.length = 0;
     npcTemplates.length = 0;
     Object.keys(enemyBanks).forEach(k => delete enemyBanks[k]);
@@ -400,7 +400,7 @@ function applyModule(data = {}, options = {}) {
     if (n.portraitSheet) opts.portraitSheet = n.portraitSheet;
     const npc = makeNPC(n.id, n.map || 'world', n.x, n.y, n.color || '#9ef7a0', n.name || n.id, n.title || '', n.desc || '', tree, quest, null, null, opts);
     if (Array.isArray(n.loop)) npc.loop = n.loop;
-    NPCS.push(npc);
+    if (typeof NPCS !== 'undefined') NPCS.push(npc);
   });
   revealHiddenNPCs();
   return moduleData;
@@ -509,7 +509,7 @@ function placeHut(x,y,b={}){
 
 // ===== Save/Load & Start =====
 function save(){
-  const npcData = NPCS.map(n=>({
+  const npcData = (typeof NPCS !== 'undefined' ? NPCS : []).map(n=>({
     id:n.id,
     map:n.map,
     x:n.x,
@@ -555,7 +555,7 @@ function load(){
   });
 
   const npcFactory = createNpcFactory(d.npcs || []);
-  NPCS.length=0;
+  if (typeof NPCS !== 'undefined') NPCS.length = 0;
   (d.npcs||[]).forEach(n=>{
     const f=npcFactory[n.id];
     if(f){
@@ -566,7 +566,7 @@ function load(){
         if(quests[n.quest.id]) npc.quest=quests[n.quest.id];
         else if(npc.quest) npc.quest.status=n.quest.status;
       }
-      NPCS.push(npc);
+      if (typeof NPCS !== 'undefined') NPCS.push(npc);
     }
   });
   party.length=0;

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -279,7 +279,7 @@ function render(gameState=state, dt){
   const offY = Math.max(0, Math.floor((vH - H) / 2));
 
   const items = gameState.itemDrops || itemDrops;
-  const entities = gameState.entities || NPCS;
+  const entities = gameState.entities || (typeof NPCS !== 'undefined' ? NPCS : []);
   const pos = gameState.party || party;
 
   // split entities into below/above
@@ -791,7 +791,7 @@ if (document.getElementById('saveBtn')) {
           renderParty();
           toast(`Leader: ${party[selectedMember].name}`);
           if(window.NanoDialog){
-            const near = NPCS.filter(n => n.map === state.map
+            const near = (typeof NPCS !== 'undefined' ? NPCS : []).filter(n => n.map === state.map
               && Math.abs(n.x - party.x) + Math.abs(n.y - party.y) < 10);
             near.forEach(n => NanoDialog.queueForNPC(n, 'start', 'leader change'));
           }

--- a/dustland-path.js
+++ b/dustland-path.js
@@ -99,7 +99,7 @@
   // Step NPCs along their waypoint loops. Invoked after player moves.
   function tickPathAI(){
     const now = Date.now();
-    for(const n of NPCS){
+    for(const n of (typeof NPCS !== 'undefined' ? NPCS : [])){
       const pts=n.loop;
       if(!Array.isArray(pts) || pts.length<2) continue;
       n._loop = n._loop || { idx:1, path:[], job:null };


### PR DESCRIPTION
## Summary
- Avoid `NPCS` reference errors by checking for its existence across engine, core, and path logic
- Skip NPC reset and save/load operations when no NPCs are present
- Safely iterate and spawn NPCs only if the global list exists

## Testing
- `npm test` *(fails: 4 tests)*
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68adf7ca82a48328aa8048075e40b638