### PR TITLE
feat: add wizard step placeholders

### DIFF
--- a/components/wizard/steps/asset-picker.js
+++ b/components/wizard/steps/asset-picker.js
@@ -5,6 +5,11 @@
         const labelEl = document.createElement('label');
         labelEl.textContent = label;
         const select = document.createElement('select');
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Select ' + label.toLowerCase();
+        if (!state[key]) placeholder.selected = true;
+        select.appendChild(placeholder);
         (options || []).forEach(name => {
           const opt = document.createElement('option');
           opt.value = name;

--- a/components/wizard/steps/confirm.js
+++ b/components/wizard/steps/confirm.js
@@ -1,5 +1,6 @@
 (function(){
   function confirmStep(message){
+    message = message || 'Review your choices.';
     return {
       render(container){
         const p = document.createElement('p');

--- a/components/wizard/steps/door-linker.js
+++ b/components/wizard/steps/door-linker.js
@@ -13,7 +13,7 @@
         function makePane(label, key){
           const pane = document.createElement('div');
           const p = document.createElement('p');
-          p.textContent = label;
+          p.textContent = label + ' - click to select a location.';
           const canvas = document.createElement('canvas');
           canvas.width = 160;
           canvas.height = 160;

--- a/components/wizard/steps/item-picker.js
+++ b/components/wizard/steps/item-picker.js
@@ -5,6 +5,11 @@
         const labelEl = document.createElement('label');
         labelEl.textContent = label;
         const select = document.createElement('select');
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Select ' + label.toLowerCase();
+        if (!state[key]) placeholder.selected = true;
+        select.appendChild(placeholder);
         (options || []).forEach(opt => {
           const o = document.createElement('option');
           if (typeof opt === 'string') {

--- a/components/wizard/steps/text.js
+++ b/components/wizard/steps/text.js
@@ -6,6 +6,7 @@
         labelEl.textContent = label;
         const input = document.createElement('input');
         input.value = state[key] || '';
+        if (!state[key]) input.placeholder = 'Enter ' + label.toLowerCase();
         container.appendChild(labelEl);
         container.appendChild(input);
         this.input = input;

--- a/components/wizard/steps/tilemap-picker.js
+++ b/components/wizard/steps/tilemap-picker.js
@@ -5,6 +5,11 @@
         var labelEl = document.createElement('label');
         labelEl.textContent = label;
         var select = document.createElement('select');
+        var placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Select ' + label.toLowerCase();
+        if (!state[key]) placeholder.selected = true;
+        select.appendChild(placeholder);
         (options || []).forEach(function(name){
           var opt = document.createElement('option');
           opt.value = name;


### PR DESCRIPTION
## Summary
- add text input placeholders
- provide select placeholders for asset, item, and tilemap pickers
- embed instructions in door-linker and confirm steps

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b97c8372a083289a0a87e3589baceb