### PR TITLE
feat: center map on selected objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.46",
+  "version": "0.7.47",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -127,6 +127,17 @@ let panning = false, panStartX = 0, panStartY = 0, panMouseX = 0, panMouseY = 0;
 const baseTileW = canvas.width / WORLD_W;
 const baseTileH = canvas.height / WORLD_H;
 
+function focusMap(x, y) {
+  if (currentMap !== 'world') return;
+  const viewW = WORLD_W / worldZoom;
+  const viewH = WORLD_H / worldZoom;
+  const maxPanX = WORLD_W - viewW;
+  const maxPanY = WORLD_H - viewH;
+  panX = clamp(x - viewW / 2, 0, maxPanX);
+  panY = clamp(y - viewH / 2, 0, maxPanY);
+}
+globalThis.focusMap = focusMap;
+
 let loopHover = null;
 const loopPlus = document.createElement('span');
 loopPlus.textContent = '+';
@@ -1642,6 +1653,7 @@ function expandHex(hex) {
 function editNPC(i) {
   const n = moduleData.npcs[i];
   showMap(n.map);
+  focusMap(n.x, n.y);
   editNPCIdx = i;
   document.getElementById('npcId').value = n.id;
   document.getElementById('npcName').value = n.name;
@@ -1833,6 +1845,7 @@ function cancelItem() {
 function editItem(i) {
   const it = moduleData.items[i];
   showMap(it.map);
+  focusMap(it.x, it.y);
   editItemIdx = i;
   document.getElementById('itemName').value = it.name;
   document.getElementById('itemId').value = it.id;
@@ -2292,6 +2305,7 @@ function renderBldgList() {
 function editBldg(i) {
   const b = moduleData.buildings[i];
   showMap('world');
+  focusMap(b.x + b.w / 2, b.y + b.h / 2);
   editBldgIdx = i;
   document.getElementById('bldgX').value = b.x;
   document.getElementById('bldgY').value = b.y;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.46';
+const ENGINE_VERSION = '0.7.47';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -410,3 +410,48 @@ test('NPC symbol is saved and restored', () => {
 test('loadMods accepts undefined', () => {
   assert.doesNotThrow(() => loadMods(undefined));
 });
+
+test('editing NPC centers map on its position', () => {
+  const prev = moduleData.npcs;
+  moduleData.npcs = [{ id: 'npc1', name: 'NPC', map: 'world', x: 80, y: 60, tree: {} }];
+  worldZoom = 3;
+  panX = 0;
+  panY = 0;
+  editNPC(0);
+  assert.strictEqual(panX, 60);
+  assert.strictEqual(panY, 45);
+  moduleData.npcs = prev;
+  worldZoom = 1;
+  panX = 0;
+  panY = 0;
+});
+
+test('editing item centers map on its position', () => {
+  const prev = moduleData.items;
+  moduleData.items = [{ id: 'it1', name: 'Item', map: 'world', x: 70, y: 10 }];
+  worldZoom = 3;
+  panX = 0;
+  panY = 0;
+  editItem(0);
+  assert.strictEqual(panX, 50);
+  assert.strictEqual(panY, 0);
+  moduleData.items = prev;
+  worldZoom = 1;
+  panX = 0;
+  panY = 0;
+});
+
+test('editing building centers map on its position', () => {
+  const prev = moduleData.buildings;
+  moduleData.buildings = [{ x: 30, y: 30, w: 10, h: 10 }];
+  worldZoom = 3;
+  panX = 0;
+  panY = 0;
+  editBldg(0);
+  assert.strictEqual(panX, 15);
+  assert.strictEqual(panY, 20);
+  moduleData.buildings = prev;
+  worldZoom = 1;
+  panX = 0;
+  panY = 0;
+});


### PR DESCRIPTION
## Summary
- center Adventure Kit map on selected NPCs, items, and buildings
- add tests for centering logic
- bump engine version to 0.7.47

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b47c1d1160832892de6a2250cf360f