### PR TITLE
feat: add Stonegate safe zone and gossip

### DIFF
--- a/docs/design/in-progress/true-dust.md
+++ b/docs/design/in-progress/true-dust.md
@@ -24,11 +24,11 @@ The Dustland opens its eyes with a whisper of grit and memory. "True Dust" drops
 3. **Bandit Purge:** Accept Mayor Ganton's deal, track the raiders along the road to Lakeside, and decide whether to expose his racket or keep the rifle.
 
 ## Implementation Checklist
-- [ ] Map Stonegate as a 2x2 hub with wall segments, safe-zone trigger, and Rygar spawn point.
-- [ ] Scatter rats and wild dogs outside the wall; ensure no spawn inside.
+- [x] Map Stonegate as a 2x2 hub with wall segments, safe-zone trigger, and Rygar spawn point.
+- [x] Scatter rats and wild dogs outside the wall; ensure no spawn inside.
 - [ ] Build the Maw Complex interior with connected rooms, random encounter tables, and a foreman's desk containing the Mira note.
 - [ ] Script Rygar follower logic and pendant animations.
-- [ ] Add Stonegate gossip NPCs referencing Mira's radio obsession and copper pendant.
+- [x] Add Stonegate gossip NPCs referencing Mira's radio obsession and copper pendant.
 - [ ] Implement radio item: proximity handler for scrap caches and static toast.
 - [ ] Place three diggable scrap caches aligned with radio static zones.
 - [ ] Define pulse rifle item rewarded by Mayor Ganton.

--- a/modules/true-dust.module.js
+++ b/modules/true-dust.module.js
@@ -1,0 +1,95 @@
+const DATA = `{
+  "seed": "true-dust",
+  "name": "true-dust",
+  "interiors": [
+    {
+      "id": "stonegate",
+      "w": 6,
+      "h": 6,
+      "grid": [
+        "🏝🏝🏝🏝🏝🏝",
+        "🏝🧱🧱🧱🧱🏝",
+        "🏝🧱🏝🏝🧱🏝",
+        "🏝🧱🏝🏝🧱🏝",
+        "🏝🧱🧱🧱🧱🏝",
+        "🏝🏝🏝🏝🏝🏝"
+      ],
+      "entryX": 2,
+      "entryY": 3
+    }
+  ],
+  "npcs": [
+    {
+      "id": "rygar",
+      "map": "stonegate",
+      "x": 2,
+      "y": 2,
+      "color": "#d4aa70",
+      "name": "Rygar",
+      "title": "Gatewatch",
+      "desc": "Keeps watch over Stonegate's gate.",
+      "tree": {
+        "start": {
+          "text": "Stay sharp. The wastes bite.",
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        }
+      }
+    },
+    {
+      "id": "gossip_mira",
+      "map": "stonegate",
+      "x": 3,
+      "y": 2,
+      "color": "#a9f59f",
+      "name": "Settler",
+      "title": "Gossip",
+      "desc": "Whispers about Mira's radio obsession.",
+      "tree": {
+        "start": {
+          "text": [
+            "Mira was always tuning the old towers.",
+            "Rygar still wears that copper pendant."
+          ],
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        }
+      }
+    }
+  ],
+  "zoneEffects": [
+    {
+      "map": "stonegate",
+      "x": 0,
+      "y": 0,
+      "w": 6,
+      "h": 6,
+      "spawns": [
+        { "name": "Scavenger Rat", "HP": 5, "ATK": 1, "DEF": 0 },
+        { "name": "Feral Dog", "HP": 8, "ATK": 2, "DEF": 1 }
+      ],
+      "minSteps": 2,
+      "maxSteps": 4
+    },
+    {
+      "map": "stonegate",
+      "x": 1,
+      "y": 1,
+      "w": 4,
+      "h": 4,
+      "noEncounters": true
+    }
+  ],
+  "start": { "map": "stonegate", "x": 2, "y": 3 }
+}`;
+
+function postLoad(module) {}
+
+globalThis.TRUE_DUST = JSON.parse(DATA);
+globalThis.TRUE_DUST.postLoad = postLoad;
+
+startGame = function () {
+  applyModule(TRUE_DUST);
+  const s = TRUE_DUST.start;
+  setMap(s.map, 'Stonegate');
+  setPartyPos(s.x, s.y);
+  updateHUD?.();
+};

--- a/test/true-dust.module.test.js
+++ b/test/true-dust.module.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('true dust module defines safe zone and spawns', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'true-dust.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /noEncounters/);
+  assert.match(src, /spawns/);
+  assert.match(src, /Rygar/);
+});


### PR DESCRIPTION
## Summary
- add True Dust module with Stonegate safe hub, spawns, and gossip NPC
- check off completed True Dust design tasks
- cover module with basic test

## Testing
- `./install-deps.sh` *(fails: mise.jdx.dev repo unreachable)*
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e7ca78e48328a72d384ad4575f94