### PR TITLE
fix: sync palette selection with interior paint

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2489,6 +2489,9 @@ if (worldPalette) {
       worldPalette.querySelectorAll('button').forEach(b => b.classList.remove('active'));
       worldPaint = isOn ? null : parseInt(btn.dataset.tile, 10);
       worldStamp = null;
+      if (currentMap !== 'world' && worldPaint != null) {
+        intPaint = worldPaint;
+      }
       if (!isOn) {
         btn.classList.add('active');
         if (paletteLabel) {

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -311,10 +311,10 @@ test('painting interior in main window', () => {
   moduleData.interiors = [{ id:'room', w:2, h:2, grid:[[TILE.FLOOR,TILE.FLOOR],[TILE.FLOOR,TILE.FLOOR]] }];
   interiors = { room: moduleData.interiors[0] };
   showMap('room');
-  intPaint = TILE.WALL;
+  worldButtons[2]._listeners.click[0]();
   canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0, button:0 });
   canvasEl._listeners.mouseup[0]({ button:0 });
-  assert.strictEqual(interiors.room.grid[0][0], TILE.WALL);
+  assert.strictEqual(interiors.room.grid[0][0], TILE.WATER);
   showMap('world');
 });
 


### PR DESCRIPTION
## Summary
- ensure world palette updates interior paint selection
- test interior painting responds to palette selection

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa4ca1e08328b4225262d09b6977