### PR TITLE
fix: align Adventure Kit checkboxes with labels

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -80,6 +80,12 @@
       border-radius: 4px;
     }
 
+    input[type=checkbox] {
+      width: auto;
+      margin-top: 0;
+      display: inline-block;
+    }
+
     .xy {
       display: flex;
       gap: 4px;


### PR DESCRIPTION
## Summary
- ensure checkboxes in the Adventure Kit remain inline with their labels for clearer reading

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a68e23c4832885d3fc843c9777e7