### PR TITLE
fix: restore Add Item button after placement

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -1526,6 +1526,7 @@ function addItem() {
   }
   editItemIdx = -1;
   document.getElementById('addItem').textContent = 'Add Item';
+  document.getElementById('addItem').style.display = 'block';
   document.getElementById('cancelItem').style.display = 'none';
   document.getElementById('delItem').style.display = 'none';
   loadMods({});


### PR DESCRIPTION
## Summary
- ensure the Add Item button reappears after placing or updating items in Adventure Kit

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae2e80694c8328aee31ccfb3ffcaaa