### PR TITLE
fix: show equip editor only for slotted items

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2020,6 +2020,9 @@ function updateModsWrap() {
   const slot = document.getElementById('itemSlot').value;
   document.getElementById('modsWrap').style.display =
     ['weapon', 'armor', 'trinket'].includes(slot) ? 'block' : 'none';
+  const equipWrap = document.getElementById('itemEquip').parentElement;
+  if (equipWrap) equipWrap.style.display = slot ? 'block' : 'none';
+  if (!slot) document.getElementById('itemEquip').value = '';
 }
 function updateUseWrap() {
   const type = document.getElementById('itemUseType').value;
@@ -2081,7 +2084,9 @@ function addItem() {
   const mods = collectMods();
   const value = parseInt(document.getElementById('itemValue').value, 10) || 0;
   let equip = null;
-  try { equip = JSON.parse(document.getElementById('itemEquip').value || 'null'); } catch (e) { equip = null; }
+  if (slot) {
+    try { equip = JSON.parse(document.getElementById('itemEquip').value || 'null'); } catch (e) { equip = null; }
+  }
   let use = null;
   const useType = document.getElementById('itemUseType').value;
   if (useType === 'heal') {

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -33,9 +33,10 @@ function stubEl(){
       if (!this._listeners || !this._listeners[type]) return;
       this._listeners[type] = this._listeners[type].filter(f => f !== fn);
     },
-    parentElement:{ appendChild(){}, querySelectorAll(){ return []; } },
+    parentElement:{ style:{}, appendChild(){}, querySelectorAll(){ return []; } },
     setAttribute(){},
     click(){},
+    focus(){},
   };
   Object.defineProperty(el,'innerHTML',{ get(){return this._innerHTML;}, set(v){ this._innerHTML=v; this.children=[]; }});
   return el;
@@ -725,6 +726,30 @@ test('closeItemEditor hides the item editor', () => {
   closeItemEditor();
   assert.strictEqual(editItemIdx, -1);
   assert.strictEqual(document.getElementById('itemEditor').style.display, 'none');
+  moduleData.items = prev;
+});
+
+test('equip editor shows only when slot set', () => {
+  const prev = moduleData.items;
+  moduleData.items = [];
+  startNewItem();
+  const equipWrap = document.getElementById('itemEquip').parentElement;
+  assert.strictEqual(equipWrap.style.display, 'none');
+  document.getElementById('itemName').value = 'NoSlot';
+  document.getElementById('itemId').value = 'noslot';
+  document.getElementById('itemEquip').value = '{"msg":"hi"}';
+  addItem();
+  assert.strictEqual(moduleData.items[0].equip, null);
+
+  startNewItem();
+  document.getElementById('itemSlot').value = 'weapon';
+  updateModsWrap();
+  assert.strictEqual(equipWrap.style.display, 'block');
+  document.getElementById('itemName').value = 'WithSlot';
+  document.getElementById('itemId').value = 'withslot';
+  document.getElementById('itemEquip').value = '{"msg":"hi"}';
+  addItem();
+  assert.deepStrictEqual(moduleData.items[1].equip, { msg: 'hi' });
   moduleData.items = prev;
 });
 


### PR DESCRIPTION
## Summary
- hide item equip editor unless a slot type is selected
- ignore equip data when saving items without a slot
- cover item editor equip toggling with tests

## Testing
- `npm test`
- `node scripts/presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9a4478a888328a3adf6aa64ff8c5e