### PR TITLE
fix: clear world palette when placing

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1717,6 +1717,7 @@ function startNewNPC() {
 }
 
 function beginPlaceNPC() {
+  clearPaletteSelection();
   placingType = 'npc';
   placingPos = null;
   placingCb = addNPC;
@@ -2001,6 +2002,7 @@ function startNewItem() {
 }
 
 function beginPlaceItem() {
+  clearPaletteSelection();
   placingType = 'item';
   placingPos = null;
   placingCb = addItem;
@@ -2616,6 +2618,7 @@ function startNewBldg() {
 }
 
 function beginPlaceBldg() {
+  clearPaletteSelection();
   placingType = 'bldg';
   placingPos = null;
   placingCb = addBuilding;
@@ -2754,6 +2757,14 @@ if (worldPalette) {
     });
   }
   worldPalette.querySelectorAll('button').forEach(bindPaletteBtn);
+}
+
+function clearPaletteSelection() {
+  if (worldPalette) worldPalette.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+  worldPaint = null;
+  worldStamp = null;
+  if (paletteLabel) paletteLabel.textContent = '';
+  updateCursor();
 }
 
 if (window.NanoPalette) {

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -86,7 +86,7 @@ for (const f of files) {
   vm.runInThisContext(code, { filename: f });
 }
 
-const { applyLoadedModule, TILE, setTile, placeHut, genWorld, addTerrainFeature, stampWorld, worldStamps, tileEmoji, gridToEmoji, clearWorld } = globalThis;
+const { applyLoadedModule, TILE, setTile, placeHut, genWorld, addTerrainFeature, stampWorld, worldStamps, tileEmoji, gridToEmoji, clearWorld, beginPlaceNPC, beginPlaceItem, beginPlaceBldg } = globalThis;
 
 test('applyLoadedModule clears previous building tiles', () => {
   genWorld(123);
@@ -404,6 +404,21 @@ test('world palette selection stays highlighted and labels color', () => {
   canvasEl._listeners.mousedown[0]({ clientX:0, clientY:0, button:0 });
   canvasEl._listeners.mouseup[0]({ button:0 });
   assert.strictEqual(btn.classList.contains('active'), true);
+});
+
+test('beginPlace* clears world palette selection', () => {
+  const funcs = [beginPlaceNPC, beginPlaceItem, beginPlaceBldg];
+  for (const fn of funcs) {
+    worldPaint = TILE.ROCK;
+    worldStamp = worldStamps.hill;
+    worldButtons[1].classList.add('active');
+    paletteLabel.textContent = 'Rock';
+    fn();
+    assert.strictEqual(worldPaint, null);
+    assert.strictEqual(worldStamp, null);
+    assert.ok(!worldButtons.some(b => b.classList.contains('active')));
+    assert.strictEqual(paletteLabel.textContent, '');
+  }
 });
 
 test('clearWorld wipes tiles and data', () => {


### PR DESCRIPTION
## Summary
- ensure add buttons clear world palette so clicking map places items immediately
- test placement buttons remove palette selection

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `./install-deps.sh` *(fails: Invalid response from proxy: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b98605ba94832899262b2c6325603c