### PR TITLE
feat: add base equipment set

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -157,6 +157,7 @@
   <script defer src="./event-bus.js"></script>
   <script defer src="./core/effects.js"></script>
   <script defer src="./core/inventory.js"></script>
+  <script defer src="./core/equipment.js"></script>
   <script defer src="./core/actions.js"></script>
   <script defer src="./core/movement.js"></script>
   <script defer src="./core/dialog.js"></script>

--- a/core/equipment.js
+++ b/core/equipment.js
@@ -1,0 +1,37 @@
+(function(){
+  registerItem({
+    id: 'pipe_blade',
+    name: 'Pipe Blade',
+    type: 'weapon',
+    slot: 'weapon',
+    mods: { ATK: 2, ADR: 12 }
+  });
+  registerItem({
+    id: 'stun_baton',
+    name: 'Stun Baton',
+    type: 'weapon',
+    slot: 'weapon',
+    mods: { ATK: 1, ADR: 15, adrenaline_gen_mod: 1.2 }
+  });
+  registerItem({
+    id: 'leather_jacket',
+    name: 'Leather Jacket',
+    type: 'armor',
+    slot: 'armor',
+    mods: { DEF: 1 }
+  });
+  registerItem({
+    id: 'scavenger_rig',
+    name: 'Scavenger Rig',
+    type: 'armor',
+    slot: 'armor',
+    mods: { DEF: 1, adrenaline_gen_mod: 1.1 }
+  });
+  registerItem({
+    id: 'juggernaut_plate',
+    name: 'Juggernaut Plate',
+    type: 'armor',
+    slot: 'armor',
+    mods: { DEF: 3, adrenaline_gen_mod: 0.9 }
+  });
+})();

--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -104,7 +104,7 @@ The prototype doesn't spend Adrenaline yet; it's a pacing probe. Once the gain c
 - [x] **New HUD:** Redesign the combat UI to include the Adrenaline bar, status effect icons, and improved health bar feedback.
 - [x] **Player Health Panel:** Update the right-side player health panel to show damage being taken in real-time, with visual effects for critical health and passing out.
 - [ ] **Implement 5-10 Specials:** Create a starter set of special moves (e.g., "Power Strike," "Stun Grenade," "First Aid").
-- [ ] **Implement Equipment:** Create a set of weapons and armor with varied combat modifiers.
+ - [x] **Implement Equipment:** Create a set of weapons and armor with varied combat modifiers.
 - [ ] **Enemy Design:** Create 3-5 new enemy types that require tactical use of specials (e.g., a "Shielded Guard" that is resistant to basic attacks).
 - [ ] **HUD Playtest:** Run quick usability tests on the new HUD and iterate on spacing and icon clarity.
 

--- a/dustland.html
+++ b/dustland.html
@@ -159,6 +159,7 @@
     <script defer src="./core/effects.js"></script>
     <script defer src="./core/spoils-cache.js"></script>
     <script defer src="./core/inventory.js"></script>
+    <script defer src="./core/equipment.js"></script>
     <script defer src="./core/actions.js"></script>
     <script defer src="./core/movement.js"></script>
     <script defer src="./core/dialog.js"></script>

--- a/test/equipment.test.js
+++ b/test/equipment.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+// Minimal stubs for globals used by core modules
+globalThis.EventBus = { emit() {} };
+globalThis.log = () => {};
+globalThis.toast = () => {};
+globalThis.player = { inv: [] };
+
+await import('../core/inventory.js');
+await import('../core/party.js');
+await import('../core/equipment.js');
+
+test('base equipment items are registered', () => {
+  const sword = getItem('pipe_blade');
+  assert.ok(sword, 'pipe_blade registered');
+  assert.strictEqual(sword.mods.ATK, 2);
+  assert.strictEqual(sword.mods.ADR, 12);
+  const armor = getItem('leather_jacket');
+  assert.ok(armor, 'leather_jacket registered');
+  assert.strictEqual(armor.mods.DEF, 1);
+});
+
+test('equipment modifiers apply to characters', () => {
+  const c = new Character('id', 'Hero', 'fighter');
+  c.equip.weapon = getItem('pipe_blade');
+  c.equip.armor = getItem('juggernaut_plate');
+  c.applyEquipmentStats();
+  assert.strictEqual(c._bonus.ATK, 2);
+  assert.strictEqual(c._bonus.DEF, 3);
+});
+
+test('adrenaline modifiers are applied', () => {
+  const c = new Character('id2', 'Scout', 'scout');
+  c.equip.armor = getItem('scavenger_rig');
+  c.applyCombatMods();
+  assert.strictEqual(c.adrGenMod, 1.1);
+});


### PR DESCRIPTION
## Summary
- register starter weapons and armor with combat modifiers
- load equipment script in game and balance tester
- mark combat design doc equipment task complete

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68adf40eca78832899d38fc03494c4b4