### PR TITLE
fix: compact inventory cards and inline equip controls

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -300,6 +300,7 @@ input[type="range"] {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
         gap: 6px;
+        align-content: start;
     }
 
     .tabwrap {
@@ -311,6 +312,10 @@ input[type="range"] {
         border: 1px dashed #2b382b;
         border-radius: 6px;
         background: #0c0f0c;
+    }
+
+    .equip-line {
+        white-space: nowrap;
     }
 
     .slot.better {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -706,7 +706,11 @@ party.forEach((m,i)=>{
 `<div class='row small'>${statLine(m.stats)}</div>`+
 `<div class='row stats'>HP ${m.hp}/${m.maxHp}  ADR ${m.adr}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div>`+
 `<div class='row'><div class='xpbar' data-xp='${m.xp}/${nextXP}'><div class='fill' style='width:${pct}%'></div></div></div>`+
-`<div class='row small'>WPN: ${wLabel}${wEq?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}  ARM: ${aLabel}${aEq?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}  TRK: ${tLabel}${tEq?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</div>`;
+`<div class='row small'>
+  <span class='equip-line'>WPN: ${wLabel}${wEq?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}</span>
+  <span class='equip-line'>ARM: ${aLabel}${aEq?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}</span>
+  <span class='equip-line'>TRK: ${tLabel}${tEq?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</span>
+</div>`;
   const portrait=c.querySelector('.portrait');
   if (typeof setPortraitDiv === 'function') {
     setPortraitDiv(portrait, m);
@@ -962,7 +966,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.20 — combat ignores held arrows on start.');
+log('v0.7.21 — compact inventory cards and inline equip controls.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode


### PR DESCRIPTION
## Summary
- keep inventory grid from stretching so item cards stay compact
- ensure equipment labels and Unequip buttons remain on one line
- bump engine version to 0.7.21

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1c5d7bb5c8328a73372a5cda08a63