### PR TITLE
feat: refactor broadcast fragment module to data string

### DIFF
--- a/docs/design/module-json-tools.md
+++ b/docs/design/module-json-tools.md
@@ -29,6 +29,14 @@ We need to let editors tinker with module layouts without touching code. Each JS
 
 ## Remaining Work
 - [ ] Refactor each existing module to the new format.
+  - [x] broadcast-fragment-1
+  - [ ] broadcast-fragment-2
+  - [ ] broadcast-fragment-3
+  - [ ] echoes
+  - [ ] dustland
+  - [ ] lootbox-demo
+  - [ ] office
+  - [ ] mara-puzzle
 - [x] Build automated tests for the import/export tools.
 - [x] Verify Adventure Kit loads JSON modules and triggers `postLoad`.
 - [x] Document the workflow in `docs/` and update README.

--- a/modules/broadcast-fragment-1.module.js
+++ b/modules/broadcast-fragment-1.module.js
@@ -1,4 +1,5 @@
-const BROADCAST_FRAGMENT_1 = {
+const DATA = `
+{
   "seed": "broadcast-1",
   "name": "broadcast-fragment-1",
   "startMap": "world",
@@ -91,5 +92,11 @@ const BROADCAST_FRAGMENT_1 = {
   "buildings": [
     { "x": 100, "y": 20, "w": 1, "h": 1, "interiorId": "radio_shack", "boarded": false }
   ]
-};
-globalThis.BROADCAST_FRAGMENT_1 = BROADCAST_FRAGMENT_1;
+}
+`;
+
+function postLoad(module) {}
+
+globalThis.BROADCAST_FRAGMENT_1 = JSON.parse(DATA);
+globalThis.BROADCAST_FRAGMENT_1.postLoad = postLoad;
+

--- a/test/abilities.test.js
+++ b/test/abilities.test.js
@@ -49,7 +49,7 @@ test('defineSpecial registers special with fields and defaults', () => {
 });
 
 test('starter specials load from data file', async () => {
-  await new Promise((r) => setTimeout(r, 50));
+  await new Promise((r) => setTimeout(r, 300));
   const ids = ['POWER_STRIKE', 'STUN_GRENADE', 'FIRST_AID', 'ADRENAL_SURGE', 'GUARD_UP'];
   ids.forEach((id) => assert.ok(globalThis.Specials[id]));
 });


### PR DESCRIPTION
## Summary
- refactor broadcast-fragment-1.module.js to use DATA string and postLoad hook
- track module refactors in module-json tooling design doc
- wait longer in abilities test for specials to load

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b217dacb788328952f0cd9f8b0a1ae