### PR TITLE
feat: improve adventure kit usability

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -328,11 +328,12 @@
       <div class="tabpanes">
         <fieldset class="card" id="npcCard" data-pane="npc">
           <legend>NPCs</legend>
+          <input id="npcFilter" placeholder="Filter NPCs..." />
           <div class="list" id="npcList"></div>
           <button class="btn" type="button" id="newNPC">+ NPC</button>
           <div id="npcEditor" style="display:none">
-          <label>ID<input id="npcId" /></label>
-          <label>Name<input id="npcName" /></label>
+          <label>ID<input id="npcId" placeholder="npc_id" /></label>
+          <label>Name<input id="npcName" placeholder="NPC name" /></label>
           <label>Description<textarea id="npcDesc" rows="2"></textarea></label>
           <label>Color<input id="npcColor" type="color" value="#9ef7a0" /></label>
           <label>Map<input id="npcMap" value="world" /></label>
@@ -354,7 +355,7 @@
               <label>Map<input id="npcFlagMap" value="world" /></label>
               <label>X<input id="npcFlagX" type="number" min="0" /></label>
               <label>Y<input id="npcFlagY" type="number" min="0" /></label>
-              <button class="btn" type="button" id="npcFlagPick">Pick Tile</button>
+              <button class="btn" type="button" id="npcFlagPick" title="Click on the map to select a tile">Pick Tile</button>
             </div>
             <div id="revealParty" style="display:none">
               <label>Name<input id="npcFlagName" list="npcFlagList" /></label>
@@ -363,7 +364,7 @@
             <label>Op<select id="npcOp"><option value=">=">&ge;</option><option value=">">&gt;</option><option value="==">==</option><option value="!=">!=</option><option value="<=">&le;</option><option value="<">&lt;</option></select></label>
             <label>Value<input id="npcVal" type="number" value="1" /></label>
           </div>
-          <button class="btn" type="button" id="npcPick">Select on Map</button>
+          <button class="btn" type="button" id="npcPick" title="Click on the map to choose location">Select on Map</button>
           <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
           <label>Quest<select id="npcQuest">
               <option value="">(none)</option>
@@ -395,17 +396,18 @@
       </fieldset>
       <fieldset class="card" id="itemCard" data-pane="items" style="display:none">
         <legend>Items</legend>
+        <input id="itemFilter" placeholder="Filter items..." />
         <div class="list" id="itemList"></div>
         <button class="btn" type="button" id="newItem">+ Item</button>
         <div id="itemEditor" style="display:none">
-          <label>Name<input id="itemName" /></label>
-          <label>ID<input id="itemId" /></label>
+          <label>Name<input id="itemName" placeholder="Item name" /></label>
+          <label>ID<input id="itemId" placeholder="item_id" /></label>
           <label>Type<input id="itemType" /></label>
           <label>Tags<input id="itemTags" /></label>
           <label>Map<input id="itemMap" value="world" /></label>
           <label>X<input id="itemX" type="number" min="0" /></label>
           <label>Y<input id="itemY" type="number" min="0" /></label>
-          <button class="btn" type="button" id="itemPick">Select on Map</button>
+          <button class="btn" type="button" id="itemPick" title="Click on the map to choose location">Select on Map</button>
           <label>Slot<select id="itemSlot">
               <option value="">(none)</option>
               <option value="weapon">Weapon</option>
@@ -472,23 +474,24 @@
           <label>Map<input id="portalMap" value="world" /></label>
           <label>X<input id="portalX" type="number" min="0" /></label>
           <label>Y<input id="portalY" type="number" min="0" /></label>
-          <button class="btn" type="button" id="portalPick">Select on Map</button>
+          <button class="btn" type="button" id="portalPick" title="Click on the map to choose location">Select on Map</button>
           <label>To Map<input id="portalToMap" value="world" /></label>
           <label>To X<input id="portalToX" type="number" min="0" /></label>
           <label>To Y<input id="portalToY" type="number" min="0" /></label>
-          <button class="btn" type="button" id="portalDestPick">Pick Destination</button>
+          <button class="btn" type="button" id="portalDestPick" title="Click on the map to choose destination">Pick Destination</button>
           <button class="btn" id="addPortal">Add Portal</button>
           <button class="btn" id="delPortal" style="display:none">Delete Portal</button>
         </div>
       </fieldset>
       <fieldset class="card" id="questCard" data-pane="quests" style="display:none">
         <legend>Quests</legend>
+        <input id="questFilter" placeholder="Filter quests..." />
         <div class="list" id="questList"></div>
         <button class="btn" type="button" id="newQuest">+ Quest</button>
         <div id="questEditor" style="display:none">
-          <label>ID<input id="questId" /></label>
-          <label>Title<input id="questTitle" /></label>
-          <label>Description<textarea id="questDesc" rows="2"></textarea></label>
+          <label>ID<input id="questId" placeholder="quest_id" /></label>
+          <label>Title<input id="questTitle" placeholder="Quest title" /></label>
+          <label>Description<textarea id="questDesc" rows="2" placeholder="Quest description"></textarea></label>
           <label>Required Item<input id="questItem" /></label>
           <label>Reward Item<input id="questReward" /></label>
           <label>XP Reward<input id="questXP" type="number" min="0" /></label>
@@ -501,20 +504,21 @@
       </fieldset>
       <fieldset class="card" id="eventCard" data-pane="events" style="display:none">
         <legend>Tile Events</legend>
+        <input id="eventFilter" placeholder="Filter events..." />
         <div class="list" id="eventList"></div>
         <button class="btn" type="button" id="newEvent">+ Event</button>
         <div id="eventEditor" style="display:none">
           <label>Map<input id="eventMap" value="world" /></label>
           <label>X<input id="eventX" type="number" min="0" /></label>
           <label>Y<input id="eventY" type="number" min="0" /></label>
-          <button class="btn" type="button" id="eventPick">Select on Map</button>
+          <button class="btn" type="button" id="eventPick" title="Click on the map to choose location">Select on Map</button>
           <label>Effect<select id="eventEffect">
               <option value="toast">Toast</option>
               <option value="log">Log</option>
               <option value="addFlag">Add Flag</option>
               <option value="modStat">Mod Stat</option>
             </select></label>
-          <label id="eventMsgWrap">Message<input id="eventMsg" /></label>
+          <label id="eventMsgWrap">Message<input id="eventMsg" placeholder="Event message" /></label>
           <label id="eventFlagWrap" style="display:none">Flag<input id="eventFlag" /></label>
           <div id="eventStatWrap" style="display:none">
             <label>Stat<select id="eventStat"></select></label>
@@ -527,11 +531,12 @@
       </fieldset>
       <fieldset class="card" id="encounterCard" data-pane="encounters" style="display:none">
         <legend>Encounters</legend>
+        <input id="encFilter" placeholder="Filter encounters..." />
         <div class="list" id="encounterList"></div>
         <button class="btn" type="button" id="newEncounter">+ Enemy</button>
         <div id="encounterEditor" style="display:none">
           <label>Map<input id="encMap" value="world" /></label>
-          <label>Name<input id="encName" /></label>
+          <label>Name<input id="encName" placeholder="Enemy name" /></label>
           <label>HP<input id="encHP" type="number" min="1" value="5" /></label>
           <label>DEF<input id="encDEF" type="number" min="0" value="0" /></label>
           <label>Loot<input id="encLoot" /></label>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -644,6 +644,21 @@ function confirmDialog(msg, onYes) {
   no.onclick = cleanup;
 }
 
+function setupListFilter(inputId, listId) {
+  const input = document.getElementById(inputId);
+  const list = document.getElementById(listId);
+  if (!input || !list) return;
+  const apply = () => {
+    const term = input.value.toLowerCase();
+    Array.from(list.children).forEach(ch => {
+      ch.style.display = ch.textContent.toLowerCase().includes(term) ? '' : 'none';
+    });
+  };
+  input.addEventListener('input', apply);
+  new MutationObserver(apply).observe(list, { childList: true });
+  apply();
+}
+
 function regenWorld() {
   moduleData.seed = Date.now();
   genWorld(moduleData.seed, { buildings: [] });
@@ -1498,6 +1513,7 @@ function startNewNPC() {
   selectedObj = null;
   drawWorld();
   showNPCEditor(true);
+  document.getElementById('npcId').focus();
 }
 
 function beginPlaceNPC() {
@@ -1663,18 +1679,20 @@ function renderNPCList() {
 
 function deleteNPC() {
   if (editNPCIdx < 0) return;
-  moduleData.npcs.splice(editNPCIdx, 1);
-  editNPCIdx = -1;
-  document.getElementById('addNPC').style.display = 'block';
-  document.getElementById('cancelNPC').style.display = 'none';
-  document.getElementById('delNPC').style.display = 'none';
-  renderNPCList();
-  selectedObj = null;
-  drawWorld();
-  document.getElementById('npcId').value = nextId('npc', moduleData.npcs);
-  document.getElementById('npcDesc').value = '';
-  loadTreeEditor();
-  showNPCEditor(false);
+  confirmDialog('Delete this NPC?', () => {
+    moduleData.npcs.splice(editNPCIdx, 1);
+    editNPCIdx = -1;
+    document.getElementById('addNPC').style.display = 'block';
+    document.getElementById('cancelNPC').style.display = 'none';
+    document.getElementById('delNPC').style.display = 'none';
+    renderNPCList();
+    selectedObj = null;
+    drawWorld();
+    document.getElementById('npcId').value = nextId('npc', moduleData.npcs);
+    document.getElementById('npcDesc').value = '';
+    loadTreeEditor();
+    showNPCEditor(false);
+  });
 }
 
 function closeNPCEditor() {
@@ -1728,6 +1746,7 @@ function startNewItem() {
   selectedObj = null;
   drawWorld();
   showItemEditor(true);
+  document.getElementById('itemName').focus();
 }
 
 function beginPlaceItem() {
@@ -1832,15 +1851,17 @@ function renderItemList() {
 
 function deleteItem() {
   if (editItemIdx < 0) return;
-  moduleData.items.splice(editItemIdx, 1);
-  editItemIdx = -1;
-  document.getElementById('addItem').textContent = 'Add Item';
-  document.getElementById('delItem').style.display = 'none';
-  loadMods({});
-  renderItemList();
-  selectedObj = null;
-  drawWorld();
-  showItemEditor(false);
+  confirmDialog('Delete this item?', () => {
+    moduleData.items.splice(editItemIdx, 1);
+    editItemIdx = -1;
+    document.getElementById('addItem').textContent = 'Add Item';
+    document.getElementById('delItem').style.display = 'none';
+    loadMods({});
+    renderItemList();
+    selectedObj = null;
+    drawWorld();
+    showItemEditor(false);
+  });
 }
 
 // --- Encounters ---
@@ -1857,6 +1878,7 @@ function startNewEncounter(){
   document.getElementById('addEncounter').textContent = 'Add Enemy';
   document.getElementById('delEncounter').style.display = 'none';
   showEncounterEditor(true);
+  document.getElementById('encName').focus();
 }
 function collectEncounter(){
   const map = document.getElementById('encMap').value.trim() || 'world';
@@ -1895,12 +1917,14 @@ function renderEncounterList(){
 }
 function deleteEncounter(){
   if(editEncounterIdx < 0) return;
-  moduleData.encounters.splice(editEncounterIdx,1);
-  editEncounterIdx = -1;
-  document.getElementById('addEncounter').textContent = 'Add Enemy';
-  document.getElementById('delEncounter').style.display = 'none';
-  renderEncounterList();
-  showEncounterEditor(false);
+  confirmDialog('Delete this enemy?', () => {
+    moduleData.encounters.splice(editEncounterIdx,1);
+    editEncounterIdx = -1;
+    document.getElementById('addEncounter').textContent = 'Add Enemy';
+    document.getElementById('delEncounter').style.display = 'none';
+    renderEncounterList();
+    showEncounterEditor(false);
+  });
 }
 
 // --- NPC Templates ---
@@ -1962,12 +1986,14 @@ function renderTemplateList(){
 }
 function deleteTemplate(){
   if(editTemplateIdx < 0) return;
-  moduleData.templates.splice(editTemplateIdx,1);
-  editTemplateIdx = -1;
-  document.getElementById('addTemplate').textContent = 'Add Template';
-  document.getElementById('delTemplate').style.display = 'none';
-  renderTemplateList();
-  showTemplateEditor(false);
+  confirmDialog('Delete this template?', () => {
+    moduleData.templates.splice(editTemplateIdx,1);
+    editTemplateIdx = -1;
+    document.getElementById('addTemplate').textContent = 'Add Template';
+    document.getElementById('delTemplate').style.display = 'none';
+    renderTemplateList();
+    showTemplateEditor(false);
+  });
 }
 
 
@@ -1998,6 +2024,7 @@ function startNewEvent() {
   document.getElementById('addEvent').textContent = 'Add Event';
   document.getElementById('delEvent').style.display = 'none';
   showEventEditor(true);
+  document.getElementById('eventMap').focus();
 }
 
 function collectEvent() {
@@ -2065,14 +2092,16 @@ function renderEventList() {
 
 function deleteEvent() {
   if (editEventIdx < 0) return;
-  moduleData.events.splice(editEventIdx, 1);
-  editEventIdx = -1;
-  document.getElementById('addEvent').textContent = 'Add Event';
-  document.getElementById('delEvent').style.display = 'none';
-  renderEventList();
-  selectedObj = null;
-  drawWorld();
-  showEventEditor(false);
+  confirmDialog('Delete this event?', () => {
+    moduleData.events.splice(editEventIdx, 1);
+    editEventIdx = -1;
+    document.getElementById('addEvent').textContent = 'Add Event';
+    document.getElementById('delEvent').style.display = 'none';
+    renderEventList();
+    selectedObj = null;
+    drawWorld();
+    showEventEditor(false);
+  });
 }
 
 // --- Portals ---
@@ -2486,6 +2515,7 @@ function startNewQuest() {
   document.getElementById('addQuest').textContent = 'Add Quest';
   document.getElementById('delQuest').style.display = 'none';
   showQuestEditor(true);
+  document.getElementById('questId').focus();
 }
 function addQuest() {
   const id = document.getElementById('questId').value.trim();
@@ -2549,17 +2579,19 @@ function updateQuestOptions() {
 
 function deleteQuest() {
   if (editQuestIdx < 0) return;
-  const q = moduleData.quests[editQuestIdx];
-  moduleData.npcs.forEach(n => { if (n.questId === q.id) n.questId = ''; });
-  moduleData.quests.splice(editQuestIdx, 1);
-  editQuestIdx = -1;
-  document.getElementById('addQuest').textContent = 'Add Quest';
-  document.getElementById('delQuest').style.display = 'none';
-  renderQuestList();
-  renderNPCList();
-  updateQuestOptions();
-  document.getElementById('questId').value = nextId('quest', moduleData.quests);
-  showQuestEditor(false);
+  confirmDialog('Delete this quest?', () => {
+    const q = moduleData.quests[editQuestIdx];
+    moduleData.npcs.forEach(n => { if (n.questId === q.id) n.questId = ''; });
+    moduleData.quests.splice(editQuestIdx, 1);
+    editQuestIdx = -1;
+    document.getElementById('addQuest').textContent = 'Add Quest';
+    document.getElementById('delQuest').style.display = 'none';
+    renderQuestList();
+    renderNPCList();
+    updateQuestOptions();
+    document.getElementById('questId').value = nextId('quest', moduleData.quests);
+    showQuestEditor(false);
+  });
 }
 
 function applyLoadedModule(data) {
@@ -2702,6 +2734,12 @@ document.getElementById('npcNextP').onclick = () => {
   setNpcPortrait();
   applyNPCChanges();
 };
+
+setupListFilter('npcFilter','npcList');
+setupListFilter('itemFilter','itemList');
+setupListFilter('questFilter','questList');
+setupListFilter('eventFilter','eventList');
+setupListFilter('encFilter','encounterList');
 document.getElementById('delItem').onclick = deleteItem;
 document.getElementById('delBldg').onclick = deleteBldg;
 document.getElementById('newInterior').onclick = startNewInterior;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.42';
+const ENGINE_VERSION = '0.7.43';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');


### PR DESCRIPTION
## Summary
- add search filters to major Adventure Kit lists
- confirm deletions and focus first fields in editors
- document expected input with placeholders and map selection tooltips

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3b3423ab88328a5bee3bf131bcdef