### PR TITLE
feat: add ASCII tile toggle setting

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -71,6 +71,7 @@
         <button class="btn" id="nanoToggle">Nano Dialog</button>
         <button class="btn" id="audioToggle">Audio: On</button>
         <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
+        <button class="btn" id="tileCharToggle">ASCII Tiles: On</button>
         <button class="btn" id="settingsClose">Close</button>
       </main>
     </div>

--- a/dustland.html
+++ b/dustland.html
@@ -73,6 +73,7 @@
         <button class="btn" id="nanoToggle">Nano Dialog</button>
         <button class="btn" id="audioToggle">Audio: On</button>
         <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
+        <button class="btn" id="tileCharToggle">ASCII Tiles: On</button>
         <button class="btn" id="settingsClose">Close</button>
       </main>
     </div>

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -160,6 +160,14 @@ function setMobileControls(on){
   return mobileButtons;
 }
 function toggleMobileControls(){ setMobileControls(!mobileControlsEnabled); }
+let tileCharsEnabled = true;
+function setTileChars(on){
+  tileCharsEnabled = on;
+  const btn=document.getElementById('tileCharToggle');
+  if(btn) btn.textContent = `ASCII Tiles: ${on ? 'On' : 'Off'}`;
+}
+function toggleTileChars(){ setTileChars(!tileCharsEnabled); }
+globalThis.toggleTileChars = toggleTileChars;
 function sfxTick(){
   if(!audioEnabled) return;
   const o=audioCtx.createOscillator();
@@ -405,10 +413,12 @@ function render(gameState=state, dt){
           }
           ctx.fillStyle = jitterColor(col, gx, gy);
           ctx.fillRect(vx*TS,vy*TS,TS,TS);
-          const ch = tileChars[t];
-          if(ch){
-            ctx.fillStyle = tileCharColors[t];
-            ctx.fillText(ch, vx*TS+4, vy*TS+12);
+          if(tileCharsEnabled){
+            const ch = tileChars[t];
+            if(ch){
+              ctx.fillStyle = tileCharColors[t];
+              ctx.fillText(ch, vx*TS+4, vy*TS+12);
+            }
           }
           if(t===TILE.DOOR){
             ctx.strokeStyle='#9ef7a0';
@@ -970,8 +980,11 @@ if (document.getElementById('saveBtn')) {
   if(audioBtn) audioBtn.onclick=()=>toggleAudio();
   const mobileBtn=document.getElementById('mobileToggle');
   if(mobileBtn) mobileBtn.onclick=()=>toggleMobileControls();
+  const tileCharBtn=document.getElementById('tileCharToggle');
+  if(tileCharBtn) tileCharBtn.onclick=()=>toggleTileChars();
   setAudio(audioEnabled);
   setMobileControls(mobileControlsEnabled);
+  setTileChars(tileCharsEnabled);
   const settingsBtn=document.getElementById('settingsBtn');
   const settings=document.getElementById('settings');
   if(settingsBtn && settings){
@@ -1024,6 +1037,7 @@ if (document.getElementById('saveBtn')) {
       case 't': case 'T': case 'g': case 'G': takeNearestItem(); break;
       case 'o': case 'O': toggleAudio(); break;
       case 'c': case 'C': toggleMobileControls(); break;
+      case 'j': case 'J': toggleTileChars(); break;
       case 'i': case 'I': showTab('inv'); break;
       case 'p': case 'P': showTab('party'); break;
       case 'q': if(!e.ctrlKey && !e.metaKey){ showTab('quests'); e.preventDefault(); } break;

--- a/test/keyboard-shortcuts.test.js
+++ b/test/keyboard-shortcuts.test.js
@@ -8,14 +8,19 @@ test('keyboard shortcuts toggle audio, mobile controls, and pickup', async () =>
   context.takeNearestItem = () => { takeCalls++; };
   const audioBtn = document.getElementById('audioToggle');
   const mobileBtn = document.getElementById('mobileToggle');
+  const tileBtn = document.getElementById('tileCharToggle');
   assert.strictEqual(audioBtn.textContent, 'Audio: On');
   assert.strictEqual(mobileBtn.textContent, 'Mobile Controls: Off');
+  assert.strictEqual(tileBtn.textContent, 'ASCII Tiles: On');
 
   context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'o' }));
   assert.strictEqual(audioBtn.textContent, 'Audio: Off');
 
   context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'c' }));
   assert.strictEqual(mobileBtn.textContent, 'Mobile Controls: On');
+
+  context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'j' }));
+  assert.strictEqual(tileBtn.textContent, 'ASCII Tiles: Off');
 
   context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'g' }));
   assert.strictEqual(takeCalls, 1);

--- a/test/persist-llm-button.test.js
+++ b/test/persist-llm-button.test.js
@@ -31,6 +31,7 @@ test('Persist LLM button hidden until Nano is ready', async () => {
   document.body.appendChild(document.getElementById('nanoToggle'));
   document.body.appendChild(document.getElementById('audioToggle'));
   document.body.appendChild(document.getElementById('mobileToggle'));
+  document.body.appendChild(document.getElementById('tileCharToggle'));
   const persistBtn = document.getElementById('persistLLM');
   document.body.appendChild(persistBtn);
 


### PR DESCRIPTION
## Summary
- add `tileCharToggle` setting to enable or disable ASCII tile overlay
- hook up keyboard shortcut `J` to toggle tile characters during play
- test keyboard shortcut for ASCII tile toggle

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b71657d63c8328840d2678cdceccfe