### PR TITLE
feat: toggle building boarded state

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -466,6 +466,7 @@
           </div>
           <canvas id="bldgCanvas" width="192" height="160" style="margin-top:4px"></canvas>
           <label>Interior<select id="bldgInterior"></select></label>
+          <label><input type="checkbox" id="bldgBoarded"> Boarded</label>
           <button class="btn" id="addBldg">Add Building</button>
           <button class="btn" type="button" id="cancelBldg" style="display:none">Cancel</button>
           <button class="btn" id="delBldg" style="display:none">Remove Building</button>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2396,6 +2396,7 @@ function startNewBldg() {
   document.getElementById('bldgY').value = 0;
   document.getElementById('bldgW').value = 6;
   document.getElementById('bldgH').value = 5;
+  document.getElementById('bldgBoarded').checked = false;
   bldgGrid = Array.from({length:5},(_,yy)=>Array.from({length:6},(_,xx)=>TILE.BUILDING));
   bldgGrid[4][3]=TILE.DOOR;
   bldgPalette.querySelectorAll('button').forEach(b=>b.classList.remove('active'));
@@ -2431,7 +2432,8 @@ function addBuilding() {
     interiorId = makeInteriorRoom();
     const I = interiors[interiorId]; I.id = interiorId; moduleData.interiors.push(I); renderInteriorList();
   }
-  const b = placeHut(x,y,{interiorId, grid:bldgGrid});
+  const boarded = document.getElementById('bldgBoarded').checked;
+  const b = placeHut(x,y,{interiorId, grid:bldgGrid, boarded});
   moduleData.buildings.push(b);
   editBldgIdx = moduleData.buildings.length - 1;
   renderBldgList();
@@ -2468,6 +2470,7 @@ function editBldg(i) {
   document.getElementById('bldgY').value = b.y;
   document.getElementById('bldgW').value = b.w;
   document.getElementById('bldgH').value = b.h;
+  document.getElementById('bldgBoarded').checked = !!b.boarded;
   bldgGrid = b.grid ? b.grid.map(r=>r.slice()) : Array.from({length:b.h},()=>Array.from({length:b.w},()=>TILE.BUILDING));
   updateInteriorOptions();
   document.getElementById('bldgInterior').value = b.interiorId || '';
@@ -2671,7 +2674,8 @@ function applyBldgChanges() {
   }
   const ob = moduleData.buildings[editBldgIdx];
   removeBuilding(ob);
-  const b = placeHut(x, y, { interiorId, grid: bldgGrid, boarded: ob.boarded });
+  const boarded = document.getElementById('bldgBoarded').checked;
+  const b = placeHut(x, y, { interiorId, grid: bldgGrid, boarded });
   moduleData.buildings[editBldgIdx] = b;
   selectedObj = { type: 'bldg', obj: b };
   placingType = null;

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -644,3 +644,20 @@ test('collectNPCFromForm retains custom portrait path', () => {
   const npc = collectNPCFromForm();
   assert.strictEqual(npc.portraitSheet, 'assets/portraits/grin_4.png');
 });
+
+test('building boarded state round trips through editor', () => {
+  const prevModuleBldgs = moduleData.buildings;
+  const prevBuilds = globalThis.buildings.slice();
+  genWorld(1, { buildings: [] });
+  moduleData.buildings = [];
+  startNewBldg();
+  document.getElementById('bldgBoarded').checked = true;
+  addBuilding();
+  assert.strictEqual(moduleData.buildings[0].boarded, true);
+  editBldg(0);
+  document.getElementById('bldgBoarded').checked = false;
+  applyBldgChanges();
+  assert.strictEqual(moduleData.buildings[0].boarded, false);
+  moduleData.buildings = prevModuleBldgs;
+  globalThis.buildings = prevBuilds;
+});


### PR DESCRIPTION
## Summary
- allow configuring whether a building is boarded in Adventure Kit
- expose boarded toggle in ACK building editor and hook into save logic
- cover boarded toggle with a new ACK test

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b75c7999f88328a6d9a00f2519e23d