### PR TITLE
feat: log combat actions

### DIFF
--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1455,6 +1455,20 @@ test('equipment modifiers apply at battle start', async () => {
   await resultPromise;
 });
 
+test('combat log records player and enemy actions', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  party.addMember(m1);
+  const resultPromise = openCombat([{ name: 'E1', hp: 2 }]);
+  handleCombatKey({ key: 'Enter' });
+  handleCombatKey({ key: 'Enter' });
+  await resultPromise;
+  const logEntries = getCombatLog();
+  assert.ok(logEntries.some(e => e.type === 'player' && e.action === 'attack'));
+  assert.ok(logEntries.some(e => e.type === 'enemy' && e.action === 'attack'));
+});
+
 test('shop npc opens dialog before trading', () => {
   NPCS.length = 0;
   party.x = 0; party.y = 0;


### PR DESCRIPTION
## Summary
- record structured combat events for player and enemy actions
- expose `getCombatLog` for post-battle analysis
- test coverage for combat logging

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*


------
https://chatgpt.com/codex/tasks/task_e_68ae46f596588328a3192f2e2a5b637a