### PR TITLE
feat: animate scanlines and random shear

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -160,8 +160,19 @@
         position: absolute;
         inset: 0;
         pointer-events: none;
-        background: repeating-linear-gradient(to bottom, rgba(255, 255, 255, .05) 0px, rgba(255, 255, 255, .05) 1px, rgba(0, 0, 0, 0) 2px);
+        background-image: linear-gradient(rgba(0, 0, 0, .1) 50%, transparent 50%);
+        background-size: 100% 2px;
+        animation: scanlines 5s linear infinite;
         mix-blend-mode: overlay
+    }
+
+    @keyframes scanlines {
+        from {
+            background-position: 0 0;
+        }
+        to {
+            background-position: 0 100%;
+        }
     }
 
     #game.shear {

--- a/fx-debug.js
+++ b/fx-debug.js
@@ -13,11 +13,37 @@
   const colorBleed = document.getElementById('fxColorBleed');
   const canvas = document.getElementById('game');
 
+  let shearTimer;
+
+  function stopShear(){
+    clearTimeout(shearTimer);
+    shearTimer = null;
+    canvas?.classList.remove('shear');
+  }
+
+  function startShear(){
+    if(shearTimer || !canvas) return;
+    function warp(){
+      canvas.classList.add('shear');
+      setTimeout(() => {
+        canvas.classList.remove('shear');
+        const delay = 2000 + Math.random() * 3000;
+        shearTimer = setTimeout(warp, delay);
+        shearTimer.unref?.();
+      }, 100).unref?.();
+    }
+    warp();
+  }
+
   function applyFx(){
     if(!canvas || !globalThis.fxConfig) return;
     canvas.classList.toggle('scanlines', !!globalThis.fxConfig.scanlines);
-    canvas.classList.toggle('shear', !!globalThis.fxConfig.crtShear);
     canvas.classList.toggle('color-bleed', !!globalThis.fxConfig.colorBleed);
+    if(globalThis.fxConfig.crtShear){
+      startShear();
+    }else{
+      stopShear();
+    }
   }
 
   function sync(){

--- a/test/fx-debug.test.js
+++ b/test/fx-debug.test.js
@@ -10,6 +10,8 @@ test('damage flash checkbox updates fxConfig', async () => {
   window.fxConfig = { damageFlash: true };
   const sandbox = { window, document, fxConfig: window.fxConfig };
   sandbox.globalThis = sandbox;
+  sandbox.setTimeout = setTimeout;
+  sandbox.clearTimeout = clearTimeout;
   document.getElementById('fxPanel').appendChild(document.getElementById('fxDamageFlash'));
   document.getElementById('hpBar').classList.add('hurt');
   const code = await fs.readFile(new URL('../fx-debug.js', import.meta.url), 'utf8');
@@ -30,6 +32,8 @@ test('fx checkboxes apply classes and update config', async () => {
   window.fxConfig = { scanlines: false, crtShear: false, colorBleed: false };
   const sandbox = { window, document, fxConfig: window.fxConfig };
   sandbox.globalThis = sandbox;
+  sandbox.setTimeout = setTimeout;
+  sandbox.clearTimeout = clearTimeout;
   document.getElementById('fxPanel').appendChild(document.getElementById('fxScanlines'));
   document.getElementById('fxPanel').appendChild(document.getElementById('fxCrtShear'));
   document.getElementById('fxPanel').appendChild(document.getElementById('fxColorBleed'));
@@ -49,6 +53,8 @@ test('fx checkboxes apply classes and update config', async () => {
   shear.dispatchEvent({ type:'change' });
   assert.equal(window.fxConfig.crtShear, true);
   assert.ok(canvas.classList.contains('shear'));
+  await new Promise(r => setTimeout(r, 150));
+  assert.ok(!canvas.classList.contains('shear'));
 
   bleed.checked = true;
   bleed.dispatchEvent({ type:'change' });


### PR DESCRIPTION
## Summary
- add animated CRT scanline overlay
- implement intermittent shear effect that schedules itself
- test FX menu shear timing

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68aefdc5ed648328b4e1aaa64b4a03c8