### PR TITLE
feat: add glinting key rejection dialog

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -406,6 +406,10 @@ const DATA = `
               "q": "turnin"
             },
             {
+              "label": "(Use Glinting Key)",
+              "to": "glint_fail"
+            },
+            {
               "label": "(Leave)",
               "to": "bye"
             }
@@ -417,6 +421,15 @@ const DATA = `
             {
               "label": "(Okay)",
               "to": "bye"
+            }
+          ]
+        },
+        "glint_fail": {
+          "text": "Kesh squints at the glinting key. Shiny things aren't always the best in this place.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
             }
           ]
         },

--- a/test/glinting-key.test.js
+++ b/test/glinting-key.test.js
@@ -23,3 +23,61 @@ test('glinting key triggers vision', async () => {
   assert.deepEqual(context.pos, { x: 2, y: 2 });
   assert.strictEqual(context.logged, 'A vision of a shining world surrounds you.');
 });
+
+test('exit door remarks on glinting key', async () => {
+  const [modSrc, dialogSrc] = await Promise.all([
+    fs.readFile(new URL('../modules/dustland.module.js', import.meta.url), 'utf8'),
+    fs.readFile(new URL('../scripts/core/dialog.js', import.meta.url), 'utf8')
+  ]);
+
+  function stubEl() {
+    return { children: [], classList: { toggle() {} }, appendChild() {}, querySelector() {}, textContent: '', innerHTML: '' };
+  }
+  const overlay = stubEl();
+  const choicesEl = stubEl();
+  const dialogText = stubEl();
+  const npcName = stubEl();
+  const npcTitle = stubEl();
+  const portEl = stubEl();
+
+  const context = {
+    player: { inv: [{ id: 'glinting_key', tags: ['key'] }] },
+    party: {},
+    state: {},
+    NPCS: [],
+    Dustland: { actions: { applyQuestReward() {} }, effects: { apply() {} } },
+    countItems: (id) => (id === 'glinting_key' ? 1 : 0),
+    dialogJoinParty: () => {},
+    processQuestFlag: () => {},
+    handleGoto: () => {},
+    document: {
+      getElementById: (id) => ({ overlay, choices: choicesEl, dialogText, npcName, npcTitle, port: portEl }[id] || stubEl()),
+      createElement: () => stubEl(),
+      querySelector: () => stubEl()
+    },
+    window: {},
+    log: () => {}
+  };
+  context.window = context;
+  vm.createContext(context);
+  vm.runInContext(dialogSrc, context);
+  vm.runInContext(modSrc, context);
+
+  const exit = context.DUSTLAND_MODULE.npcs.find((n) => n.id === 'exitdoor');
+  const normalizeDialogTree = (tree) => {
+    const out = {};
+    for (const id in tree) {
+      const n = tree[id];
+      const next = (n.choices || []).map((c) => ({ id: c.to, label: c.label, to: c.to }));
+      out[id] = { text: n.text || '', next };
+    }
+    return out;
+  };
+  const tree = normalizeDialogTree(exit.tree);
+  const dialog = { tree, node: 'start' };
+  const idx = tree.start.next.findIndex((c) => c.label === '(Use Glinting Key)');
+  assert.ok(idx > -1);
+  context.advanceDialog(dialog, idx);
+  assert.equal(dialog.node, 'glint_fail');
+  assert.match(tree.glint_fail.text, /shiny things aren't always the best in this place/i);
+});


### PR DESCRIPTION
## Summary
- add dialog when presenting Glinting Key at hall exit
- test glinting key rejection response

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3831ca5048328bbc5167da8346983