### PR TITLE
feat: convert world map grid during module export

### DIFF
--- a/test/module-json.tools.test.js
+++ b/test/module-json.tools.test.js
@@ -18,7 +18,7 @@ test('module-json export/import round trip', () => {
   try {
     const moduleFile = path.join(tmp, 'sample.module.js');
     const jsonFile = path.join(tmp, 'data', 'modules', 'sample.json');
-    const original = { hello: 'world', portraitSheet: 'assets/portraits/custom.png' };
+    const original = { hello: 'world', portraitSheet: 'assets/portraits/custom.png', world: [[0,1],[2,3]] };
     const moduleContent = `const DATA = \`\n${JSON.stringify(original, null, 2)}\n\`;\nexport function postLoad() {}`;
     fs.writeFileSync(moduleFile, moduleContent);
     runScript(['export', moduleFile], tmp);
@@ -27,9 +27,10 @@ test('module-json export/import round trip', () => {
     assert.strictEqual(exported.name, 'sample-module');
     const { name } = exported;
     assert.strictEqual(exported.portraitSheet, 'assets/portraits/custom.png');
+    assert.deepStrictEqual(exported.world, ['🏝🪨', '🌊🌿']);
     delete exported.module;
     delete exported.name;
-    assert.deepStrictEqual(exported, original);
+    assert.deepStrictEqual(exported, { ...original, world: ['🏝🪨', '🌊🌿'] });
     exported.hello = 'mars';
     exported.module = moduleFile;
     exported.name = name;
@@ -41,6 +42,7 @@ test('module-json export/import round trip', () => {
     const obj = JSON.parse(match[1]);
     assert.strictEqual(obj.hello, 'mars');
     assert.strictEqual(obj.portraitSheet, 'assets/portraits/custom.png');
+    assert.deepStrictEqual(obj.world, [[0,1],[2,3]]);
     assert.strictEqual(obj.module, undefined);
     assert.strictEqual(obj.name, 'sample-module');
   } finally {


### PR DESCRIPTION
## Summary
- convert numeric world grids to emoji on module export and back on import
- test module-json tools with a fixed world map round trip

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7414f87e08328a9e1ccb34ddc9d60