### PR TITLE
ci: add automated version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,26 @@
+name: Version Bump
+
+on:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: version-bump
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    if: "!startsWith(github.event.head_commit.message, 'chore: bump version')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: node scripts/version-bump.js
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,13 @@ Guidelines for contributors and automated agents working on Dustland CRT.
 - After touching combat, movement, or NPC logic, run `node scripts/balance-tester-agent.js` to exercise event-bus handlers and path queues.
 
 ## Commit conventions
-- Use concise messages with prefixes such as `feat:`, `fix:`, or `docs:`.
+- Use concise messages with prefixes such as `feat:`, `fix:`, `system:`, or `docs:`.
 - Commit directly to the main branch without creating new branches.
+
+## Versioning
+- Version numbers in `package.json` and `scripts/dustland-engine.js` are managed by a GitHub action.
+- Include `feat`, `fix`, or `system!` in commit messages to signal minor, patch, or major bumps.
+- Avoid manual edits to version fields.
 
 ## Documentation
 - Update README files or inline comments when behavior or APIs change.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS
 
-Maintain engine versioning.
+Engine versioning is automated.
 
-- Increment the point version (patch number) in `package.json` with each change.
-- Mirror the updated version in `dustland-engine.js` so the engine log shows the latest build.
-- This helps indicate when a new build has deployed.
+- A GitHub action updates `package.json` and `dustland-engine.js` after merges.
+- Use commit messages (`feat`, `fix`, or `system!`) to signal minor, patch, or major bumps.
+- Avoid editing version numbers by hand.

--- a/scripts/version-bump.js
+++ b/scripts/version-bump.js
@@ -1,0 +1,71 @@
+import {execSync} from 'node:child_process';
+import fs from 'node:fs';
+
+function sh(cmd) {
+  return execSync(cmd, {encoding: 'utf8'}).trim();
+}
+
+function getMessages(tag) {
+  const range = tag ? `${tag}..HEAD` : 'HEAD';
+  const out = sh(`git log ${range} --pretty=%s`);
+  return out ? out.split('\n').filter(Boolean) : [];
+}
+
+function bumpFrom(messages) {
+  let level = 'patch';
+  for (const raw of messages) {
+    const msg = raw.toLowerCase();
+    if (/^system(?:\(.+\))?!:/.test(msg) || msg.includes('breaking change')) {
+      return 'major';
+    }
+    if (msg.startsWith('feat') && level === 'patch') {
+      level = 'minor';
+    }
+  }
+  return level;
+}
+
+function inc(v, level) {
+  const parts = v.split('.').map(Number);
+  if (level === 'major') return `${parts[0] + 1}.0.0`;
+  if (level === 'minor') return `${parts[0]}.${parts[1] + 1}.0`;
+  return `${parts[0]}.${parts[1]}.${parts[2] + 1}`;
+}
+
+function main() {
+  let tag = '';
+  try {
+    tag = sh('git describe --tags --abbrev=0');
+  } catch {
+    // no tags yet
+  }
+  const messages = getMessages(tag);
+  if (!messages.length) {
+    console.log('No commits to release.');
+    return;
+  }
+
+  const pkgPath = 'package.json';
+  const enginePath = 'scripts/dustland-engine.js';
+  const pkg = JSON.parse(fs.readFileSync(pkgPath));
+  const next = inc(pkg.version, bumpFrom(messages));
+
+  pkg.version = next;
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  const eng = fs.readFileSync(enginePath, 'utf8').replace(
+    /ENGINE_VERSION = '[^']+'/, `ENGINE_VERSION = '${next}'`
+  );
+  fs.writeFileSync(enginePath, eng);
+
+  sh('git config user.name "github-actions[bot]"');
+  sh('git config user.email "github-actions[bot]@users.noreply.github.com"');
+  sh(`git add ${pkgPath} ${enginePath}`);
+  sh(`git commit -m "chore: bump version to ${next}"`);
+  sh(`git tag v${next}`);
+  sh('git pull --rebase');
+  sh('git push');
+  sh('git push --tags');
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- add GitHub Action to serialize version bumps on pushes to main
- script analyzes commit messages and updates package.json and engine version, then tags the release
- document automated versioning in AGENTS guidelines
- require `system!` prefix for major version bumps

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5a2662a608328b2998bf0a8ce69e5