### PR TITLE
feat: add done buttons to editors

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -469,6 +469,7 @@
           <button class="btn" id="addItem">Add Item</button>
           <button class="btn" type="button" id="cancelItem" style="display:none">Cancel</button>
           <button class="btn" id="delItem" style="display:none">Delete Item</button>
+          <button class="btn" type="button" id="closeItem">Done</button>
         </div>
       </fieldset>
       <fieldset class="card" id="bldgCard" data-pane="buildings" style="display:none">
@@ -493,6 +494,7 @@
           <button class="btn" id="addBldg">Add Building</button>
           <button class="btn" type="button" id="cancelBldg" style="display:none">Cancel</button>
           <button class="btn" id="delBldg" style="display:none">Remove Building</button>
+          <button class="btn" type="button" id="closeBldg">Done</button>
         </div>
       </fieldset>
       <fieldset class="card" id="intCard" data-pane="interiors" style="display:none">
@@ -510,6 +512,7 @@
           </div>
           <canvas id="intCanvas" width="192" height="144" style="margin-top:4px"></canvas>
           <button class="btn" type="button" id="delInterior" style="display:none">Delete Interior</button>
+          <button class="btn" type="button" id="closeInterior">Done</button>
         </div>
       </fieldset>
       <fieldset class="card" id="portalCard" data-pane="portals" style="display:none">

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -683,6 +683,12 @@ function deleteInterior() {
   renderInteriorList();
 }
 
+function closeInteriorEditor() {
+  editInteriorIdx = -1;
+  document.getElementById('delInterior').style.display = 'none';
+  showInteriorEditor(false);
+}
+
 function updateInteriorOptions() {
   const sel = document.getElementById('bldgInterior');
   if (!sel) return;
@@ -2121,6 +2127,19 @@ function deleteItem() {
   });
 }
 
+function closeItemEditor() {
+  editItemIdx = -1;
+  document.getElementById('addItem').textContent = 'Add Item';
+  document.getElementById('cancelItem').style.display = 'none';
+  document.getElementById('delItem').style.display = 'none';
+  loadMods({});
+  renderItemList();
+  selectedObj = null;
+  showItemEditor(false);
+  drawWorld();
+  drawInterior();
+}
+
 // --- Encounters ---
 function showEncounterEditor(show){
   document.getElementById('encounterEditor').style.display = show ? 'block' : 'none';
@@ -2911,6 +2930,19 @@ function deleteBldg() {
   showBldgEditor(false);
 }
 
+function closeBldgEditor() {
+  editBldgIdx = -1;
+  placingType = null;
+  placingPos = null;
+  selectedObj = null;
+  document.getElementById('addBldg').style.display = 'block';
+  document.getElementById('cancelBldg').style.display = 'none';
+  document.getElementById('delBldg').style.display = 'none';
+  renderBldgList();
+  showBldgEditor(false);
+  drawWorld();
+}
+
 // --- Quests ---
 function showQuestEditor(show) {
   document.getElementById('questEditor').style.display = show ? 'block' : 'none';
@@ -3188,6 +3220,9 @@ document.getElementById('addZone').onclick = addZone;
 document.getElementById('delZone').onclick = deleteZone;
 document.getElementById('delNPC').onclick = deleteNPC;
 document.getElementById('closeNPC').onclick = closeNPCEditor;
+document.getElementById('closeItem').onclick = closeItemEditor;
+document.getElementById('closeBldg').onclick = closeBldgEditor;
+document.getElementById('closeInterior').onclick = closeInteriorEditor;
 document.getElementById('newEncounter').onclick = startNewEncounter;
 document.getElementById('addEncounter').onclick = addEncounter;
 document.getElementById('cancelEncounter').onclick = () => { editEncounterIdx = -1; showEncounterEditor(false); };

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -666,6 +666,38 @@ test('editing building centers map on its position', () => {
   panY = 0;
 });
 
+test('closeItemEditor hides the item editor', () => {
+  const prev = moduleData.items;
+  moduleData.items = [{ id: 'it1', name: 'Item', map: 'world', x: 0, y: 0 }];
+  editItem(0);
+  closeItemEditor();
+  assert.strictEqual(editItemIdx, -1);
+  assert.strictEqual(document.getElementById('itemEditor').style.display, 'none');
+  moduleData.items = prev;
+});
+
+test('closeBldgEditor hides the building editor', () => {
+  const prev = moduleData.buildings;
+  moduleData.buildings = [{ x: 1, y: 1, w: 1, h: 1 }];
+  editBldg(0);
+  closeBldgEditor();
+  assert.strictEqual(editBldgIdx, -1);
+  assert.strictEqual(document.getElementById('bldgEditor').style.display, 'none');
+  moduleData.buildings = prev;
+});
+
+test('closeInteriorEditor hides the interior editor', () => {
+  const prev = moduleData.interiors;
+  moduleData.interiors = [{ id: 'int1', w: 3, h: 3, grid: Array.from({ length: 3 }, () => Array(3).fill(TILE.FLOOR)) }];
+  interiors.int1 = moduleData.interiors[0];
+  editInterior(0);
+  closeInteriorEditor();
+  assert.strictEqual(editInteriorIdx, -1);
+  assert.strictEqual(document.getElementById('intEditor').style.display, 'none');
+  moduleData.interiors = prev;
+  delete interiors.int1;
+});
+
 test('collectNPCFromForm retains custom portrait path', () => {
   moduleData.npcs = [{
     id: 'npc1', name: 'NPC', color: '#fff', map: 'world', x: 0, y: 0,


### PR DESCRIPTION
## Summary
- add Done buttons to item, building, and interior editors
- allow closing these editors without saving
- test new close editor functions

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9894125748328827c80c2e9cb7d94