### PR TITLE
fix: isolate codex cli install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dustland",
-  "version": "0.7.7",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dustland",
-    "version": "0.7.7",
+    "version": "0.7.11",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.9",
+  "version": "0.7.11",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/codex-todo-runner.js
+++ b/scripts/codex-todo-runner.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Run with `node scripts/codex-todo-runner.js` from the repo root.
+
+import {execSync} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function installCodex() {
+  try {
+    execSync('codex --version', {stdio: 'ignore'});
+  } catch {
+    console.log('Installing GitHub Codex CLI...');
+    const home = process.env.HOME || process.cwd();
+    execSync(
+      'curl -fsSL https://developers.openai.com/codex/install.sh | sh',
+      {stdio: 'inherit', cwd: home}
+    );
+  }
+}
+
+function findDesignDocs() {
+  const dir = path.join(__dirname, '..', 'docs', 'design');
+  return fs.readdirSync(dir).map(f => path.join(dir, f)).filter(f => fs.statSync(f).isFile());
+}
+
+function extractTodos(content) {
+  const todoRegex = /^\s*- \[ \] (.*)$/gm;
+  const items = [];
+  let match;
+  while ((match = todoRegex.exec(content)) !== null) {
+    items.push({text: match[1], index: match.index});
+  }
+  return items;
+}
+
+function markDone(content, index) {
+  return content.slice(0, index + 3) + 'x' + content.slice(index + 4);
+}
+
+function run() {
+  installCodex();
+  const files = findDesignDocs();
+  for (const file of files) {
+    let text = fs.readFileSync(file, 'utf8');
+    let todos = extractTodos(text);
+    while (todos.length) {
+      const todo = todos[0];
+      console.log('Working on', todo.text);
+      try {
+        execSync(`codex commit "${todo.text}"`, {stdio: 'inherit'});
+        text = markDone(text, todo.index);
+        fs.writeFileSync(file, text);
+        execSync(`git add ${file}`);
+        execSync(`git commit -m "feat: ${todo.text}"`);
+      } catch {
+        console.error('Codex failed for', todo.text);
+        break;
+      }
+      todos = extractTodos(text);
+    }
+  }
+}
+
+run();

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -950,7 +950,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.9 — add adrenaline bloom pulse.');
+log('v0.7.11 — document codex todo runner usage.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode


### PR DESCRIPTION
## Summary
- convert codex todo runner to ESM and install CLI in home directory
- document how to run codex todo runner
- bump engine version to 0.7.11

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68af93ff55148328bfb6c66419feedb0