### PR TITLE
fix: retain party after Tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dustland",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dustland",
-      "version": "0.7.4",
+    "version": "0.7.5",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -899,6 +899,7 @@ if (document.getElementById('saveBtn')) {
       case 'q': if(!e.ctrlKey && !e.metaKey){ showTab('quests'); e.preventDefault(); } break;
       case 'Tab':
         e.preventDefault();
+        e.stopImmediatePropagation();
         if (party.length>0){
           selectedMember = (selectedMember + 1) % party.length;
           renderParty();
@@ -932,7 +933,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.4 — ESLint configuration tightened.');
+log('v0.7.5 — Tab key preserves party members.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/tab-leader.test.js
+++ b/test/tab-leader.test.js
@@ -5,24 +5,34 @@ import vm from 'node:vm';
 import { JSDOM } from 'jsdom';
 
 test('Tab cycles leader without triggering NPC start events', async () => {
-  const dom = new JSDOM('<div id="party"></div>');
+  const dom = new JSDOM('<div id="party"></div><div id="combatOverlay"></div><div id="shopOverlay"></div>');
   const ctx = {
     window: dom.window,
     document: dom.window.document,
-    state: { map: 'world' },
+    overlay: null,
     party: [{ name: 'A', hp: 1 }, { name: 'B', hp: 1 }, { name: 'C', hp: 1 }],
     selectedMember: 0,
     renderParty: () => {},
     toast: () => {},
+    move: () => {},
+    interact: () => {},
+    takeNearestItem: () => {},
+    toggleAudio: () => {},
+    toggleMobileControls: () => {},
+    showTab: () => {},
     NPCS: [{ map: 'world', x: 0, y: 0 }],
     NanoDialog: { queueForNPC: () => { ctx.party.splice(1); } }
   };
   ctx.party.x = 0; ctx.party.y = 0;
   vm.createContext(ctx);
   const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
-  const start = full.indexOf("case 'Tab':") + "case 'Tab':".length;
-  const end = full.indexOf('break;', start);
-  vm.runInContext(`function handleTab(e){${full.slice(start, end)}}`, ctx);
-  ctx.handleTab({ preventDefault: () => {} });
+  const start = full.indexOf("window.addEventListener('keydown'");
+  const end = full.indexOf('\n  });', start) + 5;
+  vm.runInContext(full.slice(start, end), ctx);
+  ctx.window.addEventListener('keydown', e => {
+    if (e.key === 'Tab') ctx.NanoDialog.queueForNPC();
+  });
+  ctx.window.dispatchEvent(new ctx.window.KeyboardEvent('keydown', { key: 'Tab' }));
   assert.equal(ctx.party.length, 3);
+  assert.equal(ctx.selectedMember, 1);
 });


### PR DESCRIPTION
## Summary
- stop Tab keydown from invoking later handlers so party members aren't removed
- add regression test for Tab leader cycling
- bump engine version to 0.7.5

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af34328834832881358f6418d1fb38