### PR TITLE
feat: surface spawn issues in ACK

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -54,6 +54,13 @@
       cursor: pointer;
     }
 
+    #problemCard {
+      border-color: #a00;
+    }
+    #problemCard .list div {
+      color: #f66;
+    }
+
     label {
       display: block;
       margin-top: 4px;
@@ -314,6 +321,10 @@
       <input type="file" id="loadFile" accept="application/json" style="display:none" />
     </section>
     <aside class="editor-panel" id="editorPanel" aria-hidden="false">
+      <fieldset class="card" id="problemCard" style="display:none;border-color:#a00">
+        <legend>Problems</legend>
+        <div class="list" id="problemList"></div>
+      </fieldset>
       <div class="tabs2" role="tablist" aria-label="Editors">
         <button class="tab2 active" type="button" data-tab="npc" role="tab" aria-selected="true">NPCs</button>
         <button class="tab2" type="button" data-tab="items" role="tab" aria-selected="false">Items</button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.47",
+  "version": "0.7.48",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.47';
+const ENGINE_VERSION = '0.7.48';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -116,7 +116,7 @@ test('applyLoadedModule avoids duplicate buildings', () => {
 
 test('saveModule uses module name for download', () => {
   const origValidateSpawns = globalThis.validateSpawns;
-  globalThis.validateSpawns = () => true;
+  globalThis.validateSpawns = () => [];
   moduleNameInput.value = 'custom-name';
   const aEl = stubEl();
   const origCreate = document.createElement;
@@ -128,6 +128,19 @@ test('saveModule uses module name for download', () => {
   document.createElement = origCreate;
   global.URL = origURL;
   globalThis.validateSpawns = origValidateSpawns;
+});
+
+test('validateSpawns lists blocked spawns', () => {
+  genWorld(1);
+  setTile('world',0,0,TILE.WATER);
+  moduleData.start = { map:'world', x:0, y:0 };
+  moduleData.npcs = [{ id:'n1', map:'world', x:1, y:0 }];
+  setTile('world',1,0,TILE.WATER);
+  moduleData.items = [];
+  const issues = validateSpawns();
+  assert.strictEqual(issues.length,2);
+  assert.strictEqual(issues[0].type,'start');
+  assert.strictEqual(issues[1].type,'npc');
 });
 
 test('addTerrainFeature sprinkles noise', () => {


### PR DESCRIPTION
## Summary
- show spawn validation problems in a red panel within ACK
- allow clicking a problem to jump to the offending entity
- bump engine version to 0.7.48

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47e1518bc8328aaaa44b973309500