### PR TITLE
feat: add crate audio cues and dockhand scene

### DIFF
--- a/docs/design/blog-feedback-tasks.md
+++ b/docs/design/blog-feedback-tasks.md
@@ -22,7 +22,7 @@
 - [ ] Ensure companions respect hold-position orders under fire
 - [ ] Implement a screenshot mode
 - [ ] Refine the buggy repair mini-game to feel skill-based rather than random
-- [ ] Provide audio cues for nearby hidden supply crates
+- [x] Provide audio cues for nearby hidden supply crates
 - [ ] Add fast travel between discovered bunkers
 - [ ] Optimize the heat haze effect for lower-performance hardware
 - [ ] Include more story twists like the AI oasis caretaker reveal

--- a/docs/design/in-progress/true-dust.md
+++ b/docs/design/in-progress/true-dust.md
@@ -33,7 +33,7 @@ The Dustland opens its eyes with a whisper of grit and memory. "True Dust" drops
 - [x] Place three diggable scrap caches aligned with radio static zones.
 - [x] Define pulse rifle item rewarded by Mayor Ganton.
 - [ ] Script Rustwater corruption dialog and bandit quest chain.
-- [ ] Design Lakeside dockhand scene: give pendant fragment when Rygar present; deliver warning note when absent.
+- [x] Design Lakeside dockhand scene: give pendant fragment when Rygar present; deliver warning note when absent.
 - [x] Log quest updates for Rygar's Echo, Static Whisper, and Bandit Purge.
 - [x] Test Stonegate safety, radio range, bandit balance, and Lakeside branching outcomes.
 

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -413,6 +413,35 @@ const DATA = `
       }
     },
     {
+      "id": "hidden_crate",
+      "map": "world",
+      "x": 12,
+      "y": 12,
+      "color": "#c8bba0",
+      "name": "Buried Crate",
+      "desc": "Sand conceals a supply crate.",
+      "hintSound": true,
+      "tree": {
+        "start": {
+          "text": "You sense something under the sand.",
+          "choices": [
+            { "label": "(Dig)", "to": "dig", "once": true },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "dig": {
+          "text": "You uncover a supply crate packed with scrap.",
+          "choices": [
+            { "label": "(Take Scrap)", "to": "empty", "reward": "SCRAP 5", "effects": [ { "effect": "removeSoundSource", "id": "hidden_crate" } ] }
+          ]
+        },
+        "empty": {
+          "text": "Just disturbed sand remains.",
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        }
+      }
+    },
+    {
       "id": "tape_sage",
       "map": "hall",
       "x": 14,
@@ -2034,6 +2063,13 @@ function postLoad(module) {
       for (const choice of node.choices || []) {
         if (choice.effects) choice.effects = handleCustomEffects(choice.effects);
       }
+    }
+  }
+
+  for (const npc of module.npcs || []) {
+    const arr = globalThis.soundSources;
+    if (npc.hintSound && Array.isArray(arr)) {
+      arr.push({ id: npc.id, x: npc.x, y: npc.y, map: npc.map });
     }
   }
 

--- a/modules/true-dust.module.js
+++ b/modules/true-dust.module.js
@@ -18,6 +18,20 @@ const DATA = `{
       "entryY": 3
     },
     {
+      "id": "lakeside",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🏝🚪🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
       "id": "maw_1",
       "w": 9,
       "h": 7,
@@ -117,6 +131,33 @@ const DATA = `{
           "choices": [ { "label": "(Leave)", "to": "bye" } ]
         }
       }
+    },
+    {
+      "id": "lakeside_dockhand",
+      "map": "lakeside",
+      "x": 2,
+      "y": 2,
+      "color": "#a9f59f",
+      "name": "Dockhand",
+      "title": "Lakeside",
+      "desc": "A dockhand watching the shore.",
+      "tree": {
+        "start": {
+          "text": "The dockhand studies the waves.",
+          "choices": [
+            { "label": "(Ask about Mira)", "to": "ask" },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "with_rygar": {
+          "text": "He hands Rygar a copper pendant fragment.",
+          "choices": [ { "label": "(Take fragment)", "to": "bye", "reward": "pendant_fragment" } ]
+        },
+        "without_rygar": {
+          "text": "He warns you someone matching Mira's description was dragged onto a night boat.",
+          "choices": [ { "label": "(Leave)", "to": "bye", "reward": "warning_note" } ]
+        }
+      }
     }
   ],
   "items": [
@@ -168,6 +209,16 @@ const DATA = `{
       "type": "weapon",
       "slot": "weapon",
       "mods": { "ATK": 4, "ADR": 25 }
+    },
+    {
+      "id": "pendant_fragment",
+      "name": "Pendant Fragment",
+      "type": "quest"
+    },
+    {
+      "id": "warning_note",
+      "name": "Warning Note",
+      "type": "quest"
     }
   ],
   "quests": [
@@ -177,6 +228,8 @@ const DATA = `{
   ],
   "portals": [
     { "map": "stonegate", "x": 5, "y": 3, "toMap": "maw_1", "toX": 0, "toY": 3 },
+    { "map": "stonegate", "x": 0, "y": 3, "toMap": "lakeside", "toX": 2, "toY": 2 },
+    { "map": "lakeside", "x": 2, "y": 2, "toMap": "stonegate", "toX": 0, "toY": 3 },
     { "map": "maw_1", "x": 0, "y": 3, "toMap": "stonegate", "toX": 5, "toY": 3 },
     { "map": "maw_1", "x": 8, "y": 3, "toMap": "maw_2", "toX": 0, "toY": 3 },
     { "map": "maw_2", "x": 0, "y": 3, "toMap": "maw_1", "toX": 8, "toY": 3 },
@@ -307,6 +360,14 @@ function postLoad(module) {
     rygar.tree.joined = {
       text: 'Rygar nods and falls in step.',
       choices: [ { label: '(Leave)', to: 'bye' } ]
+    };
+  }
+  const dock = module.npcs.find(n => n.id === 'lakeside_dockhand');
+  if (dock) {
+    dock.processNode = function (node) {
+      if (node === 'ask') {
+        dialogState.node = party.some(m => m.id === 'rygar') ? 'with_rygar' : 'without_rygar';
+      }
     };
   }
   module.quests?.forEach(q => addQuest(q.id, q.title, q.desc, q));

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -373,11 +373,9 @@ function draw(t){
   }
   pctx.clearRect(0,0,prev.width,prev.height); pctx.drawImage(scene,0,0);
 
-  if (state.mapFlags && state.mapFlags.dustStorm) {
-    for (const source of soundSources) {
-      if (source.map === state.map) {
-        playWindChime(source.x, source.y);
-      }
+  for (const source of soundSources) {
+    if (source.map === state.map) {
+      playWindChime(source.x, source.y);
     }
   }
 

--- a/test/hidden-crate.sound.test.js
+++ b/test/hidden-crate.sound.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+test('hidden crate registers sound source', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'dustland.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const sandbox = { soundSources: [], NPCS: [], addQuest: () => {}, log: () => {}, console };
+  vm.runInNewContext(src, sandbox);
+  const mod = sandbox.DUSTLAND_MODULE;
+  mod.postLoad(mod);
+  assert.ok(sandbox.soundSources.some(s => s.id === 'hidden_crate'));
+});

--- a/test/true-dust.dockhand.test.js
+++ b/test/true-dust.dockhand.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+test('dockhand branches on Rygar presence', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'true-dust.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const sandbox = { party: [], dialogState: { node: 'ask' }, NPCS: [], addQuest: () => {}, log: () => {}, console };
+  vm.runInNewContext(src, sandbox);
+  const mod = sandbox.TRUE_DUST;
+  mod.postLoad(mod);
+  const dock = mod.npcs.find(n => n.id === 'lakeside_dockhand');
+  sandbox.dialogState.node = 'ask';
+  dock.processNode('ask');
+  assert.strictEqual(sandbox.dialogState.node, 'without_rygar');
+  sandbox.party.push({ id: 'rygar' });
+  sandbox.dialogState.node = 'ask';
+  dock.processNode('ask');
+  assert.strictEqual(sandbox.dialogState.node, 'with_rygar');
+});


### PR DESCRIPTION
## Summary
- chime nearby supply crates and streamline sound source handling
- introduce Lakeside dockhand encounter that reacts to Rygar
- cover new crate audio and dockhand branching with tests

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8b44be7748328bbe9d63b88645688