### PR TITLE
feat: add candy bar to office vending

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -474,7 +474,7 @@ const OFFICE_IMPL = (() => {
       name: 'Vending Machine',
       desc: 'It flashes "TRADE".',
       portraitSheet: portraits.vending,
-      shop: true,
+      shop: { inv: [ { id: 'dusty_candy' } ] },
       vending: true,
       tree: { start: { text: 'The machine hums softly.', choices: [ { label: '(Leave)', to: 'bye' } ] } }
     },
@@ -568,6 +568,7 @@ const OFFICE_IMPL = (() => {
         { map: 'world', x: WORLD_MID - 4, y: WORLD_MIDY - 2, id: 'healing_potion1', name: 'Healing Potion', type: 'consumable', use: { type: 'heal', amount: 5 } },
         { map: 'world', x: WORLD_MID + 5, y: WORLD_MIDY + 3, id: 'healing_potion2', name: 'Healing Potion', type: 'consumable', use: { type: 'heal', amount: 5 } },
         { map: 'world', x: WORLD_MID - 6, y: WORLD_MIDY + 5, id: 'healing_potion3', name: 'Healing Potion', type: 'consumable', use: { type: 'heal', amount: 5 } },
+        { id: 'dusty_candy', name: 'Dusty Candy Bar', type: 'consumable', value: 2, use: { type: 'heal', amount: 1 } },
         { id: 'fae_token', name: 'Fae Token', type: 'trinket', slot: 'trinket', mods: { LCK: 1 } },
         { id: 'rat_tail', name: 'Rat Tail', type: 'quest' },
         { id: 'rusty_dagger', name: 'Rusty Dagger', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } },
@@ -633,6 +634,8 @@ startGame = function () {
     const s = OFFICE_MODULE.start;
     setPartyPos(s.x, s.y);
     setMap(s.map);
+    player.scrap = 10;
+    updateHUD();
     refreshUI();
     log('You arrive at the office.');
   } else {

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -6,6 +6,11 @@ import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
 import { JSDOM } from 'jsdom';
 
+function extractOpenShop(code) {
+  const m = code.match(/function openShop\(npc\) {[\s\S]*?shopOverlay\.focus\(\);\r?\n}/);
+  return m && m[0];
+}
+
 test('office module boards castle and unboards via dialog', () => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const file = path.join(__dirname, '..', 'modules', 'office.module.js');
@@ -32,6 +37,30 @@ test('office module places Boots of Speed near forest entry', () => {
   assert.match(src, /id: 'boots_of_speed'/);
   assert.match(src, /x: 3,\s*y: WORLD_MIDY/);
   assert.match(src, /mods: \{ AGI: 5, move_delay_mod: 0\.5 \}/);
+});
+
+test('startGame grants 10 scrap', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const fnMatch = src.match(/startGame = function \(\) {[\s\S]*?};\n/);
+  assert(fnMatch);
+  global.player = { scrap: 0 };
+  let hudCalled = false;
+  global.updateHUD = () => { hudCalled = true; };
+  global.applyModule = () => ({});
+  global.registerItem = (it) => it;
+  global.setPartyPos = () => {};
+  global.setMap = () => {};
+  global.refreshUI = () => {};
+  global.log = () => {};
+  global.itemDrops = [];
+  global.interiors = {};
+  global.OFFICE_MODULE = { worldGen: () => ({}), start: { x: 0, y: 0, map: 'floor1' }, postLoad: () => {} };
+  vm.runInThisContext(fnMatch[0]);
+  startGame();
+  assert.equal(player.scrap, 10);
+  assert(hudCalled);
 });
 
 test('office worker lends scrap when low and missing badge', () => {
@@ -101,11 +130,6 @@ test('vending machine buys access card for scrap', () => {
   global.addToInv = () => true;
   global.getItem = () => accessCard;
 
-  function extractOpenShop(code) {
-    const m = code.match(/function openShop\(npc\) {[\s\S]*?shopOverlay\.focus\(\);\r?\n}/);
-    return m && m[0];
-  }
-
   const eng = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'dustland-engine.js'), 'utf8');
   const openShopCode = extractOpenShop(eng);
   vm.runInThisContext(openShopCode);
@@ -116,6 +140,37 @@ test('vending machine buys access card for scrap', () => {
   sellBtn.onclick();
   assert.strictEqual(player.scrap, accessCard.value);
   assert.strictEqual(player.inv.length, 0);
+});
+
+test('vending machine sells Dusty Candy Bar', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const npcMatch = src.match(/id: 'vending',[\s\S]*?shop: \{ inv: \[ \{ id: 'dusty_candy' \} \] \}/);
+  assert(npcMatch);
+  const vending = { name: 'Vending Machine', vending: true, shop: { inv: [ { id: 'dusty_candy' } ] } };
+  const itemMatch = src.match(/\{ id: 'dusty_candy',[\s\S]*?\}\s*\},/);
+  assert(itemMatch);
+  const candy = vm.runInThisContext('(' + itemMatch[0].slice(0, -1) + ')');
+
+  const dom = new JSDOM(
+    '<div id="shopOverlay"><div class="shop-window"><header><div id="shopName"></div><button id="closeShopBtn"></button></header><div class="shop-panels"><div id="shopBuy" class="slot-list"></div><div id="shopSell" class="slot-list"></div></div></div></div>'
+  );
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.requestAnimationFrame = () => {};
+  global.CURRENCY = 's';
+  global.player = { scrap: 10, inv: [] };
+  global.addToInv = () => true;
+  global.removeFromInv = () => {};
+  global.updateHUD = () => {};
+  global.getItem = (id) => (id === candy.id ? candy : null);
+  const eng = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'dustland-engine.js'), 'utf8');
+  const openShopCode = extractOpenShop(eng);
+  vm.runInThisContext(openShopCode);
+  openShop(vending);
+  const buySpan = document.querySelector('#shopBuy .slot span');
+  assert(buySpan && buySpan.textContent.includes('Dusty Candy Bar'));
 });
 
 test('office worker hides loan if you still have your badge', () => {


### PR DESCRIPTION
## Summary
- make vending machine sell a Dusty Candy Bar
- start players with 10 scrap in the office module
- cover shop inventory and starting scrap with tests

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b424ca63cc83288cb51936a5feb4a9