### PR TITLE
fix: connect damage flash toggle

### DIFF
--- a/fx-debug.js
+++ b/fx-debug.js
@@ -35,8 +35,8 @@
   sceneAlpha?.addEventListener('input', e => globalThis.fxConfig.sceneAlpha = parseFloat(e.target.value));
   offsetX?.addEventListener('input', e => globalThis.fxConfig.offsetX = parseInt(e.target.value, 10) || 0);
   offsetY?.addEventListener('input', e => globalThis.fxConfig.offsetY = parseInt(e.target.value, 10) || 0);
-  enabled?.addEventListener('input', e => globalThis.fxConfig.enabled = e.target.checked);
-  dmgFlash?.addEventListener('input', e => {
+  enabled?.addEventListener('change', e => globalThis.fxConfig.enabled = e.target.checked);
+  dmgFlash?.addEventListener('change', e => {
     globalThis.fxConfig.damageFlash = e.target.checked;
     if(!e.target.checked) document.getElementById('hpBar')?.classList.remove('hurt');
   });

--- a/test/fx-debug.test.js
+++ b/test/fx-debug.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import { JSDOM } from 'jsdom';
+
+test('damage flash checkbox updates fxConfig', async () => {
+  const html = `<div id="fxPanel"><header></header><input id="fxDamageFlash" type="checkbox" /></div><div id="hpBar" class="hurt"></div>`;
+  const dom = new JSDOM(html, { runScripts: 'outside-only' });
+  const { window } = dom;
+  window.fxConfig = { damageFlash: true };
+  const code = await fs.readFile(new URL('../fx-debug.js', import.meta.url), 'utf8');
+  window.eval(code);
+  const cb = window.document.getElementById('fxDamageFlash');
+  cb.checked = false;
+  cb.dispatchEvent(new window.Event('change', { bubbles: true }));
+  assert.equal(window.fxConfig.damageFlash, false);
+  assert.ok(!window.document.getElementById('hpBar').classList.contains('hurt'));
+  cb.checked = true;
+  cb.dispatchEvent(new window.Event('change', { bubbles: true }));
+  assert.equal(window.fxConfig.damageFlash, true);
+});


### PR DESCRIPTION
## Summary
- listen for `change` events on FX panel checkboxes
- test damage flash checkbox updates configuration and HUD

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae720e4d9883289c88a542bbb84ce9