### PR TITLE
fix: gate combat arrows until key release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -4,6 +4,11 @@ const enemyRow      = typeof document !== 'undefined' ? document.getElementById(
 const partyRow      = typeof document !== 'undefined' ? document.getElementById('combatParty') : null;
 const cmdMenu       = typeof document !== 'undefined' ? document.getElementById('combatCmd') : null;
 const turnIndicator = typeof document !== 'undefined' ? document.getElementById('turnIndicator') : null;
+const combatKeys    = {};
+
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('keyup', (e) => { combatKeys[e.key] = false; });
+}
 
 window.bossTelegraphFX = window.bossTelegraphFX || { intensity: 1, duration: 1000 };
 window.setBossTelegraphFX = (opts = {}) => {
@@ -136,6 +141,7 @@ function openCombat(enemies){
   if (!combatOverlay) return Promise.resolve({ result: 'flee' });
 
   return new Promise((resolve) => {
+    for (const k in combatKeys) combatKeys[k] = false;
     combatState.enemies = enemies.map(e => ({
       ...e,
       maxHp: e.maxHp || e.hp,
@@ -334,6 +340,8 @@ function moveChoice(dir){
 
 function handleCombatKey(e){
   if (!combatOverlay || !combatOverlay.classList.contains('shown')) return false;
+  if (e.repeat && !combatKeys[e.key]) return false;
+  combatKeys[e.key] = true;
   if ((e.key === 'Enter' || e.key === ' ') && e.repeat) return false;
   switch (e.key){
     case 'ArrowUp':    moveChoice(-1); return true;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -952,7 +952,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.19 — bandits may drop scrap.');
+log('v0.7.20 — combat ignores held arrows on start.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/combat-input.test.js
+++ b/test/combat-input.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { createGameProxy } from './test-harness.js';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('combat ignores held arrow key on start', async () => {
+  const { context, document } = createGameProxy([{ name: 'Hero', hp: 5 }]);
+  const combatCode = await fs.readFile(new URL('../scripts/core/combat.js', import.meta.url), 'utf8');
+  vm.runInContext(combatCode, context);
+  context.openCombat([{ name: 'Slime', hp: 1 }]);
+  const menu = document.getElementById('combatCmd');
+  context.handleCombatKey({ key: 'ArrowDown', repeat: true });
+  assert.ok(menu.children[0].classList.contains('sel'));
+  context.window.dispatchEvent(new context.window.KeyboardEvent('keyup', { key: 'ArrowDown' }));
+  context.handleCombatKey({ key: 'ArrowDown' });
+  assert.ok(menu.children[3].classList.contains('sel'));
+});


### PR DESCRIPTION
## Summary
- ignore held arrow keys when combat starts until key is released
- add test for ignoring held arrows at combat start
- bump engine version to 0.7.20

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1ba9cb9908328847997e270961a1c