### PR TITLE
fix: lock combat portrait variants

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -52,7 +52,10 @@ function setPortraitDiv(el, obj){
         for(let i=0;i<s.length;i++){ h = (h * 31 + s.charCodeAt(i)) | 0; }
         frame = Math.abs(h) % 4;
       }else{
-        frame = Math.floor(Math.random() * 4);
+        if (typeof obj.portraitFrame !== 'number'){
+          obj.portraitFrame = Math.floor(Math.random() * 4);
+        }
+        frame = obj.portraitFrame;
       }
       const col = frame % 2;
       const row = Math.floor(frame / 2);

--- a/test/portraits.test.js
+++ b/test/portraits.test.js
@@ -76,14 +76,15 @@ test('named NPC keeps consistent 2x2 frame', () => {
   assert.strictEqual(el1.style.backgroundPosition, el2.style.backgroundPosition);
 });
 
-test('generic portrait picks random frame each call', () => {
+test('generic portrait keeps frame once chosen', () => {
   const {context,dom} = setup();
   const npc = { id:'raider', portraitSheet:'assets/portraits/raider_4.png', portraitLock:false };
   context.Math.random = () => 0;
   const el1 = dom.window.document.createElement('div');
   context.setPortraitDiv(el1, npc);
+  const firstPos = el1.style.backgroundPosition;
   context.Math.random = () => 0.75;
   const el2 = dom.window.document.createElement('div');
   context.setPortraitDiv(el2, npc);
-  assert.notStrictEqual(el1.style.backgroundPosition, el2.style.backgroundPosition);
+  assert.strictEqual(el2.style.backgroundPosition, firstPos);
 });


### PR DESCRIPTION
## Summary
- keep NPC portrait variant fixed for entire fight
- update portrait test

## Testing
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1b76ca50c8328827db4e8d9208ec4