### PR TITLE
fix: award XP for all combat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -235,15 +235,7 @@ function checkRandomEncounter(){
   const chance = Math.min(dist * 0.02, 0.5);
   if(Math.random() < chance){
     const def = bank[Math.floor(Math.random()*bank.length)];
-    // Award XP based on enemy strength versus party level
-    Dustland.actions.startCombat(def)?.then(res => {
-      if(res && res.result !== 'flee'){
-        const avgLvl = party.reduce((s,m)=>s+(m.lvl||1),0)/(party.length||1);
-        const enemyStr = def.challenge || def.HP || 1;
-        const xp = Math.max(1, Math.ceil(enemyStr/avgLvl));
-        party.forEach(m => awardXP(m, xp));
-      }
-    });
+    return Dustland.actions.startCombat(def);
   }
 }
 function adjacentNPC(){

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -143,6 +143,16 @@ async function startCombat(defender){
 
   const result = await openCombat(enemies);
 
+  if(result && result.result !== 'flee'){
+    const avgLvl = party.reduce((s,m)=>s+(m.lvl||1),0)/(party.length||1);
+    let xp = 0;
+    for(const e of enemies){
+      const str = e.challenge || e.hp || 1;
+      xp += Math.max(1, Math.ceil(str/avgLvl));
+    }
+    party.forEach(m => awardXP(m, xp));
+  }
+
   if(attacker){
     attacker.ap = Math.max(0,(attacker.ap||0)-1);
     player.ap = attacker.ap;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -933,7 +933,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.7 — emit combat events.');
+log('v0.7.8 — emit combat events.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1446,9 +1446,11 @@ test('distance to road increases encounter chance', () => {
   let started = false;
   const origRand = Math.random;
   Math.random = () => 0;
+  const origStart = globalThis.Dustland.actions.startCombat;
   globalThis.Dustland.actions.startCombat = () => { started = true; return Promise.resolve({ result: 'flee' }); };
   checkRandomEncounter();
   Math.random = origRand;
+  globalThis.Dustland.actions.startCombat = origStart;
   assert.ok(started);
 });
 
@@ -1461,9 +1463,11 @@ test('no encounters occur on roads', () => {
   let started = false;
   const origRand = Math.random;
   Math.random = () => 0;
+  const origStart = globalThis.Dustland.actions.startCombat;
   globalThis.Dustland.actions.startCombat = () => { started = true; return Promise.resolve({ result: 'flee' }); };
   checkRandomEncounter();
   Math.random = origRand;
+  globalThis.Dustland.actions.startCombat = origStart;
   assert.ok(!started);
 });
 
@@ -1477,12 +1481,11 @@ test('random encounters award XP based on strength', async () => {
   setPartyPos(1, 0);
   const origRand = Math.random;
   Math.random = () => 0;
-  const orig = globalThis.Dustland.actions.startCombat;
-  globalThis.Dustland.actions.startCombat = () => Promise.resolve({ result: 'loot' });
-  checkRandomEncounter();
-  await Promise.resolve();
+  const origOpen = global.openCombat;
+  global.openCombat = async () => ({ result: 'loot' });
+  await checkRandomEncounter();
   Math.random = origRand;
-  globalThis.Dustland.actions.startCombat = orig;
+  global.openCombat = origOpen;
   assert.strictEqual(party[0].xp, 4);
   assert.strictEqual(party[1].xp, 4);
   party.length = 0;


### PR DESCRIPTION
## Summary
- centralize XP awards in `startCombat` so all victories grant experience
- streamline random encounter handler to rely on centralized XP logic
- bump engine version to 0.7.8

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68af4aff9e2483288ee2608a77373396