### PR TITLE
feat: add multi-room building wizard

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -668,8 +668,11 @@
     <script defer src="./components/wizard/steps/asset-picker.js"></script>
     <script defer src="./components/wizard/steps/map-placement.js"></script>
     <script defer src="./components/wizard/steps/item-picker.js"></script>
+    <script defer src="./components/wizard/steps/tilemap-picker.js"></script>
+    <script defer src="./components/wizard/steps/door-linker.js"></script>
     <script defer src="./components/wizard/steps/confirm.js"></script>
     <script defer src="./components/wizard/npc-wizard.js"></script>
+    <script defer src="./scripts/wizard-building.js"></script>
     <script defer src="./scripts/adventure-kit.js"></script>
   </body>
 

--- a/components/wizard/steps/door-linker.js
+++ b/components/wizard/steps/door-linker.js
@@ -1,7 +1,9 @@
 (function(){
-  function doorLinkerStep(entryKey, exitKey){
+  function doorLinkerStep(entryKey, exitKey, entryLabel, exitLabel){
     entryKey = entryKey || 'entry';
     exitKey = exitKey || 'exit';
+    entryLabel = entryLabel || 'World Entry';
+    exitLabel = exitLabel || 'Interior Exit';
     return {
       render(container, state){
         this.state = state;
@@ -39,8 +41,8 @@
           });
           return pane;
         }
-        wrap.appendChild(makePane('World Entry', entryKey));
-        wrap.appendChild(makePane('Interior Exit', exitKey));
+        wrap.appendChild(makePane(entryLabel, entryKey));
+        wrap.appendChild(makePane(exitLabel, exitKey));
         container.appendChild(wrap);
       },
       validate(){

--- a/docs/design/in-progress/wizard-framework.md
+++ b/docs/design/in-progress/wizard-framework.md
@@ -99,3 +99,8 @@ This wizard helps create a building with multiple interior rooms, like a house w
 - [x] **Editor Integration:** Add a "Wizards" menu to the main editor UI that lists the available wizards.
 - [x] **Playtest: Create an NPC:** Have a team member use the NPC wizard to create a complete quest NPC. Time how long it takes.
 - [ ] **Playtest: Create a Building:** Have a team member use the Building wizard to create a multi-room building. Check for broken door links.
+    1. Open the editor's **Wizards** tab.
+    2. Click **Building Wizard**.
+    3. Select two interior maps, using **Next** to move between steps.
+    4. Click tiles in each pane to place the world entry/exit and the doors between rooms.
+    5. Press **Done** and verify the module data links all doors correctly.

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -3494,6 +3494,14 @@ if (wizardList && globalThis.Dustland?.NpcWizard) {
   btn.addEventListener('click', () => openWizard(cfg));
   wizardList.appendChild(btn);
 }
+if (wizardList && globalThis.Dustland?.BuildingWizard) {
+  const cfg = globalThis.Dustland.BuildingWizard;
+  const btn = document.createElement('button');
+  btn.className = 'btn';
+  btn.textContent = cfg.title;
+  btn.addEventListener('click', () => openWizard(cfg));
+  wizardList.appendChild(btn);
+}
 
 function openWizard(cfg) {
   const modal = document.getElementById('wizardModal');

--- a/scripts/wizard-building.js
+++ b/scripts/wizard-building.js
@@ -1,27 +1,41 @@
-// Basic Building Wizard config
+// Building Wizard config
 
 globalThis.Dustland = globalThis.Dustland || {};
 Dustland.wizards = Dustland.wizards || {};
 var steps = [];
 if (Dustland.WizardSteps) {
   if (Dustland.WizardSteps.tilemapPicker) {
-    steps.push(Dustland.WizardSteps.tilemapPicker('Tilemap', ['interior_a.tmx', 'interior_b.tmx'], 'tilemap'));
+    steps.push(Dustland.WizardSteps.tilemapPicker('Room 1 Map', ['interior_a.tmx', 'interior_b.tmx'], 'room1'));
+    steps.push(Dustland.WizardSteps.tilemapPicker('Room 2 Map', ['interior_a.tmx', 'interior_b.tmx'], 'room2'));
   }
   if (Dustland.WizardSteps.doorLinker) {
-    steps.push(Dustland.WizardSteps.doorLinker('entry', 'exit'));
+    steps.push(Dustland.WizardSteps.doorLinker('entry', 'exit', 'World Entry', 'Room 1 Exit'));
+    steps.push(Dustland.WizardSteps.doorLinker('room1door', 'room2door', 'Room 1 Door', 'Room 2 Door'));
+  }
+  if (Dustland.WizardSteps.confirm) {
+    steps.push(Dustland.WizardSteps.confirm('Done'));
   }
 }
-Dustland.wizards.building = {
+const BuildingWizard = {
   name: 'BuildingWizard',
+  title: 'Building Wizard',
   steps,
   commit(state){
     state = state || {};
-    const id = (state.tilemap || 'interior').replace(/\.[^/.]+$/, '');
-    const building = { id, tilemap: state.tilemap };
-    const doors = [
-      { from: 'world', to: id, x: state.entry?.x || 0, y: state.entry?.y || 0 },
-      { from: id, to: 'world', x: state.exit?.x || 0, y: state.exit?.y || 0 }
+    const id1 = (state.room1 || 'interior').replace(/\.[^/.]+$/, '');
+    const id2 = (state.room2 || 'interior2').replace(/\.[^/.]+$/, '');
+    const buildings = [
+      { id: id1, tilemap: state.room1 },
+      { id: id2, tilemap: state.room2 }
     ];
-    return { buildings: [building], doors };
+    const doors = [
+      { from: 'world', to: id1, x: state.entry?.x || 0, y: state.entry?.y || 0 },
+      { from: id1, to: 'world', x: state.exit?.x || 0, y: state.exit?.y || 0 },
+      { from: id1, to: id2, x: state.room1door?.x || 0, y: state.room1door?.y || 0 },
+      { from: id2, to: id1, x: state.room2door?.x || 0, y: state.room2door?.y || 0 }
+    ];
+    return { buildings, doors };
   }
 };
+Dustland.BuildingWizard = BuildingWizard;
+Dustland.wizards.building = BuildingWizard;

--- a/test/wizard-building.commit.test.js
+++ b/test/wizard-building.commit.test.js
@@ -8,13 +8,25 @@ test('BuildingWizard commit links doors', async () => {
   const context = { Dustland: { WizardSteps: {}, wizards: {} } };
   vm.createContext(context);
   vm.runInContext(code, context);
-  const commit = context.Dustland.wizards.building.commit;
-  const mod = JSON.parse(JSON.stringify(commit({ tilemap: 'interior_a.tmx', entry: { x: 1, y: 2 }, exit: { x: 3, y: 4 } })));
+  const commit = context.Dustland.BuildingWizard.commit;
+  const mod = JSON.parse(JSON.stringify(commit({
+    room1: 'interior_a.tmx',
+    room2: 'interior_b.tmx',
+    entry: { x: 1, y: 2 },
+    exit: { x: 3, y: 4 },
+    room1door: { x: 5, y: 6 },
+    room2door: { x: 7, y: 8 }
+  })));
   assert.deepStrictEqual(mod, {
-    buildings: [{ id: 'interior_a', tilemap: 'interior_a.tmx' }],
+    buildings: [
+      { id: 'interior_a', tilemap: 'interior_a.tmx' },
+      { id: 'interior_b', tilemap: 'interior_b.tmx' }
+    ],
     doors: [
       { from: 'world', to: 'interior_a', x: 1, y: 2 },
-      { from: 'interior_a', to: 'world', x: 3, y: 4 }
+      { from: 'interior_a', to: 'world', x: 3, y: 4 },
+      { from: 'interior_a', to: 'interior_b', x: 5, y: 6 },
+      { from: 'interior_b', to: 'interior_a', x: 7, y: 8 }
     ]
   });
 });

--- a/test/wizard-building.test.js
+++ b/test/wizard-building.test.js
@@ -3,6 +3,6 @@ import { test } from 'node:test';
 import '../scripts/wizard-building.js';
 
 test('building wizard config exists', () => {
-  assert.ok(Dustland.wizards.building);
-  assert.equal(Dustland.wizards.building.name, 'BuildingWizard');
+  assert.ok(Dustland.BuildingWizard);
+  assert.equal(Dustland.BuildingWizard.name, 'BuildingWizard');
 });


### PR DESCRIPTION
## Summary
- wire up Building Wizard with tilemap and door linking steps
- allow door linker step to customize pane labels
- document how to verify multi-room buildings in wizard design doc

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b75b99f51c83289d22eba0c342b751