### PR TITLE
feat: expose mobile control buttons for test access

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -55,7 +55,7 @@ function toggleAudio(){ setAudio(!audioEnabled); }
 globalThis.toggleAudio = toggleAudio;
 const isMobileUA = typeof navigator !== 'undefined' && /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 let mobileControlsEnabled = isMobileUA;
-let mobileWrap = null, mobilePad = null, mobileAB = null;
+let mobileWrap = null, mobilePad = null, mobileAB = null, mobileButtons = {};
 function setMobileControls(on){
   mobileControlsEnabled = on;
   const btn=document.getElementById('mobileToggle');
@@ -63,11 +63,12 @@ function setMobileControls(on){
   document.body.classList.toggle('mobile-on', on);
   if(on){
     if(!mobileWrap){
+      mobileButtons = {};
       mobileWrap=document.createElement('div');
       mobileWrap.id='mobileControls';
       mobileWrap.style.cssText='position:fixed;left:0;right:0;bottom:0;height:180px;display:flex;justify-content:space-between;padding:20px;z-index:1000;touch-action:manipulation;';
       document.body.appendChild(mobileWrap);
-      const mk=(t,fn)=>{
+      const mk=(name,t,fn)=>{
         const b=document.createElement('button');
         b.textContent=t;
         b.style.cssText='width:48px;height:48px;border:2px solid #0f0;border-radius:8px;background:#000;color:#0f0;font-size:20px;user-select:none;outline:none;touch-action:manipulation;';
@@ -84,6 +85,7 @@ function setMobileControls(on){
         };
         b.onpointerup=up;
         b.onpointerleave=up;
+        mobileButtons[name]=b;
         return b;
       };
       const mobileMove=(dx,dy,key)=>{
@@ -99,20 +101,20 @@ function setMobileControls(on){
       mobilePad.style.cssText='display:grid;grid-template-columns:repeat(3,48px);grid-template-rows:repeat(3,48px);gap:6px;user-select:none;';
       const cells=[
         document.createElement('div'),
-        mk("↑",()=>mobileMove(0,-1,'ArrowUp')),
+        mk('up','↑',()=>mobileMove(0,-1,'ArrowUp')),
         document.createElement('div'),
-        mk("←",()=>mobileMove(-1,0,'ArrowLeft')),
+        mk('left','←',()=>mobileMove(-1,0,'ArrowLeft')),
         document.createElement('div'),
-        mk("→",()=>mobileMove(1,0,'ArrowRight')),
+        mk('right','→',()=>mobileMove(1,0,'ArrowRight')),
         document.createElement('div'),
-        mk("↓",()=>mobileMove(0,1,'ArrowDown')),
+        mk('down','↓',()=>mobileMove(0,1,'ArrowDown')),
         document.createElement('div')
       ];
       cells.forEach(c=>mobilePad.appendChild(c));
       mobileWrap.appendChild(mobilePad);
       mobileAB=document.createElement('div');
       mobileAB.style.cssText='display:flex;gap:10px;user-select:none;';
-      mobileAB.appendChild(mk('A',()=>{
+      mobileAB.appendChild(mk('A','A',()=>{
         if(overlay?.classList?.contains('shown')){
           handleDialogKey?.({ key:'Enter' });
         } else if(document.getElementById('combatOverlay')?.classList?.contains('shown')){
@@ -121,13 +123,14 @@ function setMobileControls(on){
           interact();
         }
       }));
-      mobileAB.appendChild(mk('B',takeNearestItem));
+      mobileAB.appendChild(mk('B','B',takeNearestItem));
       mobileWrap.appendChild(mobileAB);
     }
   } else {
     if(mobileWrap){ mobileWrap.remove(); mobileWrap=null; }
-    mobilePad=null; mobileAB=null;
+    mobilePad=null; mobileAB=null; mobileButtons={};
   }
+  return mobileButtons;
 }
 function toggleMobileControls(){ setMobileControls(!mobileControlsEnabled); }
 function sfxTick(){

--- a/test/mobile-controls.test.js
+++ b/test/mobile-controls.test.js
@@ -10,8 +10,7 @@ async function setup(extras={}){
 
 test('mobile buttons are non-selectable and glow on press', async () => {
   const { context, document } = await setup();
-  context.setMobileControls(true);
-  const btn = document.querySelector('button');
+  const { up: btn } = context.setMobileControls(true);
   assert.ok(btn);
   assert.ok(btn.style.cssText?.includes('user-select:none'));
   btn.onpointerdown();
@@ -29,10 +28,8 @@ test('mobile arrows navigate dialog when overlay shown', async () => {
   });
   document.getElementById('overlay').classList.add('shown');
   context.overlay = document.getElementById('overlay');
-  context.setMobileControls(true);
-  const up = [...document.querySelectorAll('button')].find(b => b.textContent === '↑');
+  const { up, down } = context.setMobileControls(true);
   up.onclick();
-  const down = [...document.querySelectorAll('button')].find(b => b.textContent === '↓');
   down.onclick();
   assert.deepStrictEqual(keys, ['ArrowUp', 'ArrowDown']);
 });
@@ -45,10 +42,8 @@ test('mobile arrows navigate combat menu when in combat', async () => {
     overlay: null
   });
   document.getElementById('combatOverlay').classList.add('shown');
-  context.setMobileControls(true);
-  const up = [...document.querySelectorAll('button')].find(b => b.textContent === '↑');
+  const { up, down } = context.setMobileControls(true);
   up.onclick();
-  const down = [...document.querySelectorAll('button')].find(b => b.textContent === '↓');
   down.onclick();
   assert.deepStrictEqual(keys, ['ArrowUp', 'ArrowDown']);
 });
@@ -61,8 +56,7 @@ test('mobile A selects combat option when in combat', async () => {
     overlay: null
   });
   document.getElementById('combatOverlay').classList.add('shown');
-  context.setMobileControls(true);
-  const a = [...document.querySelectorAll('button')].find(b => b.textContent === 'A');
+  const { A: a } = context.setMobileControls(true);
   a.onclick();
   assert.deepStrictEqual(keys, ['Enter']);
 });


### PR DESCRIPTION
## Summary
- return mobile control button references from `setMobileControls`
- simplify mobile control tests to avoid repeated `querySelector`

## Testing
- `node presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aefbfd77fc8328ac7081b1d1a65364