### PR TITLE
fix: handle missing UI elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -709,7 +709,7 @@ function collectMods() {
   });
   return mods;
 }
-function loadMods(mods) {
+function loadMods(mods = {}) {
   const mb = document.getElementById('modBuilder');
   mb.innerHTML = '';
   MOD_TYPES.forEach(m => {

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -744,6 +744,7 @@ function newBuilding(){
 
 let step=1; let building=null; let built=[];
 function openCreator(){
+  if(!creator) return; // Gracefully skip when creator UI is absent
   if(!creatorMap.grid || creatorMap.grid.length===0) genCreatorMap();
   setPartyPos(creatorMap.entryX, creatorMap.entryY);
   setMap('creator','Creator');

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.41';
+const ENGINE_VERSION = '0.7.42';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -394,3 +394,7 @@ test('editNPC expands short hex colors', () => {
   editNPC(0);
   assert.strictEqual(document.getElementById('npcColor').value, '#ff3333');
 });
+
+test('loadMods accepts undefined', () => {
+  assert.doesNotThrow(() => loadMods(undefined));
+});

--- a/test/open-creator-nodom.test.js
+++ b/test/open-creator-nodom.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const code = await fs.readFile(new URL('../scripts/dustland-core.js', import.meta.url), 'utf8');
+
+test('openCreator does nothing without DOM', () => {
+  const dom = new JSDOM('<body></body>');
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    EventBus: { on: () => {}, emit: () => {} },
+    baseStats: () => ({ STR:4, AGI:4, INT:4, PER:4, LCK:4, CHA:4 }),
+    makeMember: (id, name, role) => ({ id, name, role, stats:{}, special:[] }),
+    joinParty: () => {},
+    addToInv: () => {},
+    rand: () => 0,
+    log: () => {},
+    party: {},
+    Math: Object.assign(Object.create(Math), { random: () => 0 })
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  assert.doesNotThrow(() => context.openCreator());
+});
+


### PR DESCRIPTION
## Summary
- avoid `creator` style access when the Adventure Kit editor lacks a creator element
- guard `loadMods` against undefined data
- bump engine version to 0.7.42

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3a70e4f84832881ae6e488730aec4