### PR TITLE
docs: add hacking guide

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -117,8 +117,8 @@ _______________________________________________________________________________
   - Gameplay logic is split into tiny systems: movement, collisions,
     interactions, and rendering order. This keeps cross-file conditionals
     low and makes adding new entities like bandits or doors easy.
-  - Useful entry points:
-      * genHall(), genWorld(), seedWorldContent()
+  - Useful entry points (see docs/hacking-guide.md for more):
+      * genWorld(), seedWorldContent()
       * makeNPC(), NPCS[], quests{}, itemDrops[]
       * renderParty(), renderInv(), renderQuests()
       * takeNearestItem(), interact(), move()

--- a/docs/hacking-guide.md
+++ b/docs/hacking-guide.md
@@ -1,0 +1,38 @@
+# Hacking Dustland CRT
+
+Dustland CRT uses plain JavaScript with globals and no build step. This guide lists useful entry points for exploring or extending the game.
+
+## Architecture
+- `dustland.html` bootstraps the game.
+- Game state and module loading live in `scripts/dustland-core.js`.
+- Rendering and input are handled by `scripts/dustland-engine.js`.
+- Individual systems are in `scripts/core/`.
+
+## World and content
+- `genWorld(seed, opts)` – generate the overworld grid.
+- `seedWorldContent()` – populate default NPCs and items for a module.
+
+## NPCs and quests
+- `makeNPC(...)` – helper to build an NPC.
+- `NPCS` – array of active NPCs.
+- `quests` – quest registry managed by the quest log.
+- `itemDrops` – ground items awaiting pickup.
+
+## UI helpers
+- `renderParty()`, `renderInv()`, `renderQuests()` – refresh side panels.
+
+## Interactions and movement
+- `takeNearestItem()` – pick up adjacent items.
+- `interact()` / `interactAt(x, y)` – trigger NPC dialog or tile actions.
+- `move(dx, dy)` – move the party leader.
+
+## Modules and ACK
+- `applyModule(data)` – load module data into the game.
+- `openCreator()` – open the Adventure Construction Kit editor.
+
+## Inventory utilities
+- `uncurseItem(id)` – remove a curse from the given item.
+
+## Development tips
+- Run `npm test` to execute the test suite.
+- Run `node scripts/presubmit.js` to check HTML files for unsupported patterns.


### PR DESCRIPTION
## Summary
- refresh README entry points and link to new hacking guide
- document key functions and systems for hacking Dustland CRT

## Testing
- `npm test`
- `node scripts/presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68b21ffc85c083289aa47589aeb9d907