### PR TITLE
feat: multi-part quest collection support

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -209,6 +209,33 @@ const DATA = `
         "ATK": 5,
         "ADR": 20
       }
+    },
+    {
+      "map": "world",
+      "x": 60,
+      "y": 40,
+      "id": "signal_fragment_a",
+      "name": "Signal Fragment",
+      "type": "quest",
+      "tags": ["signal_fragment"]
+    },
+    {
+      "map": "world",
+      "x": 62,
+      "y": 42,
+      "id": "signal_fragment_b",
+      "name": "Signal Fragment",
+      "type": "quest",
+      "tags": ["signal_fragment"]
+    },
+    {
+      "map": "world",
+      "x": 64,
+      "y": 44,
+      "id": "signal_fragment_c",
+      "name": "Signal Fragment",
+      "type": "quest",
+      "tags": ["signal_fragment"]
     }
   ],
   "quests": [
@@ -292,6 +319,14 @@ const DATA = `
       "title": "Toll-Booth Etiquette",
       "desc": "You met the Duchess on the road.",
       "xp": 2
+    },
+    {
+      "id": "q_signal",
+      "title": "Broken Signal",
+      "desc": "Collect three signal fragments in the wastes.",
+      "item": "signal_fragment",
+      "count": 3,
+      "xp": 3
     }
   ],
   "npcs": [
@@ -940,6 +975,39 @@ const DATA = `
         "flag": "visits@world@20,47",
         "op": ">=",
         "value": 2
+      }
+    },
+    {
+      "id": "signal_tech",
+      "map": "world",
+      "x": 26,
+      "y": 43,
+      "color": "#9ef7a0",
+      "name": "Signal Tech",
+      "title": "Tinkerer",
+      "desc": "Fiddles with a busted radio.",
+      "questId": "q_signal",
+      "tree": {
+        "start": {
+          "text": "Radio's dead. Need fragments to spark it.",
+          "choices": [
+            { "label": "(Accept)", "to": "accept", "q": "accept" },
+            { "label": "(Turn in fragments)", "to": "turnin", "q": "turnin" },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "accept": {
+          "text": "Try the dunes; bits wash up there.",
+          "choices": [ { "label": "(Ok)", "to": "bye" } ]
+        },
+        "turnin": {
+          "text": "Got the pieces?",
+          "choices": [ { "label": "(Give fragments)", "to": "do_turnin" } ]
+        },
+        "do_turnin": {
+          "text": "Signal hums again. Nice work.",
+          "choices": [ { "label": "(Continue)", "to": "bye" } ]
+        }
       }
     },
     {

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -667,7 +667,8 @@ function renderQuests(){
   shown.forEach(v=>{
     const div=document.createElement('div');
     div.className='q';
-    div.innerHTML=`<div><b>${v.title}</b></div><div class="small">${v.desc}</div><div class="status">${v.status}</div>`;
+    const progress = (v.item && v.count) ? ` (${Math.min(countItems(v.item), v.count)}/${v.count})` : '';
+    div.innerHTML=`<div><b>${v.title}${progress}</b></div><div class="small">${v.desc}</div><div class="status">${v.status}</div>`;
     q.appendChild(div);
   });
 }

--- a/test/quest-progress.test.js
+++ b/test/quest-progress.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+async function loadRender(ctx){
+  const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
+  const start = full.indexOf('function renderQuests');
+  const end = full.indexOf('function renderParty');
+  vm.runInContext(full.slice(start, end), ctx);
+}
+
+test('quest indicator shows item count', async () => {
+  const dom = new JSDOM('<div id="quests"></div>');
+  const ctx = {
+    window: dom.window,
+    document: dom.window.document,
+    quests: { q1: { id: 'q1', title: 'Collect Stuff', desc: '', status: 'active', item: 'frag', count: 3 } },
+    countItems: () => 2
+  };
+  vm.createContext(ctx);
+  await loadRender(ctx);
+  ctx.renderQuests();
+  const text = dom.window.document.querySelector('.q b').textContent;
+  assert.equal(text, 'Collect Stuff (2/3)');
+});


### PR DESCRIPTION
## Summary
- show collected item counts in quest panel
- scatter signal fragments across Dustland and add a new multi-part quest
- cover quest progress with a dedicated test

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b272fcae188328a50e532e8582d8a8