### PR TITLE
docs: add author voice to dialog and hud design

### DIFF
--- a/docs/design/dialog-navigation.md
+++ b/docs/design/dialog-navigation.md
@@ -1,8 +1,10 @@
 # Dialog Navigation & State Machine
 
-- Author: Alex "Echo" Johnson
-- Date: 2025-08-28
-- Status: Draft
+*By Alex "Echo" Johnson*
+*Date: 2025-08-28*
+*Status: Draft*
+
+> **Echo:** Menu-driven conversations should feel deliberate and human—built with plain JavaScript and globals.
 
 ## Summary
 

--- a/docs/design/hud.md
+++ b/docs/design/hud.md
@@ -1,6 +1,8 @@
 # HUD Iterations
 
-Author: Priya "Gizmo" Sharma
+*By Priya "Gizmo" Sharma*
+
+> **Gizmo:** The HUD is a drifter's dashboard—responsive, accessible, and always within reach.
 
 ## Feedback
 Internal playtest sessions flagged two pain points:


### PR DESCRIPTION
## Summary
- replace bullet author metadata in dialog-navigation design doc with byline and voice note
- give HUD design doc a byline and Gizmo quote

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b25c5f04c483288f29ec38979003ec