### PR TITLE
feat: scale damage with adrenaline

### DIFF
--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -17,6 +17,8 @@ Sitting back and playing defensively is a losing strategy. The player who isn't 
 
 Adrenaline persists between encounters, gently cooling when a character is at full health. A full rest that restores the whole party immediately clears any stored Adrenaline.
 
+The more Adrenaline you have, the harder you hit. Damage scales with the current meter, reaching +100% at a full bar. Items that carry an `adrenaline_dmg_mod` can amplify this boost beyond 200%.
+
 > **Clown:** I'm into the forward momentum, but we should confirm the Adrenaline bar doesn't crowd the HUD. Let's prototype it with placeholder art before committing. When it's full, it could arc with energy. When you use a Special, it slams down, then starts building again. The UI itself should feel energetic.
 
 ### Specials: High Risk, High Reward

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -608,7 +608,7 @@ startGame = function () {
       name: 'Adrenaline Charm',
       type: 'trinket',
       slot: 'trinket',
-      mods: { adrenaline_gen_mod: 2 }
+      mods: { adrenaline_gen_mod: 2, adrenaline_dmg_mod: 1.5 }
     });
     if (castleId && interiors[castleId]) {
       const interior = interiors[castleId];

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -192,7 +192,7 @@ loopMinus.addEventListener('click', () => {
 
 const moduleData = { seed: Date.now(), name: 'adventure-module', npcs: [], items: [], quests: [], buildings: [], interiors: [], portals: [], events: [], encounters: [], templates: [], start: { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) } };
 const STAT_OPTS = ['ATK', 'DEF', 'LCK', 'INT', 'PER', 'CHA'];
-const MOD_TYPES = ['ATK', 'DEF', 'LCK', 'INT', 'PER', 'CHA', 'STR', 'AGI', 'ADR', 'adrenaline_gen_mod'];
+const MOD_TYPES = ['ATK', 'DEF', 'LCK', 'INT', 'PER', 'CHA', 'STR', 'AGI', 'ADR', 'adrenaline_gen_mod', 'adrenaline_dmg_mod'];
 let editNPCIdx = -1, editItemIdx = -1, editQuestIdx = -1, editBldgIdx = -1, editInteriorIdx = -1, editEventIdx = -1, editPortalIdx = -1, editEncounterIdx = -1, editTemplateIdx = -1;
 let treeData = {};
 let selectedObj = null;

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -377,6 +377,9 @@ function doAttack(dmg, type = 'basic'){
   if (!attacker || !target){ nextCombatant?.(); return; }
 
   let dealt = dmg;
+  const adrPct = Math.max(0, Math.min(1, (attacker.adr ?? 0) / (attacker.maxAdr || 100)));
+  const mult  = 1 + adrPct * (attacker.adrDmgMod || 1);
+  dealt = Math.round(dealt * mult);
 
   // Immunity to basic
   if (type === 'basic' && Array.isArray(target.immune) && target.immune.includes('basic')){

--- a/scripts/core/equipment.js
+++ b/scripts/core/equipment.js
@@ -11,7 +11,7 @@
     name: 'Stun Baton',
     type: 'weapon',
     slot: 'weapon',
-    mods: { ATK: 1, ADR: 15, adrenaline_gen_mod: 1.2 }
+    mods: { ATK: 1, ADR: 15, adrenaline_gen_mod: 1.2, adrenaline_dmg_mod: 1.2 }
   });
   registerItem({
     id: 'leather_jacket',

--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -18,6 +18,7 @@ class Character {
     this._bonus={ATK:0, DEF:0, LCK:0};
     this.special = Array.isArray(opts.special) ? [...opts.special] : [];
     this.adrGenMod = 1;
+    this.adrDmgMod = 1;
     this.cooldowns = {};
     this.guard = false;
   }
@@ -60,6 +61,7 @@ class Character {
   }
   applyCombatMods(){
     this.adrGenMod = 1;
+    this.adrDmgMod = 1;
     if(!Array.isArray(this._baseSpecial)){
       this._baseSpecial = [...this.special];
     }
@@ -69,6 +71,9 @@ class Character {
       if(it&&it.mods){
         if(typeof it.mods.adrenaline_gen_mod === 'number'){
           this.adrGenMod *= it.mods.adrenaline_gen_mod;
+        }
+        if(typeof it.mods.adrenaline_dmg_mod === 'number'){
+          this.adrDmgMod *= it.mods.adrenaline_dmg_mod;
         }
         const grant = it.mods.granted_special;
         if(grant){

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1540,6 +1540,32 @@ test('equipment modifiers apply at battle start', async () => {
   await resultPromise;
 });
 
+test('adrenaline boosts attack damage', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  m1.adr = 100;
+  party.addMember(m1);
+  const resultPromise = openCombat([{ name: 'E1', hp: 3 }]);
+  handleCombatKey({ key: 'Enter' });
+  assert.strictEqual(combatState.enemies[0].hp, 1);
+  handleCombatKey({ key: 'Enter' });
+  await resultPromise;
+});
+
+test('adrenaline damage modifiers amplify boost', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  m1.equip.trinket = { mods: { adrenaline_dmg_mod: 2 } };
+  m1.adr = 100;
+  party.addMember(m1);
+  const resultPromise = openCombat([{ name: 'E1', hp: 3 }]);
+  handleCombatKey({ key: 'Enter' });
+  const res = await resultPromise;
+  assert.strictEqual(res.result, 'loot');
+});
+
 test('enemy immune to basic attacks requires specials', async () => {
   party.length = 0;
   player.inv.length = 0;

--- a/test/equipment.test.js
+++ b/test/equipment.test.js
@@ -36,3 +36,10 @@ test('adrenaline modifiers are applied', () => {
   c.applyCombatMods();
   assert.strictEqual(c.adrGenMod, 1.1);
 });
+
+test('adrenaline damage modifiers are applied', () => {
+  const c = new Character('id3', 'Brawler', 'brawler');
+  c.equip.weapon = getItem('stun_baton');
+  c.applyCombatMods();
+  assert.strictEqual(c.adrDmgMod, 1.2);
+});


### PR DESCRIPTION
## Summary
- scale player damage with current adrenaline, up to +100%
- add `adrenaline_dmg_mod` item modifier for boosting this multiplier
- update gear, docs, and tests for adrenaline damage boosts

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68af10f717f4832898034bf91ed7cf4c