### PR TITLE
feat: expand design doc tasks

### DIFF
--- a/docs/design/blog-feedback-tasks.md
+++ b/docs/design/blog-feedback-tasks.md
@@ -34,7 +34,7 @@
 - [ ] Expand documentation on event-bus quirks for modders
 - [ ] Fix dune race leaderboards desyncing after patches
 - [ ] Prevent the decoy drone from attracting allied NPCs
-- [ ] Add more tracks to the in-game radio playlist
+- [x] Add more tracks to the in-game radio playlist
 - [ ] Let crowbars open locked crates without explosives
 - [ ] Persist trail markers in co-op even if players log out
 - [ ] Swap modular armor plates without pausing the game

--- a/docs/design/in-progress/plot-draft.md
+++ b/docs/design/in-progress/plot-draft.md
@@ -102,7 +102,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
     - [x] Hook Mara's puzzle into the Broadcast Story sequence.
     - [x] Script Jax's timed repair sequence under combat pressure. Implemented in `jax-repair.module.js`.
     - [x] Write the dialogue and branching paths for Nyx's "conversational tuning" encounter.
-- [ ] **Doppelgänger System:**
+- [x] **Doppelgänger System:**
     - [x] Create the data structure for "personas" that can be equipped by the main characters.
     - [x] Design and create the first set of alternate masks and outfits for Mara, Jax, and Nyx.
 - [ ] **Implement Key Items:**

--- a/docs/design/in-progress/true-dust.md
+++ b/docs/design/in-progress/true-dust.md
@@ -32,7 +32,7 @@ The Dustland opens its eyes with a whisper of grit and memory. "True Dust" drops
 - [x] Implement radio item: proximity handler for scrap caches and static toast.
 - [x] Place three diggable scrap caches aligned with radio static zones.
 - [x] Define pulse rifle item rewarded by Mayor Ganton.
-- [ ] Script Rustwater corruption dialog and bandit quest chain.
+- [x] Script Rustwater corruption dialog and bandit quest chain.
 - [x] Design Lakeside dockhand scene: give pendant fragment when Rygar present; deliver warning note when absent.
 - [x] Log quest updates for Rygar's Echo, Static Whisper, and Bandit Purge.
 - [x] Test Stonegate safety, radio range, bandit balance, and Lakeside branching outcomes.

--- a/modules/true-dust.module.js
+++ b/modules/true-dust.module.js
@@ -133,6 +133,35 @@ const DATA = `{
       }
     },
     {
+      "id": "ganton",
+      "map": "stonegate",
+      "x": 1,
+      "y": 2,
+      "color": "#f99",
+      "name": "Mayor Ganton",
+      "title": "Rustwater",
+      "desc": "Rustwater's mayor eyes you shiftily.",
+      "questId": "bandit_purge",
+      "tree": {
+        "start": {
+          "text": "Bandits choke the road to Lakeside. Clear them and keep quiet.",
+          "choices": [
+            { "label": "(Take job)", "to": "accept", "q": "accept", "if": { "flag": "bandit_purge_active", "op": "<", "value": 1 }, "setFlag": { "flag": "bandit_purge_active", "op": "set", "value": 1 } },
+            { "label": "(Collect reward)", "to": "reward", "q": "turnin", "if": { "flag": "bandits_cleared", "op": ">=", "value": 1 } },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "accept": {
+          "text": "Don't ask questions. Just deal with them.",
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        },
+        "reward": {
+          "text": "Ganton slips you a prototype rifle.",
+          "choices": [ { "label": "(Take rifle)", "to": "bye", "reward": "pulse_rifle" } ]
+        }
+      }
+    },
+    {
       "id": "lakeside_dockhand",
       "map": "lakeside",
       "x": 2,
@@ -158,6 +187,17 @@ const DATA = `{
           "choices": [ { "label": "(Leave)", "to": "bye", "reward": "warning_note" } ]
         }
       }
+    },
+    {
+      "id": "bandit_leader",
+      "map": "lakeside",
+      "x": 1,
+      "y": 1,
+      "color": "#f55",
+      "name": "Bandit Leader",
+      "desc": "A bandit blocks the road.",
+      "tree": { "start": { "text": "A bandit steps out, weapons drawn." } },
+      "combat": { "HP": 10, "ATK": 3, "DEF": 1, "loot": "scrap" }
     }
   ],
   "items": [
@@ -369,6 +409,10 @@ function postLoad(module) {
         dialogState.node = party.some(m => m.id === 'rygar') ? 'with_rygar' : 'without_rygar';
       }
     };
+  }
+  const bandit = module.npcs.find(n => n.id === 'bandit_leader');
+  if (bandit && bandit.combat) {
+    bandit.combat.effects = [() => setFlag('bandits_cleared', 1)];
   }
   module.quests?.forEach(q => addQuest(q.id, q.title, q.desc, q));
 }

--- a/music-demo.js
+++ b/music-demo.js
@@ -110,7 +110,8 @@
     { id: 'hopeful', name: 'Hopeful', info: 'Major lift, echoing arps.', key: 'G', bpm: 124, scale: 'major', swing: 0.04, density: 0.7, leadWave: 'triangle', bassWave: 'triangle', harmony: [0, 4, 5, 7], barStart: 'stab' },
     { id: 'triumphant', name: 'Triumphant', info: 'Bright cadence, driving hats.', key: 'G', bpm: 132, scale: 'major', swing: 0.05, density: 0.85, leadWave: 'square', bassWave: 'triangle', harmony: [0, 4, 5, 0], barStart: 'stab' },
     { id: 'melancholic', name: 'Melancholic', info: 'Bittersweet minor, wide intervals.', key: 'G', bpm: 110, scale: 'minor', swing: 0.02, density: 0.55, leadWave: 'triangle', bassWave: 'triangle', harmony: [0, 5, 3, 2], barStart: 'stab' },
-    { id: 'mystery', name: 'Mystery', info: 'Shadowy dorian feel, syncopation.', key: 'G', bpm: 96, scale: 'dorian', swing: 0.0, density: 0.4, leadWave: 'triangle', bassWave: 'square', harmony: [0, 2, 6, 2], barStart: 'stab' }
+    { id: 'mystery', name: 'Mystery', info: 'Shadowy dorian feel, syncopation.', key: 'G', bpm: 96, scale: 'dorian', swing: 0.0, density: 0.4, leadWave: 'triangle', bassWave: 'square', harmony: [0, 2, 6, 2], barStart: 'stab' },
+    { id: 'chill', name: 'Chill', info: 'Laid-back square leads with airy bass.', key: 'G', bpm: 88, scale: 'major', swing: 0.03, density: 0.4, leadWave: 'square', bassWave: 'triangle', harmony: [0, 4, 5, 4], barStart: 'stab' }
   ];
 
   // Universal seed for JSON config and Magenta basis (shared across moods)

--- a/scripts/game-state.js
+++ b/scripts/game-state.js
@@ -7,5 +7,11 @@
   function setDifficulty(mode){ state.difficulty = mode; }
   function setPersona(id, persona){ state.personas[id] = persona; }
   function getPersona(id){ return state.personas[id]; }
-  Dustland.gameState = { getState, updateState, getDifficulty, setDifficulty, setPersona, getPersona };
+  function applyPersona(memberId, personaId){
+    const persona = state.personas[personaId];
+    if (!persona) return;
+    const member = state.party.find(m => m.id === memberId);
+    if (member) member.persona = personaId;
+  }
+  Dustland.gameState = { getState, updateState, getDifficulty, setDifficulty, setPersona, getPersona, applyPersona };
 })();

--- a/test/music-demo.moods.test.js
+++ b/test/music-demo.moods.test.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('music demo includes chill mood', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'music-demo.js');
+  const src = fs.readFileSync(file, 'utf8');
+  assert.match(src, /id: 'chill'/);
+});

--- a/test/personas-apply.test.js
+++ b/test/personas-apply.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+test('applyPersona assigns persona to party member', async () => {
+  const dom = new JSDOM('<body></body>');
+  const context = { window: dom.window, document: dom.window.document, console };
+  vm.createContext(context);
+  const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
+  vm.runInContext(gs, context);
+  context.Dustland.gameState.updateState(s => { s.party = [{ id: 'mara', name: 'Mara' }]; });
+  const ps = await fs.readFile(new URL('../scripts/core/personas.js', import.meta.url), 'utf8');
+  vm.runInContext(ps, context);
+  const applyPersona = context.Dustland.gameState.applyPersona;
+  applyPersona('mara', 'mara.masked');
+  const st = context.Dustland.gameState.getState();
+  assert.strictEqual(st.party[0].persona, 'mara.masked');
+});

--- a/test/true-dust.bandit-quest.test.js
+++ b/test/true-dust.bandit-quest.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const src = await fs.readFile(new URL('../modules/true-dust.module.js', import.meta.url), 'utf8');
+
+const flags = {};
+
+function setFlag(name, val){ flags[name] = val; }
+
+test('bandit defeat sets flag', async () => {
+  const context = { setInterval: () => 0, clearInterval: () => {}, setFlag, addQuest: () => {}, party: [] };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(src, context);
+  const mod = context.TRUE_DUST;
+  mod.postLoad(mod);
+  const bandit = mod.npcs.find(n => n.id === 'bandit_leader');
+  bandit.combat.effects[0]();
+  assert.strictEqual(flags.bandits_cleared, 1);
+});

--- a/test/true-dust.module.test.js
+++ b/test/true-dust.module.test.js
@@ -41,4 +41,8 @@ test('true dust module defines safe zone and spawns', () => {
   assert.ok(radio && radio.slot === 'trinket');
   const caches = data.items.filter(i => i.id.startsWith('scrap_cache'));
   assert.strictEqual(caches.length, 3);
+  const ganton = data.npcs.find(n => n.id === 'ganton');
+  assert.ok(ganton && ganton.questId === 'bandit_purge');
+  assert.ok(ganton.tree.reward.choices.some(c => c.reward === 'pulse_rifle'));
+  assert.ok(data.npcs.some(n => n.id === 'bandit_leader'));
 });


### PR DESCRIPTION
## Summary
- add chill mood to radio playlist
- wire persona swapping into game state
- script Rustwater bandit quest with Mayor Ganton

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8d1c5fac48328a4f53a7c64aac6f4