### PR TITLE
feat: zone modifiers and wait action

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -32,7 +32,7 @@ _______________________________________________________________________________
 
 [ CONTROLS ]
   Movement .......... WASD / Arrow Keys
-  Interact/Take ..... E / Space / T (talk, use doors, take items)
+  Interact/Take/Wait ..... E / Space / T (space waits if nothing nearby)
   Inventory ......... I (click items to equip)
   Party ............. P          (radio button selects the acting member)
   Quests ............ Q
@@ -50,7 +50,7 @@ _______________________________________________________________________________
   - World buildings appear as black structures; their doors lead to
     simple interiors you can enter directly from the overworld.
   - Water is bright blue and is not walkable; items won’t spawn in water.
-  - Walking gradually restores HP for the selected party member.
+  - Walking or waiting gradually restores HP for the selected party member.
   - Movement speed improves with the leader's AGI, including equipment bonuses. Items like the Boots of Speed further reduce movement delay.
   - Special moves spend Adrenaline. Starter techniques include Power Strike,
     Stun Grenade, First Aid, Adrenal Surge, and Guard.

--- a/test/wait-zone-attrs.test.js
+++ b/test/wait-zone-attrs.test.js
@@ -1,0 +1,72 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { createGameProxy } from './test-harness.js';
+
+async function setup(zone){
+  const { context } = createGameProxy([]);
+  context.Dustland = { effects:{ tick: () => {} }, path:{}, actions:{ startCombat: () => { context.startedCombat = true; } } };
+  context.TILE = { ROAD:0 };
+  context.walkable = { 1:true, 0:true };
+  context.world = [ [1,1], [1,1] ];
+  context.WORLD_W = 2;
+  context.WORLD_H = 2;
+  context.enemyBanks = { world:[{ name:'bug', HP:1, ATK:1, DEF:0 }] };
+  context.itemDrops = [];
+  context.NPCS = [];
+  context.interiors = {};
+  context.tileEvents = [];
+  context.zoneEffects = zone? [zone] : [];
+  context.Dustland.zoneEffects = context.zoneEffects;
+  context.clamp = (v,min,max)=> Math.max(min, Math.min(max,v));
+  context.setPartyPos = (x,y)=>{ context.party.x=x; context.party.y=y; };
+  context.footstepBump = () => {};
+  context.checkAggro = () => {};
+  context.updateHUD = () => {};
+  context.renderParty = () => {};
+  context.centerCamera = () => {};
+  context.log = () => {};
+  context.toast = () => {};
+  context.hasItem = () => false;
+  context.state.map = 'world';
+  context.state.mapEntry = { map:'world', x:0, y:0 };
+  context.Math = Object.create(Math);
+  context.Math.random = () => 1;
+
+  const partyCode = await fs.readFile(new URL('../scripts/core/party.js', import.meta.url), 'utf8');
+  vm.runInContext(partyCode, context);
+  const a = new context.Character('a','A','');
+  const b = new context.Character('b','B','');
+  a.maxHp = b.maxHp = 10;
+  a.hp = b.hp = 5;
+  context.party.join(a);
+  context.party.join(b);
+  context.party.x = 0;
+  context.party.y = 0;
+
+  const moveCode = await fs.readFile(new URL('../scripts/core/movement.js', import.meta.url), 'utf8');
+  vm.runInContext(moveCode, context);
+  return context;
+}
+
+test('wait heals leader', async () => {
+  const ctx = await setup();
+  await ctx.wait();
+  assert.strictEqual(ctx.party[0].hp, 6);
+  assert.strictEqual(ctx.party[1].hp, 5);
+});
+
+test('heal zone boosts party regen', async () => {
+  const ctx = await setup({ map:'world', x:0, y:0, w:2, h:2, healMult:2 });
+  await ctx.wait();
+  assert.strictEqual(ctx.party[0].hp, 7);
+  assert.strictEqual(ctx.party[1].hp, 7);
+});
+
+test('no encounter zone blocks fights', async () => {
+  const ctx = await setup({ map:'world', x:0, y:0, w:2, h:2, noEncounters:true });
+  ctx.Math.random = () => 0;
+  await ctx.wait();
+  assert.strictEqual(ctx.startedCombat, undefined);
+});


### PR DESCRIPTION
## Summary
- support zone attributes for encounter suppression and healing boosts
- allow waiting in place when interacting with nothing
- document wait control and add tests for zone modifiers

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4f2eaa7548328902d99032614a4da