### PR TITLE
feat: add retro pixel font

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -5,13 +5,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Adventure Construction Kit</title>
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="dustland.css" />
   <style>
     body {
       margin: 0;
       background: #000;
       color: #c8f7c9;
-      font-family: system-ui, sans-serif;
+      font-family: 'Pixelify Sans', sans-serif;
       font-size: 14px;
       line-height: 1.5;
       position: relative;

--- a/balance-tester.html
+++ b/balance-tester.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
   <title>Dustland: CRT Edition</title>
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="dustland.css" />
 </head>
 <body>

--- a/dustland.css
+++ b/dustland.css
@@ -19,7 +19,7 @@
         margin: 0;
         background: radial-gradient(circle at top, #141614 0%, var(--bg) 70%);
         color: var(--ink);
-        font: 14px/1.5 system-ui, sans-serif;
+        font: 14px/1.5 'Pixelify Sans', sans-serif;
     }
 
     .wrap {

--- a/dustland.html
+++ b/dustland.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
   <title>Dustland: CRT Edition</title>
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="dustland.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- load the Pixelify Sans font in all game entry points for a blocky retro feel
- default to Pixelify Sans across game and editor interfaces

## Testing
- `./install-deps.sh`
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68aef20322c483289f7d294a2eae2906