### PR TITLE
fix: avoid redundant problem list re-render

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustland",
-  "version": "0.7.53",
+  "version": "0.7.55",
   "description": "Wasteland-style browser RPG with a CRT vibe",
   "type": "module",
   "main": "scripts/dustland-core.js",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2824,6 +2824,18 @@ function validateSpawns(){
   return issues;
 }
 
+function onProblemClick(){
+  const prob=problemRefs[parseInt(this.dataset.idx,10)];
+  if(prob.type==='npc') editNPC(prob.idx);
+  else if(prob.type==='item') editItem(prob.idx);
+  else if(prob.type==='start'){
+    showMap('world');
+    focusMap(moduleData.start.x,moduleData.start.y);
+    selectedObj=null;
+    drawWorld();
+  }
+}
+
 function renderProblems(issues){
   issues = issues || validateSpawns();
   const card = document.getElementById('problemCard');
@@ -2834,18 +2846,11 @@ function renderProblems(issues){
     return;
   }
   card.style.display='block';
-  list.innerHTML = issues.map((p,i)=>`<div data-idx="${i}">${p.msg}</div>`).join('');
-  Array.from(list.children).forEach(div=>div.onclick=()=>{
-    const prob=problemRefs[parseInt(div.dataset.idx,10)];
-    if(prob.type==='npc') editNPC(prob.idx);
-    else if(prob.type==='item') editItem(prob.idx);
-    else if(prob.type==='start'){
-      showMap('world');
-      focusMap(moduleData.start.x,moduleData.start.y);
-      selectedObj=null;
-      drawWorld();
-    }
-  });
+  const html = issues.map((p,i)=>`<div data-idx="${i}">${p.msg}</div>`).join('');
+  if(list.innerHTML !== html){
+    list.innerHTML = html;
+    Array.from(list.children).forEach(div=>div.onclick=onProblemClick);
+  }
 }
 
 function saveModule() {

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -3,7 +3,7 @@
 
 // Logging
 
-const ENGINE_VERSION = '0.7.53';
+const ENGINE_VERSION = '0.7.55';
 
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');

--- a/test/render-problems.test.js
+++ b/test/render-problems.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+test('renderProblems reuses DOM and handler', async () => {
+  const dom = new JSDOM('<div id="problemCard"><div id="problemList"></div></div>');
+  global.document = dom.window.document;
+  const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+  const clickCode = code.match(/function onProblemClick\(\){[\s\S]*?\n}\n/)[0];
+  const renderCode = code.match(/function renderProblems\(issues\){[\s\S]*?\n}\n/)[0];
+  vm.runInThisContext('var problemRefs;\n' + clickCode + renderCode);
+  const issues = [{ msg:'Player start on blocked tile', type:'start' }];
+  renderProblems(issues);
+  const list = document.getElementById('problemList');
+  const first = list.firstChild;
+  const handler = first.onclick;
+  assert.strictEqual(handler, onProblemClick);
+  renderProblems(issues);
+  assert.strictEqual(list.firstChild, first);
+  assert.strictEqual(list.firstChild.onclick, handler);
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- avoid resetting problem list DOM when contents unchanged
- persist problem click handler across renders
- bump engine version to 0.7.55
- add regression test for renderProblems DOM reuse

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b597d4d23c832891a25fd8430e86dc