### PR TITLE
fix: persist world painting in ACK saves

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2925,7 +2925,9 @@ function saveModule() {
     if (moduleData[k] !== undefined) base[k] = moduleData[k];
   });
   if (moduleData._origKeys?.includes('encounters')) base.encounters = enc;
-  if (moduleData._origKeys?.includes('world')) base.world = gridToEmoji(world);
+  const worldChanged = moduleData._origKeys?.includes('world') ||
+    world.some(row => row.some(t => t !== TILE.SAND && t !== TILE.BUILDING && t !== TILE.DOOR));
+  if (worldChanged) base.world = gridToEmoji(world);
   if (moduleData._origKeys?.includes('buildings')) base.buildings = bldgs;
   if (moduleData._origKeys?.includes('interiors')) base.interiors = ints;
   const data = base;


### PR DESCRIPTION
## Summary
- preserve painted terrain when saving modules without original world data
- test ACK round-trips painted tiles in save/load

## Testing
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7171a3d788328ab5641d25304300c