### PR TITLE
refactor: route core modules through Dustland.eventBus

### DIFF
--- a/docs/design/tech-debt-paydown.md
+++ b/docs/design/tech-debt-paydown.md
@@ -60,7 +60,7 @@ Our CRT playground is scrappy by design, but a few lingering habits slow our bui
     - [x] Namespace inventory helpers under `Dustland.inventory`.
   - [x] Namespace effects under `Dustland.effects`.
     - [x] Namespace actions under `Dustland.actions`.
-  - [ ] Update references and tests incrementally.
+  - [x] Update references and tests incrementally.
 - [x] **Phase 1.5: Reorganize the filesystem**
   - [x] move core and JS files in root under a new scripts directory
 - [ ] **Phase 2: Untangle UI from logic**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -1,5 +1,5 @@
-var Dustland = globalThis.Dustland;
-const { effects: Effects } = Dustland || {};
+const { effects: Effects } = globalThis.Dustland || {};
+var bus = (globalThis.Dustland && globalThis.Dustland.eventBus) || globalThis.EventBus;
 
 // active temporary stat modifiers
 const buffs = [];              // 2c342c / 313831
@@ -181,7 +181,7 @@ function move(dx,dy){
         centerCamera(party.x,party.y,state.map); updateHUD();
         checkAggro();
         checkRandomEncounter();
-        EventBus.emit('sfx','step');
+        bus.emit('sfx','step');
         // NPCs advance along paths after the player steps
         if (Dustland.path?.tickPathAI) Dustland.path.tickPathAI();
         moveDelay = 0;
@@ -189,7 +189,7 @@ function move(dx,dy){
       }, moveDelay);
     });
   } else {
-    EventBus.emit('sfx','denied');
+    bus.emit('sfx','denied');
   }
 }
 
@@ -269,7 +269,7 @@ function takeNearestItem() {
       log('Took ' + (def ? def.name : it.id) + '.');
       updateHUD();
       if (typeof pickupSparkle === 'function') pickupSparkle(party.x + dx, party.y + dy);
-      EventBus.emit('sfx', 'pickup');
+      bus.emit('sfx', 'pickup');
       return true;
     }
   }
@@ -284,7 +284,7 @@ function interactAt(x, y) {
   if (info.entities.length) {
     const npc = info.entities[0];
     openDialog(npc);
-    EventBus.emit('sfx', 'confirm');
+    bus.emit('sfx', 'confirm');
     return true;
   }
   if (info.items.length) {
@@ -301,19 +301,19 @@ function interactAt(x, y) {
     log('Took ' + (def ? def.name : it.id) + '.');
     updateHUD();
     if (typeof pickupSparkle === 'function') pickupSparkle(x, y);
-    EventBus.emit('sfx', 'pickup');
+    bus.emit('sfx', 'pickup');
     return true;
   }
   if(x===party.x && y===party.y && info.tile===TILE.DOOR){
     if(state.map==='world'){
       const b=buildings.find(b=> b.doorX===x && b.doorY===y);
-      if(!b){ log('No entrance here.'); EventBus.emit('sfx','denied'); return true; }
-      if(b.boarded){ log('The doorway is boarded up from the outside.'); EventBus.emit('sfx','denied'); return true; }
+      if(!b){ log('No entrance here.'); bus.emit('sfx','denied'); return true; }
+      if(b.boarded){ log('The doorway is boarded up from the outside.'); bus.emit('sfx','denied'); return true; }
       const I=interiors[b.interiorId];
       if(I){ setPartyPos(I.entryX, I.entryY); }
       setMap(b.interiorId,'Interior');
       log('You step inside.'); updateHUD();
-      EventBus.emit('sfx','confirm');
+      bus.emit('sfx','confirm');
       return true;
     }
     if(state.map!=='world'){
@@ -327,7 +327,7 @@ function interactAt(x, y) {
         setMap(target);
         log(p.desc || 'You move through the doorway.');
         updateHUD();
-        EventBus.emit('sfx','confirm');
+        bus.emit('sfx','confirm');
         return true;
       }
       const b=buildings.find(b=> b.interiorId===state.map);
@@ -336,7 +336,7 @@ function interactAt(x, y) {
         setMap('world');
         log('You step back outside.');
         updateHUD();
-        EventBus.emit('sfx','confirm');
+        bus.emit('sfx','confirm');
         return true;
       }
     }
@@ -351,7 +351,7 @@ function interact(){
     if(interactAt(party.x+dx,party.y+dy)) return true;
   }
   log('Nothing interesting.');
-  EventBus.emit('sfx','denied');
+  bus.emit('sfx','denied');
   return false;
 }
 

--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -2,6 +2,8 @@ const baseStats = () => ({STR:4, AGI:4, INT:4, PER:4, LCK:4, CHA:4});
 
 const xpCurve = [0,100,200,300,400,500,700,900,1100,1300,1500,1900,2300,2700,3100,3500,4300,5100,5900,6700];
 
+var bus = (globalThis.Dustland && globalThis.Dustland.eventBus) || globalThis.EventBus;
+
 class Character {
   constructor(id, name, role, opts={}){
     this.id=id; this.name=name; this.role=role;
@@ -27,8 +29,8 @@ class Character {
     this.xp += amt;
     log(`${this.name} gains ${amt} XP.`);
     if(typeof toast==='function') toast(`${this.name} +${amt} XP`);
-    EventBus.emit('xp:gained', { character: this, amount: amt });
-    EventBus.emit('sfx','tick');
+    bus.emit('xp:gained', { character: this, amount: amt });
+    bus.emit('sfx','tick');
     while(this.xp >= this.xpToNext()){
       this.xp -= this.xpToNext();
       this.lvl++;
@@ -41,11 +43,11 @@ class Character {
     this.hp = this.maxHp;
     this.skillPoints += 1;
     if(typeof hudBadge==='function') hudBadge('+1 Skill Point');
-    EventBus.emit('character:leveled-up', { character: this });
-    EventBus.emit('sfx','tick');
+    bus.emit('character:leveled-up', { character: this });
+    bus.emit('sfx','tick');
     log(`${this.name} leveled up to ${this.lvl}! (+10 HP, +1 SP)`);
     if((party.flags && party.flags.mentor) || (typeof hasItem==='function' && hasItem('mentor_token'))){
-      EventBus.emit('mentor:bark', { text:'Another scar, another lesson learned.', sound:'mentor' });
+      bus.emit('mentor:bark', { text:'Another scar, another lesson learned.', sound:'mentor' });
     }
   }
   applyEquipmentStats(){

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -933,7 +933,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.5 — random encounters grant XP based on strength.');
+log('v0.7.6 — use Dustland.eventBus in core modules.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/inventory-highlight.test.js
+++ b/test/inventory-highlight.test.js
@@ -7,6 +7,7 @@ import { JSDOM } from 'jsdom';
 function setup(items, equipped){
   const dom = new JSDOM('<div id="inv"></div>');
   const equips = Array.isArray(equipped) ? equipped : [equipped];
+  const bus = { emit: () => {} };
   const ctx = {
     window: dom.window,
     document: dom.window.document,
@@ -19,7 +20,8 @@ function setup(items, equipped){
     log: () => {},
     renderParty: () => {},
     updateHUD: () => {},
-    EventBus: { emit: () => {} }
+    EventBus: bus,
+    Dustland: { eventBus: bus }
   };
   ctx.equipItem = (memberIndex, invIndex) => {
     const m = ctx.party[memberIndex];

--- a/test/progression.test.js
+++ b/test/progression.test.js
@@ -1,7 +1,5 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
-import '../scripts/core/party.js';
-import '../scripts/core/npc.js';
 
 globalThis.log = () => {};
 globalThis.toast = () => {};
@@ -10,6 +8,9 @@ globalThis.updateHUD = () => {};
 globalThis.hudBadge = () => {};
 globalThis.EventBus = { emit() {} };
 globalThis.hasItem = () => false;
+
+await import('../scripts/core/party.js');
+await import('../scripts/core/npc.js');
 
 test('awardXP uses xpCurve thresholds', () => {
   const c = new Character('t','Tester','Role');

--- a/test/test-harness.js
+++ b/test/test-harness.js
@@ -137,6 +137,7 @@ export function createGameProxy(party){
     webkitAudioContext:AudioCtx,
     Audio,
     EventBus,
+    Dustland:{ eventBus: EventBus },
     requestAnimationFrame:()=>0,
     move:()=>{},
     interact:()=>{},

--- a/test/trainer-npcs.test.js
+++ b/test/trainer-npcs.test.js
@@ -6,11 +6,13 @@ import vm from 'node:vm';
 const partyCode = await fs.readFile(new URL('../scripts/core/party.js', import.meta.url), 'utf8');
 
 function setupParty(){
+  const bus = { emit: () => {} };
   const context = {
     log: () => {},
     renderParty: () => {},
     updateHUD: () => {},
-    EventBus: { emit: () => {} }
+    EventBus: bus,
+    Dustland: { eventBus: bus }
   };
   vm.createContext(context);
   vm.runInContext(partyCode, context);


### PR DESCRIPTION
## Summary
- prefer Dustland.eventBus in movement and party modules
- expose Dustland.eventBus in test harness and tests
- bump engine version to 0.7.6

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af36a103a883288e43b7573863cbd1