### PR TITLE
feat: load module scripts for JSON modules

### DIFF
--- a/docs/design/module-json-tools.md
+++ b/docs/design/module-json-tools.md
@@ -13,6 +13,7 @@ We need to let editors tinker with module layouts without touching code. Each JS
    - At the top of each module file, include `const DATA = \`{\n  ...\n}\`;` holding pure layout JSON.
    - After parsing `DATA`, run a `postLoad(module)` function to sprinkle custom logic (NPC scripts, quests, etc.).
    - Existing modules must be refactored so their gameplay logic lives in `postLoad` and the JSON stays clean.
+   - Exported JSON should record its `module` script so ACK can reload it for playtests.
 2. **Import / export scripts**
    - Add `scripts/module-json.js` with commands:
      - `node scripts/module-json.js export modules/dustland.module.js` → writes `data/modules/dustland.json`.
@@ -29,6 +30,6 @@ We need to let editors tinker with module layouts without touching code. Each JS
 ## Remaining Work
 - [ ] Refactor each existing module to the new format.
 - [x] Build automated tests for the import/export tools.
-- [ ] Verify Adventure Kit loads JSON modules and triggers `postLoad`.
+- [x] Verify Adventure Kit loads JSON modules and triggers `postLoad`.
 - [x] Document the workflow in `docs/` and update README.
 

--- a/docs/module-json-workflow.md
+++ b/docs/module-json-workflow.md
@@ -11,7 +11,7 @@ This guide shows how to round-trip a module's data between its `*.module.js` fil
 ```sh
 npm run module:export -- modules/dustland.module.js
 ```
-This writes the module's JSON to `data/modules/dustland.json`.
+This writes the module's JSON to `data/modules/dustland.json` and includes a `module` field pointing back to the script.
 
 ## Import JSON back into the module
 After editing `data/modules/dustland.json`, inject the changes back:
@@ -27,3 +27,14 @@ The script replaces the `DATA` block inside `modules/dustland.module.js`.
 4. Launch `dustland.html?ack-player=1` and load the module to verify the change.
 
 Remove any temporary JSON files when finished to keep the working tree clean.
+
+## postLoad hooks
+Adventure Kit loads a module script when the JSON includes a `module` path. After the script loads, it calls the script's `postLoad(module)` method to apply procedural logic:
+
+```json
+{
+  "module": "modules/dustland.module.js"
+}
+```
+
+If the module exposes a different global variable name, provide `moduleVar` to hint the loader.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.28",
+  "version": "0.7.30",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -966,7 +966,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.28 — module-json tooling gains tests.');
+log('v0.7.30 — ACK player loads module scripts.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/scripts/module-json.js
+++ b/scripts/module-json.js
@@ -26,14 +26,17 @@ if (cmd === 'export') {
     process.exit(1);
   }
   const obj = JSON.parse(dataStr);
+  obj.module = file;
   fs.mkdirSync(path.dirname(jsonPath), { recursive: true });
   fs.writeFileSync(jsonPath, JSON.stringify(obj, null, 2));
   console.log(`Exported ${jsonPath}`);
 } else if (cmd === 'import') {
   const jsonText = fs.readFileSync(jsonPath, 'utf8');
-  JSON.parse(jsonText); // validate
+  const obj = JSON.parse(jsonText);
+  delete obj.module;
+  const cleanText = JSON.stringify(obj, null, 2);
   const text = fs.readFileSync(modulePath, 'utf8');
-  const newText = text.replace(/const DATA = `[\s\S]*?`;/, `const DATA = \`\n${jsonText}\n\`;`);
+  const newText = text.replace(/const DATA = `[\s\S]*?`;/, `const DATA = \`\n${cleanText}\n\`;`);
   fs.writeFileSync(modulePath, newText);
   console.log(`Updated ${modulePath}`);
 } else {

--- a/test/ack-player.postload.test.js
+++ b/test/ack-player.postload.test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+test('ack-player loads module script and runs postLoad', async () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const html = `<!DOCTYPE html><body>
+    <input id="modUrl">
+    <button id="modUrlBtn"></button>
+    <input id="modFile">
+    <button id="modFileBtn"></button>
+    <div id="moduleLoader"></div>
+  </body>`;
+  const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'dangerously', resources: 'usable' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.location = window.location;
+  window.requestAnimationFrame = () => {};
+  global.requestAnimationFrame = window.requestAnimationFrame;
+  const store = {};
+  const ls = {
+    getItem: (k) => store[k] || null,
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; }
+  };
+  Object.defineProperty(window, 'localStorage', { value: ls });
+  global.localStorage = ls;
+  const UIstub = { hide: () => {}, setValue: () => {} };
+  global.UI = UIstub;
+  window.UI = UIstub;
+  window.openCreator = () => {};
+  window.params = new URLSearchParams('');
+  global.params = window.params;
+  const file = path.join(__dirname, '..', 'scripts', 'ack-player.js');
+  window.eval(fs.readFileSync(file, 'utf8'));
+  const mod = {
+    module: 'data:text/javascript,globalThis.TEST_MOD={postLoad:(m)=>{m.executed=true;}}',
+    moduleVar: 'TEST_MOD'
+  };
+  await window.loadModule(mod);
+  assert.ok(mod.executed);
+});

--- a/test/module-json.tools.test.js
+++ b/test/module-json.tools.test.js
@@ -16,8 +16,11 @@ test('module-json export/import round trip', () => {
   try {
     execSync(`node scripts/module-json.js export ${moduleFile}`);
     const exported = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
+    assert.strictEqual(exported.module, moduleFile);
+    delete exported.module;
     assert.deepStrictEqual(exported, original);
     exported.hello = 'mars';
+    exported.module = moduleFile;
     fs.writeFileSync(jsonFile, JSON.stringify(exported, null, 2));
     execSync(`node scripts/module-json.js import ${moduleFile}`);
     const updated = fs.readFileSync(moduleFile, 'utf8');
@@ -25,6 +28,7 @@ test('module-json export/import round trip', () => {
     assert(match);
     const obj = JSON.parse(match[1]);
     assert.strictEqual(obj.hello, 'mars');
+    assert.strictEqual(obj.module, undefined);
   } finally {
     fs.rmSync(moduleFile, { force: true });
     fs.rmSync(jsonFile, { force: true });


### PR DESCRIPTION
## Summary
- let JSON modules declare a `module` script that ACK player loads and post-processes via `postLoad`
- include originating script path when exporting JSON and drop it on import
- document module script hook and bump engine version to 0.7.30

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20e19b5f0832893f39346499bee0d