### PR TITLE
feat: simplify party API and restore roster

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.31",
+  "version": "0.7.32",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/balance-tester-agent.js
+++ b/scripts/balance-tester-agent.js
@@ -130,7 +130,7 @@ async function runBalanceTest() {
     console.log('Balance test checkpoint: module loaded');
 
     // Create a party
-    party.push(makeMember('player1', 'Test Player', 'Wanderer'));
+    party.join(makeMember('player1', 'Test Player', 'Wanderer'));
     setLeader(0);
     setPartyPos(2, 2);
     setMap('world', 'Test');

--- a/scripts/core/dialog.js
+++ b/scripts/core/dialog.js
@@ -96,7 +96,7 @@ function processQuestFlag(c){
   if(c.q==='turnin') defaultQuestProcessor(currentNPC,'do_turnin');
 }
 
-function joinParty(join){
+function dialogJoinParty(join){
   if(!join) return;
   const opts = {};
   if(join.portraitSheet){
@@ -105,7 +105,7 @@ function joinParty(join){
     opts.portraitSheet = currentNPC.portraitSheet;
   }
   const m=makeMember(join.id, join.name, join.role, opts);
-  if(addPartyMember(m)){
+  if(joinParty(m)){
     removeNPC(currentNPC);
   }
 }
@@ -184,7 +184,7 @@ function advanceDialog(stateObj, choiceIdx){
       return finalize(choice.failure || 'You lack the required item.', false, true);
     }
     Dustland.actions.applyQuestReward(choice.reward);
-    joinParty(choice.join);
+    dialogJoinParty(choice.join);
     processQuestFlag(choice);
     runEffects(choice.effects);
     if(choice.goto){
@@ -215,7 +215,7 @@ function advanceDialog(stateObj, choiceIdx){
     }
 
     Dustland.actions.applyQuestReward(choice.reward);
-    joinParty(choice.join);
+    dialogJoinParty(choice.join);
     processQuestFlag(choice);
     runEffects(choice.effects);
     if(choice.goto){
@@ -234,7 +234,7 @@ function advanceDialog(stateObj, choiceIdx){
   }
 
   Dustland.actions.applyQuestReward(choice.reward);
-  joinParty(choice.join);
+  dialogJoinParty(choice.join);
   processQuestFlag(choice);
   runEffects(choice.effects);
 

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -770,7 +770,7 @@ function finalizeCurrentMember(){
   const m=makeMember(building.id, building.name, building.spec||'Wanderer', {permanent:true, portraitSheet: building.portraitSheet});
   m.stats=building.stats; m.origin=building.origin; m.quirk=building.quirk;
   m.special = classSpecials[building.spec||'Wanderer'] || [];
-  addPartyMember(m);
+  joinParty(m);
   const spec = specializations[building.spec]; if(spec){ spec.gear.forEach(g=> addToInv(g)); }
   built.push(m);
   building = null;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -966,7 +966,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.31 — ACK player loads module scripts.');
+log('v0.7.32 — ACK player loads module scripts.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/character-names.test.js
+++ b/test/character-names.test.js
@@ -16,7 +16,7 @@ function setup(){
     EventBus:{ on:()=>{}, emit:()=>{} },
     baseStats:()=>({STR:4,AGI:4,INT:4,PER:4,LCK:4,CHA:4}),
     makeMember:(id,name,role)=>({id,name,role,stats:{}}),
-    addPartyMember:m=>{ party.push(m); },
+    joinParty:m=>{ party.push(m); },
     addToInv:()=>{},
     rand:()=>0,
     log:()=>{},

--- a/test/creator-stats-tooltips.test.js
+++ b/test/creator-stats-tooltips.test.js
@@ -16,7 +16,7 @@ function setup(){
     EventBus:{ on:()=>{}, emit:()=>{} },
     baseStats:()=>({STR:4,AGI:4,INT:4,PER:4,LCK:4,CHA:4}),
     makeMember:(id,name,role)=>({id,name,role,stats:{}}),
-    addPartyMember:m=>{ party.push(m); },
+    joinParty:m=>{ party.push(m); },
     addToInv:()=>{},
     rand:()=>0,
     log:()=>{},

--- a/test/cursed-helmet-ui.test.js
+++ b/test/cursed-helmet-ui.test.js
@@ -13,7 +13,7 @@ test('cursed equipment keeps label after failed unequip', async () => {
   const invCode = await fs.readFile(new URL('../scripts/core/inventory.js', import.meta.url), 'utf8');
   vm.runInContext(invCode, context);
   const mem = new context.Character('hero', 'Hero', 'Role');
-  context.party.addMember(mem);
+  context.party.join(mem);
   context.registerItem({ id: 'helm', name: 'VR Helmet', type: 'armor', slot: 'armor', cursed: true });
   context.addToInv('helm');
   context.equipItem(0, 0);

--- a/test/nanite-zone.test.js
+++ b/test/nanite-zone.test.js
@@ -45,8 +45,8 @@ async function setupContext() {
   const m2 = new context.Character('b','B','');
   m1.maxHp = m2.maxHp = 1;
   m1.hp = m2.hp = 1;
-  context.party.addMember(m1);
-  context.party.addMember(m2);
+  context.party.join(m1);
+  context.party.join(m2);
 
   const moveCode = await fs.readFile(new URL('../scripts/core/movement.js', import.meta.url), 'utf8');
   vm.runInContext(moveCode, context);

--- a/test/portraits.test.js
+++ b/test/portraits.test.js
@@ -17,7 +17,7 @@ function setup(){
     EventBus:{ on:()=>{}, emit:()=>{} },
     baseStats:()=>({STR:4,AGI:4,INT:4,PER:4,LCK:4,CHA:4}),
     makeMember:(id,name,role,opts={})=>({id,name,role,stats:{},...opts}),
-    addPartyMember:m=>{ party.push(m); },
+    joinParty:m=>{ party.push(m); },
     addToInv:()=>{},
     rand:()=>0,
     log:()=>{},

--- a/test/walking-heal-ui.test.js
+++ b/test/walking-heal-ui.test.js
@@ -30,7 +30,7 @@ test('walking heals and updates party UI', async () => {
   context.checkRandomEncounter = () => {};
   const mem = new context.Character('h', 'Hero', 'Role');
   mem.hp = 5; mem.maxHp = 10;
-  context.party.addMember(mem);
+  context.party.join(mem);
   context.renderParty();
   const partyDiv = document.getElementById('party');
   assert.match(partyDiv.children[0].innerHTML, /HP 5\/10/);


### PR DESCRIPTION
## Summary
- track fallen members on the party and add join/leave/fall/healAll/restore verbs
- store and restore original roster at combat boundaries
- bump engine version to 0.7.32

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b254fb846c8328ba16d9aa25e720a9