### PR TITLE
feat: add GameState singleton

### DIFF
--- a/docs/design/tech-debt-paydown.md
+++ b/docs/design/tech-debt-paydown.md
@@ -68,8 +68,8 @@ Our CRT playground is scrappy by design, but a few lingering habits slow our bui
   - [x] Build a tiny `ui.js` to listen for events.
   - [x] Keep old globals as shims during migration.
 - [ ] **Phase 3: Consolidate state**
-  - [ ] Create a `GameState` singleton.
-  - [ ] Provide accessors for state changes.
+  - [x] Create a `GameState` singleton.
+  - [x] Provide accessors for state changes.
 - [ ] **Phase 4: Lint for sanity**
   - [x] Add ESLint with a vanilla config.
   - [x] Expose `npm run lint`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -962,7 +962,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.22 — party roster restored after combat.');
+log('v0.7.23 — added game state singleton.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/scripts/game-state.js
+++ b/scripts/game-state.js
@@ -1,0 +1,7 @@
+(function(){
+  globalThis.Dustland = globalThis.Dustland || {};
+  const state = { party: [], world: {}, inventory: [], flags: {}, clock: 0, quests: [] };
+  function getState(){ return state; }
+  function updateState(fn){ if (typeof fn === 'function') fn(state); }
+  Dustland.gameState = { getState, updateState };
+})();

--- a/test/game-state.test.js
+++ b/test/game-state.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('game state exposes shared data and updater', async () => {
+  const code = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
+  vm.runInThisContext(code, { filename: 'game-state.js' });
+  const gs = globalThis.Dustland.gameState;
+  assert.ok(gs);
+  const state = gs.getState();
+  assert.deepEqual(state.party, []);
+  gs.updateState(s => { s.flags.level = 1; });
+  assert.equal(gs.getState().flags.level, 1);
+});


### PR DESCRIPTION
## Summary
- add global GameState singleton with get/update helpers
- bump engine to v0.7.23
- check off design plan for consolidating state

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1cecb2b7083288ca1d4f0af1c7371