### PR TITLE
docs: add engine version guidance

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -11,7 +11,7 @@ _______________________________________________________________________________
 |     ░       ░           ░                ░  ░      ░           ░    ░       |
 |                           D U S T L A N D   C R T                           |
 |                      Wasteland-style browser RPG (WIP)                      |
-|                               v0.7 .NFO                                   |
+|                               v0.7.1 .NFO                                   |
 |_____________________________________________________________________________|
 
 [ ABOUT ]
@@ -90,7 +90,7 @@ _______________________________________________________________________________
     * CRT styling and layout.
   - No external assets or libraries.
 
-[ KNOWN GOOD BEHAVIOR (v0.7) ]
+[ KNOWN GOOD BEHAVIOR (v0.7.1) ]
   - Stable boot: hall always renders before any modal (no blank canvas).
   - Items/NPCs draw before player (no sprite pop-under).
   - Loot from chests spawns on a nearby free tile (never under the player).

--- a/balance-tester.html
+++ b/balance-tester.html
@@ -19,7 +19,7 @@
       </div>
     </div>
     <aside class="panel">
-      <h1>DUSTLAND // CRT v0.7</h1>
+      <h1>DUSTLAND // CRT v0.7.1</h1>
       <div class="content" id="log"></div>
       <div class="content">
         <div class="hud">

--- a/dustland.html
+++ b/dustland.html
@@ -19,7 +19,7 @@
       </div>
     </div>
     <aside class="panel">
-      <h1>DUSTLAND // CRT v0.7</h1>
+      <h1>DUSTLAND // CRT v0.7.1</h1>
       <div class="content" id="log"></div>
       <div class="content">
         <div class="hud">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dustland",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dustland",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+Maintain engine versioning.
+
+- Increment the point version (patch number) in `package.json` with each change.
+- Mirror the updated version in `dustland-engine.js` so the engine log shows the latest build.
+- This helps indicate when a new build has deployed.

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -917,7 +917,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7 — Stable boot; items/NPCs visible; E/T to take; selected member rolls.');
+log('v0.7.1 — Stable boot; items/NPCs visible; E/T to take; selected member rolls.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode


### PR DESCRIPTION
## Summary
- note patch-version logging for the engine
- bump version to 0.7.1 and surface it in engine log, headers, and README

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68af1b1fdc448328bcd363c703ca02df