### PR TITLE
feat: help recover lost badge

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -240,13 +240,13 @@ const OFFICE_MODULE = (() => {
           ? 'Back from the forest already?'
           : 'Too busy to chat.';
         const choices = [];
-        if (player.scrap < 2)
+        if (player.scrap < 2 && !hasItem('access_card'))
           choices.push({ label: 'Borrow 2 scrap', to: 'borrow', reward: 'SCRAP 2' });
         choices.push({ label: '(Leave)', to: 'bye' });
         const nodes = { start: { text: baseText, choices } };
-        if (player.scrap < 2) {
+        if (player.scrap < 2 && !hasItem('access_card')) {
           nodes.borrow = {
-            text: 'Here, just bring it back.',
+            text: 'Here, buy back your badge.',
             choices: [ { label: '(Thanks)', to: 'bye' } ]
           };
         }

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -33,7 +33,7 @@ test('office module places Boots of Speed near forest entry', () => {
   assert.match(src, /mods: \{ AGI: 5 \}/);
 });
 
-test('office worker lends scrap when low', () => {
+test('office worker lends scrap when low and missing badge', () => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const file = path.join(__dirname, '..', 'modules', 'office.module.js');
   const src = fs.readFileSync(file, 'utf8');
@@ -45,6 +45,7 @@ test('office worker lends scrap when low', () => {
   global.player = { scrap: 1 };
   global.updateHUD = () => { hudCalled = true; };
   global.portraits = { worker: '' };
+  global.hasItem = () => false;
   vm.runInThisContext(
     fs.readFileSync(path.join(__dirname, '..', 'core', 'actions.js'), 'utf8')
   );
@@ -68,6 +69,24 @@ test('office worker hides loan if you have enough scrap', () => {
   global.player = { scrap: 5 };
   global.updateHUD = () => {};
   global.portraits = { worker: '' };
+  global.hasItem = () => false;
+  const worker = vm.runInThisContext('(' + objSrc + ')');
+  const tree = worker.tree();
+  assert(!tree.start.choices.some((c) => c.label === 'Borrow 2 scrap'));
+});
+
+test('office worker hides loan if you still have your badge', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const match = src.match(/\{\s*id: 'worker1',[\s\S]*?\n\s*\},\n\s*\{\s*id: 'worker2'/);
+  assert(match);
+  const objSrc = match[0].replace(/,\n\s*\{\s*id: 'worker2'.*/, '');
+  global.flagValue = () => 0;
+  global.player = { scrap: 1 };
+  global.updateHUD = () => {};
+  global.portraits = { worker: '' };
+  global.hasItem = (id) => id === 'access_card';
   const worker = vm.runInThisContext('(' + objSrc + ')');
   const tree = worker.tree();
   assert(!tree.start.choices.some((c) => c.label === 'Borrow 2 scrap'));


### PR DESCRIPTION
## Summary
- Only lend scrap on floor 2 if the player no longer has their access card
- Update office module tests for new lending rules

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68ae70eb0de48328a712072aac3e62c3