### PR TITLE
fix: enable interior painting in main view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.46",
+  "version": "0.7.47",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2913,6 +2913,20 @@ canvas.addEventListener('mousedown', ev => {
     updateCursor(x, y);
     return;
   }
+  if (currentMap !== 'world' && !coordTarget && !(overNpc || overItem || overEvent || overPortal)) {
+    hoverTile = { x, y };
+    const I = moduleData.interiors.find(i => i.id === currentMap);
+    if (I) {
+      setTile(currentMap, x, y, intPaint);
+      if (intPaint === TILE.DOOR) { I.entryX = x; I.entryY = y - 1; }
+      intPainting = true;
+      didPaint = true;
+      drawWorld();
+      drawInterior();
+      updateCursor(x, y);
+    }
+    return;
+  }
   hoverTarget = null;
   didDrag = false;
   if (coordTarget) {
@@ -3026,6 +3040,17 @@ canvas.addEventListener('mousemove', ev => {
     drawWorld();
     return;
   }
+  if (currentMap !== 'world' && intPainting) {
+    const I = moduleData.interiors.find(i => i.id === currentMap);
+    if (I) {
+      setTile(currentMap, x, y, intPaint);
+      if (intPaint === TILE.DOOR) { I.entryX = x; I.entryY = y - 1; }
+      didPaint = true;
+      drawWorld();
+      drawInterior();
+    }
+    return;
+  }
 
   // While placing, show ghost & bail
   if (placingType) {
@@ -3107,25 +3132,29 @@ canvas.addEventListener('mouseup', ev => {
   }
   if (ev.button !== 0) return;
   worldPainting = false;
+  intPainting = false;
   if (dragTarget) delete dragTarget._type;
   dragTarget = null;
   if (didPaint) {
-    redrawBuildings();
+    if (currentMap === 'world') redrawBuildings();
     drawWorld();
+    if (currentMap !== 'world') drawInterior();
   }
   updateCursor();
 });
 canvas.addEventListener('mouseleave', () => {
   if (panning) panning = false;
-  if (didPaint) {
+  if (didPaint && currentMap === 'world') {
     redrawBuildings();
   }
   worldPainting = false;
+  intPainting = false;
   if (dragTarget) delete dragTarget._type;
   dragTarget = null;
   hoverTile = null;
   didPaint = false;
   drawWorld();
+  if (currentMap !== 'world') drawInterior();
   updateCursor();
 });
 

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.46';
+const ENGINE_VERSION = '0.7.47';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -266,6 +266,17 @@ test('painting over building restores tiles', () => {
   assert.strictEqual(world[5][5], TILE.BUILDING);
 });
 
+test('painting interior in main window', () => {
+  moduleData.interiors = [{ id:'room', w:2, h:2, grid:[[TILE.FLOOR,TILE.FLOOR],[TILE.FLOOR,TILE.FLOOR]] }];
+  interiors = { room: moduleData.interiors[0] };
+  showMap('room');
+  intPaint = TILE.WALL;
+  canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0, button:0 });
+  canvasEl._listeners.mouseup[0]({ button:0 });
+  assert.strictEqual(interiors.room.grid[0][0], TILE.WALL);
+  showMap('world');
+});
+
 test('regenWorld creates empty map without buildings', () => {
   regenWorld();
   assert.strictEqual(globalThis.buildings.length, 0);


### PR DESCRIPTION
## Summary
- allow painting interiors directly on the main canvas
- cover interior painting with a regression test
- bump engine version to 0.7.47

## Testing
- `node scripts/presubmit.js`
- `npm test`
- `./install-deps.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b47a414dc88328af4cb8a4858431e6