### PR TITLE
feat: add GameState singleton for player health

### DIFF
--- a/core/combat.js
+++ b/core/combat.js
@@ -117,7 +117,11 @@ function closeCombat(result='flee'){
   globalThis.EventBus?.emit?.('combat:ended', { result });
   combatState.onComplete?.({ result });
   combatState.onComplete=null;
-  player.hp = party[0] ? party[0].hp : player.hp;
+  if(globalThis.gameState){
+    gameState.setPlayerHealth(party[0] ? party[0].hp : gameState.getPlayerHealth());
+  } else {
+    player.hp = party[0] ? party[0].hp : player.hp;
+  }
   updateHUD?.();
 }
 
@@ -346,7 +350,11 @@ function finishEnemyAttack(enemy, target){
   } else {
     renderCombat();
   }
-  player.hp = party[0] ? party[0].hp : player.hp;
+  if(globalThis.gameState){
+    gameState.setPlayerHealth(party[0] ? party[0].hp : gameState.getPlayerHealth());
+  } else {
+    player.hp = party[0] ? party[0].hp : player.hp;
+  }
   updateHUD?.();
   combatState.active++;
   if(combatState.active<combatState.enemies.length){

--- a/core/movement.js
+++ b/core/movement.js
@@ -165,7 +165,11 @@ function move(dx,dy){
         Effects.tick({buffs});
         if(actor){
           actor.hp = Math.min(actor.hp + 1, actor.maxHp);
-          player.hp = actor.hp;
+          if(globalThis.gameState){
+            gameState.setPlayerHealth(actor.hp);
+          } else {
+            player.hp = actor.hp;
+          }
         }
         (party||[]).forEach(m=>{
           if(m.hp >= m.maxHp){

--- a/core/party.js
+++ b/core/party.js
@@ -172,7 +172,11 @@ function trainStat(stat, memberIndex = selectedMember){
 
 function healParty(){
   (party||[]).forEach(m=>{ m.hp = m.maxHp; m.adr = 0; });
-  player.hp = party[0] ? party[0].hp : player.hp;
+  if(globalThis.gameState){
+    gameState.setPlayerHealth(party[0] ? party[0].hp : gameState.getPlayerHealth());
+  } else {
+    player.hp = party[0] ? party[0].hp : player.hp;
+  }
   renderParty?.(); updateHUD?.();
 }
 

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -130,7 +130,11 @@ async function startCombat(defender){
   if(attacker){
     attacker.ap = Math.max(0,(attacker.ap||0)-1);
     player.ap = attacker.ap;
-    player.hp = attacker.hp;
+    if(globalThis.gameState){
+      gameState.setPlayerHealth(attacker.hp);
+    } else {
+      player.hp = attacker.hp;
+    }
   }
   refreshUI();
   return result;
@@ -203,6 +207,9 @@ const enemyBanks = {};
 function registerTileEvents(list){ (list||[]).forEach(e => tileEvents.push(e)); }
 const state = { map:'world', mapFlags: {} }; // default map
 const player = { hp:10, ap:2, inv:[], scrap:0 };
+if(globalThis.gameState){
+  gameState.setPlayerHealth(player.hp);
+}
 if (typeof registerItem === 'function') {
   registerItem({
     id: 'memory_worm',

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -365,18 +365,19 @@ const TAB_BREAKPOINT = 1600;
 let activeTab = 'inv';
 
 function updateHUD(){
-  const prevHp = updateHUD._lastHpVal ?? player.hp;
-  hpEl.textContent = player.hp;
+  const prevHp = updateHUD._lastHpVal ?? (globalThis.gameState?.getPlayerHealth() ?? player.hp);
+  const curHp = globalThis.gameState?.getPlayerHealth() ?? player.hp;
+  hpEl.textContent = curHp;
   apEl.textContent = player.ap;
   if(scrEl) scrEl.textContent = player.scrap;
   const lead = typeof leader === 'function' ? leader() : null;
-  if(hpBar && player.hp < prevHp){
+  if(hpBar && curHp < prevHp){
     hpBar.classList.add('hurt');
     clearTimeout(updateHUD._hurtTimer);
     updateHUD._hurtTimer = setTimeout(()=>hpBar.classList.remove('hurt'), 300);
   }
   if(hpFill && lead){
-    const pct = Math.max(0, Math.min(100, (player.hp / (lead.maxHp || 1)) * 100));
+    const pct = Math.max(0, Math.min(100, (curHp / (lead.maxHp || 1)) * 100));
     hpFill.style.width = pct + '%';
     if(hpGhost){
       hpGhost.style.width = (updateHUD._lastHpPct ?? pct) + '%';
@@ -384,9 +385,9 @@ function updateHUD(){
     }
     updateHUD._lastHpPct = pct;
     if(lead){
-      const crit = player.hp > 0 && player.hp <= (lead.maxHp || 1) * 0.25;
+      const crit = curHp > 0 && curHp <= (lead.maxHp || 1) * 0.25;
       document.body.classList.toggle('hp-critical', crit);
-      document.body.classList.toggle('hp-out', player.hp <= 0);
+      document.body.classList.toggle('hp-out', curHp <= 0);
     }
   }
   if(adrFill && lead){
@@ -404,7 +405,7 @@ function updateHUD(){
       }
     }
   }
-  updateHUD._lastHpVal = player.hp;
+  updateHUD._lastHpVal = curHp;
 }
 
 function showTab(which){

--- a/src/state/game-state.js
+++ b/src/state/game-state.js
@@ -1,0 +1,29 @@
+class GameState {
+  static #instance;
+  #playerHealth = 0;
+
+  constructor() {
+    if (GameState.#instance) {
+      return GameState.#instance;
+    }
+    GameState.#instance = this;
+    if (typeof player !== 'undefined' && typeof player.hp === 'number') {
+      this.#playerHealth = player.hp;
+    }
+  }
+
+  getPlayerHealth() {
+    return this.#playerHealth;
+  }
+
+  setPlayerHealth(hp) {
+    this.#playerHealth = hp;
+    if (typeof player !== 'undefined') {
+      player.hp = hp;
+    }
+  }
+}
+
+const gameState = new GameState();
+Object.assign(globalThis, { GameState, gameState });
+export { GameState, gameState };

--- a/test/game-state.test.js
+++ b/test/game-state.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+global.player = { hp: 10 };
+const { GameState, gameState } = await import('../src/state/game-state.js');
+
+test('GameState singleton exposes player health', () => {
+  assert.strictEqual(gameState.getPlayerHealth(), 10);
+  gameState.setPlayerHealth(5);
+  assert.strictEqual(gameState.getPlayerHealth(), 5);
+  assert.strictEqual(player.hp, 5);
+  const gs2 = new GameState();
+  assert.strictEqual(gs2, gameState);
+});


### PR DESCRIPTION
## Summary
- add GameState class with private playerHealth and accessors
- route combat, movement, party, and HUD logic through GameState when available
- test singleton behavior and health synchronization

## Testing
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae38af40c883288a6c4e0bd5b4df7e