### PR TITLE
feat: group easy encounters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.48",
+  "version": "0.7.49",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -5,6 +5,8 @@ const partyRow      = typeof document !== 'undefined' ? document.getElementById(
 const cmdMenu       = typeof document !== 'undefined' ? document.getElementById('combatCmd') : null;
 const turnIndicator = typeof document !== 'undefined' ? document.getElementById('turnIndicator') : null;
 const combatKeys    = {};
+// Track how many turns it takes to defeat each enemy type
+const enemyTurnStats = globalThis.enemyTurnStats || (globalThis.enemyTurnStats = {});
 
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
   window.addEventListener('keyup', (e) => { combatKeys[e.key] = false; });
@@ -36,7 +38,8 @@ const combatState = {
   onComplete: null,
   log: [],
   startTime: 0,
-  afterEnemy: null
+  afterEnemy: null,
+  turns: 0
 };
 
 function recordCombatEvent(ev){
@@ -143,11 +146,13 @@ function openCombat(enemies){
 
   return new Promise((resolve) => {
     for (const k in combatKeys) combatKeys[k] = false;
+    combatState.turns = 1;
     combatState.enemies = enemies.map(e => ({
       ...e,
       maxHp: e.maxHp || e.hp,
       maxAdr: e.maxAdr || 100,
-      adr: e.adr ?? 0
+      adr: e.adr ?? 0,
+      spawnTurn: combatState.turns
     }));
     combatState.phase = 'party';
     combatState.active = 0;
@@ -517,6 +522,13 @@ function doAttack(dmg, type = 'basic'){
     log?.(`${target.name} is defeated!`);
     recordCombatEvent?.({ type: 'enemy', actor: target.name, action: 'defeated', by: attacker.name });
     globalThis.EventBus?.emit?.('enemy:defeated', { target });
+    const eid = target.id || target.name;
+    if (eid){
+      const turnsTaken = combatState.turns - (target.spawnTurn || 1) + 1;
+      const stats = enemyTurnStats[eid] || (enemyTurnStats[eid] = { total: 0, count: 0 });
+      stats.total += Math.max(1, turnsTaken);
+      stats.count += 1;
+    }
     if (target.loot) addToInv?.(target.loot);
 
     // Bandits sometimes drop scrap
@@ -779,6 +791,7 @@ function enemyAttack(){
 function startPartyTurn(){
   combatState.phase = 'party';
   combatState.active = 0;
+  combatState.turns++;
   highlightActive();
   openCommand();
 }

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -279,7 +279,16 @@ function checkRandomEncounter(){
     if(!pool.length) return;
     const hard = pool.filter(e => e.minDist);
     if(hard.length) pool = hard;
-    const def = pool[Math.floor(Math.random() * pool.length)];
+    const base = pool[Math.floor(Math.random() * pool.length)];
+    const def = { ...base };
+    const id = def.id || def.name;
+    const stats = globalThis.enemyTurnStats?.[id];
+    // If this enemy consistently falls in one turn, escalate group size
+    let count = 1;
+    if (stats && stats.count >= 3 && (stats.total / stats.count) <= 1){
+      count = 2 + Math.floor(Math.random() * 2);
+    }
+    if (count > 1) def.count = count;
     encounterCooldown = 3 + Math.floor(Math.random() * 3);
     return Dustland.actions.startCombat(def);
   }

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -122,6 +122,7 @@ async function startCombat(defender){
     const { HP, portraitSheet, npc, name, ...rest } = def || {};
     return {
       ...rest,
+      id: def.id || def.name,
       name: name || npc?.name || 'Enemy',
       hp: def.hp ?? HP ?? 5,
       npc,
@@ -130,7 +131,9 @@ async function startCombat(defender){
     };
   };
 
-  const enemies = [toEnemy(defender)];
+  const enemies = [];
+  const copies = Math.max(1, defender.count || 1);
+  for(let i=0; i<copies; i++) enemies.push(toEnemy(defender));
   const px = party.x, py = party.y, map = party.map || state.map;
   for (const n of (typeof NPCS !== 'undefined' ? NPCS : [])) {
     if (!n.combat) continue;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2,7 +2,7 @@
 // ===== Rendering & Utilities =====
 
 // Logging
-const ENGINE_VERSION = '0.7.48';
+const ENGINE_VERSION = '0.7.49';
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
 const apEl = document.getElementById('ap');

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1587,6 +1587,25 @@ test('random encounters award XP based on strength', async () => {
   party.length = 0;
 });
 
+test('trivial enemies appear in groups', () => {
+  const row = Array(10).fill(TILE.SAND);
+  applyModule({ world: [row], encounters: { world: [ { name: 'Weak', HP: 1, DEF: 0 } ] } });
+  state.map = 'world';
+  setPartyPos(5, 0);
+  global.enemyTurnStats = { Weak: { total: 3, count: 3 } };
+  let captured;
+  const origRand = Math.random;
+  Math.random = () => 0;
+  const origStart = globalThis.Dustland.actions.startCombat;
+  globalThis.Dustland.actions.startCombat = def => { captured = def; return Promise.resolve({ result: 'flee' }); };
+  checkRandomEncounter();
+  Math.random = origRand;
+  globalThis.Dustland.actions.startCombat = origStart;
+  delete global.enemyTurnStats;
+  encounterCooldown = 0;
+  assert.ok(captured.count >= 2);
+});
+
 test('distant encounters use hard enemy pool', () => {
   const row = Array(30).fill(TILE.SAND);
   row[0] = TILE.ROAD;


### PR DESCRIPTION
## Summary
- track turns to defeat enemies
- spawn extra copies when foes consistently fall in one turn
- cover grouped encounters with tests and bump engine version

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b49974a2308328a0925936ba3d7d58