### PR TITLE
fix: guard browser APIs for Node tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -671,7 +671,9 @@ function setupListFilter(inputId, listId) {
     });
   };
   input.addEventListener('input', apply);
-  new MutationObserver(apply).observe(list, { childList: true });
+  if (typeof MutationObserver !== 'undefined') {
+    new MutationObserver(apply).observe(list, { childList: true });
+  }
   apply();
 }
 
@@ -1530,7 +1532,8 @@ function startNewNPC() {
   selectedObj = null;
   drawWorld();
   showNPCEditor(true);
-  document.getElementById('npcId').focus();
+  const npcIdEl = document.getElementById('npcId');
+  if (npcIdEl && typeof npcIdEl.focus === 'function') npcIdEl.focus();
 }
 
 function beginPlaceNPC() {

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.43';
+const ENGINE_VERSION = '0.7.44';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');


### PR DESCRIPTION
## Summary
- avoid referencing MutationObserver when it is unavailable
- guard NPC id focusing in environments without DOM focus
- bump engine version to 0.7.44

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3b5a4304c8328a0a42b58a7a96b4e