### PR TITLE
feat: add wizard component with step library

### DIFF
--- a/components/wizard/steps/confirm.js
+++ b/components/wizard/steps/confirm.js
@@ -1,0 +1,15 @@
+(function(){
+  function confirmStep(message){
+    return {
+      render(container){
+        const p = document.createElement('p');
+        p.textContent = message;
+        container.appendChild(p);
+      }
+    };
+  }
+
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.WizardSteps = globalThis.Dustland.WizardSteps || {};
+  globalThis.Dustland.WizardSteps.confirm = confirmStep;
+})();

--- a/components/wizard/steps/text.js
+++ b/components/wizard/steps/text.js
@@ -1,0 +1,25 @@
+(function(){
+  function textStep(label, key){
+    return {
+      render(container, state){
+        const labelEl = document.createElement('label');
+        labelEl.textContent = label;
+        const input = document.createElement('input');
+        input.value = state[key] || '';
+        container.appendChild(labelEl);
+        container.appendChild(input);
+        this.input = input;
+      },
+      validate(){
+        return this.input && this.input.value.trim() !== '';
+      },
+      onComplete(state){
+        state[key] = this.input.value;
+      }
+    };
+  }
+
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.WizardSteps = globalThis.Dustland.WizardSteps || {};
+  globalThis.Dustland.WizardSteps.text = textStep;
+})();

--- a/components/wizard/wizard.js
+++ b/components/wizard/wizard.js
@@ -1,0 +1,54 @@
+(function(){
+  function Wizard(container, steps, opts = {}){
+    let index = 0;
+    const state = opts.initialState || {};
+    const onComplete = opts.onComplete || function(){};
+
+    function render(){
+      container.innerHTML = '';
+      const step = steps[index];
+      step?.render(container, state);
+    }
+
+    function next(){
+      const step = steps[index];
+      if(step?.validate && step.validate(state) === false) return false;
+      step?.onComplete?.(state);
+      index++;
+      if(index >= steps.length){
+        onComplete(state);
+        return true;
+      }
+      render();
+      return true;
+    }
+
+    function prev(){
+      if(index === 0) return false;
+      index--;
+      render();
+      return true;
+    }
+
+    function goTo(i){
+      if(i < 0 || i >= steps.length) return false;
+      index = i;
+      render();
+      return true;
+    }
+
+    function getState(){
+      return state;
+    }
+
+    function current(){
+      return index;
+    }
+
+    render();
+    return { next, prev, goTo, getState, current };
+  }
+
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.Wizard = Wizard;
+})();

--- a/test/wizard.test.js
+++ b/test/wizard.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+test('wizard preserves state and validates steps', async () => {
+  const dom = new JSDOM('<div id="w"></div>');
+  const context = { window: dom.window, document: dom.window.document, console };
+  vm.createContext(context);
+  const busCode = await fs.readFile(new URL('../event-bus.js', import.meta.url), 'utf8');
+  vm.runInContext(busCode, context);
+  const wizCode = await fs.readFile(new URL('../components/wizard/wizard.js', import.meta.url), 'utf8');
+  vm.runInContext(wizCode, context);
+  const textCode = await fs.readFile(new URL('../components/wizard/steps/text.js', import.meta.url), 'utf8');
+  vm.runInContext(textCode, context);
+  const confirmCode = await fs.readFile(new URL('../components/wizard/steps/confirm.js', import.meta.url), 'utf8');
+  vm.runInContext(confirmCode, context);
+  const container = dom.window.document.getElementById('w');
+  let finished = false;
+  const wizard = context.Dustland.Wizard(container, [
+    context.Dustland.WizardSteps.text('Name', 'name'),
+    context.Dustland.WizardSteps.confirm('Done')
+  ], { onComplete(){ finished = true; } });
+
+  assert.strictEqual(wizard.current(), 0);
+  assert.strictEqual(wizard.next(), false);
+  dom.window.document.querySelector('input').value = 'Alice';
+  assert.strictEqual(wizard.next(), true);
+  assert.strictEqual(wizard.getState().name, 'Alice');
+  wizard.prev();
+  assert.strictEqual(wizard.current(), 0);
+  assert.strictEqual(dom.window.document.querySelector('input').value, 'Alice');
+  wizard.next();
+  assert.strictEqual(wizard.current(), 1);
+  wizard.next();
+  assert.ok(finished);
+});


### PR DESCRIPTION
## Summary
- add global Wizard component for step-based flows
- provide reusable text and confirm steps
- test wizard state persistence and step transitions

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae46fa493c832882e2f63e83c2e8db