### PR TITLE
docs: document module json workflow

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -129,6 +129,9 @@ _______________________________________________________________________________
   - Items support `equip.flag` and `unequip` teleport/message effects.
   - Tiles: see TILE enum + colors[] + walkable[].
   - Maps can be specified as arrays of emoji strings using `tileEmoji` (numeric grids still load).
+  - Use `npm run module:export -- modules/dustland.module.js` to dump a module's layout
+    to `data/modules/dustland.json`; edit and run `npm run module:import -- modules/dustland.module.js`
+    to sync changes back.
   - Tests: run `npm install` to fetch dev deps like jsdom.
     Ensure system libs (libatk1.0-0, libatk-bridge2.0-0, libcups2, libdrm2,
     libxcomposite1, libxdamage1, libxfixes3, libxrandr2, libgbm1, libasound2,

--- a/docs/design/module-json-tools.md
+++ b/docs/design/module-json-tools.md
@@ -27,8 +27,8 @@ We need to let editors tinker with module layouts without touching code. Each JS
    - Keep procedural helpers in `scripts/`.
 
 ## Remaining Work
-- Refactor each existing module to the new format.
-- Build automated tests for the import/export tools.
-- Verify Adventure Kit loads JSON modules and triggers `postLoad`.
-- Document the workflow in `docs/` and update README.
+- [ ] Refactor each existing module to the new format.
+- [ ] Build automated tests for the import/export tools.
+- [ ] Verify Adventure Kit loads JSON modules and triggers `postLoad`.
+- [x] Document the workflow in `docs/` and update README.
 

--- a/docs/module-json-workflow.md
+++ b/docs/module-json-workflow.md
@@ -1,0 +1,29 @@
+# Module JSON Workflow
+
+This guide shows how to round-trip a module's data between its `*.module.js` file and a standalone JSON file.
+
+## Prerequisites
+- Node.js installed.
+- Module file uses the design pattern `const DATA = \`\n{...}\n\`;` at the top.
+- Commands run from the repo root.
+
+## Export a module to JSON
+```sh
+npm run module:export -- modules/dustland.module.js
+```
+This writes the module's JSON to `data/modules/dustland.json`.
+
+## Import JSON back into the module
+After editing `data/modules/dustland.json`, inject the changes back:
+```sh
+npm run module:import -- modules/dustland.module.js
+```
+The script replaces the `DATA` block inside `modules/dustland.module.js`.
+
+## Example: Dustland module
+1. Run the export command above to extract `data/modules/dustland.json`.
+2. Modify a field in the JSON (e.g., change an NPC name).
+3. Run the import command to write the JSON back into `modules/dustland.module.js`.
+4. Launch `dustland.html?ack-player=1` and load the module to verify the change.
+
+Remove any temporary JSON files when finished to keep the working tree clean.


### PR DESCRIPTION
## Summary
- add guide for exporting and importing module JSON
- note module-json tooling in main README
- check off docs task in design plan

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b205f2a1e4832887f8a3bcedbee7df