### PR TITLE
feat: add maze sword to puzzle module

### DIFF
--- a/modules/mara-puzzle.module.js
+++ b/modules/mara-puzzle.module.js
@@ -3,7 +3,18 @@ function seedWorldContent() {}
 const DATA = `{
   "seed": "mara-puzzle",
   "name": "mara-puzzle",
-  "items": [],
+  "items": [
+    {
+      "map": "dust_storm",
+      "x": 9,
+      "y": 9,
+      "id": "maze_sword",
+      "name": "Maze Sword",
+      "type": "weapon",
+      "slot": "weapon",
+      "mods": { "ATK": 10 }
+    }
+  ],
   "quests": [],
   "npcs": [],
   "interiors": [

--- a/test/mara-puzzle.module.test.js
+++ b/test/mara-puzzle.module.test.js
@@ -15,3 +15,15 @@ test('mara puzzle module defines startGame to launch dust storm', () => {
   assert.match(src, /You hear a faint chime/);
   assert.match(src, /Listen for chimes to find your way out/);
 });
+
+test('mara puzzle module hides a powerful sword in the maze', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'mara-puzzle.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const match = src.match(/const DATA = `([\s\S]*?)`;/);
+  assert.ok(match, 'DATA string not found');
+  const data = JSON.parse(match[1]);
+  const sword = data.items.find((it) => it.id === 'maze_sword');
+  assert.ok(sword, 'maze_sword not defined');
+  assert.equal(sword.mods.ATK, 10);
+});


### PR DESCRIPTION
## Summary
- hide a Maze Sword in the dust storm maze with high attack power
- test Mara puzzle module to ensure sword data is present

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f71705dc8328b73a2e85ce0fbdad