### PR TITLE
feat: expand creator specializations and quirks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -674,10 +674,26 @@ function setCreatorPortrait(){
   if(building) building.portraitSheet = img;
 }
 const specializations={
-  'Scavenger':{desc:'Finds better loot from ruins; starts with crowbar.', gear:[{id:'crowbar',name:'Crowbar',slot:'weapon',mods:{ATK:+1}}]},
-  'Gunslinger':{desc:'Higher chance to win quick fights; starts with pipe rifle.', gear:[{id:'pipe_rifle',name:'Pipe Rifle',slot:'weapon',mods:{ATK:+2}}]},
-  'Snakeoil Preacher':{desc:'Can sway naive foes; +1 CHA trinket.', gear:[{id:'tin_sun',name:'Tin Sun',slot:'trinket',mods:{LCK:+1}}]},
-  'Cogwitch':{desc:'Tinker checks succeed more often; starts with toolkit.', gear:[{id:'toolkit',name:'Toolkit',slot:'trinket',mods:{INT:+1}}]}
+  'Scavenger':{
+    desc:'Finds better loot from ruins; +1 PER and starts with crowbar.',
+    stats:{PER:+1},
+    gear:[{id:'crowbar',name:'Crowbar',slot:'weapon',mods:{ATK:+1}}]
+  },
+  'Gunslinger':{
+    desc:'Draws fast with +1 AGI and starts with pipe rifle.',
+    stats:{AGI:+1},
+    gear:[{id:'pipe_rifle',name:'Pipe Rifle',slot:'weapon',mods:{ATK:+2}}]
+  },
+  'Snakeoil Preacher':{
+    desc:'Silver tongue grants +1 CHA and a lucky Tin Sun trinket.',
+    stats:{CHA:+1},
+    gear:[{id:'tin_sun',name:'Tin Sun',slot:'trinket',mods:{LCK:+1}}]
+  },
+  'Cogwitch':{
+    desc:'Tinker checks succeed more often; +1 INT and a trusty toolkit.',
+    stats:{INT:+1},
+    gear:[{id:'toolkit',name:'Toolkit',slot:'trinket',mods:{INT:+1}}]
+  }
 };
 const classSpecials={
   Scavenger:['POWER_STRIKE'],
@@ -687,9 +703,21 @@ const classSpecials={
   Wanderer:['GUARD_UP']
 };
 const quirks={
-  'Lucky Lint':{desc:'+1 LCK. Occasionally avoid mishaps.'},
-  'Dust Allergy':{desc:'Random sneezes in dialog (harmless, funny).'},
-  'Desert Prophet':{desc:'Rare visions add hints.'}
+  'Lucky Lint':{
+    desc:'+1 LCK and start with a Lucky Coin.',
+    stats:{LCK:+1},
+    gear:[{id:'lucky_coin',name:'Lucky Coin',slot:'trinket',mods:{LCK:+1}}]
+  },
+  'Brutal Past':{
+    desc:'+1 STR and spiked knuckles for rough fights.',
+    stats:{STR:+1},
+    gear:[{id:'spiked_knuckles',name:'Spiked Knuckles',slot:'weapon',mods:{ATK:+1}}]
+  },
+  'Desert Prophet':{
+    desc:'+1 PER and a prophecy scroll that sharpens INT.',
+    stats:{PER:+1},
+    gear:[{id:'prophecy_scroll',name:'Prophecy Scroll',slot:'trinket',mods:{INT:+1}}]
+  }
 };
 const hiddenOrigins={ 'Rustborn':{desc:'You survived a machine womb. +1 PER, weird dialog tags.'} };
 const statInfo={
@@ -772,8 +800,17 @@ function finalizeCurrentMember(){
   const m=makeMember(building.id, building.name, building.spec||'Wanderer', {permanent:true, portraitSheet: building.portraitSheet});
   m.stats=building.stats; m.origin=building.origin; m.quirk=building.quirk;
   m.special = classSpecials[building.spec||'Wanderer'] || [];
+  const spec = specializations[building.spec];
+  if(spec){
+    if(spec.stats){ for(const k in spec.stats){ m.stats[k]=(m.stats[k]||0)+spec.stats[k]; } }
+    if(spec.gear){ spec.gear.forEach(g=> addToInv(g)); }
+  }
+  const quirk=quirks[building.quirk];
+  if(quirk){
+    if(quirk.stats){ for(const k in quirk.stats){ m.stats[k]=(m.stats[k]||0)+quirk.stats[k]; } }
+    if(quirk.gear){ quirk.gear.forEach(g=> addToInv(g)); }
+  }
   joinParty(m);
-  const spec = specializations[building.spec]; if(spec){ spec.gear.forEach(g=> addToInv(g)); }
   built.push(m);
   building = null;
   return m;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.37';
+const ENGINE_VERSION = '0.7.38';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/test/creator-perks.test.js
+++ b/test/creator-perks.test.js
@@ -1,0 +1,42 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const code = await fs.readFile(new URL('../scripts/dustland-core.js', import.meta.url), 'utf8');
+
+function setup(){
+  const html = `<body><div id="mapname"></div><div id="creator"></div><div id="ccStep"></div><div id="ccRight"></div><div id="ccHint"></div><button id="ccBack"></button><button id="ccNext"></button><div id="ccPortrait"></div><button id="ccStart"></button><button id="ccLoad"></button></body>`;
+  const dom = new JSDOM(html);
+  const party=[]; party.flags={}; party.map='world'; party.x=0; party.y=0;
+  const inv=[];
+  const context={
+    window:dom.window,
+    document:dom.window.document,
+    EventBus:{ on:()=>{}, emit:()=>{} },
+    baseStats:()=>({STR:4,AGI:4,INT:4,PER:4,LCK:4,CHA:4}),
+    makeMember:(id,name,role)=>({id,name,role,stats:{},special:[]}),
+    joinParty:m=>{ party.push(m); },
+    addToInv:i=>{ inv.push(i); },
+    rand:()=>0,
+    log:()=>{},
+    party,
+    Math:Object.assign(Object.create(Math),{random:()=>0})
+  };
+  vm.createContext(context);
+  vm.runInContext(code,context);
+  return {context,inv};
+}
+
+test('specialization and quirk bonuses apply',()=>{
+  const {context,inv}=setup();
+  context.openCreator();
+  vm.runInContext("building.spec='Gunslinger'; building.quirk='Lucky Lint'", context);
+  const member=vm.runInContext('finalizeCurrentMember()', context);
+  assert.strictEqual(member.stats.AGI,5);
+  assert.strictEqual(member.stats.LCK,5);
+  const ids=inv.map(i=>i.id);
+  assert(ids.includes('pipe_rifle'));
+  assert(ids.includes('lucky_coin'));
+});


### PR DESCRIPTION
## Summary
- add stat bonuses and starter gear for each specialization and quirk
- replace flavor-only quirk with Brutal Past
- apply specialization and quirk bonuses when finalizing characters
- bump engine version to 0.7.38

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3147bdf348328afb979639bb90e6e