### PR TITLE
feat: add fx toggles

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -260,11 +260,16 @@ function draw(t){
   render(state, dt/1000);
   const bx = bumpEnd > performance.now() ? bumpX : 0;
   const by = bumpEnd > performance.now() ? bumpY : 0;
-  const fx = globalThis.fxConfig;
-  dctx.globalAlpha = fx.prevAlpha;
-  dctx.drawImage(prev, (fx.offsetX || 0) + bx, (fx.offsetY || 0) + by);
-  dctx.globalAlpha = fx.sceneAlpha;
-  dctx.drawImage(scene, bx, by);
+  const fx = globalThis.fxConfig || {};
+  if(fx.enabled === false){
+    dctx.globalAlpha = 1;
+    dctx.drawImage(scene, bx, by);
+  }else{
+    dctx.globalAlpha = fx.prevAlpha;
+    dctx.drawImage(prev, (fx.offsetX || 0) + bx, (fx.offsetY || 0) + by);
+    dctx.globalAlpha = fx.sceneAlpha;
+    dctx.drawImage(scene, bx, by);
+  }
   pctx.clearRect(0,0,prev.width,prev.height); pctx.drawImage(scene,0,0);
 
   if (state.mapFlags && state.mapFlags.dustStorm) {
@@ -395,10 +400,15 @@ function updateHUD(){
   apEl.textContent = player.ap;
   if(scrEl) scrEl.textContent = player.scrap;
   const lead = typeof leader === 'function' ? leader() : null;
-  if(hpBar && player.hp < prevHp){
-    hpBar.classList.add('hurt');
-    clearTimeout(updateHUD._hurtTimer);
-    updateHUD._hurtTimer = setTimeout(()=>hpBar.classList.remove('hurt'), 300);
+  const fx = globalThis.fxConfig;
+  if(hpBar){
+    if(player.hp < prevHp && fx?.damageFlash !== false){
+      hpBar.classList.add('hurt');
+      clearTimeout(updateHUD._hurtTimer);
+      updateHUD._hurtTimer = setTimeout(()=>hpBar.classList.remove('hurt'), 300);
+    }else if(fx?.damageFlash === false){
+      hpBar.classList.remove('hurt');
+    }
   }
   if(hpFill && hpBar && lead){
     const pct = Math.max(0, Math.min(100, (player.hp / (lead.maxHp || 1)) * 100));

--- a/dustland.html
+++ b/dustland.html
@@ -81,6 +81,14 @@
       <header>FX Debug</header>
       <main>
         <div class="field">
+          <label for="fxEnabled">FX Enabled</label>
+          <input type="checkbox" id="fxEnabled" />
+        </div>
+        <div class="field">
+          <label for="fxDamageFlash">Damage Flash</label>
+          <input type="checkbox" id="fxDamageFlash" />
+        </div>
+        <div class="field">
           <label for="fxPrevAlpha">Trail Alpha</label>
           <input type="range" id="fxPrevAlpha" min="0" max="1" step="0.01" />
         </div>

--- a/fx-config.js
+++ b/fx-config.js
@@ -1,9 +1,11 @@
 (function(){
   // Runtime-adjustable visual effect configuration.
   globalThis.fxConfig = {
+    enabled: true,
     prevAlpha: 0.2,
     sceneAlpha: 0.2,
     offsetX: 1,
-    offsetY: 0
+    offsetY: 0,
+    damageFlash: true
   };
 })();

--- a/fx-debug.js
+++ b/fx-debug.js
@@ -6,6 +6,8 @@
   const sceneAlpha = document.getElementById('fxSceneAlpha');
   const offsetX = document.getElementById('fxOffsetX');
   const offsetY = document.getElementById('fxOffsetY');
+  const enabled = document.getElementById('fxEnabled');
+  const dmgFlash = document.getElementById('fxDamageFlash');
 
   function sync(){
     if(!globalThis.fxConfig) return;
@@ -13,6 +15,8 @@
     sceneAlpha.value = globalThis.fxConfig.sceneAlpha;
     offsetX.value = globalThis.fxConfig.offsetX;
     offsetY.value = globalThis.fxConfig.offsetY;
+    enabled.checked = globalThis.fxConfig.enabled !== false;
+    dmgFlash.checked = globalThis.fxConfig.damageFlash !== false;
   }
 
   function show(){
@@ -31,4 +35,9 @@
   sceneAlpha?.addEventListener('input', e => globalThis.fxConfig.sceneAlpha = parseFloat(e.target.value));
   offsetX?.addEventListener('input', e => globalThis.fxConfig.offsetX = parseInt(e.target.value, 10) || 0);
   offsetY?.addEventListener('input', e => globalThis.fxConfig.offsetY = parseInt(e.target.value, 10) || 0);
+  enabled?.addEventListener('input', e => globalThis.fxConfig.enabled = e.target.checked);
+  dmgFlash?.addEventListener('input', e => {
+    globalThis.fxConfig.damageFlash = e.target.checked;
+    if(!e.target.checked) document.getElementById('hpBar')?.classList.remove('hurt');
+  });
 })();

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -50,9 +50,10 @@ function setup(html){
   return context;
 }
 
+const HUD_HTML = `<body><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div><div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar" class="hudbar adr"><div id="adrFill"></div></div><div id="statusIcons"></div></body>`;
+
 test('hp bar flashes, updates aria values, and body gains critical/out classes', async () => {
-  const html = `<body><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div><div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar" class="hudbar adr"><div id="adrFill"></div></div><div id="statusIcons"></div></body>`;
-  const ctx = setup(html);
+  const ctx = setup(HUD_HTML);
   ctx.updateHUD();
   const bar = ctx.document.getElementById('hpBar');
   assert.equal(bar.getAttribute('aria-valuenow'), '10');
@@ -67,4 +68,14 @@ test('hp bar flashes, updates aria values, and body gains critical/out classes',
   assert.ok(ctx.document.body.classList.contains('hp-out'));
   const adrBar = ctx.document.getElementById('adrBar');
   assert.equal(adrBar.getAttribute('aria-valuemax'), '100');
+});
+
+test('damage flash can be disabled', async () => {
+  const ctx = setup(HUD_HTML);
+  ctx.updateHUD();
+  ctx.fxConfig = { damageFlash: false };
+  ctx.player.hp = 5;
+  ctx.updateHUD();
+  const bar = ctx.document.getElementById('hpBar');
+  assert.ok(!bar.classList.contains('hurt'));
 });


### PR DESCRIPTION
## Summary
- allow disabling all FX and damage flashes via debug panel
- expose FX toggles in fxConfig and wire them to rendering/HUD
- test disabling damage flash

## Testing
- `node presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5f03c2a8832887f325cf144e7e30