### PR TITLE
feat: add mentor bark event handler

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -60,7 +60,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] **Party Panel UI:** Add a compact XP bar below each character's health in the party panel. On hover, it should expand to show `currentXP / nextXP` values.
 - [x] **Skill Point Badge:** Create a small, glowing badge that appears over a character's portrait when they have unspent skill points. The badge should display the number of available points.
 - [x] **Mentor System:** Implement a simple event hook in the level-up function that can trigger a sound file and a brief on-screen text notification (a "bark"). This should be tied to a quest flag or a specific item to remain optional.
-- [ ] **Mentor Bark Handler:** Listen for `mentor:bark` events to play a sound and display the text cue.
+- [x] **Mentor Bark Handler:** Listen for `mentor:bark` events to play a sound and display the text cue.
 - [x] **Trainer UI Mockup:** Design the "Upgrade Skills" dialog. It needs a list of available upgrades (stats and abilities), their costs, and a clear "before and after" preview for any selected stat change. See `docs/design/trainer-ui-mockup.md`.
     > **Gizmo:** Let's make this UI data-driven. It should just read a list of available upgrades from the trainer NPC's data. That way, modders can add new trainers with unique skill trees just by editing a JSON file.
     > **Clown:** It can be a json blob, but keep in mind that all json lives inside the javascript to keep the "no builds no servers" running locally ethos.

--- a/dustland-core.js
+++ b/dustland-core.js
@@ -789,6 +789,11 @@ on('item:picked', (it) => {
   log?.(`Picked up ${it.name}`);
 });
 
+on('mentor:bark', (evt) => {
+  if(evt?.text) toast?.(evt.text);
+  if(evt?.sound) EventBus.emit('sfx', evt.sound);
+});
+
 // Content pack moved to modules/dustland.module.js
 
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -439,6 +439,21 @@ test('level up grants +10 max HP and a skill point', () => {
   assert.strictEqual(c.skillPoints, 1);
 });
 
+test('mentor bark plays sound and shows text', () => {
+  party.flags.mentor = true;
+  const msgs = [];
+  const prevToast = global.toast;
+  global.toast = (m) => msgs.push(m);
+  const sounds = [];
+  EventBus.on('sfx', (id) => sounds.push(id));
+  const c = new Character('m','M','Role');
+  const need = xpToNext(c.lvl);
+  c.awardXP(need);
+  assert.ok(msgs.includes('Another scar, another lesson learned.'));
+  assert.ok(sounds.includes('mentor'));
+  global.toast = prevToast;
+});
+
 test('respec consumes memory worm and restores skill points', () => {
   party.length = 0;
   player.inv.length = 0;


### PR DESCRIPTION
## Summary
- handle mentor:bark events by showing toast and playing sound
- document mentor bark handler completion
- test mentor bark triggers toast and sound on level-up

## Testing
- `node presubmit.js`
- `npm test`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68ae46e0315483288345b9fc6a6a8711