### PR TITLE
feat: add crunchy damage sound

### DIFF
--- a/dustland-engine.js
+++ b/dustland-engine.js
@@ -145,6 +145,19 @@ function sfxTick(){
   g.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime+0.1);
   o.stop(audioCtx.currentTime+0.1);
 }
+function sfxCrunch(){
+  if(!audioEnabled || typeof audioCtx?.createOscillator!=='function') return;
+  const o=audioCtx.createOscillator();
+  const g=audioCtx.createGain();
+  o.type='square';
+  o.frequency.setValueAtTime(200,audioCtx.currentTime);
+  o.frequency.exponentialRampToValueAtTime(40,audioCtx.currentTime+0.2);
+  o.connect(g); g.connect(audioCtx.destination);
+  g.gain.value=0.3;
+  o.start();
+  g.gain.exponentialRampToValueAtTime(0.001,audioCtx.currentTime+0.2);
+  o.stop(audioCtx.currentTime+0.2);
+}
 const sfxSpriteData = [
   { id:'step', start:0.00, dur:0.05 },
   { id:'pickup', start:0.05, dur:0.08 },
@@ -159,6 +172,7 @@ let sfxIndex = 0;
 function playSfx(id){
   if(!audioEnabled) return;
   if(id==='tick') return sfxTick();
+  if(id==='damage') return sfxCrunch();
   const meta=sfxSpriteData.find(s=>s.id===id);
   if(!meta) return;
   const slot=sfxIndex++%sfxPool.length;
@@ -406,6 +420,7 @@ function updateHUD(){
   const fx = globalThis.fxConfig;
   if(hpBar){
     if(player.hp < prevHp && fx?.damageFlash !== false){
+      EventBus.emit('sfx','damage');
       hpBar.classList.add('hurt');
       clearTimeout(updateHUD._hurtTimer);
       updateHUD._hurtTimer = setTimeout(()=>hpBar.classList.remove('hurt'), 300);

--- a/test/sfx.test.js
+++ b/test/sfx.test.js
@@ -94,3 +94,12 @@ test('playSfx reuses a pool of five audio elements', async () => {
   assert.strictEqual(getAudioCount(), 6);
   cleanup();
 });
+
+test('damage sfx uses oscillator without creating audio elements', async () => {
+  const { cleanup, getAudioCount, getPlays } = await setup();
+  const before = getAudioCount();
+  global._playSfx('damage');
+  assert.strictEqual(getAudioCount(), before);
+  assert.strictEqual(getPlays(), 0);
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- play a crunchy square-wave effect when the player takes damage
- test that damage sound doesn't create extra audio elements

## Testing
- `npm test`
- `node presubmit.js`
- `node balance-tester-agent.js` *(fails: showTab failed. Adventure Kit?)*

------
https://chatgpt.com/codex/tasks/task_e_68af02a3cb188328b085a4c154c5f78f