### PR TITLE
feat: improve HUD accessibility and layout

### DIFF
--- a/docs/design/hud.md
+++ b/docs/design/hud.md
@@ -1,0 +1,16 @@
+# HUD Iterations
+
+Author: Priya "Gizmo" Sharma
+
+## Feedback
+Internal playtest sessions flagged two pain points:
+- Badges cramped on narrow displays.
+- Screen readers lacked cues for health and adrenaline changes.
+
+## Changes
+- HUD grid now auto-fits badges (`minmax(100px, 1fr)`) for better responsiveness.
+- Health and adrenaline bars expose `role="progressbar"` with live `aria-*` updates.
+- Badge layout uses column flex with consistent gaps for clearer reading.
+
+## Rationale
+Keeping the CRT vibe while boosting clarity and accessibility keeps our drifters' tools sharp wherever they roam.

--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -9,6 +9,7 @@ const scrEl = document.getElementById('scrap');
 const hpBar = document.getElementById('hpBar');
 const hpFill = document.getElementById('hpFill');
 const hpGhost = document.getElementById('hpGhost');
+const adrBar = document.getElementById('adrBar');
 const adrFill = document.getElementById('adrFill');
 const statusIcons = document.getElementById('statusIcons');
 
@@ -375,9 +376,12 @@ function updateHUD(){
     clearTimeout(updateHUD._hurtTimer);
     updateHUD._hurtTimer = setTimeout(()=>hpBar.classList.remove('hurt'), 300);
   }
-  if(hpFill && lead){
+  if(hpFill && hpBar && lead){
     const pct = Math.max(0, Math.min(100, (player.hp / (lead.maxHp || 1)) * 100));
     hpFill.style.width = pct + '%';
+    hpBar.setAttribute('aria-valuenow', player.hp);
+    hpBar.setAttribute('aria-valuemax', lead.maxHp || 1);
+    hpBar.setAttribute('aria-valuemin', 0);
     if(hpGhost){
       hpGhost.style.width = (updateHUD._lastHpPct ?? pct) + '%';
       requestAnimationFrame(()=>{ hpGhost.style.width = pct + '%'; });
@@ -389,9 +393,12 @@ function updateHUD(){
       document.body.classList.toggle('hp-out', player.hp <= 0);
     }
   }
-  if(adrFill && lead){
+  if(adrFill && adrBar && lead){
     const apct = Math.max(0, Math.min(100, (lead.adr / (lead.maxAdr || 1)) * 100));
     adrFill.style.width = apct + '%';
+    adrBar.setAttribute('aria-valuenow', lead.adr);
+    adrBar.setAttribute('aria-valuemax', lead.maxAdr || 1);
+    adrBar.setAttribute('aria-valuemin', 0);
   }
   if(statusIcons){
     statusIcons.innerHTML='';

--- a/dustland.css
+++ b/dustland.css
@@ -87,7 +87,7 @@
 
     .hud {
         display: grid;
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
         gap: 8px
     }
 
@@ -95,12 +95,14 @@
         border: 1px solid #283228;
         padding: 6px 8px;
         border-radius: 8px;
-        background: #0e110e
+        background: #0e110e;
+        display: flex;
+        flex-direction: column;
+        gap: 4px
     }
 
     .hud .label {
-        font-weight: 700;
-        margin-bottom: 4px
+        font-weight: 700
     }
 
     .hudbar {

--- a/dustland.html
+++ b/dustland.html
@@ -24,7 +24,7 @@
         <div class="hud">
           <div class="badge">
             <div class="label">HP <span id="hp">10</span></div>
-            <div class="hudbar" id="hpBar">
+            <div class="hudbar" id="hpBar" role="progressbar" aria-label="Health" aria-valuemin="0" aria-valuemax="10" aria-valuenow="10">
               <div class="ghost" id="hpGhost"></div>
               <div class="fill" id="hpFill"></div>
             </div>
@@ -32,7 +32,7 @@
           </div>
           <div class="badge">
             <div class="label">Adrenaline</div>
-            <div class="hudbar adr" id="adrBar"><div class="fill" id="adrFill"></div></div>
+            <div class="hudbar adr" id="adrBar" role="progressbar" aria-label="Adrenaline" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="fill" id="adrFill"></div></div>
           </div>
           <div class="badge">AP: <span id="ap">2</span></div>
           <div class="badge">Scrap: <span id="scrap">0</span></div>

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -50,17 +50,21 @@ function setup(html){
   return context;
 }
 
-test('hp bar flashes and body gains critical/out classes', async () => {
-  const html = `<body><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div><div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrFill"></div><div id="statusIcons"></div></body>`;
+test('hp bar flashes, updates aria values, and body gains critical/out classes', async () => {
+  const html = `<body><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div><div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar" class="hudbar adr"><div id="adrFill"></div></div><div id="statusIcons"></div></body>`;
   const ctx = setup(html);
   ctx.updateHUD();
+  const bar = ctx.document.getElementById('hpBar');
+  assert.equal(bar.getAttribute('aria-valuenow'), '10');
   assert.ok(!ctx.document.body.classList.contains('hp-critical'));
   ctx.player.hp = 2;
   ctx.updateHUD();
   assert.ok(ctx.document.body.classList.contains('hp-critical'));
-  const bar = ctx.document.getElementById('hpBar');
+  assert.equal(bar.getAttribute('aria-valuenow'), '2');
   assert.ok(bar.classList.contains('hurt'));
   ctx.player.hp = 0;
   ctx.updateHUD();
   assert.ok(ctx.document.body.classList.contains('hp-out'));
+  const adrBar = ctx.document.getElementById('adrBar');
+  assert.equal(adrBar.getAttribute('aria-valuemax'), '100');
 });


### PR DESCRIPTION
## Summary
- Make HUD grid auto-fit badges for better responsiveness
- Add progressbar roles and ARIA updates to HP and adrenaline bars
- Record HUD iteration notes in design docs

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae46ef1820832885d750e3caf2a4f7