### PR TITLE
feat: add maze sword to office module

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -576,6 +576,7 @@ const OFFICE_IMPL = (() => {
         { id: 'rusty_dagger', name: 'Rusty Dagger', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } },
         { id: 'ogre_tooth', name: 'Ogre Tooth', type: 'quest' },
         { id: 'rusty_mop', name: 'Rusty Mop', type: 'weapon', slot: 'weapon', mods: { ATK: 1, ADR: 10 } },
+        { id: 'maze_sword', name: 'Maze Sword', type: 'weapon', slot: 'weapon', mods: { ATK: 10 } },
       ],
       quests: [
         {

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -39,6 +39,14 @@ test('office module places Boots of Speed near forest entry', () => {
   assert.match(src, /mods: \{ AGI: 5, move_delay_mod: 0\.5 \}/);
 });
 
+test('office module defines a powerful maze sword', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /id: 'maze_sword'/);
+  assert.match(src, /mods: \{ ATK: 10 \}/);
+});
+
 test('office module uses object visuals for elevator and vending machine', () => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const file = path.join(__dirname, '..', 'modules', 'office.module.js');


### PR DESCRIPTION
## Summary
- add Maze Sword weapon with high attack power to the office module
- test office module includes Maze Sword definition

## Testing
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b62d32e2f88328ba4cab5e74b3f73b