### PR TITLE
feat: scale loot cache scrap values and add epic shop gear

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -238,6 +238,24 @@ const DATA = `
       "tags": ["signal_fragment"]
     },
     {
+      "id": "epic_blade",
+      "name": "Epic Blade",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "epic",
+      "mods": { "ATK": 5 },
+      "value": 500
+    },
+    {
+      "id": "epic_armor",
+      "name": "Epic Armor",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "epic",
+      "mods": { "DEF": 5 },
+      "value": 500
+    },
+    {
       "map": "hall",
       "x": 14,
       "y": 18,
@@ -1100,7 +1118,13 @@ const DATA = `
           ]
         }
       },
-      "shop": true
+      "shop": {
+        "markup": 1,
+        "inv": [
+          { "id": "epic_blade" },
+          { "id": "epic_armor" }
+        ]
+      }
     },
     {
       "id": "tess_patrol",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.44",
+  "version": "0.7.45",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -179,6 +179,7 @@ function normalizeItem(it){
     cursedKnown: !!it.cursedKnown,
     rarity: it.rarity || 'common',
     value: val,
+    scrap: typeof it.scrap === 'number' ? it.scrap : undefined,
     desc: it.desc || '',
   };
 }

--- a/scripts/core/item-generator.js
+++ b/scripts/core/item-generator.js
@@ -48,6 +48,12 @@ const ItemGen = {
     armored: { min: 7, max: 10 },
     vaulted: { min: 10, max: 15 }
   },
+  scrapValues: {
+    rusted: 5,
+    sealed: 20,
+    armored: 100,
+    vaulted: 500
+  },
   pick(list, rng){
     return list[Math.floor(rng() * list.length)];
   },
@@ -66,7 +72,7 @@ const ItemGen = {
       name: `${adj} ${noun}`,
       rank,
       stats: { power },
-      scrap: Math.round(power / 2)
+      scrap: this.scrapValues[rank] || this.scrapValues.rusted
     };
     item.tags = [noun.toLowerCase()];
     if(type === 'oddity'){

--- a/scripts/core/npc.js
+++ b/scripts/core/npc.js
@@ -8,7 +8,10 @@ class NPC {
         closeDialog();
         Dustland.actions.startCombat({ ...this.combat, npc: this, name: this.name });
       } else if (this.shop && node === 'sell') {
-        const items = player.inv.map((it, idx) => ({label: `Sell ${it.name} (${Math.max(1, it.value || 0)} ${CURRENCY})`, to: 'sell', sellIndex: idx}));
+        const items = player.inv.map((it, idx) => {
+          const price = typeof it.scrap === 'number' ? it.scrap : Math.max(1, it.value || 0);
+          return { label: `Sell ${it.name} (${price} ${CURRENCY})`, to: 'sell', sellIndex: idx };
+        });
         this.tree.sell.text = items.length ? 'What are you selling?' : 'Nothing to sell.';
         items.push({label: '(Back)', to: 'start'});
         this.tree.sell.choices = items;
@@ -21,7 +24,7 @@ class NPC {
     const capChoice = (c) => {
       if (this.shop && typeof c.sellIndex === 'number') {
         const it = player.inv.splice(c.sellIndex, 1)[0];
-        const val = Math.max(1, it.value || 0);
+        const val = typeof it.scrap === 'number' ? it.scrap : Math.max(1, it.value || 0);
         player.scrap += val;
         renderInv?.(); updateHUD?.();
         textEl.textContent = `Sold ${it.name} for ${val} ${CURRENCY}.`;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.44';
+const ENGINE_VERSION = '0.7.45';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');
@@ -823,7 +823,7 @@ function openShop(npc) {
     player.inv.forEach((item, idx) => {
       const row = document.createElement('div');
       row.className = 'slot';
-      const price = Math.floor(item.value / markup);
+      const price = typeof item.scrap === 'number' ? item.scrap : Math.floor(item.value / markup);
       row.innerHTML = `<span>${item.name} - ${price} ${CURRENCY}</span><button class="btn">Sell</button>`;
       row.querySelector('button').onclick = () => {
         player.scrap += price;

--- a/test/item-generator.test.js
+++ b/test/item-generator.test.js
@@ -15,7 +15,7 @@ test('generator creates item with type, name, and stats', () => {
   assert.strictEqual(item.name, 'Grit-Stitched Repeater');
   assert.strictEqual(item.rank, 'sealed');
   assert.ok(item.stats.power >= 3 && item.stats.power <= 5);
-  assert.strictEqual(item.scrap, Math.round(item.stats.power / 2));
+  assert.strictEqual(item.scrap, ItemGen.scrapValues.sealed);
 });
 
 test('generated items have unique ids', () => {
@@ -40,7 +40,7 @@ test('generate uses updated tables', () => {
   const item = ItemGen.generate('armored', () => 0.5);
   assert.strictEqual(item.name, 'Scrap-Bound Injector');
   assert.strictEqual(item.stats.power, 9);
-  assert.strictEqual(item.scrap, 5);
+  assert.strictEqual(item.scrap, ItemGen.scrapValues.armored);
 });
 
 test('oddity items include lore snippet', () => {


### PR DESCRIPTION
## Summary
- tie item scrap values to cache rank so vaulted gear sells for 500 scrap
- show scrap value when selling items and add epic gear to Cass's shop
- bump engine version to 0.7.45

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4249696e08328a60d58502d006f8b