### PR TITLE
feat: differentiate NPC and object symbols

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -335,6 +335,7 @@
           <label>Name<input id="npcName" /></label>
           <label>Description<textarea id="npcDesc" rows="2"></textarea></label>
           <label>Color<input id="npcColor" type="color" value="#9ef7a0" /></label>
+          <label>Symbol<input id="npcSymbol" maxlength="1" value="!" /></label>
           <label>Map<input id="npcMap" value="world" /></label>
           <label>X<input id="npcX" type="number" min="0" /></label>
           <label>Y<input id="npcY" type="number" min="0" /></label>

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -550,6 +550,7 @@ const DATA = `
       "title": "Warning",
       "desc": "Faded letters warn travelers.",
       "portraitSheet": "assets/portraits/dustland-module/worn_sign_4.png",
+      "symbol": "?",
       "tree": {
         "start": {
           "text": "Rust storms east. Shelter west.",
@@ -1545,6 +1546,7 @@ const DATA = `
       "title": "Slot Machine",
       "desc": "It wheezes, eager for scrap.",
       "portraitSheet": "assets/portraits/dustland-module/slot_machine.png",
+      "symbol": "?",
       "tree": {
         "start": {
           "text": "Lights sputter behind cracked glass.",

--- a/modules/golden.module.json
+++ b/modules/golden.module.json
@@ -134,6 +134,7 @@
       "color": "#ddf",
       "name": "Dusty Chest",
       "desc": "Maybe it holds the coin.",
+      "symbol": "?",
       "tree": {
         "start": {
           "text": "A locked chest sits here.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.41",
+  "version": "0.7.43",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1462,6 +1462,7 @@ function startNewNPC() {
   document.getElementById('npcName').value = '';
   document.getElementById('npcDesc').value = '';
   document.getElementById('npcColor').value = '#9ef7a0';
+  document.getElementById('npcSymbol').value = '!';
   document.getElementById('npcMap').value = 'world';
   document.getElementById('npcX').value = 0;
   document.getElementById('npcY').value = 0;
@@ -1515,6 +1516,7 @@ function collectNPCFromForm() {
   const name = document.getElementById('npcName').value.trim();
   const desc = document.getElementById('npcDesc').value.trim();
   const color = document.getElementById('npcColor').value.trim() || '#fff';
+  const symbol = document.getElementById('npcSymbol').value.trim().charAt(0) || '!';
   const map = document.getElementById('npcMap').value.trim() || 'world';
   const x = parseInt(document.getElementById('npcX').value, 10) || 0;
   const y = parseInt(document.getElementById('npcY').value, 10) || 0;
@@ -1551,7 +1553,7 @@ function collectNPCFromForm() {
   document.getElementById('npcTree').value = JSON.stringify(tree, null, 2);
   loadTreeEditor();
 
-  const npc = { id, name, desc, color, map, x, y, tree, questId };
+  const npc = { id, name, desc, color, symbol, map, x, y, tree, questId };
   const pts = gatherLoopFields();
   if (pts.length >= 2) npc.loop = pts;
   if (combat) npc.combat = { DEF: 5 };
@@ -1610,6 +1612,7 @@ function editNPC(i) {
   document.getElementById('npcName').value = n.name;
   document.getElementById('npcDesc').value = n.desc || '';
   document.getElementById('npcColor').value = expandHex(n.color || '#ffffff');
+  document.getElementById('npcSymbol').value = n.symbol || '!';
   document.getElementById('npcMap').value = n.map;
   document.getElementById('npcX').value = n.x;
   document.getElementById('npcY').value = n.y;

--- a/scripts/core/npc.js
+++ b/scripts/core/npc.js
@@ -1,8 +1,8 @@
 // ===== NPCs =====
 var Dustland = globalThis.Dustland;
 class NPC {
-  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null,portraitLock=true}) {
-    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet,portraitLock});
+  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null,portraitLock=true,symbol='!'}) {
+    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet,portraitLock,symbol});
     const capNode = (node) => {
       if (this.combat && node === 'do_fight') {
         closeDialog();
@@ -110,6 +110,7 @@ function createNpcFactory(defs) {
       if (n.shop) opts.shop = n.shop;
       if (n.portraitSheet) opts.portraitSheet = n.portraitSheet;
       if (n.portraitLock === false) opts.portraitLock = false;
+      if (n.symbol) opts.symbol = n.symbol;
       const npc = makeNPC(
         n.id,
         n.map || 'world',

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -568,7 +568,8 @@ function save(){
     quest:n.quest?{id:n.quest.id,status:n.quest.status}:null,
     loop:n.loop,
     portraitSheet:n.portraitSheet,
-    portraitLock:n.portraitLock
+    portraitLock:n.portraitLock,
+    symbol:n.symbol
   }));
   const questData = {};
   Object.keys(quests).forEach(k=>{

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.41';
+const ENGINE_VERSION = '0.7.43';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');
@@ -416,7 +416,7 @@ function drawEntities(ctx, list, offX, offY){
     if(n.x>=camX&&n.y>=camY&&n.x<camX+vW&&n.y<camY+vH){
       const vx=(n.x-camX+offX)*TS, vy=(n.y-camY+offY)*TS;
       ctx.fillStyle=n.color; ctx.fillRect(vx,vy,TS,TS);
-      ctx.fillStyle='#000'; ctx.fillText('!',vx+5,vy+12);
+      ctx.fillStyle='#000'; ctx.fillText(n.symbol || '!',vx+5,vy+12);
     }
   }
 }

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -394,3 +394,15 @@ test('editNPC expands short hex colors', () => {
   editNPC(0);
   assert.strictEqual(document.getElementById('npcColor').value, '#ff3333');
 });
+
+test('NPC symbol is saved and restored', () => {
+  moduleData.npcs = [];
+  startNewNPC();
+  const symbolEl = document.getElementById('npcSymbol');
+  symbolEl.value = '?';
+  const npc = collectNPCFromForm();
+  assert.strictEqual(npc.symbol, '?');
+  moduleData.npcs = [npc];
+  editNPC(0);
+  assert.strictEqual(document.getElementById('npcSymbol').value, '?');
+});

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -803,7 +803,8 @@ test('createNpcFactory builds NPCs from definitions', () => {
     map: 'world',
     name: 'Tester',
     tree: '{"start":{"text":"hi","choices":[{"label":"bye","to":"bye"}]}}',
-    portraitSheet: 'assets/portraits/portrait_1000.png'
+    portraitSheet: 'assets/portraits/portrait_1000.png',
+    symbol: '?'
   }];
   const factory = createNpcFactory(defs);
   const npc = factory.t(2, 3);
@@ -813,6 +814,7 @@ test('createNpcFactory builds NPCs from definitions', () => {
   assert.strictEqual(npc.map, 'world');
   assert.strictEqual(npc.tree.start.text, 'hi');
   assert.strictEqual(npc.portraitSheet, 'assets/portraits/portrait_1000.png');
+  assert.strictEqual(npc.symbol, '?');
 });
 
 test('createNpcFactory defaults empty tree to dialog', () => {
@@ -834,6 +836,7 @@ test('openDialog displays portrait when sheet provided', () => {
   NPCS.length = 0;
   const tree = { start: { text: '', choices: [] } };
   const npc = makeNPC('p', 'world', 0, 0, '#fff', 'Port', '', '', tree, null, null, null, { portraitSheet: 'assets/portraits/kesh_4.png' });
+  assert.strictEqual(npc.symbol, '!');
   NPCS.push(npc);
   openDialog(npc);
   assert.ok(portEl.style.backgroundImage.includes('kesh_4.png'));

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -38,6 +38,7 @@ test('dustland module includes plot improvements', () => {
   const sign = data.npcs.find(n => n.id === 'road_sign');
   assert.ok(sign);
   assert.ok(sign.tree.start.text.includes('Rust storms east'));
+  assert.strictEqual(sign.symbol, '?');
   const rumor = data.npcs.some(n => Object.values(n.tree || {}).some(node => node.text && node.text.includes('Radio crackles from the north; idol whispers from the south')));
   assert.ok(rumor);
 });

--- a/test/golden.module.json.test.js
+++ b/test/golden.module.json.test.js
@@ -43,6 +43,9 @@ test('golden module json exposes core features', () => {
   assert.ok(mod.items.some((i) => i.use?.type === 'heal'), 'has healing item');
   assert.ok(mod.portals && mod.portals.length > 0, 'has portals');
 
+  const chest = mod.npcs.find(n => n.id === 'chest');
+  assert.strictEqual(chest.symbol, '?');
+
   const hut = mod.buildings.find((b) => b.interiorId === 'cabin');
   assert.strictEqual(hut.boarded, false, 'cabin is enterable');
   const w = hut.w || 6;

--- a/test/slot-machine.module.test.js
+++ b/test/slot-machine.module.test.js
@@ -20,6 +20,7 @@ test('dustland module adds slot shack with gambling options', () => {
   assert.ok(data.buildings.some(b => b.interiorId === 'slot_shack'));
   const slotNpc = data.npcs.find(n => n.id === 'slots');
   assert.ok(slotNpc);
+  assert.strictEqual(slotNpc.symbol, '?');
   const labels = slotNpc.tree.start.choices.map(c => c.label);
   assert.ok(labels.includes('(1 scrap)'));
   assert.ok(labels.includes('(5 scrap)'));


### PR DESCRIPTION
## Summary
- add `symbol` property so objects use `?` while NPCs keep `!`
- persist and render symbols, showing `?` for signs, chests and slot machines
- make symbol editable in Adventure Kit
- bump version to 0.7.43

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3a9910e70832889aee48ed5ba2c6f