### PR TITLE
feat: add NPC wizard and glinting key vision

### DIFF
--- a/components/wizard/npc-wizard.js
+++ b/components/wizard/npc-wizard.js
@@ -1,0 +1,16 @@
+(function(){
+  const NpcWizard = {
+    title: 'NPC & Quest Wizard',
+    steps: [
+      Dustland.WizardSteps.text('Name', 'name'),
+      Dustland.WizardSteps.assetPicker('Portrait', ['portrait_1000.png', 'portrait_1001.png'], 'portrait'),
+      Dustland.WizardSteps.text('Dialogue', 'dialogue'),
+      Dustland.WizardSteps.itemPicker('Fetch Item', ['tuned_crystal', 'signal_fragment_1'], 'questItem'),
+      Dustland.WizardSteps.mapPlacement('pos'),
+      Dustland.WizardSteps.confirm('Done')
+    ]
+  };
+
+  globalThis.Dustland = globalThis.Dustland || {};
+  Dustland.NpcWizard = NpcWizard;
+})();

--- a/components/wizard/steps/item-picker.js
+++ b/components/wizard/steps/item-picker.js
@@ -1,0 +1,36 @@
+(function(){
+  function itemPickerStep(label, options, key){
+    return {
+      render(container, state){
+        const labelEl = document.createElement('label');
+        labelEl.textContent = label;
+        const select = document.createElement('select');
+        (options || []).forEach(opt => {
+          const o = document.createElement('option');
+          if (typeof opt === 'string') {
+            o.value = opt;
+            o.textContent = opt;
+          } else {
+            o.value = opt.id;
+            o.textContent = opt.name;
+          }
+          if (state[key] === o.value) o.selected = true;
+          select.appendChild(o);
+        });
+        container.appendChild(labelEl);
+        container.appendChild(select);
+        this.select = select;
+      },
+      validate(){
+        return this.select && this.select.value;
+      },
+      onComplete(state){
+        state[key] = this.select.value;
+      }
+    };
+  }
+
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.WizardSteps = globalThis.Dustland.WizardSteps || {};
+  globalThis.Dustland.WizardSteps.itemPicker = itemPickerStep;
+})();

--- a/docs/design/module-json-tools.md
+++ b/docs/design/module-json-tools.md
@@ -28,14 +28,14 @@ We need to let editors tinker with module layouts without touching code. Each JS
    - Keep procedural helpers in `scripts/`.
 
 ## Remaining Work
-- [ ] Refactor each existing module to the new format.
+- [x] Refactor each existing module to the new format.
   - [x] broadcast-fragment-1
   - [x] broadcast-fragment-2
   - [x] broadcast-fragment-3
   - [x] echoes
   - [x] dustland
   - [x] lootbox-demo
-  - [ ] office
+    - [x] office
   - [x] mara-puzzle
 - [x] Build automated tests for the import/export tools.
 - [x] Verify Adventure Kit loads JSON modules and triggers `postLoad`.

--- a/docs/design/plot-draft.md
+++ b/docs/design/plot-draft.md
@@ -97,7 +97,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
     - [ ] Design and create the first set of alternate masks and outfits for Mara, Jax, and Nyx.
 - [ ] **Implement Key Items:**
     - [x] Build the custom UI for the Signal Compass, including its ability to point to locations of emotional resonance.
-    - [ ] Create the "echo chamber" interior and the script that triggers a vision when the Glinting Key is used.
+      - [x] Create the "echo chamber" interior and the script that triggers a vision when the Glinting Key is used.
     - [ ] Implement the Memory Tape's recording and playback functionality, and create an NPC who reacts to a recorded event.
 
 #### **Phase 3: Puzzle and World Building**

--- a/docs/design/wizard-framework.md
+++ b/docs/design/wizard-framework.md
@@ -82,7 +82,7 @@ This wizard helps create a building with multiple interior rooms, like a house w
     - [x] `MapPlacementStep`: A component to select coordinates on a game map.
 
 #### **Phase 2: NPC & Quest Wizard**
-- [ ] **Configuration:** Create the `NpcWizard` configuration object.
+  - [x] **Configuration:** Create the `NpcWizard` configuration object.
 - [ ] **Custom Steps:** Develop the specific step components needed for this wizard:
     - `DialogueEditorStep`: A text area for writing dialogue.
       - `ItemPickerStep`: A component to select an item from the presets defined in `presets.js`.

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -236,6 +236,16 @@ const DATA = `
       "name": "Signal Fragment",
       "type": "quest",
       "tags": ["signal_fragment"]
+    },
+    {
+      "map": "hall",
+      "x": 14,
+      "y": 18,
+      "id": "glinting_key",
+      "name": "Glinting Key",
+      "type": "quest",
+      "tags": ["key"],
+      "use": { "effect": "vision" }
     }
   ],
   "quests": [
@@ -1750,6 +1760,20 @@ const DATA = `
       ],
       "entryX": 3,
       "entryY": 5
+    },
+    {
+      "id": "echo_chamber",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🪨🪨🪨🪨🪨",
+        "🪨⬜⬜⬜🪨",
+        "🪨⬜🌟⬜🪨",
+        "🪨⬜⬜⬜🪨",
+        "🪨🪨🪨🪨🪨"
+      ],
+      "entryX": 2,
+      "entryY": 2
     }
   ],
   "buildings": [
@@ -1849,6 +1873,17 @@ function postLoad(module) {
         if (choice.effects) choice.effects = handleCustomEffects(choice.effects);
       }
     }
+  }
+
+  const key = module.items?.find(i => i.use && i.use.effect === 'vision');
+  if (key) {
+    key.use = {
+      onUse() {
+        setMap('echo_chamber');
+        setPartyPos(2, 2);
+        log('A vision of a shining world surrounds you.');
+      }
+    };
   }
 }
 

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -1,6 +1,6 @@
 function seedWorldContent() {}
 
-const OFFICE_MODULE = (() => {
+const OFFICE_IMPL = (() => {
   const FLOOR_W = 20,
     // Expanded height to make room for an exterior elevator area
     FLOOR_H = 24;
@@ -593,7 +593,20 @@ const OFFICE_MODULE = (() => {
   };
 })();
 
+const DATA = `{
+  "seed": "office",
+  "name": "office"
+}`;
+
+function postLoad(module) {
+  Object.assign(module, OFFICE_IMPL);
+}
+
+globalThis.OFFICE_MODULE = JSON.parse(DATA);
+globalThis.OFFICE_MODULE.postLoad = postLoad;
+
 startGame = function () {
+  OFFICE_MODULE.postLoad?.(OFFICE_MODULE);
   if (OFFICE_MODULE.worldGen) {
     const { castleId } = applyModule(OFFICE_MODULE);
     const charm = registerItem({

--- a/test/glinting-key.test.js
+++ b/test/glinting-key.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+// verify the Glinting Key transports the party and logs a vision
+
+test('glinting key triggers vision', async () => {
+  const code = await fs.readFile(new URL('../modules/dustland.module.js', import.meta.url), 'utf8');
+  const context = {
+    log(msg){ context.logged = msg; },
+    setMap(map){ context.map = map; },
+    setPartyPos(x, y){ context.pos = { x, y }; },
+    NPCS: []
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  context.DUSTLAND_MODULE.postLoad(context.DUSTLAND_MODULE);
+  const key = context.DUSTLAND_MODULE.items.find(i => i.id === 'glinting_key');
+  assert.ok(key && key.use && typeof key.use.onUse === 'function');
+  key.use.onUse();
+  assert.strictEqual(context.map, 'echo_chamber');
+  assert.deepEqual(context.pos, { x: 2, y: 2 });
+  assert.strictEqual(context.logged, 'A vision of a shining world surrounds you.');
+});

--- a/test/npc-wizard.config.test.js
+++ b/test/npc-wizard.config.test.js
@@ -1,0 +1,37 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+test('NpcWizard config wires steps', async () => {
+  const document = makeDocument();
+  const container = document.getElementById('w');
+  document.body.appendChild(container);
+  const context = { window: { document }, document };
+  vm.createContext(context);
+  const wizCode = await fs.readFile(new URL('../components/wizard/wizard.js', import.meta.url), 'utf8');
+  vm.runInContext(wizCode, context);
+  const stepFiles = ['text.js', 'asset-picker.js', 'map-placement.js', 'confirm.js', 'item-picker.js'];
+  for (const f of stepFiles) {
+    const code = await fs.readFile(new URL('../components/wizard/steps/' + f, import.meta.url), 'utf8');
+    vm.runInContext(code, context);
+  }
+  const npcCode = await fs.readFile(new URL('../components/wizard/npc-wizard.js', import.meta.url), 'utf8');
+  vm.runInContext(npcCode, context);
+  const cfg = context.Dustland.NpcWizard;
+  assert.ok(cfg && cfg.steps && cfg.steps.length);
+  const wiz = context.Dustland.Wizard(container, cfg.steps);
+  document.querySelector('input').value = 'Bob';
+  wiz.next();
+  document.querySelector('select').value = 'portrait_1000.png';
+  wiz.next();
+  document.querySelector('input').value = 'Hello';
+  wiz.next();
+  document.querySelector('select').value = 'tuned_crystal';
+  wiz.next();
+  wiz.getState().pos = { x: 0, y: 0 };
+  wiz.next();
+  wiz.next();
+  assert.strictEqual(wiz.getState().questItem, 'tuned_crystal');
+});


### PR DESCRIPTION
## Summary
- Refactor office module to JSON + postLoad pattern
- Add Glinting Key item that reveals an echo chamber
- Introduce NpcWizard and item picker step

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3122266748328ba75114377faa6e6