### PR TITLE
feat: add zone hazards and entry respawn

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -37,6 +37,11 @@ const DUSTLAND_MODULE = (() => {
     { map: 'hall', x: hall.entryX - 1, y: hall.entryY, events:[{ when:'enter', effect:'toast', msg:'You smell rot.' }] }
   ];
 
+  // Zones apply effects per step; top rows harbor a damaging nanite swarm
+  const zones = [
+    { map: 'world', x: 0, y: 0, w: typeof WORLD_W === 'number' ? WORLD_W : 120, h: 5, perStep: { hp: -1, msg: 'Nanite swarm!' }, negate: 'mask' }
+  ];
+
   const span = Math.max(typeof WORLD_W === 'number' ? WORLD_W : 0, typeof WORLD_H === 'number' ? WORLD_H : 0);
   const encounters = {
     world: [
@@ -51,6 +56,7 @@ const DUSTLAND_MODULE = (() => {
   const items = [
     { id: 'rusted_key', name: 'Rusted Key', type: 'quest', tags: ['key'] },
     { id: 'toolkit', name: 'Toolkit', type: 'quest', tags: ['tool'] },
+    { map: 'world', x: 5, y: midY - 5, id: 'mask', name: 'Mask', type: 'trinket', slot: 'trinket', desc: 'Filters nanite swarms.' },
     { map: 'world', x: 8, y: midY, id: 'pipe_rifle', name: 'Pipe Rifle', type: 'weapon', slot: 'weapon', mods: { ATK: 2, ADR: 15 } },
     { map: 'world', x: 10, y: midY, id: 'leather_jacket', name: 'Leather Jacket', type: 'armor', slot: 'armor', mods: { DEF: 1 } },
     { map: 'world', x: 12, y: midY, id: 'lucky_bottlecap', name: 'Lucky Bottlecap', type: 'trinket', slot: 'trinket', mods: { LCK: 1 } },
@@ -710,6 +716,7 @@ const DUSTLAND_MODULE = (() => {
     quests,
     npcs,
     events,
+    zones,
     encounters,
     interiors: [hall],
     buildings: []

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -171,6 +171,12 @@ function closeCombat(result = 'flee'){
   combatState.fallen.forEach(m => { m.hp = Math.max(1, m.hp || 0); party.push(m); });
   combatState.fallen.length = 0;
 
+  if(result === 'bruise' && state.mapEntry){
+    log?.('You wake up at the entrance.');
+    if(typeof toast==='function') toast('You wake up at the entrance.');
+    setPartyPos?.(state.mapEntry.x, state.mapEntry.y);
+  }
+
   recordCombatEvent({ type: 'system', action: 'end', result });
   globalThis.EventBus?.emit?.('combat:ended', { result });
   combatState.onComplete?.({ result });

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -8,6 +8,7 @@ bus?.on?.('combat:ended', () => { combatActive = false; });
 const buffs = [];              // 2c342c / 313831
 const tileColors = {0:'#1e271d',1:'#313831',2:'#1573ff',3:'#203320',4:'#777777',5:'#304326',6:'#4d5f4d',7:'#233223',8:'#8bd98d',9:'#000000'};// 2B382B / 203320
 let moveDelay = 0;
+const zones = globalThis.zoneEffects || [];
 
 function hexToHsv(hex) {
     // 1. Convert Hex to RGB
@@ -153,6 +154,39 @@ function onEnter(map,x,y,ctx){
   }
 }
 
+function applyZones(map,x,y){
+  for(const z of zones){
+    if((z.map||'world')!==map) continue;
+    if(x<z.x || y<z.y || x>=z.x+(z.w||0) || y>=z.y+(z.h||0)) continue;
+    if(typeof hasItem==='function'){
+      if(z.require && !hasItem(z.require)) continue;
+      if(z.negate && hasItem(z.negate)) continue;
+    } else {
+      if(z.require) continue;
+      if(z.negate) {}
+    }
+    const step = z.perStep || z.step;
+    if(step && typeof step.hp==='number'){
+      const delta = step.hp;
+      (party||[]).forEach(m=>{
+        const max = typeof m.maxHp==='number'?m.maxHp:m.hp;
+        m.hp = Math.max(0, Math.min(max, m.hp + delta));
+      });
+      renderParty?.(); updateHUD?.();
+      const msg = step.msg || (delta>0? 'You feel better.' : 'You take damage.');
+      log?.(msg);
+      if(typeof toast==='function') toast(msg);
+    }
+  }
+  if((party||[]).length && party.every(m=>m.hp<=0)){
+    log?.('Your party collapses and wakes at the entrance.');
+    if(typeof toast==='function') toast('Everyone is down!');
+    if(state.mapEntry) setPartyPos(state.mapEntry.x, state.mapEntry.y);
+    (party||[]).forEach(m=>{ m.hp = 1; });
+    renderParty?.(); updateHUD?.();
+  }
+}
+
 // ===== Interaction =====
 function canWalk(x,y){
   if(state.map==='creator') return false;
@@ -181,6 +215,7 @@ function move(dx,dy){
         setPartyPos(nx, ny);
         if(typeof footstepBump==='function') footstepBump();
         onEnter(state.map, nx, ny, { player, party, state, actor, buffs });
+        applyZones(state.map, nx, ny);
         centerCamera(party.x,party.y,state.map); updateHUD();
         checkAggro();
         checkRandomEncounter();

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -200,6 +200,7 @@ function mapLabel(id){
 function setMap(id,label){
   state.map=id;
   party.map = id;
+  state.mapEntry = null;
   mapNameEl.textContent = label || mapLabel(id);
   if(typeof centerCamera==='function') centerCamera(party.x,party.y,state.map);
   if(id==='world') setGameState(GAME_STATE.WORLD);
@@ -225,8 +226,10 @@ globalThis.getViewSize = getViewSize;
 // ===== Game state =====
 let world = [], interiors = {}, buildings = [], portals = [], npcTemplates = [];
 const tileEvents = [];
+const zoneEffects = [];
 const enemyBanks = {};
 function registerTileEvents(list){ (list||[]).forEach(e => tileEvents.push(e)); }
+function registerZoneEffects(list){ (list||[]).forEach(z => zoneEffects.push(z)); }
 const state = { map:'world', mapFlags: {} }; // default map
 const player = { hp:10, ap:2, inv:[], scrap:0 };
 if (typeof registerItem === 'function') {
@@ -240,6 +243,9 @@ if (typeof registerItem === 'function') {
 function setPartyPos(x, y){
   if(typeof x === 'number') party.x = x;
   if(typeof y === 'number') party.y = y;
+  if(!state.mapEntry || state.mapEntry.map !== state.map){
+    state.mapEntry = { map: state.map, x: party.x, y: party.y };
+  }
   incFlag(`visits@${state.map}@${party.x},${party.y}`);
 }
 const worldFlags = {};
@@ -385,6 +391,7 @@ function applyModule(data = {}, options = {}) {
   // Portals, events, and encounters
   if (moduleData.portals) portals.push(...moduleData.portals);
   if (moduleData.events) registerTileEvents(moduleData.events);
+  if (moduleData.zones) registerZoneEffects(moduleData.zones);
   if (moduleData.templates) npcTemplates.push(...moduleData.templates);
   if (moduleData.encounters) {
     Object.entries(moduleData.encounters).forEach(([map, list]) => {
@@ -850,8 +857,10 @@ const coreExports = {
   buildings,
   portals,
   tileEvents,
+  zoneEffects,
   enemyBanks,
   registerTileEvents,
+  registerZoneEffects,
   state,
   player,
   GAME_STATE,

--- a/test/nanite-zone.test.js
+++ b/test/nanite-zone.test.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { createGameProxy } from './test-harness.js';
+
+async function setupContext() {
+  const { context } = createGameProxy([]);
+  context.Dustland = { effects:{ tick: () => {} }, path:{}, actions:{ startCombat: () => {} } };
+  context.TILE = { ROAD: 0 };
+  context.walkable = { 0: true };
+  context.world = [ [0,0], [0,0] ];
+  context.itemDrops = [];
+  context.NPCS = [];
+  context.interiors = {};
+  context.tileEvents = [];
+  context.zoneEffects = [ { map:'world', x:0, y:0, w:2, h:2, perStep:{ hp:-1, msg:'Nanite swarm!' }, negate:'mask' } ];
+  context.Dustland.zoneEffects = context.zoneEffects;
+  context.clamp = (v,min,max)=> Math.max(min, Math.min(max,v));
+  context.setPartyPos = (x,y)=>{ context.party.x=x; context.party.y=y; };
+  context.footstepBump = () => {};
+  context.checkAggro = () => {};
+  context.checkRandomEncounter = () => {};
+  context.updateHUD = () => {};
+  context.renderParty = () => {};
+  context.centerCamera = () => {};
+  context.log = () => {};
+  context.toast = () => {};
+  context.hasItem = id => context.player.inv.some(i=>i.id===id);
+  context.state.map = 'world';
+  context.state.mapEntry = { map:'world', x:0, y:0 };
+  context.player.inv = [];
+  context.party.x = 0;
+  context.party.y = 0;
+
+  const partyCode = await fs.readFile(new URL('../scripts/core/party.js', import.meta.url), 'utf8');
+  vm.runInContext(partyCode, context);
+  context.party.x = 0;
+  context.party.y = 0;
+  const m1 = new context.Character('a','A','');
+  const m2 = new context.Character('b','B','');
+  m1.maxHp = m2.maxHp = 1;
+  m1.hp = m2.hp = 1;
+  context.party.addMember(m1);
+  context.party.addMember(m2);
+
+  const moveCode = await fs.readFile(new URL('../scripts/core/movement.js', import.meta.url), 'utf8');
+  vm.runInContext(moveCode, context);
+  return context;
+}
+
+test('zone drains HP and warps on wipe', async () => {
+  const ctx = await setupContext();
+  await ctx.move(1,0);
+  assert.strictEqual(ctx.party.x, 0);
+  assert.strictEqual(ctx.party[0].hp, 1);
+});
+
+test('mask negates zone damage', async () => {
+  const ctx = await setupContext();
+  ctx.player.inv.push({ id:'mask' });
+  ctx.party[0].hp = 5; ctx.party[0].maxHp = 5;
+  await ctx.move(1,0);
+  assert.strictEqual(ctx.party[0].hp, 5);
+});


### PR DESCRIPTION
## Summary
- add rectangular zone effects with optional item requirements or immunity
- track map entry and respawn party at entry after wipe
- place nanite swarm hazard and mask item in Dustland module
- cover zone damage and mask immunity with tests

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b09da0ba388328a6e4596596b09e98