### PR TITLE
feat: balance distant encounters with rare loot

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -40,7 +40,8 @@ const DUSTLAND_MODULE = (() => {
   const encounters = {
     world: [
       { name: 'Rotwalker', HP: 6, DEF: 1, loot: 'water_flask' },
-      { name: 'Scavenger', HP: 5, DEF: 0, loot: 'raider_knife' }
+      { name: 'Scavenger', HP: 5, DEF: 0, loot: 'raider_knife' },
+      { name: 'Sand Titan', HP: 20, DEF: 4, loot: 'artifact_blade', challenge: 9, minDist: 15 }
     ]
   };
 
@@ -61,7 +62,8 @@ const DUSTLAND_MODULE = (() => {
     { map: 'world', x: 18, y: midY - 2, id: 'valve', name: 'Valve', type: 'quest' },
     { map: 'world', x: 26, y: midY + 3, id: 'lost_satchel', name: 'Lost Satchel', type: 'quest' },
     { map: 'world', x: 60, y: midY - 1, id: 'rust_idol', name: 'Rust Idol', type: 'quest', tags: ['idol'] },
-    { id: 'raider_knife', name: 'Raider Knife', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } }
+    { id: 'raider_knife', name: 'Raider Knife', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } },
+    { id: 'artifact_blade', name: 'Artifact Blade', type: 'weapon', slot: 'weapon', mods: { ATK: 5, ADR: 20 } }
   ];
 
   const quests = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dustland",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dustland",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -232,9 +232,13 @@ function checkRandomEncounter(){
   if(!bank || !bank.length) return;
   const dist = distanceToRoad(party.x, party.y);
   if(dist<=0) return;
-  const chance = Math.min(dist * 0.02, 0.5);
+  // Fewer encounters the farther you wander from the road
+  const chance = Math.max(0.02, 0.3 - dist * 0.01);
   if(Math.random() < chance){
-    const def = bank[Math.floor(Math.random()*bank.length)];
+    let pool = bank;
+    const hard = bank.filter(e => e.minDist && dist >= e.minDist);
+    if(hard.length) pool = hard;
+    const def = pool[Math.floor(Math.random() * pool.length)];
     return Dustland.actions.startCombat(def);
   }
 }

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -952,7 +952,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.12 — install codex via npm.');
+log('v0.7.13 — install codex via npm.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode


### PR DESCRIPTION
## Summary
- Reduce random encounter frequency as party moves away from the road
- Add Sand Titan rare encounter with high stats and Artifact Blade drop
- Bump engine version to 0.7.13

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b08e4cf4608328ada2697f599c965a