### PR TITLE
feat: move boot log to separate file

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -248,6 +248,7 @@
     <script defer src="./scripts/dustland-path.js"></script>
     <script defer src="./scripts/dustland-nano.js"></script>
     <script defer src="./scripts/dustland-engine.js"></script>
+    <script defer src="./scripts/version-log.js"></script>
     <script defer src="./scripts/fx-debug.js"></script>
     <script defer src="./scripts/perf-debug.js"></script>
   <script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.33",
+  "version": "0.7.34",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,6 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
+const ENGINE_VERSION = '0.7.34';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');
@@ -977,7 +978,6 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-log('v0.7.33 — adds wizard scaffolding and combat telemetry.');
 if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode

--- a/scripts/version-log.js
+++ b/scripts/version-log.js
@@ -1,0 +1,1 @@
+log(`v${ENGINE_VERSION} — boot log extracted to helper file.`);


### PR DESCRIPTION
## Summary
- bump engine to 0.7.34
- move boot log into a standalone script for easier updates

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27a9041e8832896aeeeb31e3ab33a