### PR TITLE
feat: namespace inventory helpers

### DIFF
--- a/docs/design/tech-debt-paydown.md
+++ b/docs/design/tech-debt-paydown.md
@@ -52,11 +52,12 @@ Our CRT playground is scrappy by design, but a few lingering habits slow our bui
 
 - [ ] **Phase 1: Namespace the world**
   - [x] Introduce `globalThis.Dustland = {}`.
-  - [ ] Move module exports into `Dustland.*` buckets.
+  - [x] Move module exports into `Dustland.*` buckets.
     - [x] Namespace event bus under `Dustland.eventBus`.
     - [x] Namespace event flag helpers under `Dustland.eventFlags`.
     - [x] Namespace path helpers under `Dustland.path`.
     - [x] Namespace movement helpers under `Dustland.movement`.
+    - [x] Namespace inventory helpers under `Dustland.inventory`.
   - [x] Namespace effects under `Dustland.effects`.
     - [x] Namespace actions under `Dustland.actions`.
   - [ ] Update references and tests incrementally.

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -1,4 +1,5 @@
 // ===== Inventory / equipment =====
+globalThis.Dustland = globalThis.Dustland || {};
 const { emit } = globalThis.EventBus;
 
 const ITEMS = {}; // item definitions by id
@@ -231,4 +232,5 @@ function useItem(invIndex){
 }
 
 const inventoryExports = { ITEMS, itemDrops, registerItem, getItem, resolveItem, addToInv, removeFromInv, equipItem, unequipItem, normalizeItem, findItemIndex, useItem, hasItem, countItems, uncurseItem, getPartyInventoryCapacity, dropItemNearParty };
+globalThis.Dustland.inventory = inventoryExports;
 Object.assign(globalThis, inventoryExports);


### PR DESCRIPTION
## Summary
- namespace inventory helpers under Dustland.inventory
- check off namespacing item in tech debt plan

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af1fcb6ca8832885e45acbc7f9f1f4