### PR TITLE
fix: prevent duplicate skill badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -717,11 +717,18 @@ party.forEach((m,i)=>{
       portrait.style.backgroundPosition='center';
     }
   }
+  const existingBadge = portrait.querySelector('.spbadge');
   if(m.skillPoints>0){
-    const badge=document.createElement('div');
-    badge.className='spbadge';
-    badge.textContent=m.skillPoints;
-    portrait.appendChild(badge);
+    if(existingBadge){
+      existingBadge.textContent = m.skillPoints;
+    }else{
+      const badge=document.createElement('div');
+      badge.className='spbadge';
+      badge.textContent=m.skillPoints;
+      portrait.appendChild(badge);
+    }
+  }else if(existingBadge){
+    existingBadge.remove();
   }
   c.onclick=()=>selectMember(i);
   c.onfocus=()=>selectMember(i);
@@ -952,7 +959,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.19 — bandits may drop scrap.');
+log('v0.7.20 — prevent duplicate skill badges.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/skill-badge.test.js
+++ b/test/skill-badge.test.js
@@ -35,3 +35,16 @@ test('no badge when no skill points', () => {
   const badge = document.querySelector('.spbadge');
   assert.strictEqual(badge, null);
 });
+
+test('badge updates without duplication on re-render', () => {
+  const { context, document } = setup();
+  const m = context.makeMember('id','Name','Role');
+  m.skillPoints = 1;
+  context.party.push(m);
+  context.renderParty();
+  m.skillPoints = 3;
+  context.renderParty();
+  const badges = document.querySelectorAll('.spbadge');
+  assert.strictEqual(badges.length, 1);
+  assert.strictEqual(String(badges[0].textContent), '3');
+});


### PR DESCRIPTION
## Summary
- avoid appending multiple skill-point badges when rendering party
- add regression test for updating badge without duplication
- bump engine version to v0.7.20

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `./install-deps.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b1b993bdcc8328a2b3e232ac01cf14