### PR TITLE
docs: draft True Dust module design

### DIFF
--- a/docs/design/in-progress/true-dust.md
+++ b/docs/design/in-progress/true-dust.md
@@ -1,0 +1,38 @@
+# True Dust Module
+*By Alex "Echo" Johnson*
+
+The Dustland opens its eyes with a whisper of grit and memory. "True Dust" drops the caravan at a tight knot of shelter — four squat blocks huddled inside a stone wall, a no-spawn sanctuary against the wastes.
+
+## Starting Hub: Stonegate
+- **Layout:** A 2x2 cluster of brick shacks ringed by a weathered wall. The interior is flagged as a safe zone; nothing spawns within.
+- **Guardian:** Rygar, a weary gatewatch, offers to travel with the player. He fingers a copper pendant — its twin once worn by his sister Mira. With him in party, townsfolk whisper about Mira's fascination with old radio towers and the pull Rygar feels toward the deep dunes.
+- **Wild Fringe:** Rats and feral dogs gnaw at the outskirts, pushing newcomers to learn quick strikes and retreat paths.
+
+## Nearby Threat: The Maw Complex
+- **Structure:** A sprawling office husk, its halls stitched together into an interior maze.
+- **Encounters:** Each room rolls random packs of vermin or undead with a chance for small loot chests.
+- **Boss:** The final chamber holds a stitched zombie foreman. Defeating it drops a cracked radio.
+- **Radio Perk:** Equipping the radio triggers a static burst whenever the player nears a buried scrap cache. Waiting on the noise lets the player dig up materials.
+
+## Regional Play: Trade and Corruption
+- **Rustwater:** Next-door town run by Mayor Ganton. He skims caravan tolls and secretly arms bandits to keep trade scared and bribe-hungry guards in his pocket.
+- **Lakeside:** A calmer settlement by the Red Lake, cut off by the raiders. Rustwater's mayor offers a prototype pulse rifle if the player clears the road so he can resume his own profiteering route.
+
+## Quests and Hooks
+1. **Rygar's Echo:** Escort Rygar through the Maw Complex. A note in the foreman's desk mentions a girl with a copper pendant heading for Rustwater. After the bandits fall, a Lakeside dockhand either hands Rygar a blood-specked pendant fragment or, if he's absent, slips the player a warning that someone matching Mira's description was dragged onto a night boat.
+2. **Static Whisper:** Use the radio to uncover three scrap caches in the surrounding desert.
+3. **Bandit Purge:** Accept Mayor Ganton's deal, track the raiders along the road to Lakeside, and decide whether to expose his racket or keep the rifle.
+
+## Implementation Checklist
+- [ ] Map Stonegate as a 2x2 hub with wall segments, safe-zone trigger, and Rygar spawn point.
+- [ ] Scatter rats and wild dogs outside the wall; ensure no spawn inside.
+- [ ] Build the Maw Complex interior with connected rooms, random encounter tables, and a foreman's desk containing the Mira note.
+- [ ] Script Rygar follower logic and pendant animations.
+- [ ] Add Stonegate gossip NPCs referencing Mira's radio obsession and copper pendant.
+- [ ] Implement radio item: proximity handler for scrap caches and static toast.
+- [ ] Place three diggable scrap caches aligned with radio static zones.
+- [ ] Define pulse rifle item rewarded by Mayor Ganton.
+- [ ] Script Rustwater corruption dialog and bandit quest chain.
+- [ ] Design Lakeside dockhand scene: give pendant fragment when Rygar present; deliver warning note when absent.
+- [ ] Log quest updates for Rygar's Echo, Static Whisper, and Bandit Purge.
+- [ ] Test Stonegate safety, radio range, bandit balance, and Lakeside branching outcomes.


### PR DESCRIPTION
## Summary
- add design doc for new True Dust module outlining hub, threats, and questlines
- deepen Rygar's sister storyline with early hints and Lakeside follow-up
- replace implementation plan with detailed checklist for implementation

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b62f63a6e8832899e9c4c75457637b