### PR TITLE
fix: preserve NPC title in adventure kit

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -347,6 +347,7 @@
           <div id="npcEditor" style="display:none">
           <label>ID<input id="npcId" placeholder="npc_id" /></label>
           <label>Name<input id="npcName" placeholder="NPC name" /></label>
+          <label>Title<input id="npcTitle" placeholder="NPC title" /></label>
           <label>Description<textarea id="npcDesc" rows="2"></textarea></label>
           <label>Color<input id="npcColor" type="color" value="#9ef7a0" /></label>
           <label>Symbol<input id="npcSymbol" maxlength="1" value="!" /></label>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1511,6 +1511,7 @@ function startNewNPC() {
   editNPCIdx = -1;
   document.getElementById('npcId').value = nextId('npc', moduleData.npcs);
   document.getElementById('npcName').value = '';
+  document.getElementById('npcTitle').value = '';
   document.getElementById('npcDesc').value = '';
   document.getElementById('npcColor').value = '#9ef7a0';
   document.getElementById('npcSymbol').value = '!';
@@ -1576,6 +1577,7 @@ function beginPlaceNPC() {
 function collectNPCFromForm() {
   const id = document.getElementById('npcId').value.trim();
   const name = document.getElementById('npcName').value.trim();
+  const title = document.getElementById('npcTitle').value.trim();
   const desc = document.getElementById('npcDesc').value.trim();
   const color = document.getElementById('npcColor').value.trim() || '#fff';
   const symbol = document.getElementById('npcSymbol').value.trim().charAt(0) || '!';
@@ -1615,7 +1617,7 @@ function collectNPCFromForm() {
   document.getElementById('npcTree').value = JSON.stringify(tree, null, 2);
   loadTreeEditor();
 
-  const npc = { id, name, desc, color, symbol, map, x, y, tree, questId };
+  const npc = { id, name, title, desc, color, symbol, map, x, y, tree, questId };
   const pts = gatherLoopFields();
   if (pts.length >= 2) npc.loop = pts;
   if (combat) {
@@ -1692,6 +1694,7 @@ function editNPC(i) {
   editNPCIdx = i;
   document.getElementById('npcId').value = n.id;
   document.getElementById('npcName').value = n.name;
+  document.getElementById('npcTitle').value = n.title || '';
   document.getElementById('npcDesc').value = n.desc || '';
   document.getElementById('npcColor').value = expandHex(n.color || '#ffffff');
   document.getElementById('npcSymbol').value = n.symbol || '!';

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -459,6 +459,15 @@ test('NPC symbol is saved and restored', () => {
   assert.strictEqual(document.getElementById('npcSymbol').value, '?');
 });
 
+test('NPC title survives round trip', () => {
+  moduleData.npcs = [{
+    id: 'npc1', name: 'NPC', title: 'Trader', color: '#fff', map: 'world', x: 0, y: 0, tree: {}
+  }];
+  editNPC(0);
+  const npc = collectNPCFromForm();
+  assert.strictEqual(npc.title, 'Trader');
+});
+
 test('NPC combat fields round trip through editor', () => {
   moduleData.npcs = [{
     id: 'npc1', name: 'NPC', color: '#fff', map: 'world', x: 0, y: 0, tree: {},


### PR DESCRIPTION
## Summary
- add Title field to NPC editor UI
- preserve NPC title when saving and editing modules
- test that NPC titles survive Adventure Kit round trip

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6f476e8e08328842bade98fec60fb