### PR TITLE
fix: safeguard party roster

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.20",
+  "version": "0.7.22",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -154,6 +154,7 @@ function openCombat(enemies){
     combatState.onComplete = resolve;
     combatState.fallen = [];
     combatState.log = [];
+    combatState.roster = Array.from(party);
 
     (party || []).forEach(m => {
       m.maxAdr = m.maxAdr || 100;
@@ -176,8 +177,16 @@ function closeCombat(result = 'flee'){
   if (cmdMenu) cmdMenu.style.display = 'none';
   if (turnIndicator) turnIndicator.textContent = '';
 
-  // Restore fallen to party with at least 1 HP
-  combatState.fallen.forEach(m => { m.hp = Math.max(1, m.hp || 0); party.push(m); });
+  if (combatState.roster) {
+    const fallenSet = new Set(combatState.fallen);
+    combatState.roster.forEach(m => {
+      if (fallenSet.has(m)) m.hp = Math.max(1, m.hp || 0);
+    });
+    party.setMembers(combatState.roster);
+    if (typeof renderParty === 'function') renderParty();
+    if (typeof updateHUD === 'function') updateHUD();
+    combatState.roster = null;
+  }
   combatState.fallen.length = 0;
 
   if(result === 'bruise' && state.mapEntry){

--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -100,7 +100,7 @@ class Character {
   }
 }
 
-  class Party extends Array {
+class Party extends Array {
     constructor(...args){
       super(...args);
       this.map = globalThis.state ? globalThis.state.map : 'world';
@@ -108,14 +108,36 @@ class Character {
       this.y = 2;
       this.flags = {};
     }
+  push(...members){
+    const unique = members.filter(m => m && !this.includes(m));
+    return super.push(...unique);
+  }
+  unshift(...members){
+    const unique = members.filter(m => m && !this.includes(m));
+    return super.unshift(...unique);
+  }
+  setMembers(members){
+    const seen = new Set();
+    const unique = [];
+    (members||[]).forEach(m => {
+      if(m && !seen.has(m)){
+        seen.add(m);
+        unique.push(m);
+      }
+    });
+    super.splice(0, this.length, ...unique);
+    return this.length;
+  }
   addMember(member){
     if(this.length >= 6){
       log('Party is full.');
       return false;
     }
-    this.push(member);
+    if(this.includes(member)) return false;
+    super.push(member);
     member.applyEquipmentStats();
-    renderParty(); updateHUD();
+    if(typeof renderParty === 'function') renderParty();
+    if(typeof updateHUD === 'function') updateHUD();
     log(member.name+" joins the party.");
     return true;
   }
@@ -127,7 +149,8 @@ class Character {
       return false;
     }
     this.splice(idx,1);
-    renderParty(); updateHUD();
+    if(typeof renderParty === 'function') renderParty();
+    if(typeof updateHUD === 'function') updateHUD();
     if(typeof makeNPC==='function' && typeof NPCS !== 'undefined' && Array.isArray(NPCS)){
       const tree={ start:{ text:'', choices:[{label:'(Leave)', to:'bye'}] }, bye:{ text:'' } };
       const npc=makeNPC(member.id, this.map, this.x, this.y, '#fff', member.name, '', '', tree);

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -962,7 +962,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.20 — combat ignores held arrows on start.');
+log('v0.7.22 — party roster restored after combat.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/combat-party.test.js
+++ b/test/combat-party.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+await import('../scripts/core/party.js');
+
+// ensure combat preserves party roster
+// we need DOM before importing combat
+
+const { JSDOM } = await import('jsdom');
+const dom = new JSDOM(`<div id="combatOverlay"></div><div id="combatEnemies"></div><div id="combatParty"></div><div id="combatCmd"></div><div id="turnIndicator"></div>`);
+global.document = dom.window.document;
+global.window = dom.window;
+
+await import('../scripts/core/combat.js');
+
+test('party roster restores after combat', async () => {
+  globalThis.party.length = 0;
+  globalThis.player = { hp: 10, inv: [] };
+  globalThis.updateHUD = () => {};
+  globalThis.renderParty = () => {};
+  const a = globalThis.makeMember('a', 'A', 'Hero');
+  const b = globalThis.makeMember('b', 'B', 'Mage');
+  globalThis.party.push(a, b);
+  const before = Array.from(globalThis.party, m => m.id);
+
+  const p = globalThis.openCombat([]);
+  globalThis.party.splice(1, 1); // drop B
+  globalThis.party.push(a); // duplicate A
+  globalThis.closeCombat('win');
+  await p;
+
+  assert.deepStrictEqual(Array.from(globalThis.party, m => m.id), before);
+});

--- a/test/party-unique.test.js
+++ b/test/party-unique.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import '../scripts/core/party.js';
+
+test('party prevents duplicates and can reorder members', () => {
+  party.length = 0;
+  const a = makeMember('a', 'A', 'Hero');
+  const b = makeMember('b', 'B', 'Mage');
+  party.push(a);
+  party.push(a);
+  assert.strictEqual(party.length, 1);
+  party.push(b);
+  party.push(b);
+  assert.strictEqual(party.length, 2);
+  party.setMembers([b, a, a]);
+  assert.deepStrictEqual(Array.from(party, m => m.id), ['b', 'a']);
+});


### PR DESCRIPTION
## Summary
- capture party lineup at combat start and restore it when fights end
- bump engine version to 0.7.22

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1c14fdf9883288814d163be350d48