### PR TITLE
fix: calculate item scrap from stats

### DIFF
--- a/scripts/core/item-generator.js
+++ b/scripts/core/item-generator.js
@@ -48,12 +48,6 @@ const ItemGen = {
     armored: { min: 7, max: 10 },
     vaulted: { min: 10, max: 15 }
   },
-  scrapValues: {
-    rusted: 5,
-    sealed: 20,
-    armored: 100,
-    vaulted: 500
-  },
   calcScrap(item){
     let total = 0;
     const stats = item.stats || {};
@@ -86,7 +80,7 @@ const ItemGen = {
       stats: { power },
       scrap: 0
     };
-    item.scrap = this.scrapValues[rank] ?? this.calcScrap(item);
+    item.scrap = this.calcScrap(item);
     item.tags = [noun.toLowerCase()];
     if(type === 'oddity'){
       item.lore = this.pick(this.oddityLore, rng);


### PR DESCRIPTION
## Summary
- compute item scrap based on stats instead of rank constants

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b703c6a4708328acf873418bb2100f