### PR TITLE
docs: check off presubmit step for caches

### DIFF
--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -67,6 +67,6 @@ Opening a cache triggers a generator that stitches gear on the fly:
 #### Phase 4: Testing
 - [ ] Write tests to verify drop odds and tier distribution across challenge levels.
 - [ ] Simulate 1,000 cache openings per tier to ensure stat ranges stay sane.
-- [ ] Run `node scripts/presubmit.js` to confirm no async snafus in cache UI.
+- [x] Run `node scripts/presubmit.js` to confirm no async snafus in cache UI — clean run.
 
 > **Clown:** When players crack open a Vaulted Cache and a "Quantum Harmonica" drops, I want them to laugh, equip it, and blow something up with a punchline.


### PR DESCRIPTION
## Summary
- mark presubmit script run as complete in Spoils Caches design doc

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68af1db4244083289a5df1586f5132cd