### PR TITLE
docs: add task lists to design docs

### DIFF
--- a/docs/design/chiptune-ai.md
+++ b/docs/design/chiptune-ai.md
@@ -49,3 +49,11 @@ Runs standalone in a browser tab and should chirp out a tiny wasteland riff.
 - How many concurrent voices before we spike frame time?
 - Do we need per-biome instrument palettes?
 - Should seeds tie to NPC names for thematic callbacks?
+
+## Tasks
+
+- [ ] Prototype seeded melody generation with Magenta and Tone.
+- [ ] Expose mod hooks for seed and instrument parameters.
+- [ ] Add scale clamping to keep riffs musical.
+- [ ] Stress-test performance on mobile browsers.
+- [ ] Tie playback to the event bus via `music:seed`.

--- a/docs/design/dialog-navigation.md
+++ b/docs/design/dialog-navigation.md
@@ -257,10 +257,10 @@ function withImportTracking(ctx, recorder) {
 - Do we need per-node timeouts (auto-advance) for scripted scenes?
 - Should dialog rendering live in HUD or a dedicated overlay layer?
 
-## TODOs
+## Tasks
 
-- Persist LLM suggestions in ACK: Add a clear “Persist LLM nodes” control and per-choice “Accept suggestion” affordance that writes generated nodes/choices into the dialog JSON (removing volatile markers) and updates imports as needed.
-- Imports + validation enhancements: Extend imports generation (capture more effects/events and inferred queries) and add an editor validator that highlights unresolved `to` targets or missing imports with actionable UI hints.
+- [ ] Persist LLM suggestions in ACK: Add a clear “Persist LLM nodes” control and per-choice “Accept suggestion” affordance that writes generated nodes/choices into the dialog JSON (removing volatile markers) and updates imports as needed.
+- [ ] Imports + validation enhancements: Extend imports generation (capture more effects/events and inferred queries) and add an editor validator that highlights unresolved `to` targets or missing imports with actionable UI hints.
 
 ## Appendix: Minimal Runtime Sketch
 

--- a/docs/design/plot-draft.md
+++ b/docs/design/plot-draft.md
@@ -66,6 +66,11 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
 ---
 ### **Expanded Task List**
 
+#### **Phase 0: Writing Pass**
+- [ ] Draft a scene-by-scene outline with placeholder dialog for the caravan's opening leg.
+- [ ] Flesh out Mara, Jax, and Nyx arcs with at least two key conversations each.
+- [ ] Sketch early Silencer encounters with sample rival dialogue.
+
 #### **Phase 1: Narrative Foundation**
 - [x] Outline the caravan's pursuit of the fading broadcast across the Dustland.
   - The caravan catches the ghost of a broadcast near the Salt Flats and tracks its fading pulses by night.


### PR DESCRIPTION
## Summary
- track dialog engine follow-ups with checklists
- outline chiptune AI follow-up tasks
- flag needed narrative writing and dialog for the plot draft

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b340841e4c8328a4dda61e432e57e1