### PR TITLE
feat: announce enemies at combat start

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -169,6 +169,21 @@ function openCombat(enemies){
     renderCombat();
     updateHUD?.();
     combatOverlay.classList.add('shown');
+
+    const enemyNames = combatState.enemies.map(e => e.name || 'foe');
+    if (enemyNames.length) {
+      let msg;
+      if (enemyNames.length === 1) {
+        const name = enemyNames[0];
+        const article = /^[aeiou]/i.test(name) ? 'an' : 'a';
+        msg = `You encounter ${article} ${name}.`;
+      } else {
+        const last = enemyNames.pop();
+        msg = `You encounter ${enemyNames.join(', ')} and ${last}.`;
+      }
+      log?.(msg);
+    }
+
     globalThis.EventBus?.emit?.('combat:started');
     openCommand();
   });

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.41';
+const ENGINE_VERSION = '0.7.42';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/test/combat-start.test.js
+++ b/test/combat-start.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { createGameProxy } from './test-harness.js';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('combat announces encountered enemies', async () => {
+  const { context, document } = createGameProxy([{ name: 'Hero', hp: 5 }]);
+  context.party.restore = () => {};
+  context.toggleAudio();
+  const combatCode = await fs.readFile(new URL('../scripts/core/combat.js', import.meta.url), 'utf8');
+  vm.runInContext(combatCode, context);
+  const p = context.openCombat([{ name: 'Slime', hp: 1 }]);
+  const log = document.getElementById('log');
+  assert.strictEqual(log.children[0].textContent, 'You encounter a Slime.');
+  context.closeCombat('win');
+  await p;
+});


### PR DESCRIPTION
## Summary
- log a message naming enemies when combat begins
- bump engine version to 0.7.42
- add regression test for combat start announcement

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3a95e80688328821469851e259a93