### PR TITLE
docs: note memory worm boss drops

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -73,7 +73,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] **Boss Mechanics:** Implement the first boss with a telegraphed special move. This involves creating a visual cue (e.g., a "charging up" animation or effect) and a corresponding high-damage attack that triggers after a short delay.
 - [x] **Boss Visuals:** Add configurable CRT distortion and shake when a boss telegraphs a special move.
 - [x] **Respec Vendor:** Create a special vendor NPC who sells "Memory Worm" tokens for a high price (e.g., 500 scrap). This vendor should be placed in a mid-to-late game area.
-- [ ] **Memory Worm Drops:** Make boss encounters occasionally drop "Memory Worm" tokens to complement vendor purchases.
+- [x] **Memory Worm Drops:** Make boss encounters occasionally drop "Memory Worm" tokens to complement vendor purchases. Implemented a 10% drop chance on boss defeat.
 
 #### **Phase 4: Testing and Balancing (The Stopwatch)**
 - [x] **Progression Test Suite:** Write automated tests to verify:


### PR DESCRIPTION
## Summary
- mark boss memory worm drops as complete in RPG progression design doc

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68af74f5aee8832895bedd9316d8a775