### PR TITLE
fix: anchor trainer ui to viewport

### DIFF
--- a/test/trainer-ui.test.js
+++ b/test/trainer-ui.test.js
@@ -44,3 +44,10 @@ test('apply upgrade via click', async () => {
   assert.strictEqual(m.stats.STR, 5);
   assert.strictEqual(m.skillPoints, 0);
 });
+
+test('trainer ui is fixed on screen', async () => {
+  const { context, dom } = setup();
+  const box = await context.TrainerUI.showTrainer('power');
+  assert.strictEqual(box.style.position, 'fixed');
+  assert.ok(parseInt(box.style.bottom) > 0);
+});

--- a/trainer-ui.js
+++ b/trainer-ui.js
@@ -10,6 +10,7 @@
     if(!box){
       box = document.createElement('div');
       box.id = 'trainer_ui';
+      box.style.cssText = 'position:fixed;left:50%;bottom:12px;transform:translateX(-50%);display:flex;flex-direction:column;gap:6px;z-index:1000;';
     }
     box.innerHTML = '';
     upgrades.forEach(up => {


### PR DESCRIPTION
## Summary
- prevent page scroll when trainer buttons appear by using fixed overlay with bottom offset
- verify trainer UI positioning with a test

## Testing
- `./install-deps.sh`
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: Cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68af02792a14832887c6d2576dee286a