### PR TITLE
feat: add adrenaline tint and grayscale FX

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -152,7 +152,8 @@
     }
 
     #game {
-        position: relative
+        position: relative;
+        filter: var(--fxFilter, none)
     }
 
     #game.scanlines::after {
@@ -180,11 +181,11 @@
     }
 
     #game.color-bleed {
-        filter: drop-shadow(0 0 2px #9ef7a0) drop-shadow(0 0 6px #9ef7a0) drop-shadow(2px 0 0 red) drop-shadow(-2px 0 0 cyan)
+        filter: drop-shadow(0 0 2px #9ef7a0) drop-shadow(0 0 6px #9ef7a0) drop-shadow(2px 0 0 red) drop-shadow(-2px 0 0 cyan) var(--fxFilter, none)
     }
 
     body.hp-critical #game {
-        filter: grayscale(.8)
+        filter: grayscale(.8) var(--fxFilter, none)
     }
 
     body.hp-critical::after {

--- a/dustland.html
+++ b/dustland.html
@@ -102,6 +102,14 @@
           <input type="checkbox" id="fxColorBleed" />
         </div>
         <div class="field">
+          <label for="fxGrayscale">Grayscale</label>
+          <input type="checkbox" id="fxGrayscale" />
+        </div>
+        <div class="field">
+          <label for="fxAdrTint">Adrenaline Tint</label>
+          <input type="checkbox" id="fxAdrTint" />
+        </div>
+        <div class="field">
           <label for="fxPrevAlpha">Trail Alpha</label>
           <input type="range" id="fxPrevAlpha" min="0" max="1" step="0.01" />
         </div>

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -452,6 +452,24 @@ function updateHUD(){
     adrBar.setAttribute('aria-valuemax', lead.maxAdr || 1);
     adrBar.setAttribute('aria-valuemin', 0);
   }
+  if(disp && fx){
+    const filters = [];
+    if(fx.grayscale) filters.push('grayscale(1)');
+    if(fx.adrenalineTint && lead){
+      const ratio = Math.max(0, Math.min(1, lead.adr / (lead.maxAdr || 1)));
+      if(ratio > 0){
+        const sat = 1 + ratio * 1.5;
+        const hue = ratio * 90;
+        filters.push(`saturate(${sat}) hue-rotate(${hue}deg)`);
+      }
+    }
+    const fstr = filters.join(' ');
+    if(fstr){
+      disp.style.setProperty('--fxFilter', fstr);
+    }else{
+      disp.style.removeProperty('--fxFilter');
+    }
+  }
   if(statusIcons){
     statusIcons.innerHTML='';
     if(typeof buffs !== 'undefined' && lead){

--- a/scripts/fx-config.js
+++ b/scripts/fx-config.js
@@ -9,6 +9,8 @@
     damageFlash: false, // disable red flash by default; toggle via fx menu
     scanlines: false, // overlay horizontal scanlines
     crtShear: false, // slight screen skew effect
-    colorBleed: false // simple chromatic aberration
+    colorBleed: false, // simple chromatic aberration
+    grayscale: false, // render world in grayscale
+    adrenalineTint: true // green saturation scales with adrenaline
   };
 })();

--- a/scripts/fx-debug.js
+++ b/scripts/fx-debug.js
@@ -11,6 +11,8 @@
   const scanlines = document.getElementById('fxScanlines');
   const shear = document.getElementById('fxCrtShear');
   const colorBleed = document.getElementById('fxColorBleed');
+  const grayscale = document.getElementById('fxGrayscale');
+  const adrTint = document.getElementById('fxAdrTint');
   const canvas = document.getElementById('game');
 
   let shearTimer;
@@ -44,6 +46,7 @@
     }else{
       stopShear();
     }
+    globalThis.updateHUD?.();
   }
 
   function sync(){
@@ -57,6 +60,8 @@
     if(scanlines) scanlines.checked = !!globalThis.fxConfig.scanlines;
     if(shear) shear.checked = !!globalThis.fxConfig.crtShear;
     if(colorBleed) colorBleed.checked = !!globalThis.fxConfig.colorBleed;
+    if(grayscale) grayscale.checked = !!globalThis.fxConfig.grayscale;
+    if(adrTint) adrTint.checked = globalThis.fxConfig.adrenalineTint !== false;
     applyFx();
   }
 
@@ -84,6 +89,8 @@
   scanlines?.addEventListener('change', e => { globalThis.fxConfig.scanlines = e.target.checked; applyFx(); });
   shear?.addEventListener('change', e => { globalThis.fxConfig.crtShear = e.target.checked; applyFx(); });
   colorBleed?.addEventListener('change', e => { globalThis.fxConfig.colorBleed = e.target.checked; applyFx(); });
+  grayscale?.addEventListener('change', e => { globalThis.fxConfig.grayscale = e.target.checked; globalThis.updateHUD?.(); });
+  adrTint?.addEventListener('change', e => { globalThis.fxConfig.adrenalineTint = e.target.checked; globalThis.updateHUD?.(); });
 
   const dragHandle = panel?.querySelector('header');
   let dragX = 0;

--- a/test/fx-debug.test.js
+++ b/test/fx-debug.test.js
@@ -66,3 +66,27 @@ test('fx checkboxes apply classes and update config', async () => {
   assert.equal(window.fxConfig.colorBleed, false);
   assert.ok(!canvas.classList.contains('color-bleed'));
 });
+
+test('grayscale and adrenaline tint toggles update config and call updateHUD', async () => {
+  const document = makeDocument();
+  const window = { document };
+  let calls = 0;
+  function updateHUD(){ calls++; }
+  window.updateHUD = updateHUD;
+  window.fxConfig = { grayscale: false, adrenalineTint: true };
+  const sandbox = { window, document, fxConfig: window.fxConfig, updateHUD };
+  sandbox.globalThis = sandbox;
+  sandbox.setTimeout = setTimeout;
+  sandbox.clearTimeout = clearTimeout;
+  document.getElementById('fxPanel').appendChild(document.getElementById('fxGrayscale'));
+  document.getElementById('fxPanel').appendChild(document.getElementById('fxAdrTint'));
+  const code = await fs.readFile(new URL('../scripts/fx-debug.js', import.meta.url), 'utf8');
+  vm.runInNewContext(code, sandbox);
+  const gray = document.getElementById('fxGrayscale');
+  const adr = document.getElementById('fxAdrTint');
+  gray.checked = true; gray.dispatchEvent({ type:'change' });
+  adr.checked = false; adr.dispatchEvent({ type:'change' });
+  assert.equal(window.fxConfig.grayscale, true);
+  assert.equal(window.fxConfig.adrenalineTint, false);
+  assert.equal(calls, 3);
+});

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -85,3 +85,16 @@ test('damage flash disabled by default but can be enabled', async () => {
   ctx.updateHUD();
   assert.ok(bar.classList.contains('hurt'));
 });
+
+test('adrenaline tint and grayscale filters update based on config', async () => {
+  const ctx = setup(HUD_HTML);
+  ctx.fxConfig.adrenalineTint = true;
+  ctx.leader = () => ({ maxHp: 10, adr: 50, maxAdr: 100 });
+  ctx.updateHUD();
+  const filt1 = ctx.document.getElementById('game').style.getPropertyValue('--fxFilter');
+  assert.ok(/saturate/.test(filt1));
+  ctx.fxConfig.grayscale = true;
+  ctx.updateHUD();
+  const filt2 = ctx.document.getElementById('game').style.getPropertyValue('--fxFilter');
+  assert.ok(/grayscale/.test(filt2));
+});


### PR DESCRIPTION
## Summary
- add Adrenaline Tint and Grayscale checkboxes to FX panel
- tint world green and boost saturation as adrenaline rises
- support grayscale rendering and new FX tests

## Testing
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af1474f84c8328b9368eeba88fd45e