### PR TITLE
feat: break slot machine after 500 scrap payout

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2,6 +2,7 @@ function seedWorldContent() {}
 
 const DUSTLAND_MODULE = (() => {
   const midY = Math.floor(WORLD_H / 2);
+  let slotNetPayout = 0;
   function pullSlots(cost, payouts) {
     if (player.scrap < cost) {
       log('Not enough scrap.');
@@ -14,6 +15,19 @@ const DUSTLAND_MODULE = (() => {
       log(`The machine rattles and spits out ${reward} scrap.`);
     } else {
       log('The machine coughs and eats your scrap.');
+    }
+    slotNetPayout += reward - cost;
+    if (slotNetPayout >= 500) {
+      log('The machine sparks and collapses!');
+      const slotNpc = NPCS.find(n => n.id === 'slots');
+      const dropPos = slotNpc ? { map: slotNpc.map, x: slotNpc.x, y: slotNpc.y } : { map: party.map, x: party.x, y: party.y };
+      if (slotNpc) removeNPC(slotNpc);
+      const cache = SpoilsCache?.create?.('vaulted');
+      if (cache) {
+        const registered = registerItem?.(cache) || cache;
+        itemDrops?.push?.({ id: registered.id, ...dropPos });
+        globalThis.EventBus?.emit?.('spoils:drop', { cache: registered, target: slotNpc });
+      }
     }
     updateHUD?.();
   }

--- a/test/slot-machine.module.test.js
+++ b/test/slot-machine.module.test.js
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
 
 test('dustland module adds slot shack with gambling options', () => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -13,4 +14,37 @@ test('dustland module adds slot shack with gambling options', () => {
   assert.match(src, /\(1 scrap\)/);
   assert.match(src, /\(5 scrap\)/);
   assert.match(src, /\(25 scrap\)/);
+});
+
+test('slot machine drops cache after paying out 500 scrap net', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'dustland.module.js');
+  let src = fs.readFileSync(file, 'utf8');
+  src = src.replace(/updateHUD\?\.\(\);\n  }/, 'updateHUD?.();\n  }\n  globalThis.pullSlots = pullSlots;');
+  const context = {
+    WORLD_H: 20,
+    WORLD_W: 120,
+    TILE: { WALL: 0, FLOOR: 1, DOOR: 2 },
+    DC: { TALK: 0, REPAIR: 0 },
+    CURRENCY: 's',
+    player: { scrap: 1000 },
+    rng: () => 0.999,
+    log: () => {},
+    updateHUD: () => {},
+    NPCS: [{ id: 'slots', map: 'slot_shack', x: 3, y: 2 }],
+    SpoilsCache: { create: rank => ({ id: `cache-${rank}`, name: 'Cache' }) },
+    registerItem: item => item,
+    itemDrops: [],
+    EventBus: { emit: () => {} },
+    party: { map: 'slot_shack', x: 3, y: 2 }
+  };
+  context.removeNPC = npc => {
+    const i = context.NPCS.indexOf(npc);
+    if (i > -1) context.NPCS.splice(i, 1);
+  };
+  vm.runInNewContext(src, context);
+  const { pullSlots } = context;
+  for (let i = 0; i < 20; i++) pullSlots(25, [0, 10, 25, 35, 50]);
+  assert.strictEqual(context.NPCS.length, 0);
+  assert(context.itemDrops.some(d => d.id === 'cache-vaulted'));
 });


### PR DESCRIPTION
## Summary
- Make slot machine track net scrap payout and collapse after 500 scrap, dropping a vaulted spoils cache
- Add regression test ensuring the machine removes itself and drops top-tier cache after enough winnings

## Testing
- `node scripts/presubmit.js`
- `./install-deps.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bb1772648328ad2f2f7d32950012