### PR TITLE
feat: map mobile B to escape

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.32",
+  "version": "0.7.33",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -346,6 +346,7 @@ function handleCombatKey(e){
     case 'ArrowDown':  moveChoice(1);  return true;
     case 'Enter':
     case ' ':          chooseOption(); return true;
+    case 'Escape':     closeCombat('flee'); return true;
   }
   return false;
 }

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -123,7 +123,18 @@ function setMobileControls(on){
           interact();
         }
       }));
-      mobileAB.appendChild(mk('B','B',takeNearestItem));
+      mobileAB.appendChild(mk('B','B',()=>{
+        const shop = document.getElementById('shopOverlay');
+        if(overlay?.classList?.contains('shown')){
+          closeDialog?.();
+        } else if(document.getElementById('combatOverlay')?.classList?.contains('shown')){
+          handleCombatKey?.({ key:'Escape' });
+        } else if(shop?.classList?.contains('shown')){
+          shop.dispatchEvent(new KeyboardEvent('keydown', { key:'Escape' }));
+        } else {
+          window.dispatchEvent(new KeyboardEvent('keydown', { key:'Escape' }));
+        }
+      }));
       mobileWrap.appendChild(mobileAB);
     }
   } else {
@@ -966,7 +977,7 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.32 — ACK player loads module scripts.');
+log('v0.7.33 — mobile B acts as escape.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/test/mobile-controls.test.js
+++ b/test/mobile-controls.test.js
@@ -60,3 +60,28 @@ test('mobile A selects combat option when in combat', async () => {
   a.onclick();
   assert.deepStrictEqual(keys, ['Enter']);
 });
+
+test('mobile B closes dialog when overlay shown', async () => {
+  let closed = false;
+  const { context, document } = await setup({
+    closeDialog: () => { closed = true; },
+    overlay: null
+  });
+  document.getElementById('overlay').classList.add('shown');
+  context.overlay = document.getElementById('overlay');
+  const { B: b } = context.setMobileControls(true);
+  b.onclick();
+  assert.ok(closed);
+});
+
+test('mobile B flees combat', async () => {
+  const keys = [];
+  const { context, document } = await setup({
+    handleCombatKey: e => { keys.push(e.key); return true; },
+    overlay: null
+  });
+  document.getElementById('combatOverlay').classList.add('shown');
+  const { B: b } = context.setMobileControls(true);
+  b.onclick();
+  assert.deepStrictEqual(keys, ['Escape']);
+});


### PR DESCRIPTION
## Summary
- Map mobile B button to send Escape keypress, closing dialogs and shops or fleeing combat
- Allow Escape to flee combat
- Add tests for mobile B behavior and bump engine version

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b27201f5288328b24360101b0f3c24