### PR TITLE
feat: improve playability and UI feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -581,6 +581,7 @@ function save(){
   const data={worldSeed, world, player, state, buildings, interiors, itemDrops, npcs:npcData, quests:questData, party:partyData};
   localStorage.setItem('dustland_crt', JSON.stringify(data));
   log('Game saved.');
+  if (typeof toast === 'function') toast('Game saved.');
 }
 function load(){
   const j=localStorage.getItem('dustland_crt');
@@ -626,6 +627,7 @@ function load(){
   setMap(state.map);
   refreshUI();
   log('Game loaded.');
+  if (typeof toast === 'function') toast('Game loaded.');
 }
 
 const startEl = document.getElementById('start');
@@ -646,6 +648,7 @@ function resetAll(){
   party.length=0; player.inv=[]; party.flags={}; player.scrap=0;
   state.map='creator'; openCreator();
   log('Reset. Back to character creation.');
+  if (typeof toast === 'function') toast('Game reset.');
 }
 Object.assign(globalThis, { showStart, hideStart, openCreator, closeCreator, resetAll });
 

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.42';
+const ENGINE_VERSION = '0.7.43';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');
@@ -881,7 +881,9 @@ function runTests(){
 if (document.getElementById('saveBtn')) {
   document.getElementById('saveBtn').onclick=()=>save();
   document.getElementById('loadBtn').onclick=()=>{ load(); };
-  document.getElementById('resetBtn').onclick=()=>resetAll();
+  document.getElementById('resetBtn').onclick=()=>{
+    if (confirm('Reset game and return to character creation?')) resetAll();
+  };
   const nanoBtn=document.getElementById('nanoToggle');
   if(nanoBtn){
     const updateNano=()=>{ nanoBtn.textContent = `Nano Dialog: ${window.NanoDialog?.enabled ? 'On' : 'Off'}`; };
@@ -911,9 +913,15 @@ if (document.getElementById('saveBtn')) {
   const panelToggle=document.getElementById('panelToggle');
   const panel=document.querySelector('.panel');
   if(panelToggle && panel){
+    const open=globalThis.localStorage?.getItem('panel_open')==='1';
+    if(open){
+      panel.classList.add('show');
+      panelToggle.textContent='×';
+    }
     panelToggle.onclick=()=>{
-      const open=panel.classList.toggle('show');
-      panelToggle.textContent=open?'×':'☰';
+      const openState=panel.classList.toggle('show');
+      panelToggle.textContent=openState?'×':'☰';
+      globalThis.localStorage?.setItem('panel_open', openState?'1':'0');
     };
   }
 
@@ -930,6 +938,7 @@ if (document.getElementById('saveBtn')) {
     }
     const shop = document.getElementById('shopOverlay');
     if (shop?.classList?.contains('shown')) {
+      if (e.key === 'Escape') document.getElementById('closeShopBtn')?.click();
       return;
     }
     switch(e.key){


### PR DESCRIPTION
## Summary
- show toast when saving or loading to confirm actions
- confirm resets and remember panel state between sessions
- allow closing shops with Escape and bump engine version

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3b34ee29083288248c39223d9f383