### PR TITLE
feat: make fx debug panel draggable

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -835,11 +835,9 @@
 
     #fxPanel {
         position: fixed;
-        inset: 0;
-        background: rgba(0, 0, 0, .8);
+        top: 10px;
+        left: 10px;
         display: none;
-        align-items: center;
-        justify-content: center;
         z-index: 40
     }
 
@@ -855,7 +853,8 @@
     #fxPanel header {
         padding: 10px 12px;
         border-bottom: 1px solid #223022;
-        font-weight: 700
+        font-weight: 700;
+        cursor: move
     }
 
     #fxPanel main {

--- a/fx-debug.js
+++ b/fx-debug.js
@@ -21,7 +21,7 @@
 
   function show(){
     sync();
-    if(panel) panel.style.display = 'flex';
+    if(panel) panel.style.display = 'block';
   }
 
   function hide(){
@@ -40,4 +40,24 @@
     globalThis.fxConfig.damageFlash = e.target.checked;
     if(!e.target.checked) document.getElementById('hpBar')?.classList.remove('hurt');
   });
+
+  const dragHandle = panel?.querySelector('header');
+  let dragX = 0;
+  let dragY = 0;
+  function startDrag(e){
+    dragX = e.clientX - panel.offsetLeft;
+    dragY = e.clientY - panel.offsetTop;
+    document.addEventListener('mousemove', onDrag);
+    document.addEventListener('mouseup', endDrag);
+    e.preventDefault();
+  }
+  function onDrag(e){
+    panel.style.left = (e.clientX - dragX) + 'px';
+    panel.style.top = (e.clientY - dragY) + 'px';
+  }
+  function endDrag(){
+    document.removeEventListener('mousemove', onDrag);
+    document.removeEventListener('mouseup', endDrag);
+  }
+  dragHandle?.addEventListener('mousedown', startDrag);
 })();


### PR DESCRIPTION
## Summary
- allow the FX debug panel to float without dimming gameplay
- make the FX window draggable for easier in-game tuning

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae675b22788328abf01c9968c81879