### PR TITLE
fix: guard UI initialization until DOM ready

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -172,26 +172,28 @@
   <script defer src="./scripts/dustland-path.js"></script>
   <script defer src="./scripts/dustland-nano.js"></script>
   <script defer src="./scripts/dustland-engine.js"></script>
-  <script>
-    const params = new URLSearchParams(location.search);
-    const isAck = params.get('ack-player') === '1';
-    if (isAck) {
-      UI.show('moduleLoader', 'flex');
-      const btns = document.getElementById('mainButtons');
-      const nanoBtn = document.getElementById('nanoToggle');
-      const audioBtn = document.getElementById('audioToggle');
-      btns.appendChild(nanoBtn);
-      btns.appendChild(audioBtn);
-      const settingsBtn = document.getElementById('settingsBtn');
-      if (settingsBtn) UI.hide('settingsBtn');
-    }
-    if (isAck) {
-      const modeScript = document.createElement('script');
-      modeScript.defer = true;
-      modeScript.src = './scripts/ack-player.js';
-      document.body.appendChild(modeScript);
-    }
-  </script>
+    <script>
+      window.addEventListener('DOMContentLoaded', () => {
+        const params = new URLSearchParams(location.search);
+        const isAck = params.get('ack-player') === '1';
+        if (isAck) {
+          UI.show('moduleLoader', 'flex');
+          const btns = document.getElementById('mainButtons');
+          const nanoBtn = document.getElementById('nanoToggle');
+          const audioBtn = document.getElementById('audioToggle');
+          btns.appendChild(nanoBtn);
+          btns.appendChild(audioBtn);
+          const settingsBtn = document.getElementById('settingsBtn');
+          if (settingsBtn) UI.hide('settingsBtn');
+        }
+        if (isAck) {
+          const modeScript = document.createElement('script');
+          modeScript.defer = true;
+          modeScript.src = './scripts/ack-player.js';
+          document.body.appendChild(modeScript);
+        }
+      });
+    </script>
   <script type="module" src="./scripts/balance-tester-agent.js"></script>
 </body>
 </html>

--- a/dustland.html
+++ b/dustland.html
@@ -251,22 +251,24 @@
     <script defer src="./scripts/fx-debug.js"></script>
     <script defer src="./scripts/perf-debug.js"></script>
   <script>
-    const params = new URLSearchParams(location.search);
-    const isAck = params.get('ack-player') === '1';
-    if (isAck) {
-      UI.show('moduleLoader', 'flex');
-      const btns = document.getElementById('mainButtons');
-      const nanoBtn = document.getElementById('nanoToggle');
-      const audioBtn = document.getElementById('audioToggle');
-      btns.appendChild(nanoBtn);
-      btns.appendChild(audioBtn);
-      const settingsBtn = document.getElementById('settingsBtn');
-      if (settingsBtn) UI.hide('settingsBtn');
-    }
-    const modeScript = document.createElement('script');
-    modeScript.defer = true;
-    modeScript.src = isAck ? './scripts/ack-player.js' : './scripts/module-picker.js';
-    document.body.appendChild(modeScript);
+    window.addEventListener('DOMContentLoaded', () => {
+      const params = new URLSearchParams(location.search);
+      const isAck = params.get('ack-player') === '1';
+      if (isAck) {
+        UI.show('moduleLoader', 'flex');
+        const btns = document.getElementById('mainButtons');
+        const nanoBtn = document.getElementById('nanoToggle');
+        const audioBtn = document.getElementById('audioToggle');
+        btns.appendChild(nanoBtn);
+        btns.appendChild(audioBtn);
+        const settingsBtn = document.getElementById('settingsBtn');
+        if (settingsBtn) UI.hide('settingsBtn');
+      }
+      const modeScript = document.createElement('script');
+      modeScript.defer = true;
+      modeScript.src = isAck ? './scripts/ack-player.js' : './scripts/module-picker.js';
+      document.body.appendChild(modeScript);
+    });
   </script>
   <!-- Shop overlay -->
   <div class="overlay" id="shopOverlay" role="dialog" aria-modal="true" tabindex="-1">


### PR DESCRIPTION
## Summary
- wait for DOMContentLoaded before showing module UI
- ensure balance tester initializes UI after DOM ready

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b22449419c8328b83c857564c7d540