### PR TITLE
fix: add aria labels and focus styles for tabs

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -41,10 +41,10 @@
           <div class="badge">Map: <span id="mapname">—</span></div>
         </div>
         <p class="muted" style="margin-top:10px">Controls: <b>WASD/Arrows</b> move • <b>E/Space</b> interact/door & take nearby item • <b>T/G</b> take item • <b>I</b> Inventory • <b>P</b> Party • <b>Q</b> Quests • <b>O</b> audio • <b>C</b> mobile controls • <b>M</b> minimap • <b>Esc</b> close</p>
-        <div class="tabs">
-          <div class="tab active" id="tabInv">Inventory</div>
-          <div class="tab" id="tabParty">Party</div>
-          <div class="tab" id="tabQuests">Quests</div>
+        <div class="tabs" role="tablist">
+          <div class="tab active" id="tabInv" role="tab" tabindex="0" aria-label="Inventory" aria-selected="true">Inventory</div>
+          <div class="tab" id="tabParty" role="tab" tabindex="0" aria-label="Party" aria-selected="false">Party</div>
+          <div class="tab" id="tabQuests" role="tab" tabindex="0" aria-label="Quests" aria-selected="false">Quests</div>
         </div>
         <div class="tabwrap" id="tabWrap">
           <div id="inv"></div>

--- a/dustland.css
+++ b/dustland.css
@@ -302,6 +302,11 @@ input[type="range"] {
         outline: 1px solid #4f6b4f
     }
 
+    .tab:focus-visible {
+        outline: 2px solid #4f6b4f;
+        outline-offset: 2px;
+    }
+
     #inv {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));

--- a/dustland.html
+++ b/dustland.html
@@ -41,10 +41,10 @@
           <div class="badge">Map: <span id="mapname">—</span></div>
         </div>
         <p class="muted" style="margin-top:10px">Controls: <b>WASD/Arrows</b> move • <b>E/Space</b> interact/door & take nearby item • <b>T/G</b> take item • <b>I</b> Inventory • <b>P</b> Party • <b>Q</b> Quests • <b>O</b> audio • <b>C</b> mobile controls • <b>M</b> minimap • <b>Esc</b> close</p>
-        <div class="tabs">
-          <div class="tab active" id="tabInv">Inventory</div>
-          <div class="tab" id="tabParty">Party</div>
-          <div class="tab" id="tabQuests">Quests</div>
+        <div class="tabs" role="tablist">
+          <div class="tab active" id="tabInv" role="tab" tabindex="0" aria-label="Inventory" aria-selected="true">Inventory</div>
+          <div class="tab" id="tabParty" role="tab" tabindex="0" aria-label="Party" aria-selected="false">Party</div>
+          <div class="tab" id="tabQuests" role="tab" tabindex="0" aria-label="Quests" aria-selected="false">Quests</div>
         </div>
         <div class="tabwrap" id="tabWrap">
           <div id="inv"></div>

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -551,10 +551,13 @@ function showTab(which){
     inv.style.display=(which==='inv'?'grid':'none');
     partyEl.style.display=(which==='party'?'grid':'none');
     q.style.display=(which==='quests'?'grid':'none');
-    for(const el of [tInv,tP,tQ]) el.classList.remove('active');
-    if(which==='inv') tInv.classList.add('active');
-    if(which==='party') tP.classList.add('active');
-    if(which==='quests') tQ.classList.add('active');
+    for(const el of [tInv,tP,tQ]){
+      el.classList.remove('active');
+      if(el.setAttribute) el.setAttribute('aria-selected','false');
+    }
+    if(which==='inv'){ tInv.classList.add('active'); if(tInv.setAttribute) tInv.setAttribute('aria-selected','true'); }
+    if(which==='party'){ tP.classList.add('active'); if(tP.setAttribute) tP.setAttribute('aria-selected','true'); }
+    if(which==='quests'){ tQ.classList.add('active'); if(tQ.setAttribute) tQ.setAttribute('aria-selected','true'); }
   } else {
     console.error("showTab failed. Adventure Kit?");
   }
@@ -580,9 +583,18 @@ window.addEventListener('resize', updateTabsLayout);
 updateTabsLayout();
 
 if (document.getElementById('tabInv')) {
-  document.getElementById('tabInv').onclick=()=>showTab('inv');
-  document.getElementById('tabParty').onclick=()=>showTab('party');
-  document.getElementById('tabQuests').onclick=()=>showTab('quests');
+  const keyHandler = which => e => {
+    if(e.key==='Enter' || e.key===' '){ e.preventDefault(); showTab(which); }
+  };
+  const tabInv=document.getElementById('tabInv');
+  const tabParty=document.getElementById('tabParty');
+  const tabQuests=document.getElementById('tabQuests');
+  tabInv.onclick=()=>showTab('inv');
+  tabParty.onclick=()=>showTab('party');
+  tabQuests.onclick=()=>showTab('quests');
+  tabInv.onkeydown=keyHandler('inv');
+  tabParty.onkeydown=keyHandler('party');
+  tabQuests.onkeydown=keyHandler('quests');
 } else {
   console.error("showTab setup failed. Adventure Kit?");
 }


### PR DESCRIPTION
## Summary
- add ARIA roles and labels to Inventory, Party, and Quests tabs
- show keyboard focus styles for tabs
- enable keyboard activation and update aria-selected state

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b70905a9348328b09ec7c2f4916758