### PR TITLE
test: add module-json round trip

### DIFF
--- a/docs/design/module-json-tools.md
+++ b/docs/design/module-json-tools.md
@@ -28,7 +28,7 @@ We need to let editors tinker with module layouts without touching code. Each JS
 
 ## Remaining Work
 - [ ] Refactor each existing module to the new format.
-- [ ] Build automated tests for the import/export tools.
+- [x] Build automated tests for the import/export tools.
 - [ ] Verify Adventure Kit loads JSON modules and triggers `postLoad`.
 - [x] Document the workflow in `docs/` and update README.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.27",
+  "version": "0.7.28",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -966,7 +966,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.27 — module picker uses inline list.');
+log('v0.7.28 — module-json tooling gains tests.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/scripts/module-json.js
+++ b/scripts/module-json.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
 
 function usage(){
   console.log('Usage: node scripts/module-json.js <export|import> <moduleFile>');

--- a/test/module-json.tools.test.js
+++ b/test/module-json.tools.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+const modulesDir = path.join('modules');
+const dataDir = path.join('data', 'modules');
+const moduleFile = path.join(modulesDir, 'tmp-test.module.js');
+const jsonFile = path.join(dataDir, 'tmp-test.json');
+
+test('module-json export/import round trip', () => {
+  const original = { hello: 'world' };
+  const moduleContent = `const DATA = \`\n${JSON.stringify(original, null, 2)}\n\`;\nexport function postLoad() {}`;
+  fs.writeFileSync(moduleFile, moduleContent);
+  try {
+    execSync(`node scripts/module-json.js export ${moduleFile}`);
+    const exported = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
+    assert.deepStrictEqual(exported, original);
+    exported.hello = 'mars';
+    fs.writeFileSync(jsonFile, JSON.stringify(exported, null, 2));
+    execSync(`node scripts/module-json.js import ${moduleFile}`);
+    const updated = fs.readFileSync(moduleFile, 'utf8');
+    const match = updated.match(/const DATA = `([\s\S]*?)`;/);
+    assert(match);
+    const obj = JSON.parse(match[1]);
+    assert.strictEqual(obj.hello, 'mars');
+  } finally {
+    fs.rmSync(moduleFile, { force: true });
+    fs.rmSync(jsonFile, { force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- convert module-json script to ES modules
- add round-trip test for module-json import/export
- bump engine version and mark test task as complete in design docs

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2082a90548328b8b50995f4a12c8c