### PR TITLE
feat: group nearby NPCs into combat and randomize enemy targeting

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -555,7 +555,8 @@ function finishEnemyAttack(enemy, target){
     log?.(`${target.name} falls!`);
     recordCombatEvent?.({ type: 'player', actor: target.name, action: 'fall', by: enemy.name });
     combatState.fallen.push(target);
-    party.splice(0, 1);
+    const idx = party.indexOf?.(target);
+    if (idx >= 0) party.splice(idx, 1); else party.splice(0, 1);
     renderCombat();
     if ((party?.length || 0) === 0){
       log?.('The party has fallen...');
@@ -579,8 +580,10 @@ function finishEnemyAttack(enemy, target){
 }
 
 function enemyAttack(){
+  // Enemies strike a random party member.
   const enemy  = combatState.enemies[combatState.active];
-  const target = party[0];
+  const tgtIdx = Math.floor(Math.random() * ((party?.length) || 0));
+  const target = party[tgtIdx];
 
   if (!enemy || !target){ closeCombat('flee'); return; }
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1321,6 +1321,7 @@ test('healParty restores HP and clears adrenaline', () => {
 });
 
 test('startCombat forwards portraitSheet', async () => {
+  NPCS.length = 0;
   let captured;
   const orig = global.openCombat;
   global.openCombat = async (enemies) => { captured = enemies; return { result:'flee' }; };
@@ -1597,6 +1598,48 @@ test('combat log records player and enemy actions', async () => {
   const logEntries = getCombatLog();
   assert.ok(logEntries.some(e => e.type === 'player' && e.action === 'attack'));
   assert.ok(logEntries.some(e => e.type === 'enemy' && e.action === 'attack'));
+});
+
+test('enemy attacks random party member', async () => {
+  NPCS.length = 0;
+  party.length = 0;
+  const m1 = new Character('p1', 'P1', 'Role');
+  const m2 = new Character('p2', 'P2', 'Role');
+  m1.hp = m1.maxHp = 5;
+  m2.hp = m2.maxHp = 5;
+  party.addMember(m1);
+  party.addMember(m2);
+
+  const origRand = Math.random;
+  Math.random = () => 0.9; // force target index 1
+
+  const resultPromise = openCombat([{ name: 'E1', hp: 3 }]);
+  handleCombatKey({ key: 'Enter' }); // m1 attack
+  handleCombatKey({ key: 'Enter' }); // m2 attack triggers enemy phase
+
+  Math.random = origRand;
+  closeCombat('flee');
+  await resultPromise;
+
+  assert.strictEqual(m1.hp, 5);
+  assert.strictEqual(m2.hp, 4);
+});
+
+test('nearby combat NPCs join combat', async () => {
+  NPCS.length = 0;
+  party.x = 0; party.y = 0; party.map = 'world';
+  const npc1 = { id:'a', map:'world', x:0, y:0, name:'A', combat:{ HP:1 } };
+  const npc2 = { id:'b', map:'world', x:1, y:0, name:'B', combat:{ HP:1 } };
+  const npc3 = { id:'c', map:'world', x:5, y:5, name:'C', combat:{ HP:1 } };
+  NPCS.push(npc1, npc2, npc3);
+  let captured;
+  const orig = global.openCombat;
+  global.openCombat = async (enemies) => { captured = enemies; return { result:'flee' }; };
+  await startCombat({ ...npc1.combat, npc:npc1, name:npc1.name });
+  global.openCombat = orig;
+  assert.strictEqual(captured.length, 2);
+  assert.ok(captured.some(e => e.npc === npc1));
+  assert.ok(captured.some(e => e.npc === npc2));
 });
 
 test('shop npc opens dialog before trading', () => {


### PR DESCRIPTION
## Summary
- allow enemies to strike random party members and properly remove fallen
- start combat with all nearby hostile NPCs
- test coverage for new combat flow

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68af117137848328aea5e939f9db54f3