### PR TITLE
fix: close panel with mobile B key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.50",
+  "version": "0.7.51",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -3,7 +3,7 @@
 
 // Logging
 
-const ENGINE_VERSION = '0.7.50';
+const ENGINE_VERSION = '0.7.51';
 
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
@@ -59,6 +59,14 @@ globalThis.toggleAudio = toggleAudio;
 const isMobileUA = typeof navigator !== 'undefined' && /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 let mobileControlsEnabled = isMobileUA;
 let mobileWrap = null, mobilePad = null, mobileAB = null, mobileButtons = {};
+let panelToggle = null, panel = null;
+function closePanel(){
+  if(panel && panelToggle){
+    panel.classList.remove('show');
+    panelToggle.textContent='☰';
+    globalThis.localStorage?.setItem('panel_open','0');
+  }
+}
 function setMobileControls(on){
   mobileControlsEnabled = on;
   const btn=document.getElementById('mobileToggle');
@@ -135,7 +143,11 @@ function setMobileControls(on){
         } else if(shop?.classList?.contains('shown')){
           shop.dispatchEvent(new KeyboardEvent('keydown', { key:'Escape' }));
         } else {
-          window.dispatchEvent(new KeyboardEvent('keydown', { key:'Escape' }));
+          if(panel?.classList?.contains('show')){
+            closePanel();
+          } else {
+            window.dispatchEvent(new KeyboardEvent('keydown', { key:'Escape' }));
+          }
         }
       }));
       mobileWrap.appendChild(mobileAB);
@@ -915,8 +927,8 @@ if (document.getElementById('saveBtn')) {
     const closeBtn=document.getElementById('settingsClose');
     if(closeBtn) closeBtn.onclick=()=>{ settings.style.display='none'; };
   }
-  const panelToggle=document.getElementById('panelToggle');
-  const panel=document.querySelector('.panel');
+  panelToggle=document.getElementById('panelToggle');
+  panel=document.querySelector('.panel');
   if(panelToggle && panel){
     const open=globalThis.localStorage?.getItem('panel_open')==='1';
     if(open){
@@ -944,6 +956,11 @@ if (document.getElementById('saveBtn')) {
     const shop = document.getElementById('shopOverlay');
     if (shop?.classList?.contains('shown')) {
       if (e.key === 'Escape') document.getElementById('closeShopBtn')?.click();
+      return;
+    }
+    if((e.key==='b' || e.key==='B') && mobileControlsEnabled && panel?.classList?.contains('show')){
+      closePanel();
+      e.preventDefault();
       return;
     }
     switch(e.key){

--- a/test/panel-toggle.test.js
+++ b/test/panel-toggle.test.js
@@ -54,7 +54,8 @@ test('panel toggle shows and hides panel', async () => {
     load: () => {},
     resetAll: () => {},
     console,
-    open: false
+    open: false,
+    overlay: { classList: { contains: () => false } }
   };
   vm.createContext(context);
   vm.runInContext(code, context);
@@ -62,5 +63,59 @@ test('panel toggle shows and hides panel', async () => {
   toggle.onclick();
   assert.ok(panel.classList.contains('show'));
   toggle.onclick();
+  assert.ok(!panel.classList.contains('show'));
+});
+
+test('b key closes panel on mobile', async () => {
+  const document = makeDocument();
+  const canvas = document.createElement('canvas');
+  canvas.id = 'game';
+  document.body.appendChild(document.getElementById('log'));
+  document.body.appendChild(document.getElementById('hp'));
+  document.body.appendChild(document.getElementById('ap'));
+  document.body.appendChild(document.getElementById('scrap'));
+  document.body.appendChild(canvas);
+  const panel = document.createElement('div');
+  panel.className = 'panel';
+  document.body.appendChild(panel);
+  const toggleEl = document.getElementById('panelToggle');
+  document.body.appendChild(toggleEl);
+  document.body.appendChild(document.getElementById('saveBtn'));
+  document.body.appendChild(document.getElementById('loadBtn'));
+  document.body.appendChild(document.getElementById('resetBtn'));
+  document.body.appendChild(document.getElementById('settingsBtn'));
+  const settings = document.getElementById('settings');
+  document.body.appendChild(settings);
+  settings.appendChild(document.getElementById('settingsClose'));
+  let keyHandler;
+  const window = { document, AudioContext: AudioCtx, webkitAudioContext: AudioCtx, HTMLCanvasElement: class {}, addEventListener:(type,fn)=>{ if(type==='keydown') keyHandler=fn; }, removeEventListener:()=>{} };
+  window.HTMLCanvasElement.prototype.getContext = () => ({ });
+  const context = {
+    window,
+    document,
+    requestAnimationFrame: () => 0,
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    Audio: class { constructor(){ this.addEventListener = () => {}; } cloneNode(){ return new this.constructor(); } },
+    EventBus: { on: () => {}, emit: () => {} },
+    NanoDialog: { enabled: true },
+    location: { hash: '' },
+    move: () => {},
+    interact: () => {},
+    takeNearestItem: () => {},
+    save: () => {},
+    load: () => {},
+    resetAll: () => {},
+    console,
+    open: false,
+    overlay: { classList: { contains: () => false } }
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  const toggle = document.getElementById('panelToggle');
+  toggle.onclick();
+  assert.ok(panel.classList.contains('show'));
+  context.setMobileControls(true);
+  keyHandler({ key: 'b', preventDefault(){}, stopImmediatePropagation(){} });
   assert.ok(!panel.classList.contains('show'));
 });


### PR DESCRIPTION
## Summary
- add closePanel helper and wire B button/key to hide side panel on mobile
- test mobile B closing logic
- bump engine version to 0.7.51

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4f31c51988328b132cb54214b66d9