### PR TITLE
feat: expand encounter editor

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -581,8 +581,15 @@
           <label>Map<input id="encMap" value="world" /></label>
           <label>Name<input id="encName" placeholder="Enemy name" /></label>
           <label>HP<input id="encHP" type="number" min="1" value="5" /></label>
+          <label>ATK<input id="encATK" type="number" min="1" value="1" /></label>
           <label>DEF<input id="encDEF" type="number" min="0" value="0" /></label>
-          <label>Loot<input id="encLoot" /></label>
+          <label>Min Dist<input id="encMinDist" type="number" min="0" /></label>
+          <label>Max Dist<input id="encMaxDist" type="number" min="0" /></label>
+          <label>Challenge<input id="encChallenge" type="number" min="0" /></label>
+          <label>Portrait<input id="encPortrait" /></label>
+          <label>Special Cue<input id="encSpecialCue" /></label>
+          <label>Special Dmg<input id="encSpecialDmg" type="number" min="1" /></label>
+          <label>Loot<select id="encLoot"></select></label>
           <button class="btn" id="addEncounter">Add Enemy</button>
           <button class="btn" type="button" id="cancelEncounter" style="display:none">Cancel</button>
           <button class="btn" id="delEncounter" style="display:none">Delete Enemy</button>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1259,6 +1259,8 @@ function refreshChoiceDropdowns() {
   document.querySelectorAll('.choiceBoard').forEach(sel => populateInteriorDropdown(sel, sel.value));
   document.querySelectorAll('.choiceUnboard').forEach(sel => populateInteriorDropdown(sel, sel.value));
   document.querySelectorAll('.choiceSpawnTemplate').forEach(sel => populateTemplateDropdown(sel, sel.value));
+  const encLoot = document.getElementById('encLoot');
+  if (encLoot) populateItemDropdown(encLoot, encLoot.value);
 }
 
 function renderTreeEditor() {
@@ -2093,8 +2095,15 @@ function startNewEncounter(){
   document.getElementById('encMap').value = 'world';
   document.getElementById('encName').value = '';
   document.getElementById('encHP').value = 5;
+  document.getElementById('encATK').value = 1;
   document.getElementById('encDEF').value = 0;
-  document.getElementById('encLoot').value = '';
+  document.getElementById('encMinDist').value = '';
+  document.getElementById('encMaxDist').value = '';
+  document.getElementById('encChallenge').value = '';
+  document.getElementById('encPortrait').value = '';
+  document.getElementById('encSpecialCue').value = '';
+  document.getElementById('encSpecialDmg').value = '';
+  populateItemDropdown(document.getElementById('encLoot'), '');
   document.getElementById('addEncounter').textContent = 'Add Enemy';
   document.getElementById('delEncounter').style.display = 'none';
   showEncounterEditor(true);
@@ -2104,9 +2113,22 @@ function collectEncounter(){
   const map = document.getElementById('encMap').value.trim() || 'world';
   const name = document.getElementById('encName').value.trim() || 'Enemy';
   const HP = parseInt(document.getElementById('encHP').value,10) || 1;
+  const ATK = parseInt(document.getElementById('encATK').value,10) || 1;
   const DEF = parseInt(document.getElementById('encDEF').value,10) || 0;
+  const minDist = parseInt(document.getElementById('encMinDist').value,10) || 0;
+  const maxDist = parseInt(document.getElementById('encMaxDist').value,10) || 0;
+  const challenge = parseInt(document.getElementById('encChallenge').value,10) || 0;
+  const portraitSheet = document.getElementById('encPortrait').value.trim();
   const loot = document.getElementById('encLoot').value.trim();
-  return { map, name, HP, DEF, loot };
+  const specialCue = document.getElementById('encSpecialCue').value.trim();
+  const specialDmg = parseInt(document.getElementById('encSpecialDmg').value,10) || 0;
+  const entry = { map, name, HP, ATK, DEF, loot, minDist, maxDist, challenge, portraitSheet };
+  if (specialCue || specialDmg) {
+    entry.special = {};
+    if (specialCue) entry.special.cue = specialCue;
+    if (specialDmg) entry.special.dmg = specialDmg;
+  }
+  return entry;
 }
 function addEncounter(){
   const entry = collectEncounter();
@@ -2124,8 +2146,15 @@ function editEncounter(i){
   document.getElementById('encMap').value = e.map;
   document.getElementById('encName').value = e.name;
   document.getElementById('encHP').value = e.HP || 1;
+  document.getElementById('encATK').value = e.ATK || 1;
   document.getElementById('encDEF').value = e.DEF || 0;
-  document.getElementById('encLoot').value = e.loot || '';
+  document.getElementById('encMinDist').value = e.minDist || '';
+  document.getElementById('encMaxDist').value = e.maxDist || '';
+  document.getElementById('encChallenge').value = e.challenge || '';
+  document.getElementById('encPortrait').value = e.portraitSheet || '';
+  document.getElementById('encSpecialCue').value = e.special?.cue || '';
+  document.getElementById('encSpecialDmg').value = e.special?.dmg || '';
+  populateItemDropdown(document.getElementById('encLoot'), e.loot || '');
   document.getElementById('addEncounter').textContent = 'Update Enemy';
   document.getElementById('delEncounter').style.display = 'block';
   showEncounterEditor(true);


### PR DESCRIPTION
## Summary
- add loot dropdown and additional stats to encounter editor
- refresh loot options when items change

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8e206f52883288f2966b16bf36de9