### PR TITLE
feat: derive scrap value from item stats and mods

### DIFF
--- a/core/dialog.js
+++ b/core/dialog.js
@@ -9,7 +9,7 @@ let currentNPC=null;
 Object.defineProperty(globalThis,'currentNPC',{get:()=>currentNPC,set:v=>{currentNPC=v;}});
 const dialogState={ tree:null, node:null };
 let selectedChoice=0;
-const { Dustland } = globalThis;
+const { Dustland: DDialog } = globalThis;
 
 function dlgHighlightChoice(){
   [...choicesEl.children].forEach((c,i)=>{
@@ -157,7 +157,7 @@ function advanceDialog(stateObj, choiceIdx){
     if(!hasEnough){
       return finalize(choice.failure || 'You lack the required item.', false, true);
     }
-    Dustland.actions.applyQuestReward(choice.reward);
+    DDialog.actions.applyQuestReward(choice.reward);
     joinParty(choice.join);
     processQuestFlag(choice);
     runEffects(choice.effects);
@@ -188,7 +188,7 @@ function advanceDialog(stateObj, choiceIdx){
       if (itemIdx > -1) removeFromInv(itemIdx);
     }
 
-    Dustland.actions.applyQuestReward(choice.reward);
+    DDialog.actions.applyQuestReward(choice.reward);
     joinParty(choice.join);
     processQuestFlag(choice);
     runEffects(choice.effects);
@@ -207,7 +207,7 @@ function advanceDialog(stateObj, choiceIdx){
     }
   }
 
-  Dustland.actions.applyQuestReward(choice.reward);
+  DDialog.actions.applyQuestReward(choice.reward);
   joinParty(choice.join);
   processQuestFlag(choice);
   runEffects(choice.effects);
@@ -219,7 +219,7 @@ function advanceDialog(stateObj, choiceIdx){
     } else if (op === 'add') {
       incFlag(flag, value);
     } else if (op === 'clear') {
-      Dustland.eventFlags.clear(flag);
+      DDialog.eventFlags.clear(flag);
     }
   }
 

--- a/core/item-generator.js
+++ b/core/item-generator.js
@@ -45,6 +45,16 @@ const ItemGen = {
   randRange(min, max, rng){
     return min + Math.floor(rng() * (max - min + 1));
   },
+  calcScrap(item){
+    let total = 0;
+    const stats = item.stats || {};
+    for(const val of Object.values(stats))
+      if(typeof val === 'number') total += val;
+    const mods = item.mods || {};
+    for(const val of Object.values(mods))
+      if(typeof val === 'number') total += Math.abs(val);
+    return Math.max(1, Math.round(total / 2));
+  },
   generate(rank='rusted', rng=Math.random){
     const type = this.pick(this.types, rng);
     const adj = this.pick(this.adjectives, rng);
@@ -56,9 +66,9 @@ const ItemGen = {
       type,
       name: `${adj} ${noun}`,
       rank,
-      stats: { power },
-      scrap: Math.round(power / 2)
+      stats: { power }
     };
+    item.scrap = this.calcScrap(item);
     if(type === 'oddity'){
       item.lore = this.pick(this.oddityLore, rng);
     }

--- a/core/movement.js
+++ b/core/movement.js
@@ -1,5 +1,5 @@
-const { Dustland } = globalThis;
-const { effects: Effects } = Dustland || {};
+const { Dustland: DMove } = globalThis;
+const { effects: Effects } = DMove || {};
 
 // active temporary stat modifiers
 const buffs = [];              // 2c342c / 313831
@@ -180,7 +180,7 @@ function move(dx,dy){
         checkRandomEncounter();
         EventBus.emit('sfx','step');
         // NPCs advance along paths after the player steps
-        if (Dustland.path?.tickPathAI) Dustland.path.tickPathAI();
+        if (DMove.path?.tickPathAI) DMove.path.tickPathAI();
         moveDelay = 0;
         resolve();
       }, moveDelay);
@@ -197,7 +197,7 @@ function checkAggro(){
     if(n.map!==state.map) continue;
     const d = Math.abs(n.x - party.x) + Math.abs(n.y - party.y);
     if(d<=3){
-      Dustland.actions.startCombat({ ...n.combat, npc:n, name:n.name });
+      DMove.actions.startCombat({ ...n.combat, npc:n, name:n.name });
       break;
     }
   }
@@ -229,7 +229,7 @@ function checkRandomEncounter(){
   const chance = Math.min(dist * 0.02, 0.5);
   if(Math.random() < chance){
     const def = bank[Math.floor(Math.random()*bank.length)];
-    Dustland.actions.startCombat(def);
+    DMove.actions.startCombat(def);
   }
 }
 function adjacentNPC(){

--- a/core/npc.js
+++ b/core/npc.js
@@ -1,12 +1,12 @@
 // ===== NPCs =====
-const { Dustland } = globalThis;
+const { Dustland: DNpc } = globalThis;
 class NPC {
   constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null}) {
     Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet});
     const capNode = (node) => {
       if (this.combat && node === 'do_fight') {
         closeDialog();
-        Dustland.actions.startCombat({ ...this.combat, npc: this, name: this.name });
+        DNpc.actions.startCombat({ ...this.combat, npc: this, name: this.name });
       } else if (this.shop && node === 'sell') {
         const items = player.inv.map((it, idx) => ({label: `Sell ${it.name} (${Math.max(1, it.value || 0)} ${CURRENCY})`, to: 'sell', sellIndex: idx}));
         this.tree.sell.text = items.length ? 'What are you selling?' : 'Nothing to sell.';
@@ -14,7 +14,7 @@ class NPC {
         this.tree.sell.choices = items;
       } else if (this.shop && node === 'buy') {
         closeDialog();
-        Dustland.actions.openShop(this);
+        DNpc.actions.openShop(this);
         return;
       }
     };

--- a/test/item-generator.test.js
+++ b/test/item-generator.test.js
@@ -15,7 +15,7 @@ test('generator creates item with type, name, and stats', () => {
   assert.strictEqual(item.name, 'Grit-Stitched Repeater');
   assert.strictEqual(item.rank, 'sealed');
   assert.ok(item.stats.power >= 3 && item.stats.power <= 5);
-  assert.strictEqual(item.scrap, Math.round(item.stats.power / 2));
+  assert.strictEqual(item.scrap, ItemGen.calcScrap(item));
 });
 
 test('generated items have unique ids', () => {
@@ -49,4 +49,10 @@ test('oddity items include lore snippet', () => {
   const item = ItemGen.generate('rusted', rng);
   assert.strictEqual(item.type, 'oddity');
   assert.ok(ItemGen.oddityLore.includes(item.lore));
+});
+
+test('scrap value accounts for stats and mods', () => {
+  const item = { stats: { power: 4, speed: 2 }, mods: { DEF: 3 } };
+  const expected = Math.round((4 + 2 + 3) / 2);
+  assert.strictEqual(ItemGen.calcScrap(item), expected);
 });


### PR DESCRIPTION
## Summary
- compute scrap value from numeric stats and modifiers via new `calcScrap`
- adjust item generation and tests for new scrap calculation
- alias Dustland in core modules to avoid redeclaration during tests

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae080211dc8328890e87215abdddca