### PR TITLE
feat: harden wasteland encounters

### DIFF
--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -46,6 +46,8 @@ Equipment isn't just about bigger numbers. It's about changing *how* you fight.
 *   **Armor:** Provides damage resistance, but can also have passive combat effects. A "Scavenger's Rig" might grant a small amount of Adrenaline at the start of combat. A "Juggernaut Plate" could make you immune to being interrupted while using a Special.
 *   **Gadgets (Accessories):** This is where things get wild. A "Stim-Pack" gadget could allow you to convert HP into Adrenaline in an emergency. A "Targeting Visor" could increase the critical hit chance of your specials. An "Adrenaline Charm" might double the rate at which Adrenaline builds.
 
+Some wasteland horrors shrug off ordinary steel. Enemies like the Sand Colossus won't take damage unless the party carries an artifact-grade weapon, making gear progression essential, while others such as the Dune Reaper simply hit harder the deeper you wander. Rare artifact blades lie buried in the wastes for those bold enough to seek them.
+
 > **Gizmo:** The data structures for this need to be clean. An item should just have a `modifiers` object. For example: `{"adrenaline_gen_mod": 1.2, "granted_special": "CLEAVE"}`. The combat system just iterates through the equipped items and applies the modifiers at the start of a fight. This makes it incredibly easy for us, and for modders, to add new gear, but we'll need profiling to ensure modifier checks stay cheap.
 
 ### UI/UX: Clarity in Chaos

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -37,11 +37,14 @@ const DUSTLAND_MODULE = (() => {
     { map: 'hall', x: hall.entryX - 1, y: hall.entryY, events:[{ when:'enter', effect:'toast', msg:'You smell rot.' }] }
   ];
 
+  const span = Math.max(typeof WORLD_W === 'number' ? WORLD_W : 0, typeof WORLD_H === 'number' ? WORLD_H : 0);
   const encounters = {
     world: [
-      { name: 'Rotwalker', HP: 6, DEF: 1, loot: 'water_flask' },
-      { name: 'Scavenger', HP: 5, DEF: 0, loot: 'raider_knife' },
-      { name: 'Sand Titan', HP: 20, DEF: 4, loot: 'artifact_blade', challenge: 9, minDist: 15 }
+      { name: 'Rotwalker', HP: 6, DEF: 1, loot: 'water_flask', maxDist: Math.floor(span * 0.2) },
+      { name: 'Scavenger', HP: 5, DEF: 0, loot: 'raider_knife', maxDist: Math.floor(span * 0.3) },
+      { name: 'Sand Titan', HP: 20, DEF: 4, loot: 'artifact_blade', challenge: 9, minDist: Math.floor(span * 0.4) },
+      { name: 'Dune Reaper', HP: 75, DEF: 7, loot: 'artifact_blade', challenge: 32, minDist: Math.floor(span * 0.55), special: { cue: 'lashes the wind with scythes!', dmg: 10 } },
+      { name: 'Sand Colossus', HP: 80, DEF: 8, loot: 'artifact_blade', challenge: 36, minDist: Math.floor(span * 0.7), requires: 'artifact_blade', special: { cue: 'shakes the desert!', dmg: 12 } }
     ]
   };
 
@@ -63,7 +66,7 @@ const DUSTLAND_MODULE = (() => {
     { map: 'world', x: 26, y: midY + 3, id: 'lost_satchel', name: 'Lost Satchel', type: 'quest' },
     { map: 'world', x: 60, y: midY - 1, id: 'rust_idol', name: 'Rust Idol', type: 'quest', tags: ['idol'] },
     { id: 'raider_knife', name: 'Raider Knife', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } },
-    { id: 'artifact_blade', name: 'Artifact Blade', type: 'weapon', slot: 'weapon', mods: { ATK: 5, ADR: 20 } }
+    { map: 'world', x: 110, y: midY + 4, id: 'artifact_blade', name: 'Artifact Blade', type: 'weapon', slot: 'weapon', mods: { ATK: 5, ADR: 20 } }
   ];
 
   const quests = [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.13",
+  "version": "0.7.15",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -392,6 +392,13 @@ function doAttack(dmg, type = 'basic'){
   const mult  = 1 + adrPct * (attacker.adrDmgMod || 1);
   dealt = Math.round(dealt * mult);
 
+  const weapon = attacker.equip?.weapon;
+  const req = target.requires;
+  if (req && (!weapon || weapon.id !== req)){
+    dealt = 0;
+    log?.(`${attacker.name}'s attacks can't harm ${target.name}. Equip ${req}.`);
+  }
+
   // Immunity to basic
   if (type === 'basic' && Array.isArray(target.immune) && target.immune.includes('basic')){
     dealt = 0;
@@ -410,7 +417,6 @@ function doAttack(dmg, type = 'basic'){
   });
 
   // Adrenaline gain (based on weapon mods & generator mod)
-  const weapon   = attacker.equip?.weapon;
   const baseGain = (weapon?.mods?.ADR ?? 10) / 4;
   const gain     = Math.round(baseGain * (attacker.adrGenMod || 1));
   attacker.adr   = Math.min(attacker.maxAdr || 100, (attacker.adr ?? 0) + Math.max(0, gain));
@@ -461,6 +467,14 @@ function doAttack(dmg, type = 'basic'){
   }
 
   nextCombatant();
+}
+
+function testAttack(attacker, enemy, dmg = 1, type = 'basic'){
+  combatState.enemies = [enemy];
+  combatState.active = 0;
+  party.length = 0;
+  party.push(attacker);
+  doAttack(dmg, type);
 }
 
 function doSpecial(idx){
@@ -667,5 +681,5 @@ function getCombatLog(){
   return combatState.log.slice();
 }
 
-const combatExports = { openCombat, closeCombat, handleCombatKey, getCombatLog };
+const combatExports = { openCombat, closeCombat, handleCombatKey, getCombatLog, __testAttack: testAttack };
 Object.assign(globalThis, combatExports);

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -231,12 +231,13 @@ function checkRandomEncounter(){
   const bank = enemyBanks[state.map];
   if(!bank || !bank.length) return;
   const dist = distanceToRoad(party.x, party.y);
-  if(dist<=0) return;
-  // Fewer encounters the farther you wander from the road
-  const chance = Math.max(0.02, 0.3 - dist * 0.01);
+  if(dist <= 0) return;
+  const span = Math.max(WORLD_W, WORLD_H);
+  const chance = Math.max(0.02, 0.25 - (dist / span) * 0.23);
   if(Math.random() < chance){
-    let pool = bank;
-    const hard = bank.filter(e => e.minDist && dist >= e.minDist);
+    let pool = bank.filter(e => (!e.minDist || dist >= e.minDist) && (!e.maxDist || dist <= e.maxDist));
+    if(!pool.length) return;
+    const hard = pool.filter(e => e.minDist);
     if(hard.length) pool = hard;
     const def = pool[Math.floor(Math.random() * pool.length)];
     return Dustland.actions.startCombat(def);

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -952,7 +952,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.13 — install codex via npm.');
+log('v0.7.15 — install codex via npm.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1447,7 +1447,7 @@ test('distance to road reduces encounter chance', () => {
   const origRand = Math.random;
   const origStart = globalThis.Dustland.actions.startCombat;
   globalThis.Dustland.actions.startCombat = () => { started = true; return Promise.resolve({ result: 'flee' }); };
-  Math.random = () => 0.1;
+  Math.random = () => 0.23;
   setPartyPos(1, 0); // Near the road
   checkRandomEncounter();
   assert.ok(started);
@@ -1512,6 +1512,34 @@ test('distant encounters use hard enemy pool', () => {
   Math.random = origRand;
   globalThis.Dustland.actions.startCombat = origStart;
   assert.strictEqual(chosen.name, 'Hard');
+});
+
+test('enemies respect max distance', () => {
+  const row = Array(10).fill(TILE.SAND);
+  row[0] = TILE.ROAD;
+  applyModule({ world: [row], encounters: { world: [ { name: 'Near', HP: 1, DEF: 0, maxDist: 2 } ] } });
+  state.map = 'world';
+  setPartyPos(5, 0);
+  let started = false;
+  const origRand = Math.random;
+  Math.random = () => 0;
+  const origStart = globalThis.Dustland.actions.startCombat;
+  globalThis.Dustland.actions.startCombat = () => { started = true; return Promise.resolve({ result: 'flee' }); };
+  checkRandomEncounter();
+  Math.random = origRand;
+  globalThis.Dustland.actions.startCombat = origStart;
+  assert.ok(!started);
+});
+
+test('enemy requires a specific weapon', () => {
+  const enemy = { name: 'Shellback', hp: 10, requires: 'artifact_blade' };
+  const attacker = makeMember('a', 'A', 'Hero');
+  attacker.equip = { weapon: { id: 'rusted_sword', mods: { ADR: 10 } } };
+  __testAttack(attacker, enemy, 5);
+  assert.strictEqual(enemy.hp, 10);
+  attacker.equip.weapon.id = 'artifact_blade';
+  __testAttack(attacker, enemy, 5);
+  assert.strictEqual(enemy.hp, 5);
 });
 
 test('applyModule from dialog adds next fragment', async () => {


### PR DESCRIPTION
## Summary
- Scale encounters by map size and add Dune Reaper alongside Sand Colossus
- Allow artifact blade pickups and gate early monsters near the road
- Bump engine version to 0.7.15

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0920fa9fc832892a8d4dcc7e19a2b