### PR TITLE
fix: expand short hex colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.36",
+  "version": "0.7.37",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1571,13 +1571,20 @@ function applyNPCChanges() {
   drawWorld();
   drawInterior();
 }
+
+function expandHex(hex) {
+  if (typeof hex === 'string' && /^#[0-9a-fA-F]{3}$/.test(hex)) {
+    return '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
+  }
+  return hex;
+}
 function editNPC(i) {
   const n = moduleData.npcs[i];
   editNPCIdx = i;
   document.getElementById('npcId').value = n.id;
   document.getElementById('npcName').value = n.name;
   document.getElementById('npcDesc').value = n.desc || '';
-  document.getElementById('npcColor').value = n.color;
+  document.getElementById('npcColor').value = expandHex(n.color || '#ffffff');
   document.getElementById('npcMap').value = n.map;
   document.getElementById('npcX').value = n.x;
   document.getElementById('npcY').value = n.y;
@@ -1912,7 +1919,7 @@ function editTemplate(i){
   document.getElementById('templateId').value = t.id;
   document.getElementById('templateName').value = t.name;
   document.getElementById('templateDesc').value = t.desc;
-  document.getElementById('templateColor').value = t.color;
+  document.getElementById('templateColor').value = expandHex(t.color || '#ffffff');
   document.getElementById('templatePortrait').value = t.portraitSheet || '';
   document.getElementById('templateCombat').value = t.combat ? JSON.stringify(t.combat, null, 2) : '';
   document.getElementById('addTemplate').textContent = 'Update Template';

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.36';
+const ENGINE_VERSION = '0.7.37';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -388,3 +388,9 @@ test('dialog text edited in tree editor is preserved', () => {
   closeNPCEditor();
   assert.strictEqual(moduleData.npcs[0].tree.start.text, 'welcome');
 });
+
+test('editNPC expands short hex colors', () => {
+  moduleData.npcs = [{ id: 'npc1', name: 'NPC', color: '#f33', map: 'world', x: 0, y: 0, tree: {} }];
+  editNPC(0);
+  assert.strictEqual(document.getElementById('npcColor').value, '#ff3333');
+});


### PR DESCRIPTION
## Summary
- normalize 3-digit hex codes before populating NPC and template color inputs
- add regression test for short hex colors
- bump engine version to 0.7.37

## Testing
- `./install-deps.sh` *(fails: Invalid response from proxy: HTTP/1.1 403 Forbidden)*
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b302de919c8328804a4e0dce4e7470