### PR TITLE
feat: stabilize NPC portrait frames

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -145,6 +145,7 @@ const DUSTLAND_MODULE = (() => {
       title: '',
       desc: 'A dusty crate that might hide something useful.',
       portraitSheet: 'assets/portraits/crate_4.png',
+      portraitLock: false,
       tree: {
         start: {
           text: 'A dusty crate rests here.',
@@ -421,6 +422,7 @@ const DUSTLAND_MODULE = (() => {
       title: 'Bandit',
       desc: 'Scarred scav looking for trouble.',
       portraitSheet: 'assets/portraits/raider_4.png',
+      portraitLock: false,
       tree: {
         start: {
           text: 'A raider blocks the path, eyeing your gear.',
@@ -560,6 +562,7 @@ const DUSTLAND_MODULE = (() => {
       title: 'Wasteland Hunter',
       desc: 'A ruthless drifter prowling for prey.',
       portraitSheet: 'assets/portraits/portrait_1079.png',
+      portraitLock: false,
       tree: { start: { text: 'The stalker circles the wastes.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
       loop: [
         { x: 90, y: midY + 2 },
@@ -680,6 +683,7 @@ const DUSTLAND_MODULE = (() => {
       title: 'Wastes Boss',
       desc: 'A towering mass of twisted metal.',
       portraitSheet: 'assets/portraits/portrait_1084.png',
+      portraitLock: false,
       tree: { start: { text: 'The behemoth looms.', choices: [ { label: '(Leave)', to: 'bye' } ] } },
       combat: { HP: 30, ATK: 3, DEF: 2, loot: 'raider_knife', boss: true, special: { cue: 'crackles with energy!', dmg: 5, delay: 1000 } }
     }

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -43,7 +43,17 @@ function setPortraitDiv(el, obj){
   if (obj && obj.portraitSheet){
     el.style.background = 'transparent';
     if (/_4\.[a-z]+$/i.test(obj.portraitSheet)){
-      const frame = Math.floor(Math.random() * 4);
+      const generic = /portrait_\d+\.[a-z]+$/i.test(obj.portraitSheet);
+      const locked = obj.portraitLock !== false && !generic && obj.id;
+      let frame;
+      if (locked){
+        let h = 0;
+        const s = String(worldSeed) + obj.id;
+        for(let i=0;i<s.length;i++){ h = (h * 31 + s.charCodeAt(i)) | 0; }
+        frame = Math.abs(h) % 4;
+      }else{
+        frame = Math.floor(Math.random() * 4);
+      }
       const col = frame % 2;
       const row = Math.floor(frame / 2);
       const posX = col === 0 ? '0%' : '100%';

--- a/scripts/core/dialog.js
+++ b/scripts/core/dialog.js
@@ -307,21 +307,7 @@ function setPortrait(portEl, npc){
     portEl.style.background = npc.color || '#274227';
     return;
   }
-  portEl.style.background = 'transparent';
-  if(/_4\.[a-z]+$/i.test(npc.portraitSheet)){
-    const frame = Math.floor(Math.random() * 4);
-    const col = frame % 2;
-    const row = Math.floor(frame/2);
-    const posX = col === 0 ? '0%' : '100%';
-    const posY = row === 0 ? '0%' : '100%';
-    portEl.style.backgroundImage = `url(${npc.portraitSheet})`;
-    portEl.style.backgroundSize = '200% 200%';
-    portEl.style.backgroundPosition = `${posX} ${posY}`;
-  } else {
-    portEl.style.backgroundImage = `url(${npc.portraitSheet})`;
-    portEl.style.backgroundSize = '100% 100%';
-    portEl.style.backgroundPosition = 'center';
-  }
+  setPortraitDiv(portEl, npc);
 }
 
 function openDialog(npc, node='start'){

--- a/scripts/core/npc.js
+++ b/scripts/core/npc.js
@@ -1,8 +1,8 @@
 // ===== NPCs =====
 var Dustland = globalThis.Dustland;
 class NPC {
-  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null}) {
-    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet});
+  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null,portraitLock=true}) {
+    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet,portraitLock});
     const capNode = (node) => {
       if (this.combat && node === 'do_fight') {
         closeDialog();
@@ -109,6 +109,7 @@ function createNpcFactory(defs) {
       if (n.combat) opts.combat = n.combat;
       if (n.shop) opts.shop = n.shop;
       if (n.portraitSheet) opts.portraitSheet = n.portraitSheet;
+      if (n.portraitLock === false) opts.portraitLock = false;
       const npc = makeNPC(
         n.id,
         n.map || 'world',

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -557,7 +557,9 @@ function save(){
     combat:n.combat,
     shop:n.shop,
     quest:n.quest?{id:n.quest.id,status:n.quest.status}:null,
-    loop:n.loop
+    loop:n.loop,
+    portraitSheet:n.portraitSheet,
+    portraitLock:n.portraitLock
   }));
   const questData = {};
   Object.keys(quests).forEach(k=>{
@@ -565,7 +567,7 @@ function save(){
     questData[k]={title:q.title,desc:q.desc,status:q.status};
   });
   const partyData = Array.from(party, p => ({
-    id:p.id,name:p.name,role:p.role,lvl:p.lvl,xp:p.xp,skillPoints:p.skillPoints,stats:p.stats,equip:p.equip,hp:p.hp,ap:p.ap,map:p.map,x:p.x,y:p.y,maxHp:p.maxHp
+    id:p.id,name:p.name,role:p.role,lvl:p.lvl,xp:p.xp,skillPoints:p.skillPoints,stats:p.stats,equip:p.equip,hp:p.hp,ap:p.ap,map:p.map,x:p.x,y:p.y,maxHp:p.maxHp,portraitSheet:p.portraitSheet
   }));
   const data={worldSeed, world, player, state, buildings, interiors, itemDrops, npcs:npcData, quests:questData, party:partyData};
   localStorage.setItem('dustland_crt', JSON.stringify(data));

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -705,7 +705,9 @@ party.forEach((m,i)=>{
 `<div class='row'><div class='xpbar' data-xp='${m.xp}/${nextXP}'><div class='fill' style='width:${pct}%'></div></div></div>`+
 `<div class='row small'>WPN: ${wLabel}${wEq?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${aEq?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${tEq?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div>`;
   const portrait=c.querySelector('.portrait');
-  if(m.portraitSheet){
+  if (typeof setPortraitDiv === 'function') {
+    setPortraitDiv(portrait, m);
+  } else if (m.portraitSheet) {
     portrait.style.backgroundImage=`url(${m.portraitSheet})`;
     if(/_4\.[a-z]+$/i.test(m.portraitSheet)){
       portrait.style.backgroundSize='200% 200%';

--- a/test/portraits.test.js
+++ b/test/portraits.test.js
@@ -64,3 +64,26 @@ test('creator picks random default portrait', () => {
   const sheet = vm.runInContext('building.portraitSheet', context);
   assert.strictEqual(sheet, 'assets/portraits/portrait_1045.png');
 });
+
+test('named NPC keeps consistent 2x2 frame', () => {
+  const {context,dom} = setup();
+  context.worldSeed = 123;
+  const npc = { id:'grin', portraitSheet:'assets/portraits/grin_4.png' };
+  const el1 = dom.window.document.createElement('div');
+  const el2 = dom.window.document.createElement('div');
+  context.setPortraitDiv(el1, npc);
+  context.setPortraitDiv(el2, npc);
+  assert.strictEqual(el1.style.backgroundPosition, el2.style.backgroundPosition);
+});
+
+test('generic portrait picks random frame each call', () => {
+  const {context,dom} = setup();
+  const npc = { id:'raider', portraitSheet:'assets/portraits/raider_4.png', portraitLock:false };
+  context.Math.random = () => 0;
+  const el1 = dom.window.document.createElement('div');
+  context.setPortraitDiv(el1, npc);
+  context.Math.random = () => 0.75;
+  const el2 = dom.window.document.createElement('div');
+  context.setPortraitDiv(el2, npc);
+  assert.notStrictEqual(el1.style.backgroundPosition, el2.style.backgroundPosition);
+});


### PR DESCRIPTION
## Summary
- lock named NPC portrait frames per world seed while non-characters vary each encounter
- persist portrait data in saves and expose portraitLock flags for non-characters
- exercise deterministic and random portraits via tests

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b07f12bb208328a39c63921af416a4