### PR TITLE
docs: reopen playtest tasks for improvement

### DIFF
--- a/docs/design/chiptune-ai.md
+++ b/docs/design/chiptune-ai.md
@@ -52,8 +52,8 @@ Runs standalone in a browser tab and should chirp out a tiny wasteland riff.
 
 ## Tasks
 
- - [x] Prototype seeded melody generation with Magenta and Tone.
+- [x] Prototype seeded melody generation with Magenta and Tone.
 - [x] Expose mod hooks for seed and instrument parameters.
 - [x] Add scale clamping to keep riffs musical.
- - [x] Stress-test performance on mobile browsers.
+ - [ ] Stress-test performance on mobile browsers.
  - [x] Tie playback to the event bus via `music:seed`.

--- a/docs/design/combat.md
+++ b/docs/design/combat.md
@@ -102,7 +102,7 @@ The prototype doesn't spend Adrenaline yet; it's a pacing probe. Once the gain c
 - [x] **Adrenaline Generation:** Basic attacks now generate Adrenaline. This value is determined by weapon stats via the `ADR` modifier.
 - [x] **Special Move Framework:** In `scripts/core/abilities.js`, create a data structure for Specials that includes `adrenaline_cost`, `target_type` (single, aoe), `effect` (damage, stun, etc.), and `wind_up_time`.
 - [x] **Equipment Modifiers:** Update the inventory system to apply combat modifiers from equipped items at the start of each battle.
-- [x] **Adrenaline Prototype:** Script a small arena fight to validate Adrenaline gain pacing and HUD readability.
+- [ ] **Adrenaline Prototype:** Script a small arena fight to validate Adrenaline gain pacing and HUD readability.
 
 #### Phase 2: Content & UI
 - [x] **New HUD:** Redesign the combat UI to include the Adrenaline bar, status effect icons, and improved health bar feedback.
@@ -110,11 +110,11 @@ The prototype doesn't spend Adrenaline yet; it's a pacing probe. Once the gain c
 - [x] **Implement 5-10 Specials:** Added starter moves Power Strike, Stun Grenade, First Aid, Adrenal Surge, and Guard.
  - [x] **Implement Equipment:** Create a set of weapons and armor with varied combat modifiers.
 - [x] **Enemy Design:** Added four enemy types that require tactical use of specials (e.g., Shield Drone resists basic attacks, Reflective Slime counters them).
-- [x] **HUD Playtest:** Ran quick usability tests with two players and tightened bar spacing and icon contrast based on feedback.
+- [ ] **HUD Playtest:** Ran quick usability tests with two players and tightened bar spacing and icon contrast based on feedback.
 
 #### Phase 3: Polish & Balancing
 - [x] **Visual Effects:** Add VFX for Adrenaline gain, special move activations, and status effects.
 - [x] **Sound Design:** Add SFX for specials, UI feedback, and enemy telegraphing.
-- [x] **Playtesting:** Conduct extensive playtests to balance Adrenaline generation rates, special costs, and overall combat difficulty. Ensure the difficulty curve is challenging but fair.
+- [ ] **Playtesting:** Conduct extensive playtests to balance Adrenaline generation rates, special costs, and overall combat difficulty. Ensure the difficulty curve is challenging but fair.
 - [x] **AI Improvements:** Enhance enemy AI to use their own specials and coordinate attacks.
-- [x] **Telemetry:** Log combat stats during playtests to surface pacing issues and balance swings early.
+- [ ] **Telemetry:** Log combat stats during playtests to surface pacing issues and balance swings early.

--- a/docs/design/module-json-tools.md
+++ b/docs/design/module-json-tools.md
@@ -38,6 +38,6 @@ We need to let editors tinker with module layouts without touching code. Each JS
   - [x] office
   - [x] mara-puzzle
 - [x] Build automated tests for the import/export tools.
-- [x] Verify Adventure Kit loads JSON modules and triggers `postLoad`.
+- [ ] Verify Adventure Kit loads JSON modules and triggers `postLoad`.
 - [x] Document the workflow in `docs/` and update README.
 

--- a/docs/design/rpg-progression.md
+++ b/docs/design/rpg-progression.md
@@ -81,11 +81,11 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
     - Level-ups trigger at the right thresholds according to `xpCurve`.
     - HP and skill points are granted correctly.
     - Enemy stats scale as expected with their level.
-- [x] **Playtest: The First Ding:** Run internal playtests focusing on the time it takes a new player to reach their first level-up. Target: under 10 minutes of active play.
+- [ ] **Playtest: The First Ding:** Run internal playtests focusing on the time it takes a new player to reach their first level-up. Target: under 10 minutes of active play.
     - Internal sessions averaged an 8 minute first level-up, meeting the target.
-- [x] **Playtest: Trainer Flow:** Test the trainer UI for clarity and speed. A player should be able to spend a skill point and exit the dialog in under 15 seconds.
+- [ ] **Playtest: Trainer Flow:** Test the trainer UI for clarity and speed. A player should be able to spend a skill point and exit the dialog in under 15 seconds.
     - Testers completed the upgrade in an average of 12 seconds, meeting the target.
-- [x] **Playtest: Zone Difficulty:** Evaluate the "Scrap Wastes" zone to ensure the difficulty curve feels fair but engaging. Check if players feel encouraged to tackle the optional high-level enemies.
+- [ ] **Playtest: Zone Difficulty:** Evaluate the "Scrap Wastes" zone to ensure the difficulty curve feels fair but engaging. Check if players feel encouraged to tackle the optional high-level enemies.
     - Testers reported the zone as tough but fair; about two thirds attempted at least one optional enemy and enjoyed the challenge.
 
 > **Clown:** This roadmap feels solid. It's a ladder of features we can build and test one rung at a time. And every rung is something a modder can hook into and twist. Let's get to it.

--- a/docs/design/spoils-caches.md
+++ b/docs/design/spoils-caches.md
@@ -66,7 +66,7 @@ Opening a cache triggers a generator that stitches gear on the fly:
 
 #### Phase 4: Testing
 - [x] Write tests to verify drop odds and tier distribution across challenge levels.
- - [x] Simulate 1,000 cache openings per tier to ensure stat ranges stay sane.
-- [x] Run `node scripts/presubmit.js` to confirm no async snafus in cache UI — clean run.
+ - [ ] Simulate 1,000 cache openings per tier to ensure stat ranges stay sane.
+- [ ] Run `node scripts/presubmit.js` to confirm no async snafus in cache UI — clean run.
 
 > **Clown:** When players crack open a Vaulted Cache and a "Quantum Harmonica" drops, I want them to laugh, equip it, and blow something up with a punchline.

--- a/docs/qa-checks.md
+++ b/docs/qa-checks.md
@@ -2,6 +2,7 @@
 
 This document lists QA checks for each completed item across design docs.
 For each item, run the described code verification.
+Validation tasks should remain unchecked unless the process yields at least one improvement.
 
 - [x] **combat.md** — **Adrenaline Resource:** Implement the Adrenaline bar (`adr`) for all combatants in `scripts/core/party.js` and `scripts/core/combat.js`.
    - Check: confirm implementation matches description.
@@ -11,7 +12,7 @@ For each item, run the described code verification.
    - Check: confirm implementation matches description.
 - [x] **combat.md** — **Equipment Modifiers:** Update the inventory system to apply combat modifiers from equipped items at the start of each battle.
    - Check: confirm implementation matches description.
-- [x] **combat.md** — **Adrenaline Prototype:** Script a small arena fight to validate Adrenaline gain pacing and HUD readability.
+- [ ] **combat.md** — **Adrenaline Prototype:** Script a small arena fight to validate Adrenaline gain pacing and HUD readability.
    - Check: confirm implementation matches description.
 - **combat.md** — **New HUD:** Redesign the combat UI to include the Adrenaline bar, status effect icons, and improved health bar feedback.
   - Check: confirm implementation matches description.


### PR DESCRIPTION
## Summary
- Reopen playtest and manual verification tasks across design docs for more systematic validation.
- Note in QA checklist that validations only count when they produce an improvement.

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5916f07e083289ba534fe9d16bd2d