### PR TITLE
feat: scale module picker with screen size

### DIFF
--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -78,7 +78,7 @@ vm.runInThisContext(code, { filename: '../module-picker.js' });
 test('module picker shows title and dust background', () => {
   const overlay = bodyEl.children.find(c => c.id === 'modulePicker');
   assert.ok(overlay);
-  const title = overlay.children.find(c => c.id === 'gameTitle');
+  const title = overlay.querySelector('#gameTitle');
   assert.ok(title);
   assert.strictEqual(title.textContent, 'Dustland CRT');
   const canvas = overlay.children.find(c => c.id === 'dustParticles');


### PR DESCRIPTION
## Summary
- scale module picker title and menu based on viewport size
- scale dust particles with UI and keep module picker tests up to date

## Testing
- `npm test`
- `node presubmit.js dustland.html adventure-kit.html`

------
https://chatgpt.com/codex/tasks/task_e_68aefb6dbab083288347bbd385d4cf26