### PR TITLE
fix: apply dialog effect objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/dialog.js
+++ b/scripts/core/dialog.js
@@ -69,7 +69,12 @@ function normalizeDialogTree(tree){
 }
 
 function runEffects(effects){
-  for(const fn of effects||[]){ if(typeof fn==='function') fn({player,party,state}); }
+  for(const eff of effects || []){
+    if(typeof eff === 'function') eff({ player, party, state });
+    else if(eff && typeof eff === 'object' && Dustland?.effects?.apply){
+      Dustland.effects.apply([eff], { player, party, state });
+    }
+  }
 }
 
 function resolveCheck(check, actor=leader(), rng=Math.random){

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -931,7 +931,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.1 — Stable boot; items/NPCs visible; E/T to take; selected member rolls.');
+log('v0.7.2 — Stable boot; items/NPCs visible; E/T to take; selected member rolls.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -962,6 +962,18 @@ test('board/unboard effects toggle building access', () => {
   assert.strictEqual(globalThis.buildings[0].boarded, true);
   globalThis.buildings.length = 0;
 });
+test('dialog choice applies object effects', () => {
+  globalThis.buildings = [ { interiorId: 'castle', boarded: true } ];
+  const tree = { start:{ text:'hi', choices:[ { label:'open', to:'bye', effects:[ { effect:'unboardDoor', interiorId:'castle' } ] } ] }, bye:{ text:'', choices:[] } };
+  const npc = makeNPC('f', 'world', 0, 0, '#fff', 'F', '', '', tree);
+  NPCS.length = 0;
+  NPCS.push(npc);
+  openDialog(npc);
+  choicesEl.children[0].onclick();
+  closeDialog();
+  assert.strictEqual(globalThis.buildings[0].boarded, false);
+  globalThis.buildings.length = 0;
+});
 test('onEnter triggers effects and temporary stat mod', async () => {
   const world = Array.from({length:5},()=>Array.from({length:5},()=>7));
   applyModule({world});


### PR DESCRIPTION
## Summary
- ensure dialog effect objects like unboardDoor apply
- document fix with a regression test
- bump engine version to 0.7.2

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68af1f30c0708328b300c2b387f82327