### PR TITLE
feat: add Memory Worm boss drop

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -288,6 +288,7 @@ function doAttack(dmg){
     log?.(`${target.name} is defeated!`);
     globalThis.EventBus?.emit?.('enemy:defeated', { target });
     if(target.loot) addToInv?.(target.loot);
+    if(target.boss && Math.random() < 0.1){ addToInv?.('memory_worm'); }
     if(typeof SpoilsCache !== 'undefined'){
       const cache = SpoilsCache.rollDrop?.(target.challenge);
       if(cache){

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -687,7 +687,7 @@ const DUSTLAND_MODULE = (() => {
       desc: 'A towering mass of twisted metal.',
       portraitSheet: 'assets/portraits/portrait_1084.png',
       tree: { start: { text: 'The behemoth looms.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
-      combat: { HP: 30, ATK: 3, DEF: 2, loot: 'raider_knife', special: { cue: 'crackles with energy!', dmg: 5, delay: 1000 } }
+      combat: { HP: 30, ATK: 3, DEF: 2, loot: 'raider_knife', boss: true, special: { cue: 'crackles with energy!', dmg: 5, delay: 1000 } }
     }
   ];
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -459,6 +459,42 @@ test('respec consumes memory worm and restores skill points', () => {
   assert.strictEqual(c.skillPoints, 2);
 });
 
+test('bosses can drop memory worms', async () => {
+  NPCS.length = 0;
+  party.length = 0;
+  player.inv.length = 0;
+  const m = new Character('p','P','Role');
+  party.addMember(m);
+  setLeader(0);
+  registerItem({ id:'memory_worm', name:'Memory Worm', type:'token' });
+  const origRand = Math.random;
+  Math.random = () => 0.05;
+  const resultPromise = openCombat([{ name:'Boss', hp:1, boss:true }]);
+  handleCombatKey({ key:'Enter' });
+  const res = await resultPromise;
+  Math.random = origRand;
+  assert.strictEqual(res.result, 'loot');
+  assert.ok(player.inv.some(it=>it.id==='memory_worm'));
+});
+
+test('boss memory worm drop respects probability', async () => {
+  NPCS.length = 0;
+  party.length = 0;
+  player.inv.length = 0;
+  const m = new Character('p','P','Role');
+  party.addMember(m);
+  setLeader(0);
+  registerItem({ id:'memory_worm', name:'Memory Worm', type:'token' });
+  const origRand = Math.random;
+  Math.random = () => 0.5;
+  const resultPromise = openCombat([{ name:'Boss', hp:1, boss:true }]);
+  handleCombatKey({ key:'Enter' });
+  const res = await resultPromise;
+  Math.random = origRand;
+  assert.strictEqual(res.result, 'loot');
+  assert.ok(!player.inv.some(it=>it.id==='memory_worm'));
+});
+
 test('advanceDialog moves to next node', () => {
   const tree = {
     start: { text: 'hi', next: [{ id: 'bye', label: 'Bye' }] },


### PR DESCRIPTION
## Summary
- flag scrap behemoth as a boss and give bosses a 10% chance to drop a Memory Worm
- test Memory Worm boss drops and ensure existing respec token works

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: TypeError: Cannot set properties of null)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae33c50ce08328ad14940d891a931f