### PR TITLE
feat: add slot machine shack

### DIFF
--- a/test/slot-machine.module.test.js
+++ b/test/slot-machine.module.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('dustland module adds slot shack with gambling options', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'dustland.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /interiorId: 'slot_shack'/);
+  assert.match(src, /id: 'slots'/);
+  assert.match(src, /\(1 scrap\)/);
+  assert.match(src, /\(5 scrap\)/);
+  assert.match(src, /\(25 scrap\)/);
+});


### PR DESCRIPTION
## Summary
- add slot shack interior with slot machine NPC that gambles scrap
- place accessible building in the wastes linking to the new interior
- cover slot machine presence with a module test

## Testing
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`
- `timeout 5 ./install-deps.sh` (fails: Operation interrupted)


------
https://chatgpt.com/codex/tasks/task_e_68b0be6229488328802c8c4e2f1f33d3