### PR TITLE
feat: refactor broadcast fragment 2 module

### DIFF
--- a/docs/design/module-json-tools.md
+++ b/docs/design/module-json-tools.md
@@ -30,7 +30,7 @@ We need to let editors tinker with module layouts without touching code. Each JS
 ## Remaining Work
 - [ ] Refactor each existing module to the new format.
   - [x] broadcast-fragment-1
-  - [ ] broadcast-fragment-2
+  - [x] broadcast-fragment-2
   - [ ] broadcast-fragment-3
   - [ ] echoes
   - [ ] dustland

--- a/modules/broadcast-fragment-2.module.js
+++ b/modules/broadcast-fragment-2.module.js
@@ -1,8 +1,8 @@
-const BROADCAST_FRAGMENT_2 = {
+const DATA = `
+{
   "seed": "broadcast-2",
   "name": "broadcast-fragment-2",
   "startMap": "world",
-  // Positioned within WORLD_W bounds (max 119)
   "startPoint": { "x": 110, "y": 22 },
   "items": [
     { "id": "power_cell", "name": "Power Cell", "type": "quest" },
@@ -40,11 +40,11 @@ const BROADCAST_FRAGMENT_2 = {
           "choices": [ { "label": "(Take Fragment)", "to": "post_quest", "reward": "signal_fragment_2", "costItem": "power_cell", "costCount": 3 } ]
         },
         "post_quest": {
-            "text": "That was just one piece of it. The signal is a symphony! The next part seems to be coming from... a cave system to the north. It's strange, almost like it's underground.",
-            "choices": [
-                { "label": "I'll check it out.", "applyModule": "BROADCAST_FRAGMENT_3", "to": "bye" },
-                { "label": "I need a moment.", "to": "bye" }
-            ]
+          "text": "That was just one piece of it. The signal is a symphony! The next part seems to be coming from... a cave system to the north. It's strange, almost like it's underground.",
+          "choices": [
+            { "label": "I'll check it out.", "applyModule": "BROADCAST_FRAGMENT_3", "to": "bye" },
+            { "label": "I need a moment.", "to": "bye" }
+          ]
         }
       }
     },
@@ -75,5 +75,10 @@ const BROADCAST_FRAGMENT_2 = {
   "buildings": [
     { "x": 110, "y": 20, "w": 1, "h": 1, "interiorId": "comms_tower_base", "grid": [[8]] }
   ]
-};
-globalThis.BROADCAST_FRAGMENT_2 = BROADCAST_FRAGMENT_2;
+}
+`;
+
+function postLoad(module) {}
+
+globalThis.BROADCAST_FRAGMENT_2 = JSON.parse(DATA);
+globalThis.BROADCAST_FRAGMENT_2.postLoad = postLoad;


### PR DESCRIPTION
## Summary
- refactor broadcast-fragment-2 module to inline JSON data string with postLoad hook
- update module-json tools design doc checklist for broadcast-fragment-2

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b236d6c1748328ba4bb3e1c5afb9d6