### PR TITLE
feat: introduce event-driven UI module

### DIFF
--- a/ack-player.js
+++ b/ack-player.js
@@ -19,7 +19,7 @@ captureOpenCreator();
 
 let moduleData = null;
 const PLAYTEST_KEY = 'ack_playtest';
-const loader = document.getElementById('moduleLoader');
+const loaderId = 'moduleLoader';
 const urlInput = document.getElementById('modUrl');
 const urlBtn = document.getElementById('modUrlBtn');
 const fileInput = document.getElementById('modFile');
@@ -30,7 +30,7 @@ if (playData) {
   try {
     moduleData = JSON.parse(playData);
     localStorage.removeItem(PLAYTEST_KEY);
-    loader.style.display = 'none';
+    UI.hide(loaderId);
     if (realOpenCreator) {
       window.openCreator = realOpenCreator;
       realOpenCreator();
@@ -42,7 +42,7 @@ if (playData) {
 
 const autoUrl = params.get('module');
 if (!moduleData && autoUrl) {
-  urlInput.value = autoUrl;
+  UI.setValue('modUrl', autoUrl);
   fetch(autoUrl)
     .then((r) => r.json())
     .then((data) => loadModule(data))
@@ -51,7 +51,7 @@ if (!moduleData && autoUrl) {
 
 async function loadModule(data) {
   moduleData = data;
-  loader.style.display = 'none';
+  UI.hide(loaderId);
   if (realOpenCreator) {
     window.openCreator = realOpenCreator;
     realOpenCreator();

--- a/balance-tester.html
+++ b/balance-tester.html
@@ -155,6 +155,7 @@
   </div>
 
   <script defer src="./event-bus.js"></script>
+  <script defer src="./ui.js"></script>
   <script defer src="./core/effects.js"></script>
   <script defer src="./core/inventory.js"></script>
   <script defer src="./core/equipment.js"></script>
@@ -174,14 +175,14 @@
     const params = new URLSearchParams(location.search);
     const isAck = params.get('ack-player') === '1';
     if (isAck) {
-      document.getElementById('moduleLoader').style.display = 'flex';
+      UI.show('moduleLoader', 'flex');
       const btns = document.getElementById('mainButtons');
       const nanoBtn = document.getElementById('nanoToggle');
       const audioBtn = document.getElementById('audioToggle');
       btns.appendChild(nanoBtn);
       btns.appendChild(audioBtn);
       const settingsBtn = document.getElementById('settingsBtn');
-      if (settingsBtn) settingsBtn.style.display = 'none';
+      if (settingsBtn) UI.hide('settingsBtn');
     }
     if (isAck) {
       const modeScript = document.createElement('script');

--- a/dustland.html
+++ b/dustland.html
@@ -155,6 +155,7 @@
   </div>
 
     <script defer src="./event-bus.js"></script>
+    <script defer src="./ui.js"></script>
     <script defer src="./core/item-generator.js"></script>
     <script defer src="./core/effects.js"></script>
     <script defer src="./core/spoils-cache.js"></script>
@@ -176,14 +177,14 @@
     const params = new URLSearchParams(location.search);
     const isAck = params.get('ack-player') === '1';
     if (isAck) {
-      document.getElementById('moduleLoader').style.display = 'flex';
+      UI.show('moduleLoader', 'flex');
       const btns = document.getElementById('mainButtons');
       const nanoBtn = document.getElementById('nanoToggle');
       const audioBtn = document.getElementById('audioToggle');
       btns.appendChild(nanoBtn);
       btns.appendChild(audioBtn);
       const settingsBtn = document.getElementById('settingsBtn');
-      if (settingsBtn) settingsBtn.style.display = 'none';
+      if (settingsBtn) UI.hide('settingsBtn');
     }
     const modeScript = document.createElement('script');
     modeScript.defer = true;

--- a/module-picker.js
+++ b/module-picker.js
@@ -111,8 +111,7 @@ function loadModule(moduleInfo){
   script.id = 'activeModuleScript';
   script.src = `${moduleInfo.file}?_=${Date.now()}`;
   script.onload = () => {
-    const picker = document.getElementById('modulePicker');
-    if(picker) picker.remove();
+    UI.remove('modulePicker');
     window.openCreator = realOpenCreator;
     window.showStart = realShowStart;
     window.resetAll = () => {

--- a/test/ack-player.param.test.js
+++ b/test/ack-player.param.test.js
@@ -44,6 +44,10 @@ test('ack-player auto-loads module from URL param', async () => {
     configurable: true
   });
   global.localStorage = window.localStorage;
+  const busPath = path.join(__dirname, '..', 'event-bus.js');
+  window.eval(fs.readFileSync(busPath, 'utf8'));
+  const uiPath = path.join(__dirname, '..', 'ui.js');
+  window.eval(fs.readFileSync(uiPath, 'utf8'));
   const scriptPath = path.join(__dirname, '..', 'ack-player.js');
   window.eval(fs.readFileSync(scriptPath, 'utf8'));
   await new Promise((r) => setTimeout(r, 10));

--- a/test/balance-tester.nopicker.test.js
+++ b/test/balance-tester.nopicker.test.js
@@ -18,7 +18,8 @@ test('balance tester does not load module picker', () => {
     createElement: () => ({})
   };
   const location = { search: '' };
-  new Function('document', 'location', script)(document, location);
+  const UI = { show: () => {}, hide: () => {} };
+  new Function('document', 'location', 'UI', script)(document, location, UI);
   const hasModulePicker = appended.some((el) => (el.src || '').includes('module-picker.js'));
   assert.strictEqual(hasModulePicker, false, 'module picker script should not be appended');
 });

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -57,6 +57,8 @@ Object.assign(global, {
   location: { href: '' }
 });
 
+global.UI = { remove: () => {} };
+
 const bodyEl = stubEl();
 const headEl = stubEl();
 

--- a/test/module-reload.test.js
+++ b/test/module-reload.test.js
@@ -35,6 +35,8 @@ Object.assign(global, {
   location: { href: '' }
 });
 
+global.UI = { remove: () => {} };
+
 const bodyEl = stubEl();
 const headEl = stubEl();
 

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+test('ui module emits DOM updates via events', async () => {
+  const dom = new JSDOM('<div id="box" style="display:none"></div><input id="field" />');
+  const context = { window: dom.window, document: dom.window.document, console };
+  vm.createContext(context);
+  const busCode = await fs.readFile(new URL('../event-bus.js', import.meta.url), 'utf8');
+  vm.runInContext(busCode, context);
+  const uiCode = await fs.readFile(new URL('../ui.js', import.meta.url), 'utf8');
+  vm.runInContext(uiCode, context);
+  context.Dustland.ui.show('box', 'flex');
+  assert.strictEqual(dom.window.document.getElementById('box').style.display, 'flex');
+  context.Dustland.ui.hide('box');
+  assert.strictEqual(dom.window.document.getElementById('box').style.display, 'none');
+  context.Dustland.ui.setValue('field', 'hi');
+  assert.strictEqual(dom.window.document.getElementById('field').value, 'hi');
+});

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,54 @@
+(function(){
+  const bus = globalThis.Dustland?.eventBus || globalThis.EventBus;
+  if(!bus) return;
+
+  function show(id, display=''){
+    bus.emit('ui:show', { id, display });
+  }
+
+  function hide(id){
+    bus.emit('ui:hide', id);
+  }
+
+  function setText(id, text){
+    bus.emit('ui:text', { id, text });
+  }
+
+  function setValue(id, value){
+    bus.emit('ui:value', { id, value });
+  }
+
+  function remove(id){
+    bus.emit('ui:remove', id);
+  }
+
+  bus.on('ui:show', ({ id, display }) => {
+    const el = document.getElementById(id);
+    if(el) el.style.display = display;
+  });
+
+  bus.on('ui:hide', id => {
+    const el = document.getElementById(id);
+    if(el) el.style.display = 'none';
+  });
+
+  bus.on('ui:text', ({ id, text }) => {
+    const el = document.getElementById(id);
+    if(el) el.textContent = text;
+  });
+
+  bus.on('ui:value', ({ id, value }) => {
+    const el = document.getElementById(id);
+    if(el) el.value = value;
+  });
+
+  bus.on('ui:remove', id => {
+    const el = document.getElementById(id);
+    el?.remove();
+  });
+
+  const api = { show, hide, setText, setValue, remove };
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.ui = api;
+  globalThis.UI = api;
+})();


### PR DESCRIPTION
## Summary
- add a simple ui.js that emits and responds to event-bus UI events
- replace direct DOM manipulation in ack-player and module picker with UI events
- load UI module in main HTML pages and hide/show elements via events
- add tests for UI event helpers and adjust existing tests for new API

## Testing
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae36511250832890878942dec7c13f