### PR TITLE
fix: wire up wizards via registry

### DIFF
--- a/components/wizard/npc-wizard.js
+++ b/components/wizard/npc-wizard.js
@@ -31,4 +31,6 @@
 
   globalThis.Dustland = globalThis.Dustland || {};
   Dustland.NpcWizard = NpcWizard;
+  Dustland.wizards = Dustland.wizards || {};
+  Dustland.wizards.npc = NpcWizard;
 })();

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -3760,21 +3760,14 @@ renderEventList();
 loadTreeEditor();
 setPlaceholders();
 const wizardList = document.getElementById('wizardList');
-if (wizardList && globalThis.Dustland?.NpcWizard) {
-  const cfg = globalThis.Dustland.NpcWizard;
-  const btn = document.createElement('button');
-  btn.className = 'btn';
-  btn.textContent = cfg.title;
-  btn.addEventListener('click', () => openWizard(cfg));
-  wizardList.appendChild(btn);
-}
-if (wizardList && globalThis.Dustland?.BuildingWizard) {
-  const cfg = globalThis.Dustland.BuildingWizard;
-  const btn = document.createElement('button');
-  btn.className = 'btn';
-  btn.textContent = cfg.title;
-  btn.addEventListener('click', () => openWizard(cfg));
-  wizardList.appendChild(btn);
+if (wizardList && globalThis.Dustland?.wizards) {
+  Object.values(globalThis.Dustland.wizards).forEach(cfg => {
+    const btn = document.createElement('button');
+    btn.className = 'btn';
+    btn.textContent = cfg.title;
+    btn.addEventListener('click', () => openWizard(cfg));
+    wizardList.appendChild(btn);
+  });
 }
 
 function mergeWizardResult(res) {

--- a/test/npc-wizard.config.test.js
+++ b/test/npc-wizard.config.test.js
@@ -21,6 +21,7 @@ test('NpcWizard config wires steps', async () => {
   vm.runInContext(npcCode, context);
   const cfg = context.Dustland.NpcWizard;
   assert.ok(cfg && cfg.steps && cfg.steps.length);
+  assert.strictEqual(context.Dustland.wizards.npc, cfg);
   const wiz = context.Dustland.Wizard(container, cfg.steps);
   document.querySelector('input').value = 'Bob';
   wiz.next();

--- a/test/wizard-list.test.js
+++ b/test/wizard-list.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+test('all registered wizards appear in list', async () => {
+  const document = makeDocument();
+  const list = document.getElementById('wizardList');
+  document.body.appendChild(list);
+  const context = {
+    document,
+    openWizard(cfg) { context.opened = cfg; },
+    Dustland: { wizards: {
+      one: { title: 'One', steps: [] },
+      two: { title: 'Two', steps: [] }
+    } }
+  };
+  vm.createContext(context);
+  const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+  const match = code.match(/const wizardList[\s\S]*?}\n\nfunction mergeWizardResult/);
+  vm.runInContext(match[0].replace(/\n\nfunction mergeWizardResult/, ''), context);
+  const btns = list.querySelectorAll('button');
+  assert.strictEqual(btns.length, 2);
+  btns[1].dispatchEvent({ type: 'click' });
+  assert.strictEqual(context.opened, context.Dustland.wizards.two);
+});


### PR DESCRIPTION
## Summary
- register NpcWizard in global wizard registry
- list all registered wizards in Adventure Kit UI
- add tests for wizard registration and listing

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ee815f9c8328be03a55e52cdccef