### PR TITLE
fix: prevent Tab cycling from triggering NPC events

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -903,11 +903,6 @@ if (document.getElementById('saveBtn')) {
           selectedMember = (selectedMember + 1) % party.length;
           renderParty();
           toast(`Leader: ${party[selectedMember].name}`);
-          if(window.NanoDialog){
-            const near = (typeof NPCS !== 'undefined' ? NPCS : []).filter(n => n.map === state.map
-              && Math.abs(n.x - party.x) + Math.abs(n.y - party.y) < 10);
-            near.forEach(n => NanoDialog.queueForNPC(n, 'start', 'leader change'));
-          }
         }
         break;
       case 'm': case 'M': showMini=!showMini; break;

--- a/test/tab-leader.test.js
+++ b/test/tab-leader.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+test('Tab cycles leader without triggering NPC start events', async () => {
+  const dom = new JSDOM('<div id="party"></div>');
+  const ctx = {
+    window: dom.window,
+    document: dom.window.document,
+    state: { map: 'world' },
+    party: [{ name: 'A', hp: 1 }, { name: 'B', hp: 1 }, { name: 'C', hp: 1 }],
+    selectedMember: 0,
+    renderParty: () => {},
+    toast: () => {},
+    NPCS: [{ map: 'world', x: 0, y: 0 }],
+    NanoDialog: { queueForNPC: () => { ctx.party.splice(1); } }
+  };
+  ctx.party.x = 0; ctx.party.y = 0;
+  vm.createContext(ctx);
+  const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
+  const start = full.indexOf("case 'Tab':") + "case 'Tab':".length;
+  const end = full.indexOf('break;', start);
+  vm.runInContext(`function handleTab(e){${full.slice(start, end)}}`, ctx);
+  ctx.handleTab({ preventDefault: () => {} });
+  assert.equal(ctx.party.length, 3);
+});


### PR DESCRIPTION
## Summary
- stop Tab leader swapping from firing NPC start events
- test that Tab cycling does not trigger NPC events

## Testing
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68af23fca4d88328993ca5a7c0a0a7e4