### PR TITLE
feat: clarify NPC template purpose in editor

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -590,7 +590,7 @@
         </div>
       </fieldset>
       <fieldset class="card" id="templateCard" data-pane="templates" style="display:none">
-        <legend>NPC Templates</legend>
+        <legend>NPC Templates <span class="help" title="Templates for enemies that can spawn from dialog">(?)</span></legend>
         <div class="list" id="templateList"></div>
         <button class="btn" type="button" id="newTemplate">+ Template</button>
         <div id="templateEditor" style="display:none">

--- a/dustland.css
+++ b/dustland.css
@@ -633,6 +633,11 @@ input[type="range"] {
 #combatOverlay .cmd div.sel::before { content:'>'; }
 #combatOverlay .cmd div.disabled { color:#666; }
 
+    .help {
+        cursor: help;
+        color: var(--muted);
+    }
+
     .small {
         font-size: 12px;
         color: #9ab09a

--- a/test/npc-template-tooltip.test.js
+++ b/test/npc-template-tooltip.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import { JSDOM } from 'jsdom';
+
+test('NPC Templates legend includes tooltip', async () => {
+  const html = await fs.readFile(new URL('../adventure-kit.html', import.meta.url), 'utf8');
+  const dom = new JSDOM(html);
+  const tip = dom.window.document.querySelector('#templateCard legend .help');
+  assert(tip, 'help icon missing');
+  assert.strictEqual(tip.textContent.trim(), '(?)');
+  assert.ok(tip.getAttribute('title').includes('spawn from dialog'));
+});


### PR DESCRIPTION
## Summary
- add tooltip to NPC Templates section explaining templates spawn enemies from dialog
- style help icon for clarity
- test tooltip presence

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8e22a86c0832898e7d0436bb2dac9