### PR TITLE
feat: add adrenaline bloom pulse

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -153,7 +153,7 @@
 
     #game {
         position: relative;
-        filter: var(--fxFilter, none)
+        filter: var(--fxBloom, none) var(--fxFilter, none)
     }
 
     #game.scanlines::after {
@@ -181,11 +181,11 @@
     }
 
     #game.color-bleed {
-        filter: drop-shadow(0 0 2px #9ef7a0) drop-shadow(0 0 6px #9ef7a0) drop-shadow(2px 0 0 red) drop-shadow(-2px 0 0 cyan) var(--fxFilter, none)
+        filter: drop-shadow(0 0 2px #9ef7a0) drop-shadow(0 0 6px #9ef7a0) drop-shadow(2px 0 0 red) drop-shadow(-2px 0 0 cyan) var(--fxBloom, none) var(--fxFilter, none)
     }
 
     body.hp-critical #game {
-        filter: grayscale(.8) var(--fxFilter, none)
+        filter: grayscale(.8) var(--fxBloom, none) var(--fxFilter, none)
     }
 
     body.hp-critical::after {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -273,6 +273,7 @@ function draw(t){
   if (disp.width < 16) {
     return;
   }
+  pulseAdrenaline(t);
   const dt=(t-_lastTime)||0; _lastTime=t;
   render(state, dt/1000);
   const bx = bumpEnd > performance.now() ? bumpX : 0;
@@ -482,6 +483,22 @@ function updateHUD(){
     }
   }
   updateHUD._lastHpVal = player.hp;
+}
+
+function pulseAdrenaline(t){
+  if(!disp || typeof leader !== 'function') return;
+  const lead = leader();
+  const fx = globalThis.fxConfig;
+  if(!lead || fx?.adrenalineTint === false) return;
+  const ratio = Math.max(0, Math.min(1, lead.adr / (lead.maxAdr || 1)));
+  if(ratio <= 0){
+    disp.style.removeProperty('--fxBloom');
+    return;
+  }
+  const pulse = (Math.sin(t / 200) + 1) / 2;
+  const intensity = ratio * pulse;
+  const blur = intensity * 4;
+  disp.style.setProperty('--fxBloom', `brightness(${1 + intensity}) blur(${blur}px)`);
 }
 
 function showTab(which){
@@ -933,7 +950,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.8 — emit combat events.');
+log('v0.7.9 — add adrenaline bloom pulse.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -98,3 +98,16 @@ test('adrenaline tint and grayscale filters update based on config', async () =>
   const filt2 = ctx.document.getElementById('game').style.getPropertyValue('--fxFilter');
   assert.ok(/grayscale/.test(filt2));
 });
+
+test('adrenaline bloom pulses with adr ratio', async () => {
+  const ctx = setup(HUD_HTML);
+  ctx.fxConfig.adrenalineTint = true;
+  ctx.leader = () => ({ maxHp: 10, adr: 50, maxAdr: 100 });
+  ctx.pulseAdrenaline(0);
+  const bloom1 = ctx.document.getElementById('game').style.getPropertyValue('--fxBloom');
+  assert.ok(/brightness/.test(bloom1));
+  ctx.leader = () => ({ maxHp: 10, adr: 0, maxAdr: 100 });
+  ctx.pulseAdrenaline(0);
+  const bloom2 = ctx.document.getElementById('game').style.getPropertyValue('--fxBloom');
+  assert.equal(bloom2, '');
+});


### PR DESCRIPTION
## Summary
- pulse a sine-wave bloom that intensifies with adrenaline
- expose bloom filter via CSS variables for easier combination with other effects
- bump version to 0.7.9

## Testing
- ⚠️ `./install-deps.sh` (mise repo unreachable)
- ✅ `node scripts/presubmit.js`
- ✅ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af756358cc83288446287a82a4e383