### PR TITLE
feat: add boost item use type

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -465,9 +465,12 @@
           </div>
           <label>Equip<textarea id="itemEquip" rows="2"></textarea></label>
           <label>Value<input id="itemValue" type="number" min="0" /></label>
-          <label>Use Type<select id="itemUseType"><option value="">(none)</option><option value="heal">Heal</option></select></label>
+          <label>Use Type<select id="itemUseType"><option value="">(none)</option><option value="heal">Heal</option><option value="boost">Boost</option></select></label>
           <label id="itemUseAmtWrap" style="display:none">Heal Amount<input id="itemUseAmount" type="number" min="1" /></label>
-          <label id="itemUseWrap">Use<textarea id="itemUse" rows="2"></textarea></label>
+          <label id="itemBoostStatWrap" style="display:none">Boost Stat<input id="itemBoostStat" /></label>
+          <label id="itemBoostAmtWrap" style="display:none">Boost Amount<input id="itemBoostAmount" type="number" min="1" /></label>
+          <label id="itemBoostDurWrap" style="display:none">Boost Duration<input id="itemBoostDuration" type="number" min="1" /></label>
+          <label id="itemUseWrap" style="display:none">Use Text<textarea id="itemUse" rows="2"></textarea></label>
           <button class="btn" id="addItem">Add Item</button>
           <button class="btn" type="button" id="cancelItem" style="display:none">Cancel</button>
           <button class="btn" id="delItem" style="display:none">Delete Item</button>

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -162,6 +162,36 @@ const DATA = `
     },
     {
       "map": "world",
+      "x": 34,
+      "y": 47,
+      "id": "adrenaline_shot",
+      "name": "Adrenaline Shot",
+      "type": "consumable",
+      "use": {
+        "type": "boost",
+        "stat": "ATK",
+        "amount": 2,
+        "duration": 3,
+        "text": "Power surges through you."
+      }
+    },
+    {
+      "map": "world",
+      "x": 36,
+      "y": 47,
+      "id": "armor_polish",
+      "name": "Armor Polish",
+      "type": "consumable",
+      "use": {
+        "type": "boost",
+        "stat": "DEF",
+        "amount": 2,
+        "duration": 3,
+        "text": "You feel protected."
+      }
+    },
+    {
+      "map": "world",
       "x": 18,
       "y": 43,
       "id": "valve",

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2024,7 +2024,11 @@ function updateModsWrap() {
 function updateUseWrap() {
   const type = document.getElementById('itemUseType').value;
   document.getElementById('itemUseAmtWrap').style.display = type === 'heal' ? 'block' : 'none';
-  document.getElementById('itemUseWrap').style.display = type ? 'none' : 'block';
+  const boost = type === 'boost';
+  document.getElementById('itemBoostStatWrap').style.display = boost ? 'block' : 'none';
+  document.getElementById('itemBoostAmtWrap').style.display = boost ? 'block' : 'none';
+  document.getElementById('itemBoostDurWrap').style.display = boost ? 'block' : 'none';
+  document.getElementById('itemUseWrap').style.display = type ? 'block' : 'none';
 }
 function startNewItem() {
   editItemIdx = -1;
@@ -2043,6 +2047,9 @@ function startNewItem() {
   document.getElementById('itemEquip').value = '';
   document.getElementById('itemUseType').value = '';
   document.getElementById('itemUseAmount').value = 0;
+  document.getElementById('itemBoostStat').value = '';
+  document.getElementById('itemBoostAmount').value = 0;
+  document.getElementById('itemBoostDuration').value = 0;
   document.getElementById('itemUse').value = '';
   updateUseWrap();
   document.getElementById('addItem').textContent = 'Add Item';
@@ -2087,9 +2094,16 @@ function addItem() {
   if (useType === 'heal') {
     const amt = parseInt(document.getElementById('itemUseAmount').value, 10) || 0;
     use = { type: 'heal', amount: amt };
-  } else {
-    try { use = JSON.parse(document.getElementById('itemUse').value || 'null'); } catch (e) { use = null; }
+  } else if (useType === 'boost') {
+    const stat = document.getElementById('itemBoostStat').value.trim();
+    const amt = parseInt(document.getElementById('itemBoostAmount').value, 10) || 0;
+    const dur = parseInt(document.getElementById('itemBoostDuration').value, 10) || 0;
+    use = { type: 'boost', stat, amount: amt, duration: dur };
+  } else if (useType) {
+    use = { type: useType };
   }
+  const useText = document.getElementById('itemUse').value.trim();
+  if (use && useText) use.text = useText;
   const item = { id, name, desc, type, tags, map, x, y, slot, mods, value, use, equip };
   if (editItemIdx >= 0) {
     moduleData.items[editItemIdx] = item;
@@ -2139,14 +2153,32 @@ function editItem(i) {
   loadMods(it.mods);
   document.getElementById('itemValue').value = it.value || 0;
   document.getElementById('itemEquip').value = it.equip ? JSON.stringify(it.equip, null, 2) : '';
-  if (it.use && it.use.type === 'heal') {
-    document.getElementById('itemUseType').value = 'heal';
-    document.getElementById('itemUseAmount').value = it.use.amount || 0;
-    document.getElementById('itemUse').value = '';
+  if (it.use) {
+    document.getElementById('itemUseType').value = it.use.type || '';
+    if (it.use.type === 'heal') {
+      document.getElementById('itemUseAmount').value = it.use.amount || 0;
+      document.getElementById('itemBoostStat').value = '';
+      document.getElementById('itemBoostAmount').value = 0;
+      document.getElementById('itemBoostDuration').value = 0;
+    } else if (it.use.type === 'boost') {
+      document.getElementById('itemUseAmount').value = 0;
+      document.getElementById('itemBoostStat').value = it.use.stat || '';
+      document.getElementById('itemBoostAmount').value = it.use.amount || 0;
+      document.getElementById('itemBoostDuration').value = it.use.duration || 0;
+    } else {
+      document.getElementById('itemUseAmount').value = 0;
+      document.getElementById('itemBoostStat').value = '';
+      document.getElementById('itemBoostAmount').value = 0;
+      document.getElementById('itemBoostDuration').value = 0;
+    }
+    document.getElementById('itemUse').value = it.use.text || '';
   } else {
     document.getElementById('itemUseType').value = '';
     document.getElementById('itemUseAmount').value = 0;
-    document.getElementById('itemUse').value = it.use ? JSON.stringify(it.use, null, 2) : '';
+    document.getElementById('itemBoostStat').value = '';
+    document.getElementById('itemBoostAmount').value = 0;
+    document.getElementById('itemBoostDuration').value = 0;
+    document.getElementById('itemUse').value = '';
   }
   updateUseWrap();
   document.getElementById('addItem').textContent = 'Update Item';

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -428,6 +428,21 @@ test('useItem heals party member and consumes item', () => {
   assert.ok(hudCalls >= 1);
 });
 
+test('useItem boosts stat temporarily', () => {
+  party.length = 0; player.inv.length = 0; buffs.length = 0;
+  const m = new Character('b','Booster','Role');
+  m.stats.ATK = 1;
+  party.join(m);
+  const brew = registerItem({ id:'brew', name:'Battle Brew', type:'consumable', use:{ type:'boost', stat:'ATK', amount:2, duration:1, text:'You feel stronger.' } });
+  addToInv(brew);
+  const used = useItem(0);
+  assert.ok(used);
+  assert.strictEqual(m.stats.ATK, 3);
+  assert.strictEqual(player.inv.length, 0);
+  Effects.tick({ buffs });
+  assert.strictEqual(m.stats.ATK, 1);
+});
+
 test('findFreeDropTile avoids water and party tiles', () => {
   const W=120, H=90;
   const world = Array.from({length:H},()=>Array.from({length:W},()=>7));

--- a/test/item-value-estimate.test.js
+++ b/test/item-value-estimate.test.js
@@ -15,3 +15,8 @@ test('mod items with zero value are estimated', () => {
   const it = normalizeItem({ id: 'medal', name: 'Medal', mods: { LCK: 1 }, value: 0 });
   assert.strictEqual(it.value, 10);
 });
+
+test('boost items with zero value are estimated', () => {
+  const it = normalizeItem({ id: 'brew', name: 'Battle Brew', use: { type: 'boost', stat: 'ATK', amount: 2, duration: 3 }, value: 0 });
+  assert.strictEqual(it.value, 6);
+});


### PR DESCRIPTION
## Summary
- show item use text only when a use type is selected
- support temporary stat boosts via new `boost` item use type
- add sample boost consumables and tests

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4ab54b08328b9718204489d5e69