### PR TITLE
refactor: inline enemy presets

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -68,7 +68,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 
 #### **Phase 3: Content Implementation (The World)**
  - [x] **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer's `tree` object should include the **Upgrade Skills** dialog option and their unique list of available upgrades.
-- [x] **Enemy Presets:** Create a `presets.json` file to define enemy stat allocations per level. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
+  - [x] **Enemy Presets:** Define enemy stat allocations per level in `scripts/core/presets.js`. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
 - [x] **Zone Population:** Populate the "Scrap Wastes" (Levels 1-5) with 5-7 on-level enemies and one or two higher-level "challenge" enemies off the main path. Ensure the zone layout naturally funnels players back toward a trainer NPC.
 - [x] **Boss Mechanics:** Implement the first boss with a telegraphed special move. This involves creating a visual cue (e.g., a "charging up" animation or effect) and a corresponding high-damage attack that triggers after a short delay.
 - [x] **Boss Visuals:** Add configurable CRT distortion and shake when a boss telegraphs a special move.

--- a/docs/design/wizard-framework.md
+++ b/docs/design/wizard-framework.md
@@ -85,7 +85,7 @@ This wizard helps create a building with multiple interior rooms, like a house w
 - [ ] **Configuration:** Create the `NpcWizard` configuration object.
 - [ ] **Custom Steps:** Develop the specific step components needed for this wizard:
     - `DialogueEditorStep`: A text area for writing dialogue.
-    - `ItemPickerStep`: A component to select an item from `presets.json`.
+      - `ItemPickerStep`: A component to select an item from the presets defined in `presets.js`.
 - [ ] **Logic:** Write the final "commit" function for the wizard that takes the completed data and generates the new NPC and quest data objects, saving them to the appropriate module file.
 
 #### **Phase 3: Building & Interiors Wizard**

--- a/scripts/core/presets.js
+++ b/scripts/core/presets.js
@@ -1,3 +1,5 @@
-import presets from './presets.json' assert { type: 'json' };
-const enemyPresets = presets;
+const enemyPresets = {
+  Scrapper: ['STR', 'AGI'],
+  Bulwark: ['DEF', 'DEF']
+};
 Object.assign(globalThis, { enemyPresets });

--- a/scripts/core/presets.json
+++ b/scripts/core/presets.json
@@ -1,4 +1,0 @@
-{
-  "Scrapper": ["STR", "AGI"],
-  "Bulwark": ["DEF", "DEF"]
-}

--- a/test/npc-scaling.test.js
+++ b/test/npc-scaling.test.js
@@ -7,8 +7,8 @@ test('NPC Scaling', async () => {
   const partyCode = await fs.readFile(new URL('../scripts/core/party.js', import.meta.url), 'utf8');
   vm.runInThisContext(partyCode, { filename: '../scripts/core/party.js' });
 
-  const presetsJson = await fs.readFile(new URL('../scripts/core/presets.json', import.meta.url), 'utf8');
-  globalThis.enemyPresets = JSON.parse(presetsJson);
+  const presetsCode = await fs.readFile(new URL('../scripts/core/presets.js', import.meta.url), 'utf8');
+  vm.runInThisContext(presetsCode, { filename: '../scripts/core/presets.js' });
 
   const npcCode = await fs.readFile(new URL('../scripts/core/npc.js', import.meta.url), 'utf8');
   vm.runInThisContext(npcCode, { filename: '../scripts/core/npc.js' });


### PR DESCRIPTION
## Summary
- inline enemy presets constants directly into presets.js
- adjust NPC scaling test to load presets.js
- update design docs to reference presets.js instead of presets.json

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `./install-deps.sh` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68af173c5dbc83288cb70b162696fcc3