### PR TITLE
fix: hide Persist LLM button without LLM mode

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -168,7 +168,7 @@
       </header>
       <main id="dialogText"></main>
       <div class="choices" id="choices"></div>
-      <button id="persistLLM" class="btn small">Persist LLM</button>
+      <button id="persistLLM" class="btn small" style="display:none">Persist LLM</button>
     </div>
   </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.52",
+  "version": "0.7.53",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -3,7 +3,7 @@
 
 // Logging
 
-const ENGINE_VERSION = '0.7.52';
+const ENGINE_VERSION = '0.7.53';
 
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
@@ -903,7 +903,11 @@ if (document.getElementById('saveBtn')) {
   };
   const nanoBtn=document.getElementById('nanoToggle');
   if(nanoBtn){
-    const updateNano=()=>{ nanoBtn.textContent = `Nano Dialog: ${window.NanoDialog?.enabled ? 'On' : 'Off'}`; };
+    const updateNano=()=>{
+      nanoBtn.textContent = `Nano Dialog: ${window.NanoDialog?.enabled ? 'On' : 'Off'}`;
+      const persist=document.getElementById('persistLLM');
+      if(persist) persist.style.display = window.NanoDialog?.enabled ? '' : 'none';
+    };
     nanoBtn.onclick=()=>{
       if(window.NanoDialog){
         NanoDialog.enabled=!NanoDialog.enabled;

--- a/test/persist-llm-button.test.js
+++ b/test/persist-llm-button.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
+const code = full.split('// ===== Boot =====')[0];
+
+test('Persist LLM button toggles with Nano dialog mode', async () => {
+  const document = makeDocument();
+  const canvas = document.createElement('canvas');
+  canvas.id = 'game';
+  document.body.appendChild(document.getElementById('log'));
+  document.body.appendChild(document.getElementById('hp'));
+  document.body.appendChild(document.getElementById('ap'));
+  document.body.appendChild(document.getElementById('scrap'));
+  document.body.appendChild(canvas);
+  const panel = document.createElement('div');
+  panel.className = 'panel';
+  document.body.appendChild(panel);
+  const toggleEl = document.getElementById('panelToggle');
+  document.body.appendChild(toggleEl);
+  document.body.appendChild(document.getElementById('saveBtn'));
+  document.body.appendChild(document.getElementById('loadBtn'));
+  document.body.appendChild(document.getElementById('resetBtn'));
+  document.body.appendChild(document.getElementById('settingsBtn'));
+  const settings = document.getElementById('settings');
+  document.body.appendChild(settings);
+  settings.appendChild(document.getElementById('settingsClose'));
+  document.body.appendChild(document.getElementById('nanoToggle'));
+  document.body.appendChild(document.getElementById('audioToggle'));
+  document.body.appendChild(document.getElementById('mobileToggle'));
+  const persistBtn = document.getElementById('persistLLM');
+  document.body.appendChild(persistBtn);
+
+  const nano = { enabled: false, refreshIndicator: () => {} };
+  const window = {
+    document,
+    AudioContext: class {},
+    webkitAudioContext: class {},
+    HTMLCanvasElement: class {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    setTimeout: (fn) => { fn(); return 0; },
+    clearTimeout: () => {},
+    NanoDialog: nano
+  };
+  window.HTMLCanvasElement.prototype.getContext = () => ({});
+
+  const context = {
+    window,
+    document,
+    requestAnimationFrame: () => 0,
+    setTimeout: (fn) => { fn(); return 0; },
+    clearTimeout: () => {},
+    AudioContext: window.AudioContext,
+    webkitAudioContext: window.webkitAudioContext,
+    Audio: class { constructor(){ this.addEventListener = () => {}; } cloneNode(){ return new this.constructor(); } },
+    EventBus: { on: () => {}, emit: () => {} },
+    NanoDialog: nano,
+    location: { hash: '' },
+    move: () => {},
+    interact: () => {},
+    takeNearestItem: () => {},
+    save: () => {},
+    load: () => {},
+    resetAll: () => {},
+    console,
+    open: false,
+    overlay: { classList: { contains: () => false } }
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+
+  assert.strictEqual(persistBtn.style.display, 'none');
+  document.getElementById('nanoToggle').onclick();
+  assert.notStrictEqual(persistBtn.style.display, 'none');
+});
+


### PR DESCRIPTION
## Summary
- hide Persist LLM button unless Nano dialog mode is active
- bump engine version to 0.7.53
- test button visibility toggles with Nano dialog

## Testing
- `node scripts/presubmit.js`
- `./install-deps.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5923ccb888328a56054e5516e1c20