### PR TITLE
fix: handle quotes in codex todo runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dustland",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dustland",
-    "version": "0.7.11",
+    "version": "0.7.12",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/codex-todo-runner.js
+++ b/scripts/codex-todo-runner.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Run with `node scripts/codex-todo-runner.js` from the repo root.
 
-import {execSync} from 'node:child_process';
+import {execSync, execFileSync} from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
@@ -26,7 +26,7 @@ function findDesignDocs() {
   return fs.readdirSync(dir).map(f => path.join(dir, f)).filter(f => fs.statSync(f).isFile());
 }
 
-function extractTodos(content) {
+export function extractTodos(content) {
   const todoRegex = /^\s*- \[ \] (.*)$/gm;
   const items = [];
   let match;
@@ -36,11 +36,11 @@ function extractTodos(content) {
   return items;
 }
 
-function markDone(content, index) {
+export function markDone(content, index) {
   return content.slice(0, index + 3) + 'x' + content.slice(index + 4);
 }
 
-function run() {
+export function run() {
   installCodex();
   const files = findDesignDocs();
   for (const file of files) {
@@ -50,7 +50,7 @@ function run() {
       const todo = todos[0];
       console.log('Working on', todo.text);
       try {
-        execSync(`codex commit "${todo.text}"`, {stdio: 'inherit'});
+        execFileSync('codex', ['commit', todo.text], {stdio: 'inherit'});
         text = markDone(text, todo.index);
         fs.writeFileSync(file, text);
         execSync(`git add ${file}`);
@@ -64,4 +64,4 @@ function run() {
   }
 }
 
-run();
+if (process.argv[1] === fileURLToPath(import.meta.url)) run();

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -950,7 +950,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.11 — document codex todo runner usage.');
+log('v0.7.12 — handle quotes in codex todo runner.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/codex-todo-runner.test.js
+++ b/test/codex-todo-runner.test.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import {test} from 'node:test';
+import {extractTodos, markDone} from '../scripts/codex-todo-runner.js';
+
+test('extractTodos handles quoted text', () => {
+  const content = '- [ ] **Implement 5-10 Specials:** Create a starter set of special moves (e.g., "Power Strike," "Stun Grenade," "First Aid").';
+  const todos = extractTodos(content);
+  assert.equal(todos.length, 1);
+  assert.equal(todos[0].text, '**Implement 5-10 Specials:** Create a starter set of special moves (e.g., "Power Strike," "Stun Grenade," "First Aid").');
+  const done = markDone(content, todos[0].index);
+  assert.match(done, /\[x\]/);
+});


### PR DESCRIPTION
## Summary
- avoid shell parsing issues in Codex TODO runner by calling the CLI without a shell and exporting helpers for tests
- add tests for TODO extraction with quoted text
- bump engine patch version

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68afad3c59208328a31e2d84c8ad8729