### PR TITLE
fix: enable space to select dialog

### DIFF
--- a/docs/design/dialog-navigation.md
+++ b/docs/design/dialog-navigation.md
@@ -34,7 +34,7 @@ Menu-driven conversations that feel deliberate and human, built with plain JavaS
 
 - Reuse existing button styles from the HUD and editor for dialog choice buttons.
 - Layout: portrait stack — line text, then a vertical list of buttons; optional "Back" and "Close" appear contextually.
-- Keyboard: arrows/WASD to move focus; Enter to select; Esc to close.
+- Keyboard: arrows/WASD to move focus; Enter or Space to select; Esc to close.
 - Accessibility: ensure focus order matches visual order; no hidden focus traps.
 
 ## Data Model (ACK)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/dialog.js
+++ b/scripts/core/dialog.js
@@ -41,7 +41,9 @@ function handleDialogKey(e){
     case 'd':
     case 'D':
       dlgMoveChoice(1); return true;
-    case 'Enter':{
+    case 'Enter':
+    case ' ': // space
+    case 'Spacebar':{
       const el=choicesEl.children[selectedChoice];
       if(el?.click) el.click(); else el?.onclick?.();
       return true; }

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -952,7 +952,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.15 — install codex via npm.');
+log('v0.7.16 — space selects dialog options.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1040,6 +1040,19 @@ test('handleDialogKey navigates dialog choices with WASD', () => {
   assert.deepStrictEqual(picked, ['Two', 'One']);
 });
 
+test('space selects dialog choice', () => {
+  NPCS.length = 0;
+  const npc = { id: 'nav', name: 'Nav', tree: { start: { text: '', choices: [ { label: 'One' } ] } } };
+  NPCS.push(npc);
+  openDialog(npc);
+  const picked = [];
+  choicesEl.children[0].click = () => picked.push('One');
+
+  handleDialogKey({ key: ' ' });
+
+  assert.deepStrictEqual(picked, ['One']);
+});
+
 test('party enforces maximum size of six', () => {
   party.length = 0;
   const members = [


### PR DESCRIPTION
## Summary
- let spacebar activate the highlighted dialog option
- update dialog navigation docs and test
- bump engine version to 0.7.16

## Testing
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b09b580190832884160cee20fd9a7d