### PR TITLE
fix: restore timers after tests

### DIFF
--- a/test/fast-timeouts.js
+++ b/test/fast-timeouts.js
@@ -2,9 +2,9 @@ const realTimeout = globalThis.setTimeout;
 const realClearTimeout = globalThis.clearTimeout;
 
 globalThis.setTimeout = (fn) => { queueMicrotask(fn); return 0; };
-globalThis.clearTimeout = () => {};
+globalThis.clearTimeout = realClearTimeout;
 
-export function restoreTimeouts(){
+process.on('exit', () => {
   globalThis.setTimeout = realTimeout;
   globalThis.clearTimeout = realClearTimeout;
-}
+});


### PR DESCRIPTION
## Summary
- restore real clearTimeout and reset timers after suite exits to prevent hang

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `./install-deps.sh` *(fails: Invalid response from proxy)*
- `node scripts/balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68af143794708328a807e0f8042bed48