### PR TITLE
fix: reset adrenaline on fall

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -554,6 +554,7 @@ function finishEnemyAttack(enemy, target){
   if (target.hp <= 0){
     log?.(`${target.name} falls!`);
     recordCombatEvent?.({ type: 'player', actor: target.name, action: 'fall', by: enemy.name });
+    target.adr = 0; // lose adrenaline on defeat
     combatState.fallen.push(target);
     party.splice(0, 1);
     renderCombat();

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1134,6 +1134,24 @@ test('fallen party members are revived after combat', async () => {
   assert.ok(party[0].hp >= 1);
 });
 
+test('falling resets adrenaline', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  m1.hp = 1;
+  m1.adr = 30;
+  party.addMember(m1);
+
+  const resultPromise = openCombat([
+    { name:'E1', hp:3 }
+  ]);
+
+  handleCombatKey({ key:'Enter' });
+  const res = await resultPromise;
+  assert.strictEqual(res.result, 'bruise');
+  assert.strictEqual(m1.adr, 0);
+});
+
 test('combat hp bars update after damage', async () => {
   party.length = 0;
   player.inv.length = 0;


### PR DESCRIPTION
## Summary
- reset adrenaline when a party member falls in combat
- test that falling clears adrenaline

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68af10b35120832890e0990db6e274c4