### PR TITLE
fix: hide persistLLM button until Nano initializes

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -906,7 +906,10 @@ if (document.getElementById('saveBtn')) {
     const updateNano=()=>{
       nanoBtn.textContent = `Nano Dialog: ${window.NanoDialog?.enabled ? 'On' : 'Off'}`;
       const persist=document.getElementById('persistLLM');
-      if(persist) persist.style.display = window.NanoDialog?.enabled ? '' : 'none';
+      if(persist){
+        const ready=window.NanoDialog?.isReady?.();
+        persist.style.display = window.NanoDialog?.enabled && ready ? '' : 'none';
+      }
     };
     nanoBtn.onclick=()=>{
       if(window.NanoDialog){
@@ -917,6 +920,7 @@ if (document.getElementById('saveBtn')) {
       updateNano();
     };
     updateNano();
+    if(window.NanoDialog?.init) NanoDialog.init().then(updateNano);
   }
   const audioBtn=document.getElementById('audioToggle');
   if(audioBtn) audioBtn.onclick=()=>toggleAudio();
@@ -1015,7 +1019,6 @@ disp.addEventListener('touchstart',e=>{
 // ===== Boot =====
 if (typeof bootMap === 'function') bootMap(); // ensure a grid exists before first frame
 requestAnimationFrame(draw);
-if (window.NanoDialog) NanoDialog.init();
 
 { // skip normal boot flow in ACK player mode
   const params = new URLSearchParams(location.search);

--- a/test/persist-llm-button.test.js
+++ b/test/persist-llm-button.test.js
@@ -7,7 +7,7 @@ import { makeDocument } from './test-harness.js';
 const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
 const code = full.split('// ===== Boot =====')[0];
 
-test('Persist LLM button toggles with Nano dialog mode', async () => {
+test('Persist LLM button hidden until Nano is ready', async () => {
   const document = makeDocument();
   const canvas = document.createElement('canvas');
   canvas.id = 'game';
@@ -34,7 +34,7 @@ test('Persist LLM button toggles with Nano dialog mode', async () => {
   const persistBtn = document.getElementById('persistLLM');
   document.body.appendChild(persistBtn);
 
-  const nano = { enabled: false, refreshIndicator: () => {} };
+  const nano = { enabled: false, isReady: () => false, refreshIndicator: () => {} };
   const window = {
     document,
     AudioContext: class {},
@@ -74,6 +74,10 @@ test('Persist LLM button toggles with Nano dialog mode', async () => {
   vm.runInContext(code, context);
 
   assert.strictEqual(persistBtn.style.display, 'none');
+  document.getElementById('nanoToggle').onclick();
+  assert.strictEqual(persistBtn.style.display, 'none');
+  nano.isReady = () => true;
+  document.getElementById('nanoToggle').onclick();
   document.getElementById('nanoToggle').onclick();
   assert.notStrictEqual(persistBtn.style.display, 'none');
 });


### PR DESCRIPTION
## Summary
- Hide Persist LLM button until Nano dialog is initialized and enabled
- Ensure Nano initialization updates the button state
- Cover behavior in tests

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b62b6d57e88328a782cd8723571c26