### PR TITLE
feat: add Rygar follower and pendant glint

### DIFF
--- a/docs/design/in-progress/true-dust.md
+++ b/docs/design/in-progress/true-dust.md
@@ -27,7 +27,7 @@ The Dustland opens its eyes with a whisper of grit and memory. "True Dust" drops
 - [x] Map Stonegate as a 2x2 hub with wall segments, safe-zone trigger, and Rygar spawn point.
 - [x] Scatter rats and wild dogs outside the wall; ensure no spawn inside.
 - [x] Build the Maw Complex interior with four connected rooms, random encounter tables, and a foreman's desk containing the Mira note.
-- [ ] Script Rygar follower logic and pendant animations.
+- [x] Script Rygar follower logic and pendant animations.
 - [x] Add Stonegate gossip NPCs referencing Mira's radio obsession and copper pendant.
 - [ ] Implement radio item: proximity handler for scrap caches and static toast.
 - [ ] Place three diggable scrap caches aligned with radio static zones.

--- a/modules/true-dust.module.js
+++ b/modules/true-dust.module.js
@@ -229,7 +229,34 @@ const DATA = `{
   "start": { "map": "stonegate", "x": 2, "y": 3 }
 }`;
 
-function postLoad(module) {}
+function startPendant() {
+  if (startPendant._t) return;
+  startPendant._t = setInterval(() => {
+    const r = party.find(m => m.id === 'rygar');
+    if (!r) {
+      clearInterval(startPendant._t);
+      startPendant._t = null;
+      return;
+    }
+    if (typeof playFX === 'function') playFX('status');
+    if (typeof log === 'function') log("Rygar's pendant glints.");
+  }, 8000);
+}
+
+function postLoad(module) {
+  const rygar = module.npcs.find(n => n.id === 'rygar');
+  if (!rygar || !rygar.tree || !rygar.tree.start) return;
+  rygar.tree.start.choices.unshift({
+    label: 'Travel with us',
+    join: { id: 'rygar', name: 'Rygar', role: 'Guard' },
+    effects: [startPendant],
+    to: 'joined'
+  });
+  rygar.tree.joined = {
+    text: 'Rygar nods and falls in step.',
+    choices: [ { label: '(Leave)', to: 'bye' } ]
+  };
+}
 
 globalThis.TRUE_DUST = JSON.parse(DATA);
 globalThis.TRUE_DUST.postLoad = postLoad;


### PR DESCRIPTION
## Summary
- let Rygar join the party with an optional dialog choice
- animate Rygar's pendant with a periodic glint effect
- check off follower task in True Dust design doc

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7054bdd808328989e059670fcccfe