### PR TITLE
feat: add stat tooltips in creator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -683,6 +683,14 @@ const quirks={
   'Desert Prophet':{desc:'Rare visions add hints.'}
 };
 const hiddenOrigins={ 'Rustborn':{desc:'You survived a machine womb. +1 PER, weird dialog tags.'} };
+const statInfo={
+  STR:{name:'Strength',benefit:'helps with DC checks'},
+  AGI:{name:'Agility',benefit:'speeds up movement'},
+  INT:{name:'Intelligence',benefit:'helps with DC checks'},
+  PER:{name:'Perception',benefit:'helps with DC checks'},
+  LCK:{name:'Luck',benefit:'boosts damage and healing'},
+  CHA:{name:'Charisma',benefit:'helps with DC checks'}
+};
 
 // Pool of placeholder names to auto-fill the creator
 function defaultDrifterName(n){ return 'Drifter '+n; }
@@ -724,7 +732,7 @@ function renderStep(){
   }
   if(step===2){
     ccHint.textContent='Distribute 6 points among stats.';
-    r.innerHTML=`<div class='grid'>${Object.keys(building.stats).map(k=>`<div class='field'><label>${k}</label><div class='range'><button data-k='${k}' data-d='-1'>−</button><div id='v_${k}' class='pill'>${building.stats[k]}</div><button data-k='${k}' data-d='1'>+</button></div></div>`).join('')}</div><div class='small'>Points left: <span id='pts'></span></div>`;
+    r.innerHTML=`<div class='grid'>${Object.keys(building.stats).map(k=>{const info=statInfo[k]||{name:k,benefit:'helps with DC checks'};return `<div class='field'><label title='${info.name}: ${info.benefit}'>${k}</label><div class='range'><button data-k='${k}' data-d='-1'>−</button><div id='v_${k}' class='pill'>${building.stats[k]}</div><button data-k='${k}' data-d='1'>+</button></div></div>`}).join('')}</div><div class='small'>Points left: <span id='pts'></span></div>`;
     let pool=6; const base=baseStats(); for(const k in base){ pool -= (building.stats[k]-base[k]); }
     const ptsEl=document.getElementById('pts'); function upd(){ ptsEl.textContent=pool; for(const k in building.stats){ document.getElementById('v_'+k).textContent=building.stats[k]; } } upd();
     r.querySelectorAll('button').forEach(b=> b.onclick=()=>{ const k=b.dataset.k, d=parseInt(b.dataset.d,10); if(d>0 && pool<=0) return; if(d<0 && building.stats[k]<=1) return; building.stats[k]+=d; pool-=d; upd(); });

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -952,7 +952,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.16 — space selects dialog options.');
+log('v0.7.17 — space selects dialog options.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/creator-stats-tooltips.test.js
+++ b/test/creator-stats-tooltips.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const code = await fs.readFile(new URL('../scripts/dustland-core.js', import.meta.url), 'utf8');
+
+function setup(){
+  const html = `<body><div id="mapname"></div><div id="creator"></div><div id="ccStep"></div><div id="ccRight"></div><div id="ccHint"></div><button id="ccBack"></button><button id="ccNext"></button><div id="ccPortrait"></div><button id="ccStart"></button><button id="ccLoad"></button></body>`;
+  const dom = new JSDOM(html);
+  const party=[]; party.flags={}; party.map='world'; party.x=0; party.y=0;
+  const context={
+    window:dom.window,
+    document:dom.window.document,
+    EventBus:{ on:()=>{}, emit:()=>{} },
+    baseStats:()=>({STR:4,AGI:4,INT:4,PER:4,LCK:4,CHA:4}),
+    makeMember:(id,name,role)=>({id,name,role,stats:{}}),
+    addPartyMember:m=>{ party.push(m); },
+    addToInv:()=>{},
+    rand:()=>0,
+    log:()=>{},
+    party,
+    Math:Object.assign(Object.create(Math),{random:()=>0})
+  };
+  vm.createContext(context);
+  vm.runInContext(code,context);
+  return {context,dom};
+}
+
+test('stat labels include names and benefits',()=>{
+  const {context,dom}=setup();
+  context.openCreator();
+  dom.window.document.getElementById('ccNext').onclick();
+  const labels=[...dom.window.document.querySelectorAll('#ccRight label')];
+  const expected={
+    STR:'Strength: helps with DC checks',
+    AGI:'Agility: speeds up movement',
+    INT:'Intelligence: helps with DC checks',
+    PER:'Perception: helps with DC checks',
+    LCK:'Luck: boosts damage and healing',
+    CHA:'Charisma: helps with DC checks'
+  };
+  labels.forEach(l=>{
+    const key=l.textContent;
+    assert.strictEqual(l.getAttribute('title'), expected[key]);
+  });
+});


### PR DESCRIPTION
## Summary
- show stat names and benefits when hovering over stats in the character creator
- test tooltips
- bump engine version

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09eeae9b483289bb30db3f0cd89e4