### PR TITLE
docs: guide modders on broadcast fragments

### DIFF
--- a/docs/broadcast-fragments-tutorial.md
+++ b/docs/broadcast-fragments-tutorial.md
@@ -1,0 +1,14 @@
+# Broadcast Fragment Tutorial
+
+*By Priya "Gizmo" Sharma*
+
+This guide shows modders how to build a story fragment that plugs into the Broadcast Story sequence.
+
+1. Copy an existing fragment like `modules/intro-fragment.module.js` and rename it.
+2. In the new module, set `startMap` and `startPoint` inside the `DATA` block to define where the fragment begins.
+3. Add any custom scripts or assets the fragment needs under `modules/` and `assets/`.
+4. Run `npm run module:export -- <module>` and commit the generated JSON under `data/modules/` for review.
+5. Test the fragment by launching `dustland.html?ack-player=1` and selecting **Broadcast Story** from the module picker.
+6. Once verified, send a pull request and update `docs/design/in-progress/plot-draft.md` if the fragment advances the main narrative.
+
+Fragments stay lightweight—avoid persistent state and rely on the event bus for cross-module communication. See `docs/event-bus-quirks.md` for pitfalls.

--- a/docs/design/blog-feedback-tasks.md
+++ b/docs/design/blog-feedback-tasks.md
@@ -31,7 +31,7 @@
 - [ ] Slow fuel depot respawns to encourage strategic convoy runs
 - [ ] Continue adding lore snippets to ancient billboards
 - [ ] Give wind turbines tangible gameplay benefits
-- [ ] Expand documentation on event-bus quirks for modders
+- [x] Expand documentation on event-bus quirks for modders
 - [ ] Fix dune race leaderboards desyncing after patches
 - [ ] Prevent the decoy drone from attracting allied NPCs
 - [x] Add more tracks to the in-game radio playlist

--- a/docs/design/in-progress/plot-draft.md
+++ b/docs/design/in-progress/plot-draft.md
@@ -130,7 +130,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
 - [ ] **Playtest the Narrative Arc:** Conduct a full playthrough of the first three broadcast fragment modules to ensure the story flows logically and the mystery unfolds at a compelling pace.
 - [ ] **Test Character Arcs:** Get feedback on the signature encounters for each character to make sure they are both fun and effective at teaching the character's core mechanics.
 - [ ] **Puzzle Usability Testing:** Have players who are unfamiliar with the puzzles test them to ensure they are challenging but not frustrating. Implement quick resets based on their feedback.
-- [ ] **Modding Tools and Documentation:** Create a tutorial for the modding community that explains how to use the broadcast fragment system to create their own stories within the Dustland universe.
+- [x] **Modding Tools and Documentation:** Create a tutorial for the modding community that explains how to use the broadcast fragment system to create their own stories within the Dustland universe.
 
 ### Verification Instructions
 

--- a/docs/event-bus-quirks.md
+++ b/docs/event-bus-quirks.md
@@ -1,0 +1,12 @@
+# Event Bus Quirks
+
+*By Priya "Gizmo" Sharma*
+
+The global event bus powers most game interactions. Keep these behaviors in mind when extending modules:
+
+- Handlers run synchronously in the order they were registered; expensive work blocks later listeners.
+- Events are broadcast with a plain `emit(type, data)` call; missing listeners fail silently.
+- Remove listeners with `off(type, handler)` during `postLoad` teardown to avoid leaks across modules.
+- The bus does not clone payloads. Mutating `data` inside a handler affects downstream listeners.
+
+Use the bus sparingly and prefer explicit function calls when modules share tight coupling.


### PR DESCRIPTION
## Summary
- document event bus quirks for module authors
- add tutorial for building broadcast fragments
- check off related tasks in design docs

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8d9d20890832892a8fb5b76d2678d