### PR TITLE
fix: remove default module from core startGame

### DIFF
--- a/dustland-core.js
+++ b/dustland-core.js
@@ -753,7 +753,7 @@ if (creator?.addEventListener) creator.addEventListener('keydown', e => {
 });
 
 function startGame(){
-  applyModule(MARA_PUZZLE);
+  // No default module; callers should apply their own module data.
 }
 
 on('inventory:changed', () => {

--- a/test/core-startgame.test.js
+++ b/test/core-startgame.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('core startGame has no default module', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const src = fs.readFileSync(path.join(__dirname, '..', 'dustland-core.js'), 'utf8');
+  const match = src.match(/function startGame\(\)\{[\s\S]*?\n\}/);
+  assert(match);
+  assert(!match[0].includes('applyModule'));
+});


### PR DESCRIPTION
## Summary
- stop `dustland-core` from applying MARA_PUZZLE by default
- add test ensuring `startGame` doesn't auto-apply modules

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e16b1a08328bc695293623f3a75