### PR TITLE
test: replace jsdom with harness

### DIFF
--- a/test/fx-debug.test.js
+++ b/test/fx-debug.test.js
@@ -1,58 +1,62 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
 import fs from 'node:fs/promises';
-import { JSDOM } from 'jsdom';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
 
 test('damage flash checkbox updates fxConfig', async () => {
-  const html = `<div id="fxPanel"><header></header><input id="fxDamageFlash" type="checkbox" /></div><div id="hpBar" class="hurt"></div>`;
-  const dom = new JSDOM(html, { runScripts: 'outside-only' });
-  const { window } = dom;
+  const document = makeDocument();
+  const window = { document };
   window.fxConfig = { damageFlash: true };
+  const sandbox = { window, document, fxConfig: window.fxConfig };
+  sandbox.globalThis = sandbox;
+  document.getElementById('fxPanel').appendChild(document.getElementById('fxDamageFlash'));
+  document.getElementById('hpBar').classList.add('hurt');
   const code = await fs.readFile(new URL('../fx-debug.js', import.meta.url), 'utf8');
-  window.eval(code);
-  const cb = window.document.getElementById('fxDamageFlash');
+  vm.runInNewContext(code, sandbox);
+  const cb = document.getElementById('fxDamageFlash');
   cb.checked = false;
-  cb.dispatchEvent(new window.Event('change', { bubbles: true }));
+  cb.dispatchEvent({ type:'change' });
   assert.equal(window.fxConfig.damageFlash, false);
-  assert.ok(!window.document.getElementById('hpBar').classList.contains('hurt'));
+  assert.ok(!document.getElementById('hpBar').classList.contains('hurt'));
   cb.checked = true;
-  cb.dispatchEvent(new window.Event('change', { bubbles: true }));
+  cb.dispatchEvent({ type:'change' });
   assert.equal(window.fxConfig.damageFlash, true);
 });
 
 test('fx checkboxes apply classes and update config', async () => {
-  const html = `<div id="fxPanel"><header></header>
-    <input id="fxScanlines" type="checkbox" />
-    <input id="fxCrtShear" type="checkbox" />
-    <input id="fxColorBleed" type="checkbox" />
-  </div><canvas id="game"></canvas>`;
-  const dom = new JSDOM(html, { runScripts: 'outside-only' });
-  const { window } = dom;
+  const document = makeDocument();
+  const window = { document };
   window.fxConfig = { scanlines: false, crtShear: false, colorBleed: false };
+  const sandbox = { window, document, fxConfig: window.fxConfig };
+  sandbox.globalThis = sandbox;
+  document.getElementById('fxPanel').appendChild(document.getElementById('fxScanlines'));
+  document.getElementById('fxPanel').appendChild(document.getElementById('fxCrtShear'));
+  document.getElementById('fxPanel').appendChild(document.getElementById('fxColorBleed'));
+  const canvas = document.getElementById('game');
   const code = await fs.readFile(new URL('../fx-debug.js', import.meta.url), 'utf8');
-  window.eval(code);
-  const canvas = window.document.getElementById('game');
-  const scan = window.document.getElementById('fxScanlines');
-  const shear = window.document.getElementById('fxCrtShear');
-  const bleed = window.document.getElementById('fxColorBleed');
+  vm.runInNewContext(code, sandbox);
+  const scan = document.getElementById('fxScanlines');
+  const shear = document.getElementById('fxCrtShear');
+  const bleed = document.getElementById('fxColorBleed');
 
   scan.checked = true;
-  scan.dispatchEvent(new window.Event('change', { bubbles: true }));
+  scan.dispatchEvent({ type:'change' });
   assert.equal(window.fxConfig.scanlines, true);
   assert.ok(canvas.classList.contains('scanlines'));
 
   shear.checked = true;
-  shear.dispatchEvent(new window.Event('change', { bubbles: true }));
+  shear.dispatchEvent({ type:'change' });
   assert.equal(window.fxConfig.crtShear, true);
   assert.ok(canvas.classList.contains('shear'));
 
   bleed.checked = true;
-  bleed.dispatchEvent(new window.Event('change', { bubbles: true }));
+  bleed.dispatchEvent({ type:'change' });
   assert.equal(window.fxConfig.colorBleed, true);
   assert.ok(canvas.classList.contains('color-bleed'));
 
   bleed.checked = false;
-  bleed.dispatchEvent(new window.Event('change', { bubbles: true }));
+  bleed.dispatchEvent({ type:'change' });
   assert.equal(window.fxConfig.colorBleed, false);
   assert.ok(!canvas.classList.contains('color-bleed'));
 });

--- a/test/keyboard-shortcuts.test.js
+++ b/test/keyboard-shortcuts.test.js
@@ -1,116 +1,22 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
-import fs from 'node:fs/promises';
-import vm from 'node:vm';
-import { JSDOM } from 'jsdom';
-
-const full = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
-
-class AudioCtx {
-  createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
-  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
-  get destination(){ return {}; }
-  resume(){}
-  suspend(){}
-  get currentTime(){ return 0; }
-}
-
-class Audio {
-  constructor(){ this.addEventListener = () => {}; }
-  cloneNode(){ return new Audio(); }
-  play(){ return Promise.resolve(); }
-  pause(){}
-}
+import { createGameProxy } from './test-harness.js';
 
 test('keyboard shortcuts toggle audio, mobile controls, and pickup', async () => {
-  const html = `<body>
-  <div id="log"></div>
-  <div id="hp"></div>
-  <div id="ap"></div>
-  <div id="scrap"></div>
-  <canvas id="game"></canvas>
-  <button id="saveBtn"></button>
-  <button id="loadBtn"></button>
-  <button id="resetBtn"></button>
-  <button id="nanoToggle"></button>
-  <button id="audioToggle"></button>
-  <button id="mobileToggle"></button>
-  <button id="settingsBtn"></button>
-  <div id="settings"><button id="settingsClose"></button></div>
-  <div id="panelToggle"></div>
-  <div class="panel"></div>
-  <div class="tabs"></div>
-  <div id="tabInv"></div>
-  <div id="tabParty"></div>
-  <div id="tabQuests"></div>
-  <div id="inv"></div>
-  <div id="party"></div>
-  <div id="quests"></div>
-  <div id="overlay"></div>
-  <div id="combatOverlay"></div>
-  <div id="moduleLoader"></div>
-  </body>`;
-  const dom = new JSDOM(html, { url:'https://example.com' });
-  Object.defineProperty(dom.window.HTMLCanvasElement.prototype, 'getContext', { value: () => ({ fillRect(){}, strokeRect(){}, drawImage(){}, clearRect(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){}, save(){}, restore(){}, translate(){}, fillText(){}, globalAlpha:1, font:'' }) });
-  dom.window.AudioContext = AudioCtx;
-  dom.window.webkitAudioContext = AudioCtx;
-  dom.window.Audio = Audio;
-
-  const party = [];
-  party.flags = {};
+  const { context, document } = createGameProxy([]);
   let takeCalls = 0;
-  const context = {
-    window: dom.window,
-    document: dom.window.document,
-    navigator: { userAgent: 'Test' },
-    AudioContext: AudioCtx,
-    webkitAudioContext: AudioCtx,
-    Audio: Audio,
-    EventBus: { on: () => {}, emit: () => {} },
-    requestAnimationFrame: () => 0,
-    move: () => {},
-    interact: () => {},
-    showTab: () => {},
-    takeNearestItem: () => { takeCalls++; },
-    renderParty: () => {},
-    toast: () => {},
-    NPCS: [],
-    party,
-    selectedMember: 0,
-    state: { map: 'world' },
-    player: { hp:10, ap:2, scrap:0 },
-    save: () => {},
-    load: () => {},
-    resetAll: () => {},
-    genWorld: () => {},
-    buildings: [],
-    interiors: {},
-    assert: () => {},
-    openCreator: () => {},
-    closeCreator: () => {},
-    startGame: () => {},
-    overlay: null,
-    handleDialogKey: () => false,
-    handleCombatKey: () => false,
-    showMini: false,
-    console,
-    URLSearchParams,
-    location: { search:'', hash:'' }
-  };
-  vm.createContext(context);
-  vm.runInContext(full, context);
-
-  const audioBtn = context.document.getElementById('audioToggle');
-  const mobileBtn = context.document.getElementById('mobileToggle');
+  context.takeNearestItem = () => { takeCalls++; };
+  const audioBtn = document.getElementById('audioToggle');
+  const mobileBtn = document.getElementById('mobileToggle');
   assert.strictEqual(audioBtn.textContent, 'Audio: On');
   assert.strictEqual(mobileBtn.textContent, 'Mobile Controls: Off');
 
-  dom.window.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key:'o' }));
+  context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'o' }));
   assert.strictEqual(audioBtn.textContent, 'Audio: Off');
 
-  dom.window.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key:'c' }));
+  context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'c' }));
   assert.strictEqual(mobileBtn.textContent, 'Mobile Controls: On');
 
-  dom.window.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key:'g' }));
+  context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'g' }));
   assert.strictEqual(takeCalls, 1);
 });

--- a/test/mobile-controls.test.js
+++ b/test/mobile-controls.test.js
@@ -1,50 +1,19 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
-import fs from 'node:fs/promises';
-import vm from 'node:vm';
-import { JSDOM } from 'jsdom';
+import { createGameProxy } from './test-harness.js';
 
-const full = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
-const code = full.split('function sfxTick')[0];
-
-class AudioCtx {
-  createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
-  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
-  get destination(){ return {}; }
-  get currentTime(){ return 0; }
-}
-
-async function setup(html, extras={}){
-  const dom = new JSDOM(html);
-  dom.window.AudioContext = AudioCtx;
-  dom.window.webkitAudioContext = AudioCtx;
-  const context = {
-    window: dom.window,
-    document: dom.window.document,
-    requestAnimationFrame: () => 0,
-    AudioContext: AudioCtx,
-    webkitAudioContext: AudioCtx,
-    Audio: class { constructor(){ this.addEventListener = () => {}; } },
-    EventBus: { on: () => {}, emit: () => {} },
-    NanoDialog: { enabled: true },
-    location: { hash: '' },
-    move: () => {},
-    interact: () => {},
-    takeNearestItem: () => {},
-    console,
-    ...extras
-  };
-  vm.createContext(context);
-  vm.runInContext(code, context);
-  return { dom, context };
+async function setup(extras={}){
+  const { context, document } = createGameProxy([]);
+  Object.assign(context, extras);
+  return { context, document };
 }
 
 test('mobile buttons are non-selectable and glow on press', async () => {
-  const { context } = await setup('<body><canvas id="game" width="640" height="480"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>');
+  const { context, document } = await setup();
   context.setMobileControls(true);
-  const btn = context.document.querySelector('button');
+  const btn = document.querySelector('button');
   assert.ok(btn);
-  assert.strictEqual(btn.style.userSelect, 'none');
+  assert.ok(btn.style.cssText?.includes('user-select:none'));
   btn.onpointerdown();
   assert.strictEqual(btn.style.boxShadow, '0 0 8px #0f0');
   btn.onpointerup();
@@ -53,47 +22,47 @@ test('mobile buttons are non-selectable and glow on press', async () => {
 
 test('mobile arrows navigate dialog when overlay shown', async () => {
   const keys=[];
-  const html = '<body><div id="overlay" class="shown"></div><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>';
-  const { dom, context } = await setup(html, {
+  const { context, document } = await setup({
     handleDialogKey: e => { keys.push(e.key); return true; },
     move: () => { keys.push('move'); },
     overlay: null
   });
-  context.overlay = dom.window.document.getElementById('overlay');
+  document.getElementById('overlay').classList.add('shown');
+  context.overlay = document.getElementById('overlay');
   context.setMobileControls(true);
-  const up = [...context.document.querySelectorAll('button')].find(b => b.textContent === '↑');
+  const up = [...document.querySelectorAll('button')].find(b => b.textContent === '↑');
   up.onclick();
-  const down = [...context.document.querySelectorAll('button')].find(b => b.textContent === '↓');
+  const down = [...document.querySelectorAll('button')].find(b => b.textContent === '↓');
   down.onclick();
   assert.deepStrictEqual(keys, ['ArrowUp', 'ArrowDown']);
 });
 
 test('mobile arrows navigate combat menu when in combat', async () => {
   const keys=[];
-  const html = '<body><div id="combatOverlay" class="shown"></div><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>';
-  const { context } = await setup(html, {
+  const { context, document } = await setup({
     handleCombatKey: e => { keys.push(e.key); return true; },
     move: () => { keys.push('move'); },
     overlay: null
   });
+  document.getElementById('combatOverlay').classList.add('shown');
   context.setMobileControls(true);
-  const up = [...context.document.querySelectorAll('button')].find(b => b.textContent === '↑');
+  const up = [...document.querySelectorAll('button')].find(b => b.textContent === '↑');
   up.onclick();
-  const down = [...context.document.querySelectorAll('button')].find(b => b.textContent === '↓');
+  const down = [...document.querySelectorAll('button')].find(b => b.textContent === '↓');
   down.onclick();
   assert.deepStrictEqual(keys, ['ArrowUp', 'ArrowDown']);
 });
 
 test('mobile A selects combat option when in combat', async () => {
   const keys = [];
-  const html = '<body><div id="combatOverlay" class="shown"></div><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div></body>';
-  const { context } = await setup(html, {
+  const { context, document } = await setup({
     handleCombatKey: e => { keys.push(e.key); return true; },
     interact: () => { keys.push('interact'); },
     overlay: null
   });
+  document.getElementById('combatOverlay').classList.add('shown');
   context.setMobileControls(true);
-  const a = [...context.document.querySelectorAll('button')].find(b => b.textContent === 'A');
+  const a = [...document.querySelectorAll('button')].find(b => b.textContent === 'A');
   a.onclick();
   assert.deepStrictEqual(keys, ['Enter']);
 });

--- a/test/skill-badge.test.js
+++ b/test/skill-badge.test.js
@@ -2,64 +2,36 @@ import assert from 'node:assert';
 import { test } from 'node:test';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
-import { JSDOM } from 'jsdom';
+import { createGameProxy } from './test-harness.js';
 
 const partyCode = await fs.readFile(new URL('../core/party.js', import.meta.url), 'utf8');
-const engineCode = await fs.readFile(new URL('../dustland-engine.js', import.meta.url), 'utf8');
 
 function setup(){
-  const html = `<body><div id="log"></div><span id="hp"></span><span id="ap"></span><span id="scrap"></span><canvas id="game"></canvas><div class="tabs"></div><div id="inv"></div><div id="party"></div><div id="quests"></div><div id="tabInv"></div><div id="tabParty"></div><div id="tabQuests"></div></body>`;
-  const dom = new JSDOM(html);
-  const AudioCtx = class { resume(){} suspend(){} };
-  dom.window.AudioContext = AudioCtx;
-  dom.window.webkitAudioContext = AudioCtx;
-  dom.window.Audio = class { constructor(){ } cloneNode(){ return new dom.window.Audio(); } play(){} pause(){} };
-  dom.window.HTMLCanvasElement.prototype.getContext = () => ({});
-  dom.window.NanoDialog = { enabled: true, init: () => {} };
-  dom.window.requestAnimationFrame = () => 0;
-  dom.window.cancelAnimationFrame = () => {};
-  dom.window.URLSearchParams = class { constructor(){ } get(){ return null; } };
-  const context = {
-    window: dom.window,
-    document: dom.window.document,
-    player: { hp:10, ap:2, scrap:0 },
-    EventBus: { emit: () => {}, on: () => {} },
-    unequipItem: () => {},
-    log: () => {},
-    localStorage: { getItem: () => null, setItem() {}, removeItem() {}, clear() {} },
-    showStart: () => {},
-    openCreator: () => {},
-    AudioContext: AudioCtx,
-    webkitAudioContext: AudioCtx,
-    Audio: dom.window.Audio,
-    NanoDialog: dom.window.NanoDialog,
-    requestAnimationFrame: dom.window.requestAnimationFrame,
-    cancelAnimationFrame: dom.window.cancelAnimationFrame,
-    URLSearchParams: dom.window.URLSearchParams,
-    location: dom.window.location,
-  };
-  vm.createContext(context);
+  const party=[];
+  const { context, document } = createGameProxy(party);
+  const ids=['log','hp','ap','scrap','inv','party','quests','tabInv','tabParty','tabQuests','game'];
+  ids.forEach(id=>document.body.appendChild(document.getElementById(id)));
+  document.body.appendChild(document.querySelector('.tabs'));
   vm.runInContext(partyCode, context);
-  vm.runInContext(engineCode, context);
-  return { context, dom };
+  return { context, document };
 }
 
 test('renders skill point badge when points available', () => {
-  const { context, dom } = setup();
+  const { context, document } = setup();
   const m = context.makeMember('id','Name','Role');
   m.skillPoints = 2;
   context.party.push(m);
   context.renderParty();
-  const badge = dom.window.document.querySelector('.spbadge');
+  const badge = document.querySelector('.spbadge');
   assert.ok(badge, 'badge exists');
-  assert.strictEqual(badge.textContent, '2');
+  assert.strictEqual(String(badge.textContent), '2');
 });
 
 test('no badge when no skill points', () => {
-  const { context, dom } = setup();
+  const { context, document } = setup();
   const m = context.makeMember('id','Name','Role');
   context.party.push(m);
   context.renderParty();
-  const badge = dom.window.document.querySelector('.spbadge');
+  const badge = document.querySelector('.spbadge');
   assert.strictEqual(badge, null);
 });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -2,20 +2,22 @@ import assert from 'node:assert';
 import { test } from 'node:test';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
-import { JSDOM } from 'jsdom';
+import { makeDocument } from './test-harness.js';
 
 test('ui module emits DOM updates via events', async () => {
-  const dom = new JSDOM('<div id="box" style="display:none"></div><input id="field" />');
-  const context = { window: dom.window, document: dom.window.document, console };
+  const document = makeDocument();
+  document.getElementById('box').style.display = 'none';
+  document.getElementById('field');
+  const context = { window: { document }, document, console };
   vm.createContext(context);
   const busCode = await fs.readFile(new URL('../event-bus.js', import.meta.url), 'utf8');
   vm.runInContext(busCode, context);
   const uiCode = await fs.readFile(new URL('../ui.js', import.meta.url), 'utf8');
   vm.runInContext(uiCode, context);
   context.Dustland.ui.show('box', 'flex');
-  assert.strictEqual(dom.window.document.getElementById('box').style.display, 'flex');
+  assert.strictEqual(document.getElementById('box').style.display, 'flex');
   context.Dustland.ui.hide('box');
-  assert.strictEqual(dom.window.document.getElementById('box').style.display, 'none');
+  assert.strictEqual(document.getElementById('box').style.display, 'none');
   context.Dustland.ui.setValue('field', 'hi');
-  assert.strictEqual(dom.window.document.getElementById('field').value, 'hi');
+  assert.strictEqual(document.getElementById('field').value, 'hi');
 });

--- a/test/wizard.test.js
+++ b/test/wizard.test.js
@@ -2,11 +2,13 @@ import assert from 'node:assert';
 import { test } from 'node:test';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
-import { JSDOM } from 'jsdom';
+import { makeDocument } from './test-harness.js';
 
 test('wizard preserves state and validates steps', async () => {
-  const dom = new JSDOM('<div id="w"></div>');
-  const context = { window: dom.window, document: dom.window.document, console };
+  const document = makeDocument();
+  const containerEl = document.getElementById('w');
+  document.body.appendChild(containerEl);
+  const context = { window: { document }, document, console };
   vm.createContext(context);
   const busCode = await fs.readFile(new URL('../event-bus.js', import.meta.url), 'utf8');
   vm.runInContext(busCode, context);
@@ -16,7 +18,7 @@ test('wizard preserves state and validates steps', async () => {
   vm.runInContext(textCode, context);
   const confirmCode = await fs.readFile(new URL('../components/wizard/steps/confirm.js', import.meta.url), 'utf8');
   vm.runInContext(confirmCode, context);
-  const container = dom.window.document.getElementById('w');
+  const container = containerEl;
   let finished = false;
   const wizard = context.Dustland.Wizard(container, [
     context.Dustland.WizardSteps.text('Name', 'name'),
@@ -25,12 +27,12 @@ test('wizard preserves state and validates steps', async () => {
 
   assert.strictEqual(wizard.current(), 0);
   assert.strictEqual(wizard.next(), false);
-  dom.window.document.querySelector('input').value = 'Alice';
+  document.querySelector('input').value = 'Alice';
   assert.strictEqual(wizard.next(), true);
   assert.strictEqual(wizard.getState().name, 'Alice');
   wizard.prev();
   assert.strictEqual(wizard.current(), 0);
-  assert.strictEqual(dom.window.document.querySelector('input').value, 'Alice');
+  assert.strictEqual(document.querySelector('input').value, 'Alice');
   wizard.next();
   assert.strictEqual(wizard.current(), 1);
   wizard.next();


### PR DESCRIPTION
## Summary
- replace JSDOM usage with custom test harness across several tests
- expand test harness with event dispatch, DOM query, and classList helpers for new tests

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68aef64ea1bc8328ac9a190a72ce01d2