### PR TITLE
feat: add radio cache mechanic to True Dust

### DIFF
--- a/docs/design/in-progress/true-dust.md
+++ b/docs/design/in-progress/true-dust.md
@@ -29,8 +29,8 @@ The Dustland opens its eyes with a whisper of grit and memory. "True Dust" drops
 - [x] Build the Maw Complex interior with four connected rooms, random encounter tables, and a foreman's desk containing the Mira note.
 - [x] Script Rygar follower logic and pendant animations.
 - [x] Add Stonegate gossip NPCs referencing Mira's radio obsession and copper pendant.
-- [ ] Implement radio item: proximity handler for scrap caches and static toast.
-- [ ] Place three diggable scrap caches aligned with radio static zones.
+- [x] Implement radio item: proximity handler for scrap caches and static toast.
+- [x] Place three diggable scrap caches aligned with radio static zones.
 - [x] Define pulse rifle item rewarded by Mayor Ganton.
 - [ ] Script Rustwater corruption dialog and bandit quest chain.
 - [ ] Design Lakeside dockhand scene: give pendant fragment when Rygar present; deliver warning note when absent.

--- a/modules/true-dust.module.js
+++ b/modules/true-dust.module.js
@@ -130,6 +130,39 @@ const DATA = `{
       "y": 3
     },
     {
+      "id": "cracked_radio",
+      "name": "Cracked Radio",
+      "type": "trinket",
+      "slot": "trinket"
+    },
+    {
+      "id": "scrap_cache_1",
+      "name": "Buried Cache",
+      "type": "spoils-cache",
+      "rank": "rusted",
+      "map": "stonegate",
+      "x": 0,
+      "y": 1
+    },
+    {
+      "id": "scrap_cache_2",
+      "name": "Buried Cache",
+      "type": "spoils-cache",
+      "rank": "rusted",
+      "map": "stonegate",
+      "x": 5,
+      "y": 4
+    },
+    {
+      "id": "scrap_cache_3",
+      "name": "Buried Cache",
+      "type": "spoils-cache",
+      "rank": "rusted",
+      "map": "stonegate",
+      "x": 2,
+      "y": 0
+    },
+    {
       "id": "pulse_rifle",
       "name": "Pulse Rifle",
       "type": "weapon",
@@ -243,6 +276,20 @@ function startPendant() {
   }, 8000);
 }
 
+function startRadio() {
+  if (startRadio._t) return;
+  const caches = TRUE_DUST.items.filter(i => i.id.startsWith('scrap_cache'));
+  startRadio._t = setInterval(() => {
+    const hasRadio = party.some(m => m.equip?.trinket?.id === 'cracked_radio');
+    if (!hasRadio) return;
+    const near = caches.some(c => party.map === c.map && Math.abs(party.x - c.x) <= 1 && Math.abs(party.y - c.y) <= 1);
+    if (near) {
+      if (typeof toast === 'function') toast('Static bursts from the radio.');
+      if (typeof log === 'function') log('The radio crackles with static.');
+    }
+  }, 1000);
+}
+
 function postLoad(module) {
   const rygar = module.npcs.find(n => n.id === 'rygar');
   if (!rygar || !rygar.tree || !rygar.tree.start) return;
@@ -266,4 +313,5 @@ startGame = function () {
   const s = TRUE_DUST.start;
   setMap(s.map, 'Stonegate');
   setPartyPos(s.x, s.y);
+  startRadio();
 };

--- a/test/true-dust.module.test.js
+++ b/test/true-dust.module.test.js
@@ -37,4 +37,8 @@ test('true dust module defines safe zone and spawns', () => {
   assert.strictEqual(note.map, 'maw_4');
   assert.strictEqual(note.x, 7);
   assert.strictEqual(note.y, 3);
+  const radio = data.items.find(i => i.id === 'cracked_radio');
+  assert.ok(radio && radio.slot === 'trinket');
+  const caches = data.items.filter(i => i.id.startsWith('scrap_cache'));
+  assert.strictEqual(caches.length, 3);
 });


### PR DESCRIPTION
## Summary
- add cracked radio trinket and buried scrap caches to True Dust module
- pulse radio for nearby caches with startRadio helper
- document progress in True Dust design checklist

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b707f79390832895d324950c0b122e