### PR TITLE
test: add module json tooling coverage

### DIFF
--- a/docs/design/module-json-tools.md
+++ b/docs/design/module-json-tools.md
@@ -28,7 +28,7 @@ We need to let editors tinker with module layouts without touching code. Each JS
 
 ## Remaining Work
 - [ ] Refactor each existing module to the new format.
-- [ ] Build automated tests for the import/export tools.
+- [x] Build automated tests for the import/export tools.
 - [ ] Verify Adventure Kit loads JSON modules and triggers `postLoad`.
 - [x] Document the workflow in `docs/` and update README.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.27",
+  "version": "0.7.28",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -966,7 +966,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.27 — module picker uses inline list.');
+log('v0.7.28 — add module json tooling tests.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/scripts/module-json.js
+++ b/scripts/module-json.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
 
 function usage(){
   console.log('Usage: node scripts/module-json.js <export|import> <moduleFile>');

--- a/test/module-json.tools.test.js
+++ b/test/module-json.tools.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+function runScript(args, cwd){
+  execFileSync('node', [path.join(repoRoot, 'scripts', 'module-json.js'), ...args], { cwd });
+}
+
+test('module-json export/import round trip', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'modjson-'));
+  try {
+    const moduleFile = path.join(tmp, 'sample.module.js');
+    const initial = 'const DATA = `\n{\n  "msg": "hello"\n}`;';
+    fs.writeFileSync(moduleFile, initial);
+    runScript(['export', moduleFile], tmp);
+    const jsonFile = path.join(tmp, 'data', 'modules', 'sample.json');
+    const exported = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
+    assert.strictEqual(exported.msg, 'hello');
+    exported.msg = 'world';
+    fs.writeFileSync(jsonFile, JSON.stringify(exported, null, 2));
+    runScript(['import', moduleFile], tmp);
+    const updated = fs.readFileSync(moduleFile, 'utf8');
+    assert.ok(updated.includes('"msg": "world"'));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- convert module-json script to ESM imports
- test import/export round trip for module json tooling
- bump engine version to 0.7.28 and check off design doc task

## Testing
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b20cfd65cc832886a4af871f86c4d3