### PR TITLE
feat: show stat deltas in trainer UI

### DIFF
--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -64,7 +64,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] **Trainer UI Mockup:** Design the "Upgrade Skills" dialog. It needs a list of available upgrades (stats and abilities), their costs, and a clear "before and after" preview for any selected stat change. See `docs/design/trainer-ui-mockup.md`.
     > **Gizmo:** Let's make this UI data-driven. It should just read a list of available upgrades from the trainer NPC's data. That way, modders can add new trainers with unique skill trees just by editing a JSON file.
     > **Clown:** It can be a json blob, but keep in mind that all json lives inside the javascript to keep the "no builds no servers" running locally ethos.
-- [ ] **Trainer UI Implementation:** Build the data-driven "Upgrade Skills" overlay showing upgrade costs and before/after stat changes.
+- [x] **Trainer UI Implementation:** Build the data-driven "Upgrade Skills" overlay showing upgrade costs and before/after stat changes.
 
 #### **Phase 3: Content Implementation (The World)**
  - [x] **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer's `tree` object should include the **Upgrade Skills** dialog option and their unique list of available upgrades.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -966,7 +966,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.23 — added game state singleton.');
+  log('v0.7.24 — trainer UI shows stat deltas.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/scripts/trainer-ui.js
+++ b/scripts/trainer-ui.js
@@ -3,9 +3,10 @@
     return globalThis.TRAINER_UPGRADES || {};
   }
 
-  async function showTrainer(id, memberIndex){
+  async function showTrainer(id, memberIndex = 0){
     const data = loadTrainerData();
     const upgrades = data[id] || [];
+    const member = globalThis.party?.[memberIndex];
     let box = document.getElementById('trainer_ui');
     if(!box){
       box = document.createElement('div');
@@ -15,7 +16,13 @@
     box.innerHTML = '';
     upgrades.forEach(up => {
       const btn = document.createElement('button');
-      btn.textContent = `${up.label} (Cost:${up.cost})`;
+      if(member){
+        const base = up.stat === 'HP' ? member.maxHp : (member.stats[up.stat] || 0);
+        const after = base + (up.delta || 0);
+        btn.textContent = `${up.label} (Cost:${up.cost}) ${base}\u2192${after}`;
+      } else {
+        btn.textContent = `${up.label} (Cost:${up.cost})`;
+      }
       btn.addEventListener('click', () => {
         applyUpgrade(id, up.id, memberIndex);
       });

--- a/test/trainer-ui.test.js
+++ b/test/trainer-ui.test.js
@@ -25,21 +25,23 @@ function setup(){
   return { context, dom };
 }
 
-test('render trainer options', async () => {
-  const { context, dom } = setup();
-  await context.TrainerUI.showTrainer('power');
-  const buttons = dom.window.document.querySelectorAll('#trainer_ui button');
-  assert.strictEqual(buttons.length, 2);
-  assert.ok(buttons[0].textContent.includes('STR'));
-});
+  test('render trainer options with stat deltas', async () => {
+    const { context, dom } = setup();
+    const m = context.makeMember('id', 'Name', 'Role');
+    context.party.push(m);
+    await context.TrainerUI.showTrainer('power', 0);
+    const buttons = dom.window.document.querySelectorAll('#trainer_ui button');
+    assert.strictEqual(buttons.length, 2);
+    assert.ok(buttons[0].textContent.includes('4→5'));
+  });
 
 test('apply upgrade via click', async () => {
   const { context, dom } = setup();
   const m = context.makeMember('id', 'Name', 'Role');
   m.skillPoints = 1;
   context.party.push(m);
-  await context.TrainerUI.showTrainer('power');
-  const btn = dom.window.document.querySelector('#trainer_ui button');
+    await context.TrainerUI.showTrainer('power', 0);
+    const btn = dom.window.document.querySelector('#trainer_ui button');
   btn.click();
   assert.strictEqual(m.stats.STR, 5);
   assert.strictEqual(m.skillPoints, 0);


### PR DESCRIPTION
## Summary
- display before/after stat values in trainer upgrade buttons
- cover trainer UI stat deltas with tests
- bump engine version to 0.7.24 and mark design doc item complete

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1d8796f0c83289fc233fe7f91b185