### PR TITLE
balance: boost road raider attack

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -1087,6 +1087,7 @@ const DATA = `
         }
       },
       "combat": {
+        "ATK": 4,
         "DEF": 5,
         "loot": "raider_knife"
       }


### PR DESCRIPTION
## Summary
- beef up Road Raider attack so it can harm low-level parties

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5939ec5e4832884b807d63c2c574e