### PR TITLE
feat: bandit scrap drops

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -453,6 +453,13 @@ function doAttack(dmg, type = 'basic'){
     globalThis.EventBus?.emit?.('enemy:defeated', { target });
     if (target.loot) addToInv?.(target.loot);
 
+    // Bandits sometimes drop scrap
+    if (/bandit/i.test(target.id) && Math.random() < 0.5){
+      player.scrap = (player.scrap || 0) + 1;
+      updateHUD?.();
+      log?.('You find 1 scrap on the bandit.');
+    }
+
     // Special boss drop chance
     if (target.boss && Math.random() < 0.1){ addToInv?.('memory_worm'); }
 

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -952,7 +952,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.18 — space selects dialog options.');
+log('v0.7.19 — bandits may drop scrap.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1168,6 +1168,22 @@ test('defeated enemies can drop spoils cache', async () => {
   assert.ok(logs.some(l => l.includes('Sealed Cache')));
 });
 
+test('bandits can drop scrap on defeat', async () => {
+  NPCS.length = 0;
+  party.length = 0;
+  player.inv.length = 0;
+  player.scrap = 0;
+  const m1 = new Character('p1','P1','Role');
+  party.addMember(m1);
+  const origRand = Math.random;
+  Math.random = () => 0;
+  const resultPromise = openCombat([{ id:'bandit', name:'Bandit', hp:1 }]);
+  handleCombatKey({ key:'Enter' });
+  await resultPromise;
+  Math.random = origRand;
+  assert.strictEqual(player.scrap, 1);
+});
+
 test('fallen party members are revived after combat', async () => {
   NPCS.length = 0;
   party.length = 0;


### PR DESCRIPTION
## Summary
- let bandits occasionally drop scrap on defeat
- bump engine version to 0.7.19 and log new feature
- test bandit scrap drops

## Testing
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1aed0a86c83288e8ed88868e7c99c