### PR TITLE
feat: support scrap rewards in dialog

### DIFF
--- a/adventure-kit.js
+++ b/adventure-kit.js
@@ -700,7 +700,9 @@ function addChoiceRow(container, ch = {}) {
   const gotoRel = !!goto.rel;
   const isXP = typeof reward === 'string' && /^xp\s*\d+/i.test(reward);
   const xpVal = isXP ? parseInt(reward.replace(/[^0-9]/g, ''), 10) : '';
-  const isItem = reward && !isXP;
+  const isScrap = typeof reward === 'string' && /^scrap\s*\d+/i.test(reward);
+  const scrapVal = isScrap ? parseInt(reward.replace(/[^0-9]/g, ''), 10) : '';
+  const isItem = reward && !isXP && !isScrap;
   const itemVal = isItem ? reward : '';
   const effs = Array.isArray(ch.effects) ? ch.effects : [];
   const boardEff = effs.find(e => e.effect === 'boardDoor');
@@ -718,8 +720,9 @@ function addChoiceRow(container, ch = {}) {
     <label>To<select class="choiceTo"></select></label>
     <button class="btn delChoice" type="button">x</button>
     <details class="choiceAdv"><summary>Advanced</summary>
-      <label>Reward<select class="choiceRewardType"><option value="" ${!reward?'selected':''}></option><option value="xp" ${isXP?'selected':''}>XP</option><option value="item" ${isItem?'selected':''}>Item</option></select>
+      <label>Reward<select class="choiceRewardType"><option value="" ${!reward?'selected':''}></option><option value="xp" ${isXP?'selected':''}>XP</option><option value="scrap" ${isScrap?'selected':''}>Scrap</option><option value="item" ${isItem?'selected':''}>Item</option></select>
         <input type="number" class="choiceRewardXP" value="${xpVal}" style="display:${isXP?'inline-block':'none'}"/>
+        <input type="number" class="choiceRewardScrap" value="${scrapVal}" style="display:${isScrap?'inline-block':'none'}"/>
         <select class="choiceRewardItem" style="display:${isItem?'inline-block':'none'}"></select></label>
       <label>Stat<select class="choiceStat"></select></label>
       <label>DC<input type="number" class="choiceDC" value="${dc || ''}"/><span class="small">Target number for stat check.</span></label>
@@ -788,9 +791,11 @@ function addChoiceRow(container, ch = {}) {
   populateInteriorDropdown(row.querySelector('.choiceUnboard'), unboardId);
   const rewardTypeSel = row.querySelector('.choiceRewardType');
   const rewardXP = row.querySelector('.choiceRewardXP');
+  const rewardScrap = row.querySelector('.choiceRewardScrap');
   const rewardItem = row.querySelector('.choiceRewardItem');
   rewardTypeSel.addEventListener('change', () => {
     rewardXP.style.display = rewardTypeSel.value === 'xp' ? 'inline-block' : 'none';
+    rewardScrap.style.display = rewardTypeSel.value === 'scrap' ? 'inline-block' : 'none';
     rewardItem.style.display = rewardTypeSel.value === 'item' ? 'inline-block' : 'none';
     updateTreeData();
   });
@@ -937,9 +942,11 @@ function updateTreeData() {
       const to = toEl.value.trim();
       const rewardType = chEl.querySelector('.choiceRewardType').value;
       const xpTxt = chEl.querySelector('.choiceRewardXP').value.trim();
+      const scrapTxt = chEl.querySelector('.choiceRewardScrap').value.trim();
       const itemReward = chEl.querySelector('.choiceRewardItem').value.trim();
       let reward = '';
       if (rewardType === 'xp' && xpTxt) reward = `XP ${parseInt(xpTxt, 10)}`;
+      else if (rewardType === 'scrap' && scrapTxt) reward = `SCRAP ${parseInt(scrapTxt, 10)}`;
       else if (rewardType === 'item' && itemReward) reward = itemReward;
       const stat = chEl.querySelector('.choiceStat').value.trim();
       const dcTxt = chEl.querySelector('.choiceDC').value.trim();

--- a/test/dialog.effects.test.js
+++ b/test/dialog.effects.test.js
@@ -131,6 +131,68 @@ test('updateTreeData captures door board/unboard effects', () => {
   assert.deepStrictEqual(treeData.start.choices[0].effects, [ { effect: 'unboardDoor', interiorId: 'castle' } ]);
 });
 
+test('updateTreeData captures scrap reward', () => {
+  treeData = {};
+  const choiceEl = {
+    querySelector(sel){
+      switch(sel){
+        case '.choiceLabel': return { value: 'borrow' };
+        case '.choiceTo': return { value: 'bye', style:{} };
+        case '.choiceRewardType': return { value: 'scrap' };
+        case '.choiceRewardXP': return { value: '' };
+        case '.choiceRewardScrap': return { value: '2' };
+        case '.choiceRewardItem': return { value: '' };
+        case '.choiceStat':
+        case '.choiceDC':
+        case '.choiceSuccess':
+        case '.choiceFailure':
+        case '.choiceCostItem':
+        case '.choiceCostSlot':
+        case '.choiceReqItem':
+        case '.choiceReqSlot':
+        case '.choiceJoinId':
+        case '.choiceJoinName':
+        case '.choiceJoinRole':
+        case '.choiceGotoMap':
+        case '.choiceGotoX':
+        case '.choiceGotoY':
+        case '.choiceQ':
+        case '.choiceFlag':
+        case '.choiceOp':
+        case '.choiceVal':
+          return { value: '' };
+        case '.choiceOnce':
+          return { checked: false };
+        case '.choiceBoard':
+        case '.choiceUnboard':
+          return { value: '' };
+        default:
+          return { value: '' };
+      }
+    }
+  };
+  const nodeEl = {
+    querySelector(sel){
+      switch(sel){
+        case '.nodeId': return { value: 'start' };
+        case '.nodeText': return { value: 'hi' };
+        default: return { value: '' };
+      }
+    },
+    querySelectorAll(sel){ return sel === '.choices > div' ? [choiceEl] : []; },
+    classList:{ contains(){ return false; } },
+    style:{},
+  };
+  elements['treeEditor'] = {
+    querySelectorAll(sel){ return sel === '.node' ? [nodeEl] : []; }
+  };
+  elements['npcTree'] = { value: '' };
+  elements['treeWarning'] = { textContent: '' };
+
+  updateTreeData();
+  assert.strictEqual(treeData.start.choices[0].reward, 'SCRAP 2');
+});
+
 test('updateTreeData removes deleted nodes', () => {
   treeData = { start: { text: '', choices: [] }, node1: { text: '', choices: [] } };
   const nodeEl = {


### PR DESCRIPTION
## Summary
- Allow Adventure Kit dialog choices to grant scrap like XP or items
- Cover scrap reward serialization with a new test

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: showTab failed; Adventure Kit?)*

------
https://chatgpt.com/codex/tasks/task_e_68ae66f451d883288681db87b971089e