### PR TITLE
fix: sync demo and docs version

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -11,7 +11,7 @@ _______________________________________________________________________________
 |     ░       ░           ░                ░  ░      ░           ░    ░       |
 |                           D U S T L A N D   C R T                           |
 |                      Wasteland-style browser RPG (WIP)                      |
-|                               v0.7.2 .NFO                                   |
+|                               v0.16.0 .NFO                                  |
 |_____________________________________________________________________________|
 
 [ ABOUT ]
@@ -91,7 +91,7 @@ _______________________________________________________________________________
     * CRT styling and layout.
   - No external assets or libraries.
 
-[ KNOWN GOOD BEHAVIOR (v0.7.2) ]
+[ KNOWN GOOD BEHAVIOR (v0.16.0) ]
   - Stable boot: hall always renders before any modal (no blank canvas).
   - Items/NPCs draw before player (no sprite pop-under).
   - Loot from chests spawns on a nearby free tile (never under the player).

--- a/balance-tester.html
+++ b/balance-tester.html
@@ -19,7 +19,7 @@
       </div>
     </div>
     <aside class="panel">
-      <h1>DUSTLAND // CRT v0.7.2</h1>
+      <h1 id="title">DUSTLAND // CRT</h1>
       <div class="content" id="log"></div>
       <div class="content">
         <div class="hud">
@@ -175,6 +175,7 @@
   <script defer src="./scripts/dustland-engine.js"></script>
     <script>
       window.addEventListener('DOMContentLoaded', () => {
+        document.getElementById('title').textContent += ' v' + ENGINE_VERSION;
         const params = new URLSearchParams(location.search);
         const isAck = params.get('ack-player') === '1';
         if (isAck) {

--- a/dustland.html
+++ b/dustland.html
@@ -19,7 +19,7 @@
       </div>
     </div>
     <aside class="panel">
-      <h1>DUSTLAND // CRT v0.7.2</h1>
+      <h1 id="title">DUSTLAND // CRT</h1>
       <div class="content" id="log"></div>
       <div class="content">
         <div class="hud">
@@ -256,6 +256,7 @@
     <script defer src="./scripts/perf-debug.js"></script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
+      document.getElementById('title').textContent += ' v' + ENGINE_VERSION;
       const params = new URLSearchParams(location.search);
       const isAck = params.get('ack-player') === '1';
       if (isAck) {


### PR DESCRIPTION
## Summary
- display game version from ENGINE_VERSION on demo pages
- update README to match current version

## Testing
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b708a4ad7c832894bbab8c4f7a5c70