### PR TITLE
fix: derive module name during export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.30",
+  "version": "0.7.31",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -966,7 +966,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.30 — ACK player loads module scripts.');
+log('v0.7.31 — ACK player loads module scripts.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/scripts/module-json.js
+++ b/scripts/module-json.js
@@ -27,6 +27,7 @@ if (cmd === 'export') {
   }
   const obj = JSON.parse(dataStr);
   obj.module = file;
+  obj.name = obj.name || `${baseName}-module`;
   fs.mkdirSync(path.dirname(jsonPath), { recursive: true });
   fs.writeFileSync(jsonPath, JSON.stringify(obj, null, 2));
   console.log(`Exported ${jsonPath}`);

--- a/test/module-json.tools.test.js
+++ b/test/module-json.tools.test.js
@@ -17,10 +17,14 @@ test('module-json export/import round trip', () => {
     execSync(`node scripts/module-json.js export ${moduleFile}`);
     const exported = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
     assert.strictEqual(exported.module, moduleFile);
+    assert.strictEqual(exported.name, 'tmp-test-module');
+    const { name } = exported;
     delete exported.module;
+    delete exported.name;
     assert.deepStrictEqual(exported, original);
     exported.hello = 'mars';
     exported.module = moduleFile;
+    exported.name = name;
     fs.writeFileSync(jsonFile, JSON.stringify(exported, null, 2));
     execSync(`node scripts/module-json.js import ${moduleFile}`);
     const updated = fs.readFileSync(moduleFile, 'utf8');
@@ -29,6 +33,7 @@ test('module-json export/import round trip', () => {
     const obj = JSON.parse(match[1]);
     assert.strictEqual(obj.hello, 'mars');
     assert.strictEqual(obj.module, undefined);
+    assert.strictEqual(obj.name, 'tmp-test-module');
   } finally {
     fs.rmSync(moduleFile, { force: true });
     fs.rmSync(jsonFile, { force: true });


### PR DESCRIPTION
## Summary
- ensure module JSON exports include a `name` derived from the file
- cover module-json export/import round trip including module name
- bump engine version to 0.7.31

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b222d63a8083289402bf2af77f968b