### PR TITLE
feat: estimate item value from effects

### DIFF
--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -148,8 +148,21 @@ function uncurseItem(id){
   return found;
 }
 
+function estimateItemValue(it){
+  let val = 0;
+  if(it.use && it.use.type==='heal'){
+    val += it.use.amount || 0;
+  }
+  for(const v of Object.values(it.mods || {})){
+    if(v>0) val += v*10;
+  }
+  return val;
+}
+
 function normalizeItem(it){
   if(!it) return null;
+  const baseValue = typeof it.value === 'number' ? it.value : 0;
+  const val = baseValue > 0 ? baseValue : estimateItemValue(it);
   return {
     id: it.id || '',
     name: it.name || 'Unknown',
@@ -164,7 +177,7 @@ function normalizeItem(it){
     cursed: !!it.cursed,
     cursedKnown: !!it.cursedKnown,
     rarity: it.rarity || 'common',
-    value: Math.max(1, it.value ?? 0),
+    value: val,
     desc: it.desc || '',
   };
 }

--- a/test/item-value-estimate.test.js
+++ b/test/item-value-estimate.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+// Stub minimal globals used by inventory
+globalThis.EventBus = { emit() {} };
+
+await import('../scripts/core/inventory.js');
+
+test('heal items with zero value are estimated', () => {
+  const it = normalizeItem({ id: 'potion', name: 'Potion', use: { type: 'heal', amount: 5 }, value: 0 });
+  assert.strictEqual(it.value, 5);
+});
+
+test('mod items with zero value are estimated', () => {
+  const it = normalizeItem({ id: 'medal', name: 'Medal', mods: { LCK: 1 }, value: 0 });
+  assert.strictEqual(it.value, 10);
+});


### PR DESCRIPTION
## Summary
- derive base value for items lacking worth from healing amount or positive mods
- verify value estimation logic with unit tests

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68af1b9590f883289ca5bfa068b0d2c0