### PR TITLE
feat: add zone spawn tables with cooldown

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -140,6 +140,7 @@ _______________________________________________________________________________
     The main game still runs from the repo download alone.
 
 [ FEATURE LOG ]
+  - Zones support spawn tables with probability and min/max steps between combat.
   - ACK player can fetch modules by URL, load local JSON, or auto-load via &module=URL (defaults to modules/golden.module.json).
   - World map editor supports mousewheel zoom and right-drag panning.
   - World map editor includes a stamp icon for 16x16 terrain chunks.

--- a/test/zone-spawn.test.js
+++ b/test/zone-spawn.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { createGameProxy } from './test-harness.js';
+
+async function setup(){
+  const { context } = createGameProxy([]);
+  context.Dustland = { effects:{ tick: () => {} }, path:{}, actions:{ startCombat: def => { context.spawned = def; context.combatCount = (context.combatCount||0)+1; } } };
+  context.TILE = { ROAD:0 };
+  context.walkable = { 0:true };
+  context.world = [[0]];
+  context.WORLD_W = 1;
+  context.WORLD_H = 1;
+  context.enemyBanks = { world: [] };
+  context.itemDrops = [];
+  context.NPCS = [];
+  context.interiors = {};
+  context.tileEvents = [];
+  context.zoneEffects = [ { map:'world', x:0, y:0, w:1, h:1, spawns:[{ name:'bug', HP:1, ATK:1, DEF:0, prob:1 }], minSteps:2, maxSteps:2 } ];
+  context.Dustland.zoneEffects = context.zoneEffects;
+  context.clamp = (v,min,max)=> Math.max(min, Math.min(max,v));
+  context.setPartyPos = (x,y)=>{ context.party.x=x; context.party.y=y; };
+  context.footstepBump = () => {};
+  context.checkAggro = () => {};
+  context.updateHUD = () => {};
+  context.renderParty = () => {};
+  context.centerCamera = () => {};
+  context.log = () => {};
+  context.toast = () => {};
+  context.hasItem = () => false;
+  context.state.map = 'world';
+  context.state.mapEntry = { map:'world', x:0, y:0 };
+  context.Math = Object.create(Math);
+  context.Math.random = () => 0;
+
+  const partyCode = await fs.readFile(new URL('../scripts/core/party.js', import.meta.url), 'utf8');
+  vm.runInContext(partyCode, context);
+  const a = new context.Character('a','A','');
+  a.maxHp = a.hp = 10;
+  context.party.join(a);
+  context.party.x = 0;
+  context.party.y = 0;
+
+  const moveCode = await fs.readFile(new URL('../scripts/core/movement.js', import.meta.url), 'utf8');
+  vm.runInContext(moveCode, context);
+  return context;
+}
+
+test('zone spawns respect probability and cooldown', async () => {
+  const ctx = await setup();
+  await ctx.wait();
+  assert.strictEqual(ctx.spawned.name, 'bug');
+  assert.strictEqual(ctx.combatCount, 1);
+  await ctx.wait();
+  assert.strictEqual(ctx.combatCount, 1);
+  await ctx.wait();
+  assert.strictEqual(ctx.combatCount, 1);
+  await ctx.wait();
+  assert.strictEqual(ctx.combatCount, 2);
+});


### PR DESCRIPTION
## Summary
- allow zones to define encounter tables with per-entry probability
- support zone-defined min/max steps between combat
- document feature and add regression test

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b662969fa48328ab2be49beb732f53