### PR TITLE
feat: add Nyx NPC with branching dialog

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -79,7 +79,7 @@ _______________________________________________________________________________
   - modules/dustland.module.js
     * NPCs, items, world data, and quests for the core adventure.
   - modules/golden.module.json
-    * Sample module showcasing a fetch quest, stat gate, joinable NPC, timed spawn, event toasts, portal, chest loot drop, healing potion, and combat; default module for ACK player.
+    * Sample module showcasing a fetch quest, stat gate, joinable NPC, timed spawn, event toasts, portal, chest loot drop, healing potion, combat, and a deep branching dialog NPC; default module for ACK player.
   - adventure-kit.html / scripts/adventure-kit.js
     * Map/NPC/item/quest editor for making modules. Includes palette-based
       interior and building editors with customizable door placement.

--- a/modules/golden.module.json
+++ b/modules/golden.module.json
@@ -421,6 +421,86 @@
           ]
         }
       }
+    },
+    {
+      "id": "nyx",
+      "map": "world",
+      "x": 4,
+      "y": 15,
+      "color": "#ccf",
+      "name": "Nyx",
+      "desc": "A wanderer with layered stories.",
+      "tree": {
+        "start": {
+          "text": "Greetings, traveler. What do you seek?",
+          "choices": [
+            { "label": "Who are you?", "to": "who" },
+            { "label": "Tell me a tale", "to": "tale" },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "who": {
+          "text": "I am Nyx. Do you seek wisdom or power?",
+          "choices": [
+            { "label": "Wisdom", "to": "wisdom" },
+            { "label": "Power", "to": "power" },
+            { "label": "(Back)", "to": "start" }
+          ]
+        },
+        "wisdom": {
+          "text": "Wisdom requires patience. Proceed?",
+          "choices": [
+            { "label": "Yes", "to": "lesson" },
+            { "label": "No", "to": "start" }
+          ]
+        },
+        "lesson": {
+          "text": "The dust remembers those who listen. Ask further?",
+          "choices": [
+            { "label": "Tell me more", "to": "secret" },
+            { "label": "That's enough", "to": "start" }
+          ]
+        },
+        "secret": {
+          "text": "You carry the weight of forgotten tales.",
+          "choices": [
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "power": {
+          "text": "Power corrupts. Do you still want it?",
+          "choices": [
+            { "label": "Yes", "to": "trial" },
+            { "label": "No", "to": "start" }
+          ]
+        },
+        "trial": {
+          "text": "Face the trial another time.",
+          "choices": [
+            { "label": "(Back)", "to": "start" }
+          ]
+        },
+        "tale": {
+          "text": "What kind of tale?",
+          "choices": [
+            { "label": "Heroic", "to": "heroic" },
+            { "label": "Tragic", "to": "tragic" },
+            { "label": "(Back)", "to": "start" }
+          ]
+        },
+        "heroic": {
+          "text": "A hero rose from dust.",
+          "choices": [
+            { "label": "(Back)", "to": "tale" }
+          ]
+        },
+        "tragic": {
+          "text": "The sand swallowed cities.",
+          "choices": [
+            { "label": "(Back)", "to": "tale" }
+          ]
+        }
+      }
     }
   ],
   "events": [

--- a/test/nyx.dialog.test.js
+++ b/test/nyx.dialog.test.js
@@ -1,0 +1,64 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function stubEl() {
+  return { children: [], classList: { toggle() {} }, appendChild() {}, querySelector() {}, innerHTML: '', textContent: '' };
+}
+
+const overlay = stubEl();
+const choicesEl = stubEl();
+const dialogText = stubEl();
+const npcName = stubEl();
+const npcTitle = stubEl();
+const portEl = stubEl();
+
+global.document = {
+  getElementById: (id) => ({ overlay, choices: choicesEl, dialogText, npcName, npcTitle, port: portEl }[id] || stubEl()),
+  createElement: () => stubEl(),
+  querySelector: () => stubEl()
+};
+
+global.window = global;
+
+global.player = { inv: [] };
+global.party = { x: 0, y: 0 };
+global.state = {};
+global.Dustland = { actions: { applyQuestReward() {} }, effects: { apply() {} } };
+global.countItems = () => 0;
+global.dialogJoinParty = () => {};
+global.processQuestFlag = () => {};
+global.handleGoto = () => {};
+
+await import('../scripts/core/dialog.js');
+const { advanceDialog } = globalThis;
+
+function normalizeDialogTree(tree) {
+  const out = {};
+  for (const id in tree) {
+    const n = tree[id];
+    const next = (n.choices || []).map((c) => ({ id: c.to, label: c.label, to: c.to }));
+    out[id] = { text: n.text || '', next };
+  }
+  return out;
+}
+
+test('nyx dialog branches deeply', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'golden.module.json');
+  const mod = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const nyx = mod.npcs.find((n) => n.id === 'nyx');
+  assert.ok(nyx, 'nyx npc exists');
+  const tree = normalizeDialogTree(nyx.tree);
+  const dialog = { tree, node: 'start' };
+  advanceDialog(dialog, 0);
+  assert.equal(dialog.node, 'who');
+  advanceDialog(dialog, 0);
+  assert.equal(dialog.node, 'wisdom');
+  advanceDialog(dialog, 0);
+  assert.equal(dialog.node, 'lesson');
+  advanceDialog(dialog, 0);
+  assert.equal(dialog.node, 'secret');
+});


### PR DESCRIPTION
## Summary
- add Nyx wanderer NPC with multi-path dialog to golden module
- document branching dialog sample in README
- test Nyx dialog navigation through deep branches

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2730db4c083288a524c28e8178064