### PR TITLE
Fix openCreator race and Dustland redeclaration in ACK playtest

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -5,8 +5,16 @@
 
 // Prevent the engine from auto-starting the creator or start menu
 window.showStart = () => {};
-const realOpenCreator = openCreator;
-window.openCreator = () => {};
+let realOpenCreator = null;
+function captureOpenCreator() {
+  if (typeof window.openCreator === 'function') {
+    realOpenCreator = window.openCreator;
+    window.openCreator = () => {};
+  } else {
+    setTimeout(captureOpenCreator, 0);
+  }
+}
+captureOpenCreator();
 
 
 let moduleData = null;
@@ -23,8 +31,10 @@ if (playData) {
     moduleData = JSON.parse(playData);
     localStorage.removeItem(PLAYTEST_KEY);
     loader.style.display = 'none';
-    window.openCreator = realOpenCreator;
-    realOpenCreator();
+    if (realOpenCreator) {
+      window.openCreator = realOpenCreator;
+      realOpenCreator();
+    }
   } catch (e) {
     localStorage.removeItem(PLAYTEST_KEY);
   }
@@ -42,8 +52,10 @@ if (!moduleData && autoUrl) {
 async function loadModule(data) {
   moduleData = data;
   loader.style.display = 'none';
-  window.openCreator = realOpenCreator;
-  realOpenCreator();
+  if (realOpenCreator) {
+    window.openCreator = realOpenCreator;
+    realOpenCreator();
+  }
 }
 
 urlBtn.onclick = async () => {

--- a/core/dialog.js
+++ b/core/dialog.js
@@ -9,7 +9,7 @@ let currentNPC=null;
 Object.defineProperty(globalThis,'currentNPC',{get:()=>currentNPC,set:v=>{currentNPC=v;}});
 const dialogState={ tree:null, node:null };
 let selectedChoice=0;
-const { Dustland } = globalThis;
+var Dustland = globalThis.Dustland;
 
 function dlgHighlightChoice(){
   [...choicesEl.children].forEach((c,i)=>{

--- a/core/movement.js
+++ b/core/movement.js
@@ -1,4 +1,4 @@
-const { Dustland } = globalThis;
+var Dustland = globalThis.Dustland;
 const { effects: Effects } = Dustland || {};
 
 // active temporary stat modifiers

--- a/core/npc.js
+++ b/core/npc.js
@@ -1,5 +1,5 @@
 // ===== NPCs =====
-const { Dustland } = globalThis;
+var Dustland = globalThis.Dustland;
 class NPC {
   constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null}) {
     Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet});


### PR DESCRIPTION
## Summary
- Wait for `openCreator` before stubbing it so ACK player no longer throws `ReferenceError`
- Replace `const { Dustland }` with reusable `var Dustland` in core scripts to prevent redeclaration crashes

## Testing
- `./install-deps.sh`
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(errors: showTab failed, TypeError: Cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68ae09006b7083289a4b1e2dfb68ef08