### PR TITLE
test: consolidate module-json round trip checks

### DIFF
--- a/test/module-json.tools.test.js
+++ b/test/module-json.tools.test.js
@@ -3,13 +3,9 @@ import { test } from 'node:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execSync, execFileSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-const modulesDir = path.join('modules');
-const dataDir = path.join('data', 'modules');
-const moduleFile = path.join(modulesDir, 'tmp-test.module.js');
-const jsonFile = path.join(dataDir, 'tmp-test.json');
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 
@@ -18,14 +14,17 @@ function runScript(args, cwd){
 }
 
 test('module-json export/import round trip', () => {
-  const original = { hello: 'world', portraitSheet: 'assets/portraits/custom.png' };
-  const moduleContent = `const DATA = \`\n${JSON.stringify(original, null, 2)}\n\`;\nexport function postLoad() {}`;
-  fs.writeFileSync(moduleFile, moduleContent);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'modjson-'));
   try {
-    execSync(`node scripts/module-json.js export ${moduleFile}`);
+    const moduleFile = path.join(tmp, 'sample.module.js');
+    const jsonFile = path.join(tmp, 'data', 'modules', 'sample.json');
+    const original = { hello: 'world', portraitSheet: 'assets/portraits/custom.png' };
+    const moduleContent = `const DATA = \`\n${JSON.stringify(original, null, 2)}\n\`;\nexport function postLoad() {}`;
+    fs.writeFileSync(moduleFile, moduleContent);
+    runScript(['export', moduleFile], tmp);
     const exported = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
     assert.strictEqual(exported.module, moduleFile);
-    assert.strictEqual(exported.name, 'tmp-test-module');
+    assert.strictEqual(exported.name, 'sample-module');
     const { name } = exported;
     assert.strictEqual(exported.portraitSheet, 'assets/portraits/custom.png');
     delete exported.module;
@@ -35,7 +34,7 @@ test('module-json export/import round trip', () => {
     exported.module = moduleFile;
     exported.name = name;
     fs.writeFileSync(jsonFile, JSON.stringify(exported, null, 2));
-    execSync(`node scripts/module-json.js import ${moduleFile}`);
+    runScript(['import', moduleFile], tmp);
     const updated = fs.readFileSync(moduleFile, 'utf8');
     const match = updated.match(/const DATA = `([\s\S]*?)`;/);
     assert(match);
@@ -43,28 +42,7 @@ test('module-json export/import round trip', () => {
     assert.strictEqual(obj.hello, 'mars');
     assert.strictEqual(obj.portraitSheet, 'assets/portraits/custom.png');
     assert.strictEqual(obj.module, undefined);
-    assert.strictEqual(obj.name, 'tmp-test-module');
-  } finally {
-    fs.rmSync(moduleFile, { force: true });
-    fs.rmSync(jsonFile, { force: true });
-  }
-});
-
-test('module-json export/import round trip in temp workspace', () => {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'modjson-'));
-  try {
-    const tmpModule = path.join(tmp, 'sample.module.js');
-    const initial = 'const DATA = `\n{\n  "msg": "hello"\n}`;';
-    fs.writeFileSync(tmpModule, initial);
-    runScript(['export', tmpModule], tmp);
-    const outJson = path.join(tmp, 'data', 'modules', 'sample.json');
-    const exported = JSON.parse(fs.readFileSync(outJson, 'utf8'));
-    assert.strictEqual(exported.msg, 'hello');
-    exported.msg = 'world';
-    fs.writeFileSync(outJson, JSON.stringify(exported, null, 2));
-    runScript(['import', tmpModule], tmp);
-    const updated = fs.readFileSync(tmpModule, 'utf8');
-    assert.ok(updated.includes('"msg": "world"'));
+    assert.strictEqual(obj.name, 'sample-module');
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- merge overlapping module-json tests into one round trip check in a temp workspace
- verify module path, name, and portrait fields are preserved through export/import

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5acae674c832897cad9c5bccab08a