### PR TITLE
feat: add cache stat simulation script

### DIFF
--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -66,7 +66,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 
 #### Phase 4: Testing
 - [x] Write tests to verify drop odds and tier distribution across challenge levels.
-- [ ] Simulate 1,000 cache openings per tier to ensure stat ranges stay sane.
+ - [x] Simulate 1,000 cache openings per tier to ensure stat ranges stay sane.
 - [x] Run `node scripts/presubmit.js` to confirm no async snafus in cache UI — clean run.
 
 > **Clown:** When players crack open a Vaulted Cache and a "Quantum Harmonica" drops, I want them to laugh, equip it, and blow something up with a punchline.

--- a/scripts/cache-sim.js
+++ b/scripts/cache-sim.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import './core/item-generator.js';
+
+const ranges = ItemGen.statRanges;
+for (const rank of Object.keys(ranges)) {
+  let min = Infinity;
+  let max = -Infinity;
+  const { min: expectedMin, max: expectedMax } = ranges[rank];
+  for (let i = 0; i < 1000; i++) {
+    const item = ItemGen.generate(rank);
+    const power = item.stats.power;
+    if (power < min) min = power;
+    if (power > max) max = power;
+    if (power < expectedMin || power > expectedMax) {
+      console.error(`${rank} power ${power} out of range ${expectedMin}-${expectedMax}`);
+      process.exit(1);
+    }
+  }
+  console.log(`${rank}: min=${min} max=${max}`);
+}


### PR DESCRIPTION
## Summary
- add script to simulate 1,000 spoils cache openings per rank and report stat ranges
- mark design task for cache stat simulation as complete

## Testing
- `node scripts/cache-sim.js`
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1bb5935748328ae31fb9c51478ff0