### PR TITLE
feat: add CRT scanline, shear, and color bleed FX

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -151,6 +151,27 @@
         border-radius: 2px
     }
 
+    #game {
+        position: relative
+    }
+
+    #game.scanlines::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background: repeating-linear-gradient(to bottom, rgba(255, 255, 255, .05) 0px, rgba(255, 255, 255, .05) 1px, rgba(0, 0, 0, 0) 2px);
+        mix-blend-mode: overlay
+    }
+
+    #game.shear {
+        transform: skewX(2deg)
+    }
+
+    #game.color-bleed {
+        filter: drop-shadow(0 0 2px #9ef7a0) drop-shadow(0 0 6px #9ef7a0) drop-shadow(2px 0 0 red) drop-shadow(-2px 0 0 cyan)
+    }
+
     body.hp-critical #game {
         filter: grayscale(.8)
     }

--- a/dustland.html
+++ b/dustland.html
@@ -89,6 +89,18 @@
           <input type="checkbox" id="fxDamageFlash" />
         </div>
         <div class="field">
+          <label for="fxScanlines">Scanlines</label>
+          <input type="checkbox" id="fxScanlines" />
+        </div>
+        <div class="field">
+          <label for="fxCrtShear">CRT Shear</label>
+          <input type="checkbox" id="fxCrtShear" />
+        </div>
+        <div class="field">
+          <label for="fxColorBleed">Color Bleed</label>
+          <input type="checkbox" id="fxColorBleed" />
+        </div>
+        <div class="field">
           <label for="fxPrevAlpha">Trail Alpha</label>
           <input type="range" id="fxPrevAlpha" min="0" max="1" step="0.01" />
         </div>

--- a/fx-config.js
+++ b/fx-config.js
@@ -6,6 +6,9 @@
     sceneAlpha: 0.2,
     offsetX: 0, // horizontal blur offset (disabled by default)
     offsetY: 0, // vertical blur offset (disabled by default)
-    damageFlash: false // disable red flash by default; toggle via fx menu
+    damageFlash: false, // disable red flash by default; toggle via fx menu
+    scanlines: false, // overlay horizontal scanlines
+    crtShear: false, // slight screen skew effect
+    colorBleed: false // simple chromatic aberration
   };
 })();

--- a/fx-debug.js
+++ b/fx-debug.js
@@ -8,6 +8,17 @@
   const offsetY = document.getElementById('fxOffsetY');
   const enabled = document.getElementById('fxEnabled');
   const dmgFlash = document.getElementById('fxDamageFlash');
+  const scanlines = document.getElementById('fxScanlines');
+  const shear = document.getElementById('fxCrtShear');
+  const colorBleed = document.getElementById('fxColorBleed');
+  const canvas = document.getElementById('game');
+
+  function applyFx(){
+    if(!canvas || !globalThis.fxConfig) return;
+    canvas.classList.toggle('scanlines', !!globalThis.fxConfig.scanlines);
+    canvas.classList.toggle('shear', !!globalThis.fxConfig.crtShear);
+    canvas.classList.toggle('color-bleed', !!globalThis.fxConfig.colorBleed);
+  }
 
   function sync(){
     if(!globalThis.fxConfig) return;
@@ -17,6 +28,10 @@
     offsetY.value = globalThis.fxConfig.offsetY;
     enabled.checked = globalThis.fxConfig.enabled !== false;
     dmgFlash.checked = globalThis.fxConfig.damageFlash !== false;
+    if(scanlines) scanlines.checked = !!globalThis.fxConfig.scanlines;
+    if(shear) shear.checked = !!globalThis.fxConfig.crtShear;
+    if(colorBleed) colorBleed.checked = !!globalThis.fxConfig.colorBleed;
+    applyFx();
   }
 
   function show(){
@@ -40,6 +55,9 @@
     globalThis.fxConfig.damageFlash = e.target.checked;
     if(!e.target.checked) document.getElementById('hpBar')?.classList.remove('hurt');
   });
+  scanlines?.addEventListener('change', e => { globalThis.fxConfig.scanlines = e.target.checked; applyFx(); });
+  shear?.addEventListener('change', e => { globalThis.fxConfig.crtShear = e.target.checked; applyFx(); });
+  colorBleed?.addEventListener('change', e => { globalThis.fxConfig.colorBleed = e.target.checked; applyFx(); });
 
   const dragHandle = panel?.querySelector('header');
   let dragX = 0;
@@ -60,4 +78,5 @@
     document.removeEventListener('mouseup', endDrag);
   }
   dragHandle?.addEventListener('mousedown', startDrag);
+  applyFx();
 })();

--- a/test/fx-debug.test.js
+++ b/test/fx-debug.test.js
@@ -19,3 +19,40 @@ test('damage flash checkbox updates fxConfig', async () => {
   cb.dispatchEvent(new window.Event('change', { bubbles: true }));
   assert.equal(window.fxConfig.damageFlash, true);
 });
+
+test('fx checkboxes apply classes and update config', async () => {
+  const html = `<div id="fxPanel"><header></header>
+    <input id="fxScanlines" type="checkbox" />
+    <input id="fxCrtShear" type="checkbox" />
+    <input id="fxColorBleed" type="checkbox" />
+  </div><canvas id="game"></canvas>`;
+  const dom = new JSDOM(html, { runScripts: 'outside-only' });
+  const { window } = dom;
+  window.fxConfig = { scanlines: false, crtShear: false, colorBleed: false };
+  const code = await fs.readFile(new URL('../fx-debug.js', import.meta.url), 'utf8');
+  window.eval(code);
+  const canvas = window.document.getElementById('game');
+  const scan = window.document.getElementById('fxScanlines');
+  const shear = window.document.getElementById('fxCrtShear');
+  const bleed = window.document.getElementById('fxColorBleed');
+
+  scan.checked = true;
+  scan.dispatchEvent(new window.Event('change', { bubbles: true }));
+  assert.equal(window.fxConfig.scanlines, true);
+  assert.ok(canvas.classList.contains('scanlines'));
+
+  shear.checked = true;
+  shear.dispatchEvent(new window.Event('change', { bubbles: true }));
+  assert.equal(window.fxConfig.crtShear, true);
+  assert.ok(canvas.classList.contains('shear'));
+
+  bleed.checked = true;
+  bleed.dispatchEvent(new window.Event('change', { bubbles: true }));
+  assert.equal(window.fxConfig.colorBleed, true);
+  assert.ok(canvas.classList.contains('color-bleed'));
+
+  bleed.checked = false;
+  bleed.dispatchEvent(new window.Event('change', { bubbles: true }));
+  assert.equal(window.fxConfig.colorBleed, false);
+  assert.ok(!canvas.classList.contains('color-bleed'));
+});


### PR DESCRIPTION
## Summary
- add scanline, CRT shear, and color bleed options to FX panel
- implement CSS classes and JS hooks to apply new effects
- cover new FX toggles with unit tests

## Testing
- `./install-deps.sh`
- `node presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef1830aa883288222c9a5e6ee601f