### PR TITLE
fix: refresh lists after wizard and guard spawn fields

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1411,10 +1411,10 @@ function updateTreeData() {
           const value = valTxt ? parseInt(valTxt, 10) : undefined;
           c.setFlag = { flag: setFlagName, op, value };
         }
-        const spawnTemplate = chEl.querySelector('.choiceSpawnTemplate').value.trim();
+        const spawnTemplate = chEl.querySelector('.choiceSpawnTemplate')?.value.trim();
         if (spawnTemplate) {
-          const x = chEl.querySelector('.choiceSpawnX').value.trim();
-          const y = chEl.querySelector('.choiceSpawnY').value.trim();
+          const x = chEl.querySelector('.choiceSpawnX')?.value.trim() || '0';
+          const y = chEl.querySelector('.choiceSpawnY')?.value.trim() || '0';
           c.spawn = { templateId: spawnTemplate, x: parseInt(x, 10), y: parseInt(y, 10) };
         }
         choices.push(c);
@@ -3639,6 +3639,17 @@ function mergeWizardResult(res) {
     else moduleData[k] = v;
   });
   if (typeof applyModule === 'function') applyModule(moduleData, { fullReset: false });
+  // Refresh lists so wizard changes appear immediately.
+  if (typeof renderNPCList === 'function') renderNPCList();
+  if (typeof renderItemList === 'function') renderItemList();
+  if (typeof renderQuestList === 'function') renderQuestList();
+  if (typeof renderBldgList === 'function') renderBldgList();
+  if (typeof renderInteriorList === 'function') renderInteriorList();
+  if (typeof renderEventList === 'function') renderEventList();
+  if (typeof renderPortalList === 'function') renderPortalList();
+  if (typeof renderZoneList === 'function') renderZoneList();
+  if (typeof renderEncounterList === 'function') renderEncounterList();
+  if (typeof renderTemplateList === 'function') renderTemplateList();
 }
 
 function openWizard(cfg) {


### PR DESCRIPTION
## Summary
- refresh entity lists after wizards commit results
- avoid null spawn fields when adding choices

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8e45717d883289dcf209064ebf90a