### PR TITLE
fix: load broadcast story and cue Mara puzzle

### DIFF
--- a/modules/mara-puzzle.module.js
+++ b/modules/mara-puzzle.module.js
@@ -17,12 +17,12 @@ const DATA = `{
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🚪🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🏝🔔🏝🏝🏝🏝🏝🏝🏝🏝🏝🔔🏝🏝🏝🧱",
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
-        "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
-        "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🔔🏝🏝🏝🏝🏝🏝🏝🏝🧱",
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
         "🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
@@ -39,9 +39,18 @@ const DATA = `{
   ],
   "events": [
     { "map": "dust_storm", "x": 10, "y": 18, "events": [{ "when": "enter", "effect": "dustStorm", "active": true }] },
-    { "map": "dust_storm", "x": 10, "y": 10, "events": [{ "when": "enter", "effect": "addSoundSource", "id": "chime1", "x": 10, "y": 10 }] },
-    { "map": "dust_storm", "x": 5, "y": 5, "events": [{ "when": "enter", "effect": "addSoundSource", "id": "chime2", "x": 5, "y": 5 }] },
-    { "map": "dust_storm", "x": 15, "y": 5, "events": [{ "when": "enter", "effect": "addSoundSource", "id": "chime3", "x": 15, "y": 5 }] }
+    { "map": "dust_storm", "x": 10, "y": 10, "events": [
+      { "when": "enter", "effect": "addSoundSource", "id": "chime1", "x": 10, "y": 10 },
+      { "when": "enter", "effect": "log", "msg": "A distant chime echoes." }
+    ] },
+    { "map": "dust_storm", "x": 5, "y": 5, "events": [
+      { "when": "enter", "effect": "addSoundSource", "id": "chime2", "x": 5, "y": 5 },
+      { "when": "enter", "effect": "log", "msg": "Wind rattles a chime." }
+    ] },
+    { "map": "dust_storm", "x": 15, "y": 5, "events": [
+      { "when": "enter", "effect": "addSoundSource", "id": "chime3", "x": 15, "y": 5 },
+      { "when": "enter", "effect": "log", "msg": "A faint bell rings." }
+    ] }
   ],
   "portals": [
     { "map": "dust_storm", "x": 10, "y": 6, "toMap": "world", "toX": 10, "toY": 10, "desc": "You emerge from the dust storm." }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.38';
+const ENGINE_VERSION = '0.7.39';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -5,7 +5,7 @@ const MODULES = [
   { id: 'echoes', name: 'Echoes', file: 'modules/echoes.module.js' },
   { id: 'office', name: 'Office', file: 'modules/office.module.js' },
   { id: 'lootbox-demo', name: 'Loot Box Demo', file: 'modules/lootbox-demo.module.js' },
-  { id: 'broadcast', name: 'Broadcast Story', file: 'broadcast-story.js' },
+  { id: 'broadcast', name: 'Broadcast Story', file: 'scripts/broadcast-story.js' },
   { id: 'mara', name: 'Mara Puzzle', file: 'modules/mara-puzzle.module.js' },
   { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' }
 ];


### PR DESCRIPTION
## Summary
- point broadcast story path at scripts folder so module loads
- add visible chimes and messages to Mara Puzzle
- bump engine to 0.7.39

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b33a69558c8328b0fd6bda183e3680