### PR TITLE
feat: boost slot machine with leader luck

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2,13 +2,22 @@ function seedWorldContent() {}
 
 const DUSTLAND_MODULE = (() => {
   const midY = Math.floor(WORLD_H / 2);
+  // Slot machine gambling; leader luck above 7 nudges rewards upward
   function pullSlots(cost, payouts) {
     if (player.scrap < cost) {
       log('Not enough scrap.');
       return;
     }
     player.scrap -= cost;
-    const reward = payouts[Math.floor(rng() * payouts.length)];
+    const lead = typeof leader === 'function' ? leader() : null;
+    const luck = (lead?.stats?.LCK || 0) + (lead?._bonus?.LCK || 0);
+    const eff = Math.max(0, luck - 7);
+    let idx = Math.floor(rng() * payouts.length);
+    if (eff > 0 && Math.random() < eff * 0.05) {
+      idx = Math.min(idx + 1, payouts.length - 1);
+      log('Lucky spin!');
+    }
+    const reward = payouts[idx];
     if (reward > 0) {
       player.scrap += reward;
       log(`The machine rattles and spits out ${reward} scrap.`);

--- a/test/slot-machine-luck.test.js
+++ b/test/slot-machine-luck.test.js
@@ -1,0 +1,42 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('leader luck above 7 boosts slot machine payout', async () => {
+  const code = await fs.readFile(new URL('../modules/dustland.module.js', import.meta.url), 'utf8');
+  globalThis.WORLD_H = 10;
+  globalThis.WORLD_W = 10;
+  globalThis.TILE = { WALL: 1, FLOOR: 0, DOOR: 2 };
+  globalThis.player = { scrap: 5 };
+  globalThis.DC = { TALK: 10, REPAIR: 10 };
+  globalThis.CURRENCY = 'scrap';
+  globalThis.logMessages = [];
+  globalThis.log = (m) => logMessages.push(m);
+  globalThis.updateHUD = () => {};
+  globalThis.addToInv = () => {};
+  globalThis.rng = () => 0;
+  globalThis.applyModule = () => ({ start: {} });
+  const mod = vm.runInThisContext(code + '\nDUSTLAND_MODULE', { filename: 'dustland.module.js' });
+
+  const slotNpc = mod.npcs.find(n => n.id === 'slots');
+  globalThis.party = [{ stats: { LCK: 7 }, _bonus: { LCK: 0 }, name: 'Hero' }];
+  globalThis.leader = () => party[0];
+  const origRandom = Math.random;
+  Math.random = () => 0;
+
+  // Luck at 7 does not influence outcome
+  slotNpc.tree.start.choices[0].effects[0]();
+  assert.equal(player.scrap, 4);
+
+  // Luck above 7 can improve the result
+  player.scrap = 5;
+  party[0].stats.LCK = 8;
+  logMessages.length = 0;
+  slotNpc.tree.start.choices[0].effects[0]();
+  assert.equal(player.scrap, 5);
+  assert.ok(logMessages.some(m => m.includes('Lucky spin')));
+
+  Math.random = origRandom;
+});
+


### PR DESCRIPTION
## Summary
- let high leader luck nudge slot machine rewards upward
- add regression test for slot machine luck

## Testing
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1b9218cb48328a0c98f1c558eee13