### PR TITLE
feat: add boss telegraph screen effects

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -5,6 +5,12 @@ const partyRow = typeof document !== 'undefined' ? document.getElementById('comb
 const cmdMenu = typeof document !== 'undefined' ? document.getElementById('combatCmd') : null;
 const turnIndicator = typeof document !== 'undefined' ? document.getElementById('turnIndicator') : null;
 
+window.bossTelegraphFX = window.bossTelegraphFX || { intensity:1, duration:1000 };
+window.setBossTelegraphFX = (opts={}) => {
+  if(typeof opts.intensity === 'number') window.bossTelegraphFX.intensity = opts.intensity;
+  if(typeof opts.duration === 'number') window.bossTelegraphFX.duration = opts.duration;
+};
+
 if(cmdMenu){
   cmdMenu.addEventListener('click', (e) => {
     const opts = [...cmdMenu.children];
@@ -356,6 +362,11 @@ function enemyAttack(){
   if(!enemy || !target){ closeCombat('flee'); return; }
   if(enemy.special && !enemy._didSpecial){
     enemy._didSpecial=true;
+    const fx=window.bossTelegraphFX||{};
+    const delay=enemy.special.delay ?? fx.duration ?? 1000;
+    const animDur=fx.duration ?? delay;
+    combatOverlay?.style?.setProperty?.('--telegraphIntensity', fx.intensity ?? 1);
+    combatOverlay?.style?.setProperty?.('--telegraphDuration', animDur+'ms');
     combatOverlay?.classList.add('warning');
     log?.(`${enemy.name} ${enemy.special.cue||'charges up!'}`);
     setTimeout(()=>{
@@ -364,7 +375,7 @@ function enemyAttack(){
       target.hp-=dmg;
       log?.(`${enemy.name} unleashes for ${dmg} damage.`);
       finishEnemyAttack(enemy,target);
-    }, enemy.special.delay ?? 1000);
+    }, delay);
     return;
   }
   target.hp-=1;

--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -71,7 +71,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] **Enemy Presets:** Create a `presets.json` file to define enemy stat allocations per level. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
 - [x] **Zone Population:** Populate the "Scrap Wastes" (Levels 1-5) with 5-7 on-level enemies and one or two higher-level "challenge" enemies off the main path. Ensure the zone layout naturally funnels players back toward a trainer NPC.
 - [x] **Boss Mechanics:** Implement the first boss with a telegraphed special move. This involves creating a visual cue (e.g., a "charging up" animation or effect) and a corresponding high-damage attack that triggers after a short delay.
-- [ ] **Boss Visuals:** Add screen effects like CRT distortion or shake when a boss telegraphs a special move.
+- [x] **Boss Visuals:** Add configurable CRT distortion and shake when a boss telegraphs a special move.
 - [x] **Respec Vendor:** Create a special vendor NPC who sells "Memory Worm" tokens for a high price (e.g., 500 scrap). This vendor should be placed in a mid-to-late game area.
 - [ ] **Memory Worm Drops:** Make boss encounters occasionally drop "Memory Worm" tokens to complement vendor purchases.
 

--- a/dustland.css
+++ b/dustland.css
@@ -481,9 +481,31 @@
     }
 
 /* Combat UI */
-#combatOverlay { background:rgba(0,0,0,.8); pointer-events:auto; z-index:10; right:var(--panelW); }
-#combatOverlay.warning { animation:bossWarn .3s steps(1) 4; }
+#combatOverlay {
+  background:rgba(0,0,0,.8);
+  pointer-events:auto;
+  z-index:10;
+  right:var(--panelW);
+  --telegraphIntensity:1;
+  --telegraphDuration:1000ms;
+}
+#combatOverlay.warning {
+  animation:bossWarn .3s steps(1) 4,
+    screenShake .1s steps(2) infinite,
+    crtDistort var(--telegraphDuration) ease-in-out;
+  --shakeMag:calc(var(--telegraphIntensity)*2px);
+}
 @keyframes bossWarn { 50% { background:rgba(80,0,0,.8); } }
+@keyframes screenShake {
+  0%,100% { transform:translate(0,0); }
+  25% { transform:translate(var(--shakeMag),var(--shakeMag)); }
+  50% { transform:translate(calc(var(--shakeMag)*-1),var(--shakeMag)); }
+  75% { transform:translate(var(--shakeMag),calc(var(--shakeMag)*-1)); }
+}
+@keyframes crtDistort {
+  0%,100% { filter:none; }
+  50% { filter:contrast(2) saturate(1.5) hue-rotate(10deg); }
+}
 #combatOverlay .combat-window {
   pointer-events:auto;
   width:min(640px,92vw);


### PR DESCRIPTION
## Summary
- add CSS screen shake and CRT distortion for boss telegraph warning
- expose global `setBossTelegraphFX` to adjust effect intensity and duration
- document boss visual telegraph in progression design doc

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*
- `npx --yes playwright install chromium firefox webkit` *(fails: Download failed: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae33c1a274832880d12c7ae164c48f