### PR TITLE
fix: allow space to select combat option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -325,11 +325,12 @@ function moveChoice(dir){
 
 function handleCombatKey(e){
   if (!combatOverlay || !combatOverlay.classList.contains('shown')) return false;
-  if (e.key === 'Enter' && e.repeat) return false;
+  if ((e.key === 'Enter' || e.key === ' ') && e.repeat) return false;
   switch (e.key){
     case 'ArrowUp':    moveChoice(-1); return true;
     case 'ArrowDown':  moveChoice(1);  return true;
-    case 'Enter':      chooseOption(); return true;
+    case 'Enter':
+    case ' ':          chooseOption(); return true;
   }
   return false;
 }

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -952,7 +952,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.13 — install codex via npm.');
+log('v0.7.14 — install codex via npm.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1251,6 +1251,21 @@ test('combat menu can be clicked', async () => {
   assert.strictEqual(res.result, 'loot');
 });
 
+test('space selects combat option', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  party.addMember(m1);
+
+  const resultPromise = openCombat([
+    { name:'E1', hp:1 }
+  ]);
+
+  handleCombatKey({ key:' ' });
+  const res = await resultPromise;
+  assert.strictEqual(res.result, 'loot');
+});
+
 test('turn indicator updates with active member', async () => {
   party.length = 0;
   player.inv.length = 0;


### PR DESCRIPTION
## Summary
- allow Space key to select combat option
- test combat selection with Space key
- bump engine version to 0.7.14

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b09526ed208328b9d1b1b0c0878fbc