### PR TITLE
fix: medkit heals 10 and syncs HUD

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -157,7 +157,7 @@ const DATA = `
       "type": "consumable",
       "use": {
         "type": "heal",
-        "amount": 5
+        "amount": 10
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.44",
+  "version": "0.7.45",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -220,6 +220,8 @@ function useItem(invIndex){
     emit('sfx','tick');
     player.inv.splice(invIndex,1);
     notifyInventoryChanged();
+    player.hp = party[0] ? party[0].hp : player.hp;
+    if(typeof updateHUD === 'function') updateHUD();
     return true;
   }
   if(typeof it.use.onUse === 'function'){

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.44';
+const ENGINE_VERSION = '0.7.45';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -413,14 +413,19 @@ test('interactAt picks up adjacent item', () => {
 
 test('useItem heals party member and consumes item', () => {
   party.length = 0; player.inv.length = 0;
+  let hudCalls = 0;
+  global.updateHUD = () => { hudCalls++; };
   const m = new Character('h','Healer','Role');
   m.hp = 5; m.maxHp = 10;
   party.join(m);
   const tonic = registerItem({ id:'tonic', name:'Tonic', type:'consumable', use:{ type:'heal', amount:3 } });
   addToInv(tonic);
+  hudCalls = 0;
   useItem(0);
   assert.strictEqual(m.hp, 8);
+  assert.strictEqual(player.hp, 8);
   assert.strictEqual(player.inv.length, 0);
+  assert.ok(hudCalls >= 1);
 });
 
 test('findFreeDropTile avoids water and party tiles', () => {

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -76,3 +76,9 @@ test('dustland module warns about hall monster', () => {
   exitdoor.processNode('start');
   assert.ok(exitdoor.tree.start.text.includes('rotwalker at the top of the hall'));
 });
+
+test('medkit heals for 10 HP', () => {
+  const data = loadModuleData();
+  const med = data.items.find(i => i.id === 'medkit');
+  assert.strictEqual(med.use?.amount, 10);
+});


### PR DESCRIPTION
## Summary
- buff medkit to restore 10 HP
- refresh HUD and player HP when using healing items
- bump engine version to 0.7.45

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b424379a888328b49dc1c473beae13