### PR TITLE
feat: add luck-based combat boosts

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -54,6 +54,7 @@ _______________________________________________________________________________
   - Movement speed improves with the leader's AGI, including equipment bonuses. Items like the Boots of Speed further reduce movement delay.
   - Special moves spend Adrenaline. Starter techniques include Power Strike,
     Stun Grenade, First Aid, Adrenal Surge, and Guard.
+  - Luck may boost attacks, soften incoming blows, and enhance healing from potions. Lucky moments are called out in the log.
 
 [ CHARACTER CREATION ]
   - Start a new game at boot if no save is present.

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -398,6 +398,13 @@ function doAttack(dmg, type = 'basic'){
     log?.(`${target.name} shrugs off the attack.`);
   }
 
+  const luck = (attacker.stats?.LCK || 0) + (attacker._bonus?.LCK || 0);
+  const eff  = Math.max(0, luck - 4);
+  if (Math.random() < eff * 0.05){
+    dealt += 1;
+    log?.('Lucky strike!');
+  }
+
   target.hp -= dealt;
 
   recordCombatEvent?.({
@@ -631,7 +638,13 @@ function enemyAttack(){
 
     setTimeout(() => {
       combatOverlay?.classList.remove('warning');
-      const dmg = enemy.special.dmg || 5;
+      let dmg = enemy.special.dmg || 5;
+      const luck = (target.stats?.LCK || 0) + (target._bonus?.LCK || 0);
+      const eff  = Math.max(0, luck - 4);
+      if (Math.random() < eff * 0.05 && dmg > 0){
+        dmg = Math.max(0, dmg - 1);
+        log?.('Lucky break!');
+      }
       target.hp -= dmg;
       recordCombatEvent?.({ type: 'enemy', actor: enemy.name, action: 'special', target: target.name, damage: dmg, targetHp: target.hp });
       log?.(`${enemy.name} unleashes for ${dmg} damage.`);
@@ -647,6 +660,12 @@ function enemyAttack(){
     target.guard = false;
     dmg = Math.max(0, dmg - 1);
     log?.(`${target.name} guards against the attack.`);
+  }
+  const luck = (target.stats?.LCK || 0) + (target._bonus?.LCK || 0);
+  const eff  = Math.max(0, luck - 4);
+  if (Math.random() < eff * 0.05 && dmg > 0){
+    dmg = Math.max(0, dmg - 1);
+    log?.('Lucky break!');
   }
   target.hp -= dmg;
 

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -207,10 +207,15 @@ function useItem(invIndex){
   if(it.use.type==='heal'){
     const who = (party[selectedMember]||party[0]);
     if(!who){ log('No party member to heal.'); return false; }
+    const base   = it.use.amount;
+    const luck   = (who.stats?.LCK || 0) + (who._bonus?.LCK || 0);
+    const eff    = Math.max(0, luck - 4);
+    const bonus  = Math.floor(base * eff * 0.05);
     const before = who.hp;
-    who.hp = Math.min(who.hp + it.use.amount, who.maxHp);
+    who.hp = Math.min(who.hp + base + bonus, who.maxHp);
     const healed = who.hp - before;
     log(`${who.name} drinks ${it.name} (+${healed} HP).`);
+    if (bonus > 0) log('Lucky boost!');
     if (typeof toast === 'function') toast(`${who.name} +${healed} HP`);
     emit('sfx','tick');
     player.inv.splice(invIndex,1);

--- a/test/luck-effects.test.js
+++ b/test/luck-effects.test.js
@@ -1,0 +1,105 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import './fast-timeouts.js';
+
+function stubEl(){
+  const el = {
+    style:{},
+    classList:{
+      _set:new Set(),
+      toggle(c){ this._set.has(c)?this._set.delete(c):this._set.add(c); },
+      add(c){ this._set.add(c); },
+      remove(c){ this._set.delete(c); },
+      contains(c){ return this._set.has(c); }
+    },
+    textContent:'',
+    onclick:null,
+    _innerHTML:'',
+    children:[],
+    appendChild(child){ this.children.push(child); child.parentElement=this; },
+    prepend(child){ this.children.unshift(child); child.parentElement=this; },
+    querySelector: () => stubEl(),
+    querySelectorAll: () => [],
+    addEventListener(){},
+    parentElement:{ appendChild:()=>{}, querySelectorAll:()=>[] }
+  };
+  Object.defineProperty(el,'innerHTML',{ get(){return this._innerHTML;}, set(v){ this._innerHTML=v; this.children=[]; }});
+  return el;
+}
+
+const combatOverlay = stubEl();
+const combatEnemies = stubEl();
+const combatParty = stubEl();
+const combatCmd = stubEl();
+const turnIndicator = stubEl();
+
+global.document = {
+  getElementById: (id) => ({ combatOverlay, combatEnemies, combatParty, combatCmd, turnIndicator })[id] || stubEl(),
+  createElement: () => stubEl()
+};
+
+global.window = global;
+global.logMessages = [];
+global.log = (m) => logMessages.push(m);
+global.toast = () => {};
+global.renderInv = () => {};
+global.renderParty = () => {};
+global.updateHUD = () => {};
+global.player = { inv: [], hp: 10 };
+
+global.requestAnimationFrame = () => {};
+
+const files = [
+  '../scripts/event-bus.js',
+  '../scripts/core/party.js',
+  '../scripts/core/inventory.js',
+  '../scripts/core/combat.js'
+];
+for (const f of files) {
+  const code = await fs.readFile(new URL(f, import.meta.url), 'utf8');
+  vm.runInThisContext(code, { filename: f });
+}
+
+party.length = 0;
+const hero = makeMember('h', 'Hero');
+hero.stats.LCK = 10;
+hero.maxHp = 20;
+hero.hp = 5;
+party.push(hero);
+selectedMember = 0;
+
+test('luck boosts healing potions', () => {
+  logMessages.length = 0;
+  player.inv = [{ id:'pot', name:'Potion', use:{ type:'heal', amount:5 } }];
+  useItem(0);
+  assert.strictEqual(hero.hp, 11);
+  assert.ok(logMessages.some(m => m.includes('Luck')));
+});
+
+test('luck can boost damage dealt', () => {
+  logMessages.length = 0;
+  hero.hp = hero.maxHp;
+  const enemy = { name:'Slime', hp:10, maxHp:10 };
+  const r = Math.random; Math.random = () => 0;
+  openCombat([enemy]);
+  doAttack(1);
+  Math.random = r;
+  assert.strictEqual(combatState.enemies[0].hp, 8);
+  assert.ok(logMessages.some(m => m.includes('Luck')));
+  closeCombat('flee');
+});
+
+test('luck can reduce damage taken', () => {
+  logMessages.length = 0;
+  hero.hp = 10;
+  const enemy = { name:'Bat', hp:1, maxHp:1 };
+  openCombat([enemy]);
+  const r = Math.random; Math.random = () => 0;
+  enemyAttack();
+  Math.random = r;
+  assert.strictEqual(hero.hp, 10);
+  assert.ok(logMessages.some(m => m.includes('Luck')));
+  closeCombat('flee');
+});


### PR DESCRIPTION
## Summary
- let luck give bonus healing for potions and log lucky sips
- add lucky strike and lucky break hooks to combat for damage swing
- document luck mechanics and test them

## Testing
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b092c578108328be45e20849082737