### PR TITLE
fix: run lootbox demo postLoad

### DIFF
--- a/modules/lootbox-demo.module.js
+++ b/modules/lootbox-demo.module.js
@@ -121,6 +121,7 @@ globalThis.LOOTBOX_DEMO_MODULE = JSON.parse(DATA);
 globalThis.LOOTBOX_DEMO_MODULE.postLoad = postLoad;
 
 startGame = function(){
+  LOOTBOX_DEMO_MODULE.postLoad?.(LOOTBOX_DEMO_MODULE);
   applyModule(LOOTBOX_DEMO_MODULE);
   setFlag('dummy_challenge', 5);
   const s = LOOTBOX_DEMO_MODULE.start;

--- a/test/lootbox-demo.module.test.js
+++ b/test/lootbox-demo.module.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+test('lootbox demo startGame runs postLoad before applying module', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'lootbox-demo.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const calls = [];
+  const context = { Math };
+  context.globalThis = context;
+  context.applyModule = () => { calls.push('apply'); };
+  context.setFlag = () => {};
+  context.setPartyPos = () => {};
+  context.setMap = () => {};
+  context.makeNPC = () => ({}) ;
+  context.NPCS = [];
+  vm.runInNewContext(src, context);
+  context.LOOTBOX_DEMO_MODULE.postLoad = () => { calls.push('post'); };
+  context.startGame();
+  assert.deepStrictEqual(calls, ['post', 'apply']);
+});


### PR DESCRIPTION
## Summary
- ensure loot box demo initializes module with postLoad before applying data
- add regression test for loot box demo startGame

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8da4423c0832886b4b09aaf9451b9