### PR TITLE
fix: limit shop height and block movement

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -651,7 +651,7 @@
   border: 1px solid #2b3b2b;
   border-radius: 8px;
   box-shadow: 0 0 20px #000;
-  max-height: 80vh;
+  max-height: min(480px, 92vh);
   display: flex;
   flex-direction: column;
 }

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -780,6 +780,7 @@ function openShop(npc) {
     shopOverlay.removeEventListener('keydown', handleKey);
   }
   function handleKey(e) {
+    e.stopPropagation();
     if (e.key === 'Escape') { close(); return; }
     if (e.key === 'ArrowDown') {
       focusIdx = (focusIdx + 1) % focusables.length;
@@ -863,6 +864,10 @@ if (document.getElementById('saveBtn')) {
     const combat = document.getElementById('combatOverlay');
     if(combat?.classList?.contains('shown')){
       if(handleCombatKey?.(e)) e.preventDefault();
+      return;
+    }
+    const shop = document.getElementById('shopOverlay');
+    if (shop?.classList?.contains('shown')) {
       return;
     }
     switch(e.key){

--- a/test/shop.ui.test.js
+++ b/test/shop.ui.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+function extractOpenShop(code) {
+  const match = code.match(/function openShop\(npc\) {[\s\S]*?shopOverlay\.focus\(\);\n}/);
+  return match && match[0];
+}
+
+test('shop window height matches combat menu', async () => {
+  const css = await fs.readFile(new URL('../dustland.css', import.meta.url), 'utf8');
+  const combat = css.match(/#combatOverlay \.combat-window\s*{[^}]*height:\s*([^;]+);/);
+  const shop = css.match(/\.shop-window\s*{[^}]*max-height:\s*([^;]+);/);
+  assert.ok(combat && shop);
+  const norm = s => s.replace(/\s+/g, '');
+  assert.strictEqual(norm(shop[1]), norm(combat[1]));
+});
+
+test('arrow keys in shop do not move the player', async () => {
+  const dom = new JSDOM('<div id="shopOverlay"><div class="shop-window"><header><div id="shopName"></div><button id="closeShopBtn"></button></header><div class="shop-panels"><div id="shopBuy" class="slot-list"></div><div id="shopSell" class="slot-list"></div></div></div></div>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.requestAnimationFrame = () => {};
+  global.log = () => {};
+  global.toast = () => {};
+  global.CURRENCY = 's';
+  global.player = { scrap: 10, inv: [] };
+  global.getItem = id => ({ id, name: id, value: 1 });
+  global.addToInv = () => true;
+  global.removeFromInv = () => {};
+  global.updateHUD = () => {};
+
+  const code = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
+  const openShopCode = extractOpenShop(code);
+  vm.runInThisContext(openShopCode);
+
+  let moved = 0;
+  window.addEventListener('keydown', () => { moved++; });
+
+  openShop({ name: 'Shopkeep', shop: { inv: [] } });
+  const shopOverlay = document.getElementById('shopOverlay');
+  const evt = new dom.window.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+  shopOverlay.dispatchEvent(evt);
+  assert.strictEqual(moved, 0);
+});


### PR DESCRIPTION
## Summary
- prevent movement while navigating the shop
- cap shop window height to match combat menu
- add tests for shop height and keyboard handling

## Testing
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68af1b6279308328b48c0ca6b35b84d9