### PR TITLE
feat: refine equipment suggestions on leader change

### DIFF
--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -152,7 +152,24 @@ function awardXP(who, amt){ who.awardXP(amt); }
 function applyEquipmentStats(m){ m.applyEquipmentStats(); }
 function applyCombatMods(m){ m.applyCombatMods(); }
 function leader(){ return party.leader(); }
-function setLeader(idx){ selectedMember = idx; }
+function setLeader(idx){
+  selectedMember = idx;
+  const m = party[selectedMember];
+  if(!m) return;
+  for(const slot of ['weapon','armor','trinket']){
+    if(!m.equip[slot] && Array.isArray(player?.inv)){
+      const candidates = player.inv.filter(it => it.slot === slot);
+      if(candidates.length){
+        const max = Math.max(...candidates.map(it => calcItemValue(it)));
+        const best = candidates.filter(it => calcItemValue(it) === max);
+        const choice = best[Math.floor(Math.random()*best.length)];
+        const invIdx = player.inv.indexOf(choice);
+        if(invIdx !== -1) equipItem(selectedMember, invIdx);
+      }
+    }
+  }
+  if(typeof renderInv === 'function') renderInv();
+}
 
 function respec(memberIndex=selectedMember){
   const m = party[memberIndex];

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -554,6 +554,18 @@ function renderInv(){
     }
   });
   const member=party[selectedMember]||party[0];
+  const suggestions = {};
+  if(member){
+    for(const slot of ['weapon','armor','trinket']){
+      const eq=member.equip[slot];
+      const candidates = others.filter(it => it.slot===slot && (!eq || calcItemValue(it)>calcItemValue(eq)));
+      if(candidates.length){
+        const max=Math.max(...candidates.map(it=>calcItemValue(it)));
+        const best=candidates.filter(it=>calcItemValue(it)===max);
+        suggestions[slot]=best[Math.floor(Math.random()*best.length)];
+      }
+    }
+  }
   Object.entries(caches).forEach(([rank, items]) => {
     const row=document.createElement('div');
     row.className='slot cache-slot';
@@ -584,11 +596,8 @@ function renderInv(){
   others.forEach(it => {
     const row=document.createElement('div');
     row.className='slot';
-    if(it.slot && member){
-      const eq=member.equip[it.slot];
-      if(!eq || calcItemValue(it)>calcItemValue(eq)){
-        row.classList.add('better');
-      }
+    if(it.slot && suggestions[it.slot]===it){
+      row.classList.add('better');
     }
     const baseLabel = it.name + (it.slot?` [${it.slot}]`:'');
     const label = (it.cursed && it.cursedKnown)? `${baseLabel} (cursed)` : baseLabel;

--- a/test/inventory-highlight.test.js
+++ b/test/inventory-highlight.test.js
@@ -6,16 +6,27 @@ import { JSDOM } from 'jsdom';
 
 function setup(items, equipped){
   const dom = new JSDOM('<div id="inv"></div>');
+  const equips = Array.isArray(equipped) ? equipped : [equipped];
   const ctx = {
     window: dom.window,
     document: dom.window.document,
     player: { inv: items },
-    party: [{ equip: equipped }],
+    party: equips.map(eq => ({ equip: eq })),
     selectedMember: 0,
     SpoilsCache: { renderIcon: () => null, open: () => {}, openAll: () => {} },
-    equipItem: () => {},
     useItem: () => {},
-    CURRENCY: ''
+    CURRENCY: '',
+    log: () => {},
+    renderParty: () => {},
+    updateHUD: () => {},
+    EventBus: { emit: () => {} }
+  };
+  ctx.equipItem = (memberIndex, invIndex) => {
+    const m = ctx.party[memberIndex];
+    const it = ctx.player.inv[invIndex];
+    if(!m || !it) return;
+    m.equip[it.slot] = it;
+    ctx.player.inv.splice(invIndex,1);
   };
   vm.createContext(ctx);
   return ctx;
@@ -25,6 +36,13 @@ async function loadRender(ctx){
   const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
   const start = full.indexOf('function calcItemValue');
   const end = full.indexOf('function renderQuests');
+  vm.runInContext(full.slice(start, end), ctx);
+}
+
+async function loadSetLeader(ctx){
+  const full = await fs.readFile(new URL('../scripts/core/party.js', import.meta.url), 'utf8');
+  const start = full.indexOf('let selectedMember');
+  const end = full.indexOf('function respec');
   vm.runInContext(full.slice(start, end), ctx);
 }
 
@@ -41,4 +59,45 @@ test('better items are highlighted', async () => {
   assert.equal(slots.length, 2);
   assert.ok(slots[0].classList.contains('better'));
   assert.ok(!slots[1].classList.contains('better'));
+});
+
+test('leader change re-evaluates highlights', async () => {
+  const items = [
+    { name: 'Bronze Sword', slot: 'weapon', value: 3 }
+  ];
+  const eqs = [
+    { weapon: { name: 'Steel Sword', slot: 'weapon', value: 4 } },
+    { weapon: { name: 'Rusty Sword', slot: 'weapon', value: 1 } }
+  ];
+  const ctx = setup(items, eqs);
+  await loadRender(ctx);
+  await loadSetLeader(ctx);
+  ctx.renderInv();
+  let slots = ctx.document.querySelectorAll('.slot');
+  assert.equal(slots.length, 1);
+  assert.ok(!slots[0].classList.contains('better'));
+  ctx.setLeader(1);
+  slots = ctx.document.querySelectorAll('.slot');
+  assert.equal(slots.length, 1);
+  assert.ok(slots[0].classList.contains('better'));
+});
+
+test('setLeader equips missing gear and suggests a single upgrade per slot', async () => {
+  const items = [
+    { name: 'Axe', slot: 'weapon', value: 2 },
+    { name: 'Chain', slot: 'armor', value: 2 },
+    { name: 'Scale', slot: 'armor', value: 2 }
+  ];
+  const eqs = [
+    { weapon: { name: 'Spear', slot: 'weapon', value: 3 }, armor: { name: 'Cloth', slot: 'armor', value: 1 } },
+    { weapon: null, armor: { name: 'Tunic', slot: 'armor', value: 1 } }
+  ];
+  const ctx = setup(items, eqs);
+  await loadRender(ctx);
+  await loadSetLeader(ctx);
+  vm.runInContext('Math.random = () => 0;', ctx);
+  ctx.setLeader(1);
+  assert.ok(ctx.party[1].equip.weapon);
+  const better = ctx.document.querySelectorAll('.slot.better');
+  assert.equal(better.length, 1);
 });


### PR DESCRIPTION
## Summary
- auto-equip best gear when switching leader if a slot is empty
- highlight only one upgrade per slot after changing leaders
- test leader equipment suggestions and auto-equip behavior

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'innerHTML'))*

------
https://chatgpt.com/codex/tasks/task_e_68af1abf73748328b904b0365d05670e