### PR TITLE
feat: gate NPC waypoints behind patrol toggle

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -369,9 +369,9 @@
             <label>X<input id="npcX" type="number" min="0" /></label>
             <label>Y<input id="npcY" type="number" min="0" /></label>
           </div>
-          <label>Patrol Waypoints</label>
-          <div id="npcLoopPts"></div>
-          <button class="btn" type="button" id="addLoopPt">+ Waypoint</button>
+          <label><input type="checkbox" id="npcPatrol"> Patrol NPC</label>
+          <div id="npcLoopPts" style="display:none"></div>
+          <button class="btn" type="button" id="addLoopPt" style="display:none">+ Waypoint</button>
           <div class="portrait" id="npcPort"></div>
           <div class="row" style="margin:8px 0">
             <span class="pill" id="npcPrevP">&lt;</span>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1628,6 +1628,24 @@ function updateNPCOptSections() {
     document.getElementById('npcHidden').checked ? 'block' : 'none';
 }
 
+function updatePatrolSection() {
+  const patrol = document.getElementById('npcPatrol').checked;
+  const loopWrap = document.getElementById('npcLoopPts');
+  const addBtn = document.getElementById('addLoopPt');
+  if (loopWrap) loopWrap.style.display = patrol ? 'block' : 'none';
+  if (addBtn) addBtn.style.display = patrol ? 'block' : 'none';
+  if (patrol) {
+    if (selectedObj && selectedObj.type === 'npc') {
+      selectedObj.obj.loop = selectedObj.obj.loop || [{ x: selectedObj.obj.x, y: selectedObj.obj.y }];
+      renderLoopFields(selectedObj.obj.loop);
+    }
+  } else {
+    if (selectedObj && selectedObj.type === 'npc') delete selectedObj.obj.loop;
+    renderLoopFields([]);
+    showLoopControls(null);
+  }
+}
+
 function renderLoopFields(pts) {
   const wrap = document.getElementById('npcLoopPts');
   if (!wrap) return;
@@ -1721,6 +1739,8 @@ function startNewNPC() {
   document.getElementById('npcX').value = 0;
   document.getElementById('npcY').value = 0;
   renderLoopFields([]);
+  document.getElementById('npcPatrol').checked = false;
+  updatePatrolSection();
   npcPortraitIndex = 0;
   npcPortraitPath = '';
   setNpcPortrait();
@@ -1825,8 +1845,10 @@ function collectNPCFromForm() {
   loadTreeEditor();
 
   const npc = { id, name, title, desc, color, symbol, map, x, y, tree, questId };
-  const pts = gatherLoopFields();
-  if (pts.length >= 2) npc.loop = pts;
+  if (document.getElementById('npcPatrol').checked) {
+    const pts = gatherLoopFields();
+    if (pts.length >= 2) npc.loop = pts;
+  }
   if (combat) {
     const HP = parseInt(document.getElementById('npcHP').value, 10) || 1;
     const ATK = parseInt(document.getElementById('npcATK').value, 10) || 0;
@@ -1911,6 +1933,8 @@ function editNPC(i) {
   document.getElementById('npcX').value = n.x;
   document.getElementById('npcY').value = n.y;
   renderLoopFields(n.loop || []);
+  document.getElementById('npcPatrol').checked = Array.isArray(n.loop) && n.loop.length >= 2;
+  updatePatrolSection();
   npcPortraitIndex = npcPortraits.indexOf(n.portraitSheet);
   if (npcPortraitIndex < 0) {
     npcPortraitIndex = 0;
@@ -3318,6 +3342,11 @@ document.getElementById('npcFlagType').addEventListener('change', updateFlagBuil
 document.getElementById('npcEditor').addEventListener('input', applyNPCChanges);
 document.getElementById('moduleName').value = moduleData.name;
 document.getElementById('npcEditor').addEventListener('change', applyNPCChanges);
+document.getElementById('npcPatrol').addEventListener('change', () => {
+  updatePatrolSection();
+  applyNPCChanges();
+});
+updatePatrolSection();
 document.getElementById('bldgEditor').addEventListener('input', applyBldgChanges);
 document.getElementById('bldgEditor').addEventListener('change', applyBldgChanges);
 document.getElementById('npcFlagPick').onclick = () => { coordTarget = { x: 'npcFlagX', y: 'npcFlagY', map: 'npcFlagMap' }; };
@@ -3766,13 +3795,13 @@ canvas.addEventListener('click', ev => {
   if (didPaint) { didPaint = false; return; }
   if (didDrag) { didDrag = false; return; }
   const { x, y } = canvasPos(ev);
-  if (selectedObj && selectedObj.type === 'npc') {
+  if (selectedObj && selectedObj.type === 'npc' && selectedObj.obj.loop) {
     const npc = selectedObj.obj;
     if (x === npc.x && y === npc.y) {
       showLoopControls({ idx: 0, x: npc.x, y: npc.y });
       return;
     }
-    const pts = npc.loop || [];
+    const pts = npc.loop;
     const li = pts.findIndex(p => p.x === x && p.y === y);
     if (li >= 0) { showLoopControls({ idx: li, x: pts[li].x, y: pts[li].y }); return; }
   }

--- a/test/npc-patrol.test.js
+++ b/test/npc-patrol.test.js
@@ -1,0 +1,92 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+function mkInput(document, id, value = '') {
+  const el = document.createElement('input');
+  el.id = id;
+  el.value = value;
+  document.body.appendChild(el);
+  return el;
+}
+
+function mkCheckbox(document, id, checked = false) {
+  const el = document.createElement('input');
+  el.type = 'checkbox';
+  el.id = id;
+  el.checked = checked;
+  document.body.appendChild(el);
+  return el;
+}
+
+function mkTextarea(document, id, value = '') {
+  const el = document.createElement('textarea');
+  el.id = id;
+  el.value = value;
+  document.body.appendChild(el);
+  return el;
+}
+
+test('collectNPCFromForm uses patrol checkbox for loops', async () => {
+  const document = makeDocument();
+  // required fields with minimal values
+  mkInput(document, 'npcId', 'n');
+  mkInput(document, 'npcName', 'Name');
+  mkInput(document, 'npcTitle', '');
+  mkTextarea(document, 'npcDesc', '');
+  mkInput(document, 'npcColor', '#fff');
+  mkInput(document, 'npcSymbol', '!');
+  mkInput(document, 'npcMap', 'world');
+  mkInput(document, 'npcX', '0');
+  mkInput(document, 'npcY', '0');
+  mkTextarea(document, 'npcDialog', 'hi');
+  mkInput(document, 'npcQuest', '');
+  mkTextarea(document, 'npcAccept', '');
+  mkTextarea(document, 'npcTurnin', '');
+  mkCheckbox(document, 'npcCombat', false);
+  mkCheckbox(document, 'npcShop', false);
+  mkInput(document, 'shopMarkup', '2');
+  mkCheckbox(document, 'npcHidden', false);
+  mkCheckbox(document, 'npcLocked', false);
+  mkCheckbox(document, 'npcPortraitLock', true);
+  mkInput(document, 'npcOp', '>=');
+  mkInput(document, 'npcVal', '1');
+  mkTextarea(document, 'npcTree', '');
+  mkInput(document, 'npcHP', '5');
+  mkInput(document, 'npcATK', '0');
+  mkInput(document, 'npcDEF', '0');
+  mkInput(document, 'npcLoot', '');
+  mkCheckbox(document, 'npcBoss', false);
+  mkInput(document, 'npcSpecialCue', '');
+  mkInput(document, 'npcSpecialDmg', '');
+  mkInput(document, 'npcSpecialDelay', '');
+  mkCheckbox(document, 'npcPatrol', false);
+
+  const context = {
+    document,
+    npcPortraitPath: '',
+    npcPortraitIndex: 0,
+    npcPortraits: [],
+    updateTreeData() {},
+    applyCombatTree() {},
+    removeCombatTree() {},
+    loadTreeEditor() {},
+    getRevealFlag() { return ''; },
+    gatherLoopFields() { return [{ x: 0, y: 0 }, { x: 1, y: 0 }]; }
+  };
+  vm.createContext(context);
+  const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+  const start = code.indexOf('function collectNPCFromForm');
+  const end = code.indexOf('// Add a new NPC', start);
+  vm.runInContext(code.slice(start, end), context);
+
+  const npc1 = context.collectNPCFromForm();
+  assert.ok(!('loop' in npc1));
+
+  document.getElementById('npcPatrol').checked = true;
+  const npc2 = context.collectNPCFromForm();
+  assert.deepStrictEqual(npc2.loop, [{ x: 0, y: 0 }, { x: 1, y: 0 }]);
+});
+


### PR DESCRIPTION
## Summary
- add Patrol NPC checkbox that reveals waypoint controls
- hide map waypoint UI when patrol disabled
- test NPC form only collects loops when patrol is enabled

## Testing
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a5931e848328b3aeb6e83560e2c6