### PR TITLE
feat: add module JSON import/export tooling

### DIFF
--- a/docs/design/module-json-tools.md
+++ b/docs/design/module-json-tools.md
@@ -14,10 +14,10 @@ We need to let editors tinker with module layouts without touching code. Each JS
    - After parsing `DATA`, run a `postLoad(module)` function to sprinkle custom logic (NPC scripts, quests, etc.).
    - Existing modules must be refactored so their gameplay logic lives in `postLoad` and the JSON stays clean.
 2. **Import / export scripts**
-   - Add `scripts/module-json.js` with commands:
+   - [x] Add `scripts/module-json.js` with commands:
      - `node scripts/module-json.js export modules/dustland.module.js` → writes `data/modules/dustland.json`.
      - `node scripts/module-json.js import modules/dustland.module.js` → injects JSON back into the multiline string.
-   - Wire npm aliases:
+   - [x] Wire npm aliases:
      - `npm run module:export -- <file>`
      - `npm run module:import -- <file>`
 3. **Module picker management**
@@ -27,8 +27,8 @@ We need to let editors tinker with module layouts without touching code. Each JS
      - `npm run module:add -- modules/foo.module.js`
      - `npm run module:remove -- modules/foo.module.js`
 4. **Directory layout**
-   - Store exported JSON under `data/modules/`.
-   - Keep procedural helpers in `scripts/`.
+   - [x] Store exported JSON under `data/modules/`.
+   - [x] Keep procedural helpers in `scripts/`.
 
 ## Remaining Work
 - Refactor each existing module to the new format.

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "dustland",
-  "version": "0.7.24",
+  "version": "0.7.25",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",
   "scripts": {
     "serve": "http-server -p 8080",
     "test": "node --test",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "module:export": "node scripts/module-json.js export",
+    "module:import": "node scripts/module-json.js import"
   },
   "author": "",
   "license": "MIT",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -966,7 +966,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-  log('v0.7.24 — trainer UI shows stat deltas.');
+  log('v0.7.25 — trainer UI shows stat deltas.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/scripts/module-json.js
+++ b/scripts/module-json.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+
+function usage(){
+  console.log('Usage: node scripts/module-json.js <export|import> <moduleFile>');
+  process.exit(1);
+}
+
+const [cmd, file] = process.argv.slice(2);
+if (!cmd || !file) usage();
+
+const modulePath = path.resolve(file);
+const baseName = path.basename(modulePath).replace(/\.module\.js$/, '');
+const jsonPath = path.join('data', 'modules', `${baseName}.json`);
+
+function extractData(str){
+  const match = str.match(/const DATA = `([\s\S]*?)`;/);
+  return match ? match[1] : null;
+}
+
+if (cmd === 'export') {
+  const text = fs.readFileSync(modulePath, 'utf8');
+  const dataStr = extractData(text);
+  if (!dataStr) {
+    console.error('DATA block not found.');
+    process.exit(1);
+  }
+  const obj = JSON.parse(dataStr);
+  fs.mkdirSync(path.dirname(jsonPath), { recursive: true });
+  fs.writeFileSync(jsonPath, JSON.stringify(obj, null, 2));
+  console.log(`Exported ${jsonPath}`);
+} else if (cmd === 'import') {
+  const jsonText = fs.readFileSync(jsonPath, 'utf8');
+  JSON.parse(jsonText); // validate
+  const text = fs.readFileSync(modulePath, 'utf8');
+  const newText = text.replace(/const DATA = `[\s\S]*?`;/, `const DATA = \`\n${jsonText}\n\`;`);
+  fs.writeFileSync(modulePath, newText);
+  console.log(`Updated ${modulePath}`);
+} else {
+  usage();
+}


### PR DESCRIPTION
## Summary
- add script to export/import module JSON data
- wire npm scripts and bump engine version
- document module JSON tooling progress

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b1f698360c8328af266dfd2bd56088