### PR TITLE
fix: center camera on party collapse

### DIFF
--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -205,6 +205,7 @@ function applyZones(map,x,y){
     log?.('Your party collapses and wakes at the entrance.');
     if(typeof toast==='function') toast('Everyone is down!');
     if(state.mapEntry) setPartyPos(state.mapEntry.x, state.mapEntry.y);
+    centerCamera?.(party.x, party.y, state.map);
     (party||[]).forEach(m=>{ m.hp = 1; });
     renderParty?.(); updateHUD?.();
   }

--- a/test/party-collapse-camera.test.js
+++ b/test/party-collapse-camera.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { createGameProxy } from './test-harness.js';
+
+test('camera recenters on party collapse', async () => {
+  const { context } = createGameProxy([]);
+  context.log = () => {};
+  context.toast = () => {};
+  context.renderParty = () => {};
+  context.updateHUD = () => {};
+  context.setPartyPos = (x, y) => { context.party.x = x; context.party.y = y; };
+  let centered = null;
+  context.centerCamera = (x, y, map) => { centered = { x, y, map }; };
+  context.state.map = 'world';
+  context.state.mapEntry = { map: 'world', x: 5, y: 6 };
+  const partyCode = await fs.readFile(new URL('../scripts/core/party.js', import.meta.url), 'utf8');
+  vm.runInContext(partyCode, context);
+  const mem = new context.Character('t','Tester','');
+  mem.hp = 0;
+  mem.maxHp = 10;
+  context.party.join(mem);
+  const moveCode = await fs.readFile(new URL('../scripts/core/movement.js', import.meta.url), 'utf8');
+  vm.runInContext(moveCode, context);
+  context.applyZones('world', 0, 0);
+  assert.deepStrictEqual(centered, { x: 5, y: 6, map: 'world' });
+});


### PR DESCRIPTION
## Summary
- center the camera on the party after a total wipe
- add regression test for camera recenters after party collapse

## Testing
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b71b1663548328907358b4280825f2