### PR TITLE
fix: select NPC from problem list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.52",
+  "version": "0.7.53",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1707,12 +1707,21 @@ function editNPC(i) {
   showNPCEditor(true);
   selectedObj = { type: 'npc', obj: n };
   drawWorld();
+  renderNPCList();
 }
 function renderNPCList() {
   const list = document.getElementById('npcList');
   const npcs = moduleData.npcs.map((n, i) => ({ n, i })).sort((a, b) => a.n.id.localeCompare(b.n.id));
   list.innerHTML = npcs.map(({ n, i }) => `<div data-idx="${i}">${n.id} @${n.map} (${n.x},${n.y})${n.questId ? ` [${n.questId}]` : ''}</div>`).join('');
-  Array.from(list.children).forEach(div => div.onclick = () => editNPC(parseInt(div.dataset.idx, 10)));
+  Array.from(list.children).forEach(div => {
+    const idx = parseInt(div.dataset.idx, 10);
+    div.onclick = () => editNPC(idx);
+    if (idx === editNPCIdx) {
+      div.style.outline = '1px solid #4f6b4f';
+      div.style.background = '#141a14';
+      div.scrollIntoView({ block: 'nearest' });
+    }
+  });
   updateQuestOptions();
   refreshChoiceDropdowns();
   renderProblems();

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -3,7 +3,7 @@
 
 // Logging
 
-const ENGINE_VERSION = '0.7.52';
+const ENGINE_VERSION = '0.7.53';
 
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');


### PR DESCRIPTION
## Summary
- highlight problem NPC in NPC list when selected
- bump engine version to 0.7.53

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b59067fcf483288f61511996786b13