### PR TITLE
fix: limit shop window height

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -650,6 +650,9 @@
   border: 1px solid #2b3b2b;
   border-radius: 8px;
   box-shadow: 0 0 20px #000;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .shop-window header {
@@ -664,11 +667,16 @@
   display: flex;
   padding: 12px;
   gap: 24px;
+  flex: 1;
+  min-height: 0;
 }
 
 .shop-inv, .player-inv {
   flex: 1;
   padding: 0 12px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .shop-window .slot {
@@ -686,6 +694,8 @@
   flex-direction: column;
   gap: 8px;
   margin-top: 8px;
+  overflow-y: auto;
+  flex: 1;
 }
 
     #creator .win {


### PR DESCRIPTION
## Summary
- limit shop window height to 80vh and enable scrolling for shop lists

## Testing
- `npm test`
- `node presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68af0f04c40c832881d90f0199826745