### PR TITLE
feat: lockable chests and generator meter

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -380,6 +380,7 @@
           </div>
           <label><input type="checkbox" id="npcPortraitLock" checked> Lock Portrait</label>
           <label><input type="checkbox" id="npcHidden"> Hidden NPC</label>
+          <label><input type="checkbox" id="npcLocked"> Locked NPC</label>
           <div id="revealOpts" style="display:none">
             <label>Flag Type<select id="npcFlagType"><option value="visits">Visited Tile</option><option value="party">Party Flag</option></select></label>
             <div id="revealVisit">

--- a/docs/design/blog-feedback-tasks.md
+++ b/docs/design/blog-feedback-tasks.md
@@ -35,7 +35,7 @@
 - [ ] Fix dune race leaderboards desyncing after patches
 - [ ] Prevent the decoy drone from attracting allied NPCs
 - [x] Add more tracks to the in-game radio playlist
-- [ ] Let crowbars open locked crates without explosives
+- [x] Let crowbars open locked crates without explosives
 - [ ] Persist trail markers in co-op even if players log out
 - [ ] Swap modular armor plates without pausing the game
 - [ ] Introduce dyeable clothing options
@@ -62,7 +62,7 @@
 - [ ] Provide sound cues for cracked stone hiding caches
 - [ ] Improve firewall guidance for LAN co-op setup
 - [ ] Fix cat companion pathfinding on ladders
-- [ ] Add a warning meter before generators overload
+- [x] Add a warning meter before generators overload
 - [ ] Dim the nighttime glow of glass shard collectibles
 - [ ] Offer unique faction perks earlier in the reputation system
 - [ ] Provide manual save points in story missions

--- a/modules/golden.module.json
+++ b/modules/golden.module.json
@@ -44,6 +44,20 @@
         "amount": 5
       },
       "value": 5
+    },
+    {
+      "id": "makeshift_charge",
+      "name": "Makeshift Charge",
+      "type": "quest"
+    },
+    {
+      "map": "world",
+      "x": 8,
+      "y": 7,
+      "id": "chest_key",
+      "name": "Chest Key",
+      "type": "quest",
+      "tags": ["key"]
     }
   ],
   "quests": [
@@ -135,38 +149,40 @@
       "name": "Dusty Chest",
       "desc": "Maybe it holds the coin.",
       "symbol": "?",
+      "locked": true,
       "tree": {
-        "start": {
+        "locked": {
           "text": "A locked chest sits here.",
           "choices": [
-            {
-              "label": "(Open)",
-              "to": "open",
-              "once": true
-            },
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
+            { "label": "(Use Key)", "to": "open", "once": true, "reqItem": "chest_key", "effects": [ { "effect": "unlockNPC", "npcId": "chest" } ] },
+            { "label": "(Use Explosive)", "to": "open", "once": true, "reqItem": "makeshift_charge", "effects": [ { "effect": "unlockNPC", "npcId": "chest" } ] },
+            { "label": "(Pry with Crowbar)", "to": "crowbar_open", "once": true, "reqItem": "crowbar", "effects": [ { "effect": "unlockNPC", "npcId": "chest" } ] },
+            { "label": "(Leave)", "to": "bye" }
           ]
         },
         "open": {
-          "text": "Inside is a shiny coin.",
+          "text": "The chest creaks open, revealing a shiny coin.",
           "choices": [
-            {
-              "label": "(Take Coin)",
-              "to": "empty",
-              "reward": "golden_coin"
-            }
+            { "label": "(Take Coin)", "to": "empty", "reward": "golden_coin", "effects": [ { "effect": "addFlag", "flag": "chest_looted" } ] }
+          ]
+        },
+        "crowbar_open": {
+          "text": "The crowbar pops the lid with a squeal.",
+          "choices": [
+            { "label": "(Take Coin)", "to": "empty", "reward": "golden_coin", "effects": [ { "effect": "addFlag", "flag": "chest_looted" } ] }
           ]
         },
         "empty": {
           "text": "The chest is empty.",
           "choices": [
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
+            { "label": "(Lock Chest)", "to": "locked_empty", "reqItem": "chest_key", "effects": [ { "effect": "lockNPC", "npcId": "chest" } ] },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "locked_empty": {
+          "text": "The chest is empty and locked.",
+          "choices": [
+            { "label": "(Leave)", "to": "bye" }
           ]
         }
       }

--- a/modules/jax-repair.module.js
+++ b/modules/jax-repair.module.js
@@ -41,11 +41,34 @@ startGame = function () {
   setPartyPos(s.x, s.y);
   setMap(s.map, 'Repair Bay');
   log('The generator sputters! Hold off the attack while Jax repairs it.');
-  let time = 5;
+  const meter = document.createElement('div');
+  meter.id = 'generator-meter';
+  meter.style.position = 'absolute';
+  meter.style.left = '10px';
+  meter.style.bottom = '10px';
+  meter.style.width = '120px';
+  meter.style.height = '12px';
+  meter.style.background = '#400';
+  const fill = document.createElement('div');
+  fill.style.height = '100%';
+  fill.style.background = '#f00';
+  meter.appendChild(fill);
+  document.body.appendChild(meter);
+  const max = 5;
+  let time = max;
+  function update(){
+    const ratio = time / max;
+    fill.style.width = (ratio * 100) + '%';
+    if (ratio < 0.4) fill.style.background = '#ff0';
+    if (ratio < 0.2) fill.style.background = '#f00';
+  }
+  update();
   const timer = setInterval(() => {
     time--;
+    update();
     if (time <= 0) {
       clearInterval(timer);
+      meter.remove();
       log('Repair complete!');
     } else {
       log(time + '...');

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -997,6 +997,8 @@ const ADV_HTML = {
       </fieldset>`,
   doors: `<label>Board Door<select class="choiceBoard"></select></label>
       <label>Unboard Door<select class="choiceUnboard"></select></label>`,
+  npcLock: `<label>Lock NPC<select class="choiceLockNPC"></select></label>
+      <label>Unlock NPC<select class="choiceUnlockNPC"></select></label>`,
   flagEff: `<fieldset class="choiceSubGroup"><legend>Flag Effect</legend>
         <label>Flag Name<input class="choiceSetFlagName" list="choiceFlagList"/></label>
         <label>Operation<select class="choiceSetFlagOp"><option value="set">Set</option><option value="add">Add</option><option value="clear">Clear</option></select></label>
@@ -1045,6 +1047,10 @@ function addChoiceRow(container, ch = {}) {
   const unboardEff = effs.find(e => e.effect === 'unboardDoor');
   const boardId = boardEff ? boardEff.interiorId || '' : '';
   const unboardId = unboardEff ? unboardEff.interiorId || '' : '';
+  const lockEff = effs.find(e => e.effect === 'lockNPC');
+  const unlockEff = effs.find(e => e.effect === 'unlockNPC');
+  const lockId = lockEff ? lockEff.npcId || '' : '';
+  const unlockId = unlockEff ? unlockEff.npcId || '' : '';
   const setFlagName = setFlag?.flag || '';
   const setFlagOp = setFlag?.op || 'set';
   const setFlagVal = setFlag?.value ?? '';
@@ -1066,6 +1072,7 @@ function addChoiceRow(container, ch = {}) {
         <option value="join">Join NPC</option>
         <option value="goto">Goto</option>
         <option value="doors">Doors</option>
+        <option value="npcLock">NPC Lock</option>
         <option value="flagEff">Flag Effect</option>
         <option value="spawn">Spawn NPC</option>
         <option value="quest">Quest Tag</option>
@@ -1172,6 +1179,11 @@ function addChoiceRow(container, ch = {}) {
     addAdv('doors');
     if (boardId) row.querySelector('.choiceBoard').value = boardId;
     if (unboardId) row.querySelector('.choiceUnboard').value = unboardId;
+  }
+  if (lockId || unlockId) {
+    addAdv('npcLock');
+    if (lockId) row.querySelector('.choiceLockNPC').value = lockId;
+    if (unlockId) row.querySelector('.choiceUnlockNPC').value = unlockId;
   }
   if (setFlagName) {
     addAdv('flagEff');
@@ -1282,6 +1294,8 @@ function refreshChoiceDropdowns() {
   document.querySelectorAll('.choiceRewardItem').forEach(sel => populateItemDropdown(sel, sel.value));
   document.querySelectorAll('.choiceBoard').forEach(sel => populateInteriorDropdown(sel, sel.value));
   document.querySelectorAll('.choiceUnboard').forEach(sel => populateInteriorDropdown(sel, sel.value));
+  document.querySelectorAll('.choiceLockNPC').forEach(sel => populateNPCDropdown(sel, sel.value));
+  document.querySelectorAll('.choiceUnlockNPC').forEach(sel => populateNPCDropdown(sel, sel.value));
   document.querySelectorAll('.choiceSpawnTemplate').forEach(sel => populateTemplateDropdown(sel, sel.value));
   const encLoot = document.getElementById('encLoot');
   if (encLoot) populateItemDropdown(encLoot, encLoot.value);
@@ -1426,15 +1440,19 @@ function updateTreeData() {
           c.ifOnce = { node: ifOnceNode, label: ifOnceLabel };
           if (ifOnceUsed) c.ifOnce.used = true;
         }
-        const boardId = chEl.querySelector('.choiceBoard')?.value.trim();
-        const unboardId = chEl.querySelector('.choiceUnboard')?.value.trim();
-        if (flag) c.if = { flag, op, value: val != null && !Number.isNaN(val) ? val : 0 };
-        const effs = [];
-        if (boardId) effs.push({ effect: 'boardDoor', interiorId: boardId });
-        if (unboardId) effs.push({ effect: 'unboardDoor', interiorId: unboardId });
-        if (effs.length) c.effects = effs;
-        if (setFlagName) {
-          const op = chEl.querySelector('.choiceSetFlagOp').value;
+      const boardId = chEl.querySelector('.choiceBoard')?.value.trim();
+      const unboardId = chEl.querySelector('.choiceUnboard')?.value.trim();
+      const lockNpc = chEl.querySelector('.choiceLockNPC')?.value.trim();
+      const unlockNpc = chEl.querySelector('.choiceUnlockNPC')?.value.trim();
+      if (flag) c.if = { flag, op, value: val != null && !Number.isNaN(val) ? val : 0 };
+      const effs = [];
+      if (boardId) effs.push({ effect: 'boardDoor', interiorId: boardId });
+      if (unboardId) effs.push({ effect: 'unboardDoor', interiorId: unboardId });
+      if (lockNpc) effs.push({ effect: 'lockNPC', npcId: lockNpc });
+      if (unlockNpc) effs.push({ effect: 'unlockNPC', npcId: unlockNpc });
+      if (effs.length) c.effects = effs;
+      if (setFlagName) {
+        const op = chEl.querySelector('.choiceSetFlagOp').value;
           const valTxt = chEl.querySelector('.choiceSetFlagValue').value.trim();
           const value = valTxt ? parseInt(valTxt, 10) : undefined;
           c.setFlag = { flag: setFlagName, op, value };
@@ -1675,6 +1693,7 @@ function startNewNPC() {
   setNpcPortrait();
   document.getElementById('npcPortraitLock').checked = true;
   document.getElementById('npcHidden').checked = false;
+  document.getElementById('npcLocked').checked = false;
   document.getElementById('npcFlagType').value = 'visits';
   document.getElementById('npcFlagMap').value = 'world';
   document.getElementById('npcFlagX').value = 0;
@@ -1744,6 +1763,7 @@ function collectNPCFromForm() {
   const shop = document.getElementById('npcShop').checked;
   const shopMarkup = parseInt(document.getElementById('shopMarkup').value, 10) || 2;
   const hidden = document.getElementById('npcHidden').checked;
+  const locked = document.getElementById('npcLocked').checked;
   const portraitLock = document.getElementById('npcPortraitLock').checked;
   const flag = getRevealFlag();
   const op = document.getElementById('npcOp').value;
@@ -1797,6 +1817,7 @@ function collectNPCFromForm() {
   if (npcPortraitPath) npc.portraitSheet = npcPortraitPath;
   else if (npcPortraitIndex > 0) npc.portraitSheet = npcPortraits[npcPortraitIndex];
   if (!portraitLock) npc.portraitLock = false;
+  if (locked) npc.locked = true;
   return npc;
 }
 
@@ -1866,6 +1887,7 @@ function editNPC(i) {
   setNpcPortrait();
   document.getElementById('npcPortraitLock').checked = n.portraitLock !== false;
   document.getElementById('npcHidden').checked = !!n.hidden;
+  document.getElementById('npcLocked').checked = !!n.locked;
   if (n.reveal?.flag?.startsWith('visits@')) {
     document.getElementById('npcFlagType').value = 'visits';
     const parts = n.reveal.flag.split('@');

--- a/scripts/core/dialog.js
+++ b/scripts/core/dialog.js
@@ -324,6 +324,9 @@ function openDialog(npc, node='start'){
   const rawTree = typeof npc.tree === 'function' ? npc.tree() : npc.tree;
   dialogState.tree=normalizeDialogTree(rawTree||{});
   dialogState.node=node;
+  if(npc.locked && dialogState.tree.locked){
+    dialogState.node='locked';
+  }
   nameEl.textContent=npc.name;
   titleEl.textContent=npc.title;
 

--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -101,6 +101,18 @@
               if (b) b.boarded = true;
             }
             break; }
+          case 'lockNPC': {
+            if (eff.npcId && typeof NPCS !== 'undefined') {
+              const n = NPCS.find(n => n.id === eff.npcId);
+              if (n) n.locked = true;
+            }
+            break; }
+          case 'unlockNPC': {
+            if (eff.npcId && typeof NPCS !== 'undefined') {
+              const n = NPCS.find(n => n.id === eff.npcId);
+              if (n) n.locked = false;
+            }
+            break; }
           case 'modStat': {
             const target = ctx.actor || ctx.player;
             if (target && target.stats && eff.stat) {

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -678,3 +678,53 @@ test('building boarded state round trips through editor', () => {
   moduleData.buildings = prevModuleBldgs;
   globalThis.buildings = prevBuilds;
 });
+
+test('npc locked state round trips through editor', () => {
+  const prev = moduleData.npcs;
+  moduleData.npcs = [];
+  startNewNPC();
+  document.getElementById('npcLocked').checked = true;
+  addNPC();
+  assert.strictEqual(moduleData.npcs[0].locked, true);
+  editNPC(0);
+  document.getElementById('npcLocked').checked = false;
+  applyNPCChanges();
+  assert.strictEqual(moduleData.npcs[0].locked, undefined);
+  moduleData.npcs = prev;
+});
+
+test('updateTreeData captures NPC lock effects', () => {
+  treeData = {};
+  const wrap = document.getElementById('treeEditor');
+  const field = (value = '', checked = false) => ({ value, checked, style: {} });
+  const choiceEl = {
+    querySelector(sel) {
+      if (sel === '.choiceLockNPC') return field('chest');
+      if (sel === '.choiceUnlockNPC') return field('door');
+      if (sel === '.choiceLabel') return field('Lock');
+      if (sel === '.choiceGotoTarget') return field('player');
+      if (sel === '.choiceGotoRel' || sel === '.choiceOnce' || sel === '.choiceIfOnceUsed') return field('', false);
+      return field('');
+    },
+    querySelectorAll() { return []; }
+  };
+  const nodeEl = {
+    classList: { contains: () => false },
+    style: {},
+    querySelector(sel) {
+      if (sel === '.nodeId') return field('start');
+      if (sel === '.nodeText') return field('hi');
+      return field('');
+    },
+    querySelectorAll(sel) {
+      if (sel === '.choices > div') return [choiceEl];
+      return [];
+    }
+  };
+  wrap.querySelectorAll = sel => sel === '.node' ? [nodeEl] : [];
+  updateTreeData();
+  assert.deepStrictEqual(treeData.start.choices[0].effects, [
+    { effect: 'lockNPC', npcId: 'chest' },
+    { effect: 'unlockNPC', npcId: 'door' }
+  ]);
+});

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1005,6 +1005,21 @@ test('board/unboard effects toggle building access', () => {
   assert.strictEqual(globalThis.buildings[0].boarded, true);
   globalThis.buildings.length = 0;
 });
+test('lock/unlock effects toggle npc access', () => {
+  const tree = { locked:{ text:'locked', choices:[{ label:'(Leave)', to:'bye' }] }, start:{ text:'open', choices:[{ label:'(Leave)', to:'bye' }] }, bye:{ text:'', choices:[] } };
+  const npc = makeNPC('ch', 'world', 0, 0, '#fff', 'Chest', '', '', tree);
+  NPCS.length = 0;
+  NPCS.push(npc);
+  Effects.apply([{ effect: 'lockNPC', npcId: 'ch' }]);
+  openDialog(npc);
+  assert.strictEqual(textEl.textContent, 'locked');
+  closeDialog();
+  Effects.apply([{ effect: 'unlockNPC', npcId: 'ch' }]);
+  openDialog(npc);
+  assert.strictEqual(textEl.textContent, 'open');
+  closeDialog();
+  NPCS.length = 0;
+});
 test('dialog choice applies object effects', () => {
   globalThis.buildings = [ { interiorId: 'castle', boarded: true } ];
   const tree = { start:{ text:'hi', choices:[ { label:'open', to:'bye', effects:[ { effect:'unboardDoor', interiorId:'castle' } ] } ] }, bye:{ text:'', choices:[] } };

--- a/test/golden.module.json.test.js
+++ b/test/golden.module.json.test.js
@@ -41,9 +41,24 @@ test('golden module json exposes core features', () => {
     'has hidden npc reveal'
   );
   assert.ok(mod.items.some((i) => i.use?.type === 'heal'), 'has healing item');
+  assert.ok(mod.items.some((i) => i.id === 'chest_key'), 'has chest key');
   assert.ok(mod.portals && mod.portals.length > 0, 'has portals');
 
-  const chest = mod.npcs.find(n => n.id === 'chest');
+  const chest = mod.npcs.find((n) => n.id === 'chest');
+  assert.ok(chest.locked, 'chest starts locked');
+  assert.ok(
+    (chest.tree.locked.choices || []).some((c) => c.reqItem === 'crowbar'),
+    'crowbar can open chest'
+  );
+  assert.ok(
+    (chest.tree.locked.choices || []).some((c) => c.reqItem === 'chest_key'),
+    'key can open chest'
+  );
+  assert.ok(
+    (chest.tree.empty.choices || []).some((c) => c.effects?.some((e) => e.effect === 'lockNPC')),
+    'chest can be relocked'
+  );
+
   assert.strictEqual(chest.symbol, '?');
 
   const hut = mod.buildings.find((b) => b.interiorId === 'cabin');

--- a/test/jax-repair.module.test.js
+++ b/test/jax-repair.module.test.js
@@ -11,4 +11,5 @@ test('jax repair module defines countdown', () => {
   assert.match(src, /startGame\s*=\s*function/);
   assert.match(src, /Repair Bay/);
   assert.match(src, /setInterval/);
+  assert.match(src, /generator-meter/);
 });


### PR DESCRIPTION
## Summary
- Allow crowbars, explosives, or keys to open a lockable Dusty Chest
- Expose lockNPC/unlockNPC effects and make dialog respect locked NPCs
- Show on-screen generator warning meter during Jax repair countdown
- Add Adventure Kit controls for locking NPCs and emitting lock/unlock effects

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97c4726c48328a28ebdfe37d759fd