### PR TITLE
fix: quest gating for Echoes doors

### DIFF
--- a/modules/echoes.module.js
+++ b/modules/echoes.module.js
@@ -27,8 +27,8 @@ const ECHOES_MODULE = (() => {
   ];
 
   const quests = [
-    { id: 'q_spark', title: 'Spark the Way', desc: 'Find the Spark Key to open the workshop.' },
-    { id: 'q_cog', title: 'Unlock the Archive', desc: 'Find the Cog Key to reach the beacon.' },
+    { id: 'q_spark', title: 'Spark the Way', desc: 'Find the Spark Key to open the workshop.', item: 'spark_key' },
+    { id: 'q_cog', title: 'Unlock the Archive', desc: 'Find the Cog Key to reach the beacon.', item: 'cog_key' },
     { id: 'q_beacon', title: 'Light the Beacon', desc: 'Defeat the Gear Ghoul and claim hope.' }
   ];
 
@@ -67,10 +67,12 @@ const ECHOES_MODULE = (() => {
         start: {
           text: 'The door is sealed.',
           choices: [
+            { label: '(Search for Spark Key)', to: 'accept', q: 'accept' },
             { label: '(Use Spark Key)', to: 'do_turnin', q: 'turnin' },
             { label: '(Leave)', to: 'bye' }
           ]
         },
+        accept: { text: 'Its lock crackles for a Spark Key.', choices: [ { label: '(Leave)', to: 'bye' } ] },
         do_turnin: { text: 'The door slides aside.', choices: [ { label: '(Continue)', to: 'bye', goto: { map: 'workshop', x: 1, y: workshop.entryY } } ] }
       }
     },
@@ -108,10 +110,12 @@ const ECHOES_MODULE = (() => {
         start: {
           text: 'The door is locked tight.',
           choices: [
+            { label: '(Search for Cog Key)', to: 'accept', q: 'accept' },
             { label: '(Use Cog Key)', to: 'do_turnin', q: 'turnin' },
             { label: '(Leave)', to: 'bye' }
           ]
         },
+        accept: { text: 'Its hinges await a Cog Key.', choices: [ { label: '(Leave)', to: 'bye' } ] },
         do_turnin: { text: 'The door creaks open.', choices: [ { label: '(Continue)', to: 'bye', goto: { map: 'archive', x: 1, y: archive.entryY } } ] }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -931,7 +931,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.1 — Stable boot; items/NPCs visible; E/T to take; selected member rolls.');
+log('v0.7.2 — Echoes doors accept keys after quest.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/echoes.module.test.js
+++ b/test/echoes.module.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('echoes module doors require quests with matching keys', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'echoes.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /id: 'q_spark'[\s\S]*item: 'spark_key'/);
+  assert.match(src, /door_workshop[\s\S]*\(Search for Spark Key\)[\s\S]*q: 'accept'/);
+  assert.match(src, /id: 'q_cog'[\s\S]*item: 'cog_key'/);
+  assert.match(src, /door_archive[\s\S]*\(Search for Cog Key\)[\s\S]*q: 'accept'/);
+});


### PR DESCRIPTION
## Summary
- ensure Echoes doors accept keys only after starting related quests
- bump engine version to 0.7.2
- add tests for Echoes door quests

## Testing
- `node scripts/presubmit.js`
- `./install-deps.sh`
- `npm test`
- `node scripts/balance-tester-agent.js` *(fails: Cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68af1df5d9f48328998c90dc74766abc