### PR TITLE
feat: add brush size slider to adventure kit noise painting

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -21,7 +21,7 @@ _______________________________________________________________________________
   module player so you can craft and try your own wasteland tales. It’s
   still built to be easy to run and easy to hack. Tiny inline SFX add a bit of
   snap without requiring extra assets.
-  The terrain editor lets you paint features with organic noise.
+  The terrain editor lets you paint features with organic noise and adjustable brush sizes.
 
 [ HOW TO RUN ]
   - Play online: https://weatheredclown.github.io/dustland/dustland.html

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -304,6 +304,7 @@
             <div id="paletteLabel"></div>
           </div>
           <button class="btn" id="noiseToggle" title="Toggle organic brush noise">Noise: On</button>
+          <label for="brushSize">Brush Size <input type="range" id="brushSize" min="1" max="10" value="1"><span id="brushSizeLabel">1</span></label>
         </div>
         <div class="btn-group">
           <div style="padding:0px 13px 0px 0px;font-family: sans-serif;">

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -262,6 +262,8 @@ let worldStamp = null;
 let worldPainting = false;
 let didPaint = false;
 const noiseToggle = document.getElementById('noiseToggle');
+const brushSizeSlider = document.getElementById('brushSize');
+const brushSizeLabel = document.getElementById('brushSizeLabel');
 let worldPaintNoise = true;
 let brushSize = 1;
 if (noiseToggle) {
@@ -270,6 +272,13 @@ if (noiseToggle) {
     noiseToggle.textContent = `Noise: ${worldPaintNoise ? 'On' : 'Off'}`;
   });
   noiseToggle.textContent = 'Noise: On';
+}
+if (brushSizeSlider) {
+  if (brushSizeLabel) brushSizeLabel.textContent = brushSizeSlider.value;
+  brushSizeSlider.addEventListener('input', () => {
+    brushSize = parseInt(brushSizeSlider.value, 10);
+    if (brushSizeLabel) brushSizeLabel.textContent = brushSizeSlider.value;
+  });
 }
 
 function addTerrainFeature(x, y, tile) {

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -242,6 +242,23 @@ test('addTerrainFeature sprinkles noise', () => {
   assert.strictEqual(prev, TILE.SAND);
 });
 
+test('brushSize slider adjusts noise radius', () => {
+  genWorld(1);
+  for (let dy=-2; dy<=2; dy++) {
+    for (let dx=-2; dx<=2; dx++) {
+      setTile('world', 5+dx, 5+dy, TILE.SAND);
+    }
+  }
+  const slider = document.getElementById('brushSize');
+  slider.value = '2';
+  if (slider._listeners && slider._listeners.input) slider._listeners.input[0]();
+  const rnd = Math.random;
+  Math.random = () => 0;
+  addTerrainFeature(5,5,TILE.ROCK);
+  Math.random = rnd;
+  assert.strictEqual(world[3][5], TILE.ROCK);
+});
+
 test('stampWorld applies a stamp pattern', () => {
   genWorld(1);
   const stamp = worldStamps.cross;


### PR DESCRIPTION
## Summary
- add brush size range slider to adventure kit noise painting
- wire slider to noise brush logic and label
- document adjustable brush sizes and test slider

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b87909f3088328b17de4fe012b916f