### PR TITLE
feat: expose spoils cache tier weights

### DIFF
--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -52,7 +52,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 - [x] Define `SpoilsCache` item type and rank data structure.
 - [x] Implement drop roll tied to enemy `challenge` rating.
 - [x] Create modular item generator for type, name, and stats.
-- [ ] Expose tier weight configuration for modding.
+- [x] Expose tier weight configuration for modding.
 
 #### Phase 2: UI/UX
 - [x] Add cache icons and quick-open animations.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -937,7 +937,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.2 — Boots speed movement; delay mods supported.');
+log('v0.7.3 — Spoils Cache tier weights moddable.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/spoils-cache.test.js
+++ b/test/spoils-cache.test.js
@@ -41,6 +41,13 @@ test('pickRank tuned for challenge tiers', () => {
   assert.strictEqual(SpoilsCache.pickRank(9, () => 0.95), 'armored');
 });
 
+test('tierWeights can be overridden for modding', () => {
+  const orig = SpoilsCache.tierWeights;
+  SpoilsCache.tierWeights = { 1: [['sealed', 1]] };
+  assert.strictEqual(SpoilsCache.pickRank(1, () => 0.5), 'sealed');
+  SpoilsCache.tierWeights = orig;
+});
+
 test('renderIcon creates element with rank class', () => {
   global.document = {
     createElement(tag){


### PR DESCRIPTION
## Summary
- allow mods to override spoils cache tier weights
- bump engine version to 0.7.3

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af21c2e0648328a5171257e0123e71