### PR TITLE
feat: add FX debug panel for ghosting

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -260,8 +260,11 @@ function draw(t){
   render(state, dt/1000);
   const bx = bumpEnd > performance.now() ? bumpX : 0;
   const by = bumpEnd > performance.now() ? bumpY : 0;
-  dctx.globalAlpha=0.20; dctx.drawImage(prev, 1 + bx, by);
-  dctx.globalAlpha=0.2; dctx.drawImage(scene, bx, by);
+  const fx = globalThis.fxConfig;
+  dctx.globalAlpha = fx.prevAlpha;
+  dctx.drawImage(prev, (fx.offsetX || 0) + bx, (fx.offsetY || 0) + by);
+  dctx.globalAlpha = fx.sceneAlpha;
+  dctx.drawImage(scene, bx, by);
   pctx.clearRect(0,0,prev.width,prev.height); pctx.drawImage(scene,0,0);
 
   if (state.mapFlags && state.mapFlags.dustStorm) {

--- a/dustland.css
+++ b/dustland.css
@@ -833,6 +833,38 @@
         gap: 8px
     }
 
+    #fxPanel {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, .8);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        z-index: 40
+    }
+
+    #fxPanel .win {
+        width: min(340px, 92vw);
+        background: #0b0d0b;
+        border: 1px solid #2a382a;
+        border-radius: 12px;
+        box-shadow: 0 20px 80px rgba(0, 0, 0, .7);
+        overflow: hidden
+    }
+
+    #fxPanel header {
+        padding: 10px 12px;
+        border-bottom: 1px solid #223022;
+        font-weight: 700
+    }
+
+    #fxPanel main {
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px
+    }
+
     #nanoStatus {
         position: fixed;
         top: 6px;

--- a/dustland.html
+++ b/dustland.html
@@ -54,6 +54,7 @@
           <button class="btn" id="loadBtn">Load</button>
           <button class="btn" id="resetBtn">Reset</button>
           <button class="btn" id="settingsBtn">Settings</button>
+          <button class="btn" id="fxBtn">FX</button>
         </div>
         </div>
       </aside>
@@ -70,6 +71,32 @@
         <button class="btn" id="audioToggle">Audio: On</button>
         <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
         <button class="btn" id="settingsClose">Close</button>
+      </main>
+    </div>
+  </div>
+
+  <!-- FX Debug Panel -->
+  <div id="fxPanel">
+    <div class="win">
+      <header>FX Debug</header>
+      <main>
+        <div class="field">
+          <label for="fxPrevAlpha">Trail Alpha</label>
+          <input type="range" id="fxPrevAlpha" min="0" max="1" step="0.01" />
+        </div>
+        <div class="field">
+          <label for="fxSceneAlpha">Scene Alpha</label>
+          <input type="range" id="fxSceneAlpha" min="0" max="1" step="0.01" />
+        </div>
+        <div class="field">
+          <label for="fxOffsetX">Offset X</label>
+          <input type="number" id="fxOffsetX" step="1" />
+        </div>
+        <div class="field">
+          <label for="fxOffsetY">Offset Y</label>
+          <input type="number" id="fxOffsetY" step="1" />
+        </div>
+        <button class="btn" id="fxClose">Close</button>
       </main>
     </div>
   </div>
@@ -155,6 +182,7 @@
   </div>
 
     <script defer src="./event-bus.js"></script>
+    <script defer src="./fx-config.js"></script>
     <script defer src="./ui.js"></script>
     <script defer src="./core/item-generator.js"></script>
     <script defer src="./core/effects.js"></script>
@@ -175,6 +203,7 @@
     <script defer src="./dustland-path.js"></script>
     <script defer src="./dustland-nano.js"></script>
     <script defer src="./dustland-engine.js"></script>
+    <script defer src="./fx-debug.js"></script>
   <script>
     const params = new URLSearchParams(location.search);
     const isAck = params.get('ack-player') === '1';

--- a/fx-config.js
+++ b/fx-config.js
@@ -1,0 +1,9 @@
+(function(){
+  // Runtime-adjustable visual effect configuration.
+  globalThis.fxConfig = {
+    prevAlpha: 0.2,
+    sceneAlpha: 0.2,
+    offsetX: 1,
+    offsetY: 0
+  };
+})();

--- a/fx-debug.js
+++ b/fx-debug.js
@@ -1,0 +1,34 @@
+(function(){
+  const panel = document.getElementById('fxPanel');
+  const openBtn = document.getElementById('fxBtn');
+  const closeBtn = document.getElementById('fxClose');
+  const prevAlpha = document.getElementById('fxPrevAlpha');
+  const sceneAlpha = document.getElementById('fxSceneAlpha');
+  const offsetX = document.getElementById('fxOffsetX');
+  const offsetY = document.getElementById('fxOffsetY');
+
+  function sync(){
+    if(!globalThis.fxConfig) return;
+    prevAlpha.value = globalThis.fxConfig.prevAlpha;
+    sceneAlpha.value = globalThis.fxConfig.sceneAlpha;
+    offsetX.value = globalThis.fxConfig.offsetX;
+    offsetY.value = globalThis.fxConfig.offsetY;
+  }
+
+  function show(){
+    sync();
+    if(panel) panel.style.display = 'flex';
+  }
+
+  function hide(){
+    if(panel) panel.style.display = 'none';
+  }
+
+  openBtn?.addEventListener('click', show);
+  closeBtn?.addEventListener('click', hide);
+
+  prevAlpha?.addEventListener('input', e => globalThis.fxConfig.prevAlpha = parseFloat(e.target.value));
+  sceneAlpha?.addEventListener('input', e => globalThis.fxConfig.sceneAlpha = parseFloat(e.target.value));
+  offsetX?.addEventListener('input', e => globalThis.fxConfig.offsetX = parseInt(e.target.value, 10) || 0);
+  offsetY?.addEventListener('input', e => globalThis.fxConfig.offsetY = parseInt(e.target.value, 10) || 0);
+})();


### PR DESCRIPTION
## Summary
- add centralized `fxConfig` for visual tuning
- expose runtime FX debug panel to tweak ghosting
- read ghosting settings from `fxConfig` in engine

## Testing
- `npm test`
- `node presubmit.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae5cfa11b883289d8338d591665025