### PR TITLE
feat: expose item desc and npc portrait lock

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -364,6 +364,7 @@
             <span class="pill">Portrait</span>
             <span class="pill" id="npcNextP">&gt;</span>
           </div>
+          <label><input type="checkbox" id="npcPortraitLock" checked> Lock Portrait</label>
           <label><input type="checkbox" id="npcHidden"> Hidden NPC</label>
           <div id="revealOpts" style="display:none">
             <label>Flag Type<select id="npcFlagType"><option value="visits">Visited Tile</option><option value="party">Party Flag</option></select></label>
@@ -426,6 +427,7 @@
           <label>Name<input id="itemName" placeholder="Item name" /></label>
           <label>ID<input id="itemId" placeholder="item_id" /></label>
           <label>Type<input id="itemType" /></label>
+          <label>Description<textarea id="itemDesc" rows="2"></textarea></label>
           <label>Tags<input id="itemTags" /></label>
           <label>Map<input id="itemMap" value="world" /></label>
           <label>X<input id="itemX" type="number" min="0" /></label>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1669,6 +1669,7 @@ function startNewNPC() {
   npcPortraitIndex = 0;
   npcPortraitPath = '';
   setNpcPortrait();
+  document.getElementById('npcPortraitLock').checked = true;
   document.getElementById('npcHidden').checked = false;
   document.getElementById('npcFlagType').value = 'visits';
   document.getElementById('npcFlagMap').value = 'world';
@@ -1739,6 +1740,7 @@ function collectNPCFromForm() {
   const shop = document.getElementById('npcShop').checked;
   const shopMarkup = parseInt(document.getElementById('shopMarkup').value, 10) || 2;
   const hidden = document.getElementById('npcHidden').checked;
+  const portraitLock = document.getElementById('npcPortraitLock').checked;
   const flag = getRevealFlag();
   const op = document.getElementById('npcOp').value;
   const val = parseInt(document.getElementById('npcVal').value, 10) || 0;
@@ -1790,6 +1792,7 @@ function collectNPCFromForm() {
   if (hidden && flag) npc.hidden = true, npc.reveal = { flag, op, value: val };
   if (npcPortraitPath) npc.portraitSheet = npcPortraitPath;
   else if (npcPortraitIndex > 0) npc.portraitSheet = npcPortraits[npcPortraitIndex];
+  if (!portraitLock) npc.portraitLock = false;
   return npc;
 }
 
@@ -1857,6 +1860,7 @@ function editNPC(i) {
     npcPortraitPath = '';
   }
   setNpcPortrait();
+  document.getElementById('npcPortraitLock').checked = n.portraitLock !== false;
   document.getElementById('npcHidden').checked = !!n.hidden;
   if (n.reveal?.flag?.startsWith('visits@')) {
     document.getElementById('npcFlagType').value = 'visits';
@@ -1967,6 +1971,7 @@ function startNewItem() {
   document.getElementById('itemName').value = '';
   document.getElementById('itemId').value = '';
   document.getElementById('itemType').value = '';
+  document.getElementById('itemDesc').value = '';
   document.getElementById('itemTags').value = '';
   document.getElementById('itemMap').value = 'world';
   document.getElementById('itemX').value = 0;
@@ -2004,6 +2009,7 @@ function addItem() {
   const name = document.getElementById('itemName').value.trim();
   const id = document.getElementById('itemId').value.trim();
   const type = document.getElementById('itemType').value.trim();
+  const desc = document.getElementById('itemDesc').value.trim();
   const tags = document.getElementById('itemTags').value.split(',').map(t=>t.trim()).filter(Boolean);
   const map = document.getElementById('itemMap').value.trim() || 'world';
   const x = parseInt(document.getElementById('itemX').value, 10) || 0;
@@ -2021,7 +2027,7 @@ function addItem() {
   } else {
     try { use = JSON.parse(document.getElementById('itemUse').value || 'null'); } catch (e) { use = null; }
   }
-  const item = { id, name, type, tags, map, x, y, slot, mods, value, use, equip };
+  const item = { id, name, desc, type, tags, map, x, y, slot, mods, value, use, equip };
   if (editItemIdx >= 0) {
     moduleData.items[editItemIdx] = item;
   } else {
@@ -2058,6 +2064,7 @@ function editItem(i) {
   document.getElementById('itemName').value = it.name;
   document.getElementById('itemId').value = it.id;
   document.getElementById('itemType').value = it.type || '';
+  document.getElementById('itemDesc').value = it.desc || '';
   document.getElementById('itemTags').value = (it.tags || []).join(',');
   document.getElementById('itemMap').value = it.map;
   document.getElementById('itemX').value = it.x;


### PR DESCRIPTION
## Summary
- allow setting an item's description in the Adventure Kit
- add a portrait lock toggle for NPCs

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8e66cc0d08328ae78425cd90e64c9