### PR TITLE
Document custom portrait paths in module exports

### DIFF
--- a/docs/module-json-workflow.md
+++ b/docs/module-json-workflow.md
@@ -28,6 +28,15 @@ The script replaces the `DATA` block inside `modules/dustland.module.js`.
 
 Remove any temporary JSON files when finished to keep the working tree clean.
 
+## Custom portraits
+Modules may reference portrait images by setting a `portraitSheet` field to a
+path under `assets/`. The `module-json` tooling keeps these relative paths
+intact during export and import:
+
+```json
+{ "portraitSheet": "assets/portraits/my_npc.png" }
+```
+
 ## postLoad hooks
 Adventure Kit loads a module script when the JSON includes a `module` path. After the script loads, it calls the script's `postLoad(module)` method to apply procedural logic:
 

--- a/test/module-json.tools.test.js
+++ b/test/module-json.tools.test.js
@@ -10,13 +10,14 @@ const moduleFile = path.join(modulesDir, 'tmp-test.module.js');
 const jsonFile = path.join(dataDir, 'tmp-test.json');
 
 test('module-json export/import round trip', () => {
-  const original = { hello: 'world' };
+  const original = { hello: 'world', portraitSheet: 'assets/portraits/custom.png' };
   const moduleContent = `const DATA = \`\n${JSON.stringify(original, null, 2)}\n\`;\nexport function postLoad() {}`;
   fs.writeFileSync(moduleFile, moduleContent);
   try {
     execSync(`node scripts/module-json.js export ${moduleFile}`);
     const exported = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
     assert.strictEqual(exported.module, moduleFile);
+    assert.strictEqual(exported.portraitSheet, 'assets/portraits/custom.png');
     delete exported.module;
     assert.deepStrictEqual(exported, original);
     exported.hello = 'mars';
@@ -28,6 +29,7 @@ test('module-json export/import round trip', () => {
     assert(match);
     const obj = JSON.parse(match[1]);
     assert.strictEqual(obj.hello, 'mars');
+    assert.strictEqual(obj.portraitSheet, 'assets/portraits/custom.png');
     assert.strictEqual(obj.module, undefined);
   } finally {
     fs.rmSync(moduleFile, { force: true });


### PR DESCRIPTION
## Summary
- Note that module JSON can reference portrait images via paths under `assets/`
- Test `module-json` tooling to ensure portrait paths round-trip intact

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2237f9eac8328a8000a92a2b135ed