### PR TITLE
fix: correct module picker path

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -240,7 +240,7 @@
     }
     const modeScript = document.createElement('script');
     modeScript.defer = true;
-    modeScript.src = isAck ? './ack-player.js' : './module-picker.js';
+    modeScript.src = isAck ? './scripts/ack-player.js' : './scripts/module-picker.js';
     document.body.appendChild(modeScript);
   </script>
   <!-- Shop overlay -->


### PR DESCRIPTION
## Summary
- fix module picker script path in `dustland.html`

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68af1512e17c8328a21c1bccecd297df