### PR TITLE
fix: handle missing map label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.36",
+  "version": "0.7.37",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -201,7 +201,9 @@ function setMap(id,label){
   state.map=id;
   party.map = id;
   state.mapEntry = null;
-  mapNameEl.textContent = label || mapLabel(id);
+  if (mapNameEl) {
+    mapNameEl.textContent = label || mapLabel(id);
+  }
   if(typeof centerCamera==='function') centerCamera(party.x,party.y,state.map);
   if(id==='world') setGameState(GAME_STATE.WORLD);
   else if(id==='creator') setGameState(GAME_STATE.CREATOR);

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.36';
+const ENGINE_VERSION = '0.7.37';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');


### PR DESCRIPTION
## Summary
- guard against missing map name DOM element to prevent null errors
- bump engine version to 0.7.37

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b302c86ff08328a2c0ff460eb0a40b