### PR TITLE
feat: use item type as equipment slot

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -443,7 +443,15 @@
         <div id="itemEditor" style="display:none">
           <label>Name<input id="itemName" placeholder="Item name" /></label>
           <label>ID<input id="itemId" placeholder="item_id" /></label>
-          <label>Type<input id="itemType" /></label>
+          <label>Type<select id="itemType">
+              <option value=""></option>
+              <option value="weapon">Weapon</option>
+              <option value="armor">Armor</option>
+              <option value="trinket">Trinket</option>
+              <option value="consumable">Consumable</option>
+              <option value="quest">Quest</option>
+              <option value="misc">Misc</option>
+            </select></label>
           <label>Description<textarea id="itemDesc" rows="2"></textarea></label>
           <label>Tags<input id="itemTags" list="tagOptions" /></label>
           <datalist id="tagOptions"></datalist>
@@ -453,12 +461,6 @@
             <label>Y<input id="itemY" type="number" min="0" /></label>
           </div>
           <button class="btn" type="button" id="itemPick" title="Click on the map to choose location">Select on Map</button>
-          <label>Slot<select id="itemSlot">
-              <option value="">(none)</option>
-              <option value="weapon">Weapon</option>
-              <option value="armor">Armor</option>
-              <option value="trinket">Trinket</option>
-            </select></label>
           <div id="modsWrap" style="display:none">
             <label>Mods</label>
             <div id="modBuilder"></div>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1281,6 +1281,12 @@ function populateSlotDropdown(sel, selected = '') {
   sel.value = selected;
 }
 
+function populateTypeDropdown(sel, selected = '') {
+  const types = ['', 'weapon', 'armor', 'trinket', 'consumable', 'quest', 'misc'];
+  sel.innerHTML = types.map(t => `<option value="${t}">${t}</option>`).join('');
+  sel.value = selected;
+}
+
 function populateItemDropdown(sel, selected = '') {
   sel.innerHTML = '<option value=""></option>' + moduleData.items.map(it => `<option value="${it.id}">${it.id}</option>`).join('');
   sel.value = selected;
@@ -2017,12 +2023,12 @@ function showItemEditor(show) {
 }
 
 function updateModsWrap() {
-  const slot = document.getElementById('itemSlot').value;
-  document.getElementById('modsWrap').style.display =
-    ['weapon', 'armor', 'trinket'].includes(slot) ? 'block' : 'none';
+  const type = document.getElementById('itemType').value;
+  const isEquip = ['weapon', 'armor', 'trinket'].includes(type);
+  document.getElementById('modsWrap').style.display = isEquip ? 'block' : 'none';
   const equipWrap = document.getElementById('itemEquip').parentElement;
-  if (equipWrap) equipWrap.style.display = slot ? 'block' : 'none';
-  if (!slot) document.getElementById('itemEquip').value = '';
+  if (equipWrap) equipWrap.style.display = isEquip ? 'block' : 'none';
+  if (!isEquip) document.getElementById('itemEquip').value = '';
 }
 function updateUseWrap() {
   const type = document.getElementById('itemUseType').value;
@@ -2043,7 +2049,6 @@ function startNewItem() {
   document.getElementById('itemMap').value = 'world';
   document.getElementById('itemX').value = 0;
   document.getElementById('itemY').value = 0;
-  document.getElementById('itemSlot').value = '';
   updateModsWrap();
   loadMods({});
   document.getElementById('itemValue').value = 0;
@@ -2087,11 +2092,11 @@ function addItem() {
   const map = document.getElementById('itemMap').value.trim() || 'world';
   const x = parseInt(document.getElementById('itemX').value, 10) || 0;
   const y = parseInt(document.getElementById('itemY').value, 10) || 0;
-  const slot = document.getElementById('itemSlot').value || null;
+  const isEquip = ['weapon', 'armor', 'trinket'].includes(type);
   const mods = collectMods();
   const value = parseInt(document.getElementById('itemValue').value, 10) || 0;
   let equip = null;
-  if (slot) {
+  if (isEquip) {
     try { equip = JSON.parse(document.getElementById('itemEquip').value || 'null'); } catch (e) { equip = null; }
   }
   let use = null;
@@ -2109,7 +2114,7 @@ function addItem() {
   }
   const useText = document.getElementById('itemUse').value.trim();
   if (use && useText) use.text = useText;
-  const item = { id, name, desc, type, tags, map, x, y, slot, mods, value, use, equip };
+  const item = { id, name, desc, type, tags, map, x, y, mods, value, use, equip };
   if (editItemIdx >= 0) {
     moduleData.items[editItemIdx] = item;
   } else {
@@ -2153,7 +2158,6 @@ function editItem(i) {
   document.getElementById('itemMap').value = it.map;
   document.getElementById('itemX').value = it.x;
   document.getElementById('itemY').value = it.y;
-  document.getElementById('itemSlot').value = it.slot || '';
   updateModsWrap();
   loadMods(it.mods);
   document.getElementById('itemValue').value = it.value || 0;
@@ -3135,7 +3139,13 @@ function applyLoadedModule(data) {
   moduleData._origKeys = Object.keys(data);
   moduleData.name = data.name || 'adventure-module';
   moduleData.npcs = data.npcs || [];
-  moduleData.items = data.items || [];
+  moduleData.items = (data.items || []).map(it => {
+    if (it && it.slot && (!it.type || ['weapon','armor','trinket'].includes(it.slot))) {
+      it.type = it.type || it.slot;
+    }
+    delete it.slot;
+    return it;
+  });
   initTags();
   moduleData.quests = data.quests || [];
   moduleData.buildings = data.buildings || [];
@@ -3347,7 +3357,8 @@ document.getElementById('delInterior').onclick = deleteInterior;
 document.getElementById('delQuest').onclick = deleteQuest;
 document.getElementById('delEvent').onclick = deleteEvent;
 document.getElementById('delPortal').onclick = deletePortal;
-document.getElementById('itemSlot').addEventListener('change', updateModsWrap);
+populateTypeDropdown(document.getElementById('itemType'));
+document.getElementById('itemType').addEventListener('change', updateModsWrap);
 document.getElementById('itemUseType').addEventListener('change', updateUseWrap);
 document.getElementById('eventEffect').addEventListener('change', updateEventEffectFields);
 document.getElementById('eventPick').onclick = () => { coordTarget = { x: 'eventX', y: 'eventY' }; };

--- a/scripts/core/dialog.js
+++ b/scripts/core/dialog.js
@@ -185,7 +185,7 @@ function advanceDialog(stateObj, choiceIdx){
     const requiredCount = choice.reqCount || 1;
     const hasEnough = choice.reqItem
       ? countItems(choice.reqItem) >= requiredCount
-      : player.inv.some(it => it.slot === choice.reqSlot);
+      : player.inv.some(it => it.type === choice.reqSlot);
 
     if(!hasEnough){
       return finalize(choice.failure || 'You lack the required item.', false, true);
@@ -205,7 +205,7 @@ function advanceDialog(stateObj, choiceIdx){
     const costCount = choice.costCount || 1;
     const hasEnough = choice.costItem
       ? countItems(choice.costItem) >= costCount
-      : player.inv.some(it => it.slot === choice.costSlot);
+      : player.inv.some(it => it.type === choice.costSlot);
 
     if(!hasEnough){
       return finalize(choice.failure || 'You lack the required item.', false, true);
@@ -217,7 +217,7 @@ function advanceDialog(stateObj, choiceIdx){
         if (itemIdx > -1) removeFromInv(itemIdx);
       }
     } else if (choice.costSlot) {
-      const itemIdx = player.inv.findIndex(it=> it.slot===choice.costSlot);
+      const itemIdx = player.inv.findIndex(it=> it.type===choice.costSlot);
       if (itemIdx > -1) removeFromInv(itemIdx);
     }
 

--- a/scripts/core/equipment.js
+++ b/scripts/core/equipment.js
@@ -3,35 +3,30 @@
     id: 'pipe_blade',
     name: 'Pipe Blade',
     type: 'weapon',
-    slot: 'weapon',
     mods: { ATK: 2, ADR: 12 }
   });
   registerItem({
     id: 'stun_baton',
     name: 'Stun Baton',
     type: 'weapon',
-    slot: 'weapon',
     mods: { ATK: 1, ADR: 15, adrenaline_gen_mod: 1.2, adrenaline_dmg_mod: 1.2 }
   });
   registerItem({
     id: 'leather_jacket',
     name: 'Leather Jacket',
     type: 'armor',
-    slot: 'armor',
     mods: { DEF: 1 }
   });
   registerItem({
     id: 'scavenger_rig',
     name: 'Scavenger Rig',
     type: 'armor',
-    slot: 'armor',
     mods: { DEF: 1, adrenaline_gen_mod: 1.1 }
   });
   registerItem({
     id: 'juggernaut_plate',
     name: 'Juggernaut Plate',
     type: 'armor',
-    slot: 'armor',
     mods: { DEF: 3, adrenaline_gen_mod: 0.9 }
   });
 })();

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -4,6 +4,7 @@ const { emit } = globalThis.EventBus;
 
 const ITEMS = {}; // item definitions by id
 const itemDrops = []; // {map,x,y,id}
+const EQUIP_TYPES = ['weapon','armor','trinket'];
 function cloneItem(it){
   return {
     ...it,
@@ -70,8 +71,8 @@ function removeFromInv(invIndex) {
 
 function equipItem(memberIndex, invIndex){
   const m=party[memberIndex]; const it=player.inv[invIndex];
-  if(!m||!it||!it.slot){ log('Cannot equip that.'); return; }
-  const slot = it.slot;
+  if(!m||!it||!EQUIP_TYPES.includes(it.type)){ log('Cannot equip that.'); return; }
+  const slot = it.type;
   const prevEq = m.equip[slot];
   if(prevEq){
     if(prevEq.cursed){
@@ -171,13 +172,13 @@ function normalizeItem(it){
   if(!it) return null;
   const baseValue = typeof it.value === 'number' ? it.value : 0;
   const val = baseValue > 0 ? baseValue : estimateItemValue(it);
+  const type = it.type || it.slot || 'misc';
   return {
     id: it.id || '',
     name: it.name || 'Unknown',
-    type: it.type || 'misc',
+    type,
     rank: it.rank,
     tags: Array.isArray(it.tags) ? it.tags.map(t=>t.toLowerCase()) : [],
-    slot: it.slot || null,
     mods: it.mods ? { ...it.mods } : {},
     use: it.use || null,
     equip: it.equip || null,

--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -210,7 +210,7 @@ function setLeader(idx){
   if(!m) return;
   for(const slot of ['weapon','armor','trinket']){
     if(!m.equip[slot] && Array.isArray(player?.inv)){
-      const candidates = player.inv.filter(it => it.slot === slot);
+      const candidates = player.inv.filter(it => it.type === slot);
       if(candidates.length){
         const max = Math.max(...candidates.map(it => calcItemValue(it)));
         const best = candidates.filter(it => calcItemValue(it) === max);

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -3,7 +3,7 @@ const { on } = globalThis.EventBus;
 /**
  * @typedef {Object} Item
  * @property {string} name
- * @property {string} [slot]
+ * @property {string} type
  * @property {Object<string, number>} [mods]
  * @property {{type:string, amount?:number, onUse?:Function}} [use]
  * @property {string} [desc]
@@ -684,22 +684,22 @@ const specializations={
   'Scavenger':{
     desc:'Finds better loot from ruins; +1 PER and starts with crowbar.',
     stats:{PER:+1},
-    gear:[{id:'crowbar',name:'Crowbar',slot:'weapon',mods:{ATK:+1}}]
+    gear:[{id:'crowbar',name:'Crowbar',type:'weapon',mods:{ATK:+1}}]
   },
   'Gunslinger':{
     desc:'Draws fast with +1 AGI and starts with pipe rifle.',
     stats:{AGI:+1},
-    gear:[{id:'pipe_rifle',name:'Pipe Rifle',slot:'weapon',mods:{ATK:+2}}]
+    gear:[{id:'pipe_rifle',name:'Pipe Rifle',type:'weapon',mods:{ATK:+2}}]
   },
   'Snakeoil Preacher':{
     desc:'Silver tongue grants +1 CHA and a lucky Tin Sun trinket.',
     stats:{CHA:+1},
-    gear:[{id:'tin_sun',name:'Tin Sun',slot:'trinket',mods:{LCK:+1}}]
+    gear:[{id:'tin_sun',name:'Tin Sun',type:'trinket',mods:{LCK:+1}}]
   },
   'Cogwitch':{
     desc:'Tinker checks succeed more often; +1 INT and a trusty toolkit.',
     stats:{INT:+1},
-    gear:[{id:'toolkit',name:'Toolkit',slot:'trinket',mods:{INT:+1}}]
+    gear:[{id:'toolkit',name:'Toolkit',type:'trinket',mods:{INT:+1}}]
   }
 };
 const classSpecials={
@@ -713,17 +713,17 @@ const quirks={
   'Lucky Lint':{
     desc:'+1 LCK and start with a Lucky Coin.',
     stats:{LCK:+1},
-    gear:[{id:'lucky_coin',name:'Lucky Coin',slot:'trinket',mods:{LCK:+1}}]
+    gear:[{id:'lucky_coin',name:'Lucky Coin',type:'trinket',mods:{LCK:+1}}]
   },
   'Brutal Past':{
     desc:'+1 STR and spiked knuckles for rough fights.',
     stats:{STR:+1},
-    gear:[{id:'spiked_knuckles',name:'Spiked Knuckles',slot:'weapon',mods:{ATK:+1}}]
+    gear:[{id:'spiked_knuckles',name:'Spiked Knuckles',type:'weapon',mods:{ATK:+1}}]
   },
   'Desert Prophet':{
     desc:'+1 PER and a prophecy scroll that sharpens INT.',
     stats:{PER:+1},
-    gear:[{id:'prophecy_scroll',name:'Prophecy Scroll',slot:'trinket',mods:{INT:+1}}]
+    gear:[{id:'prophecy_scroll',name:'Prophecy Scroll',type:'trinket',mods:{INT:+1}}]
   }
 };
 const hiddenOrigins={ 'Rustborn':{desc:'You survived a machine womb. +1 PER, weird dialog tags.'} };
@@ -812,7 +812,7 @@ function finalizeCurrentMember(){
   const specEquipIds=[];
   if(spec){
     if(spec.stats){ for(const k in spec.stats){ m.stats[k]=(m.stats[k]||0)+spec.stats[k]; } }
-    if(spec.gear){ spec.gear.forEach(g=>{ addToInv(g); if(g.slot) specEquipIds.push(g.id); }); }
+  if(spec.gear){ spec.gear.forEach(g=>{ addToInv(g); if(['weapon','armor','trinket'].includes(g.type)) specEquipIds.push(g.id); }); }
   }
   const quirk=quirks[building.quirk];
   if(quirk){

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -678,7 +678,7 @@ function renderInv(){
   if(member){
     for(const slot of ['weapon','armor','trinket']){
       const eq=member.equip[slot];
-      const candidates = others.filter(it => it.slot===slot && (!eq || calcItemValue(it)>calcItemValue(eq)));
+      const candidates = others.filter(it => it.type===slot && (!eq || calcItemValue(it)>calcItemValue(eq)));
       if(candidates.length){
         const max=Math.max(...candidates.map(it=>calcItemValue(it)));
         const best=candidates.filter(it=>calcItemValue(it)===max);
@@ -716,15 +716,15 @@ function renderInv(){
   others.forEach(it => {
     const row=document.createElement('div');
     row.className='slot';
-    if(it.slot && suggestions[it.slot]===it){
+    if(['weapon','armor','trinket'].includes(it.type) && suggestions[it.type]===it){
       row.classList.add('better');
     }
-    const baseLabel = it.name + (it.slot?` [${it.slot}]`:'');
+    const baseLabel = it.name + (['weapon','armor','trinket'].includes(it.type)?` [${it.type}]`:'');
     const label = (it.cursed && it.cursedKnown)? `${baseLabel} (cursed)` : baseLabel;
     row.innerHTML = `<div style="display:flex;gap:8px;align-items:center;justify-content:space-between">
         <span>${label}</span>
         <span style="display:flex;gap:6px">
-          ${it.slot? `<button class="btn" data-a="equip">Equip</button>`:''}
+          ${['weapon','armor','trinket'].includes(it.type)? `<button class="btn" data-a="equip">Equip</button>`:''}
           ${it.use?  `<button class="btn" data-a="use">Use</button>`:''}
         </span>
       </div>`;
@@ -752,7 +752,7 @@ function renderInv(){
     if(equipBtn) equipBtn.onclick=()=> equipItem(selectedMember, player.inv.indexOf(it));
     const useBtn = row.querySelector('button[data-a="use"]');
     if(useBtn) useBtn.onclick=()=> useItem(player.inv.indexOf(it));
-    row.onclick=e=>{ if(e.target.tagName==='BUTTON') return; if(it.slot) equipItem(selectedMember, player.inv.indexOf(it)); };
+    row.onclick=e=>{ if(e.target.tagName==='BUTTON') return; if(['weapon','armor','trinket'].includes(it.type)) equipItem(selectedMember, player.inv.indexOf(it)); };
     inv.appendChild(row);
   });
 }

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -729,20 +729,21 @@ test('closeItemEditor hides the item editor', () => {
   moduleData.items = prev;
 });
 
-test('equip editor shows only when slot set', () => {
+test('equip editor shows only for equippable types', () => {
   const prev = moduleData.items;
   moduleData.items = [];
   startNewItem();
   const equipWrap = document.getElementById('itemEquip').parentElement;
   assert.strictEqual(equipWrap.style.display, 'none');
-  document.getElementById('itemName').value = 'NoSlot';
-  document.getElementById('itemId').value = 'noslot';
+  document.getElementById('itemName').value = 'NoType';
+  document.getElementById('itemId').value = 'notype';
+  document.getElementById('itemType').value = 'consumable';
   document.getElementById('itemEquip').value = '{"msg":"hi"}';
   addItem();
   assert.strictEqual(moduleData.items[0].equip, null);
 
   startNewItem();
-  document.getElementById('itemSlot').value = 'weapon';
+  document.getElementById('itemType').value = 'weapon';
   updateModsWrap();
   assert.strictEqual(equipWrap.style.display, 'block');
   document.getElementById('itemName').value = 'WithSlot';

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -186,7 +186,7 @@ test('cursed items reveal on unequip attempt and stay equipped', () => {
   player.inv.length = 0;
   const mem = new Character('t1','Tester','Role');
   party.join(mem);
-  const cursed = normalizeItem({ id:'mask', name:'Mask', type:'armor', slot:'armor', cursed:true });
+  const cursed = normalizeItem({ id:'mask', name:'Mask', type:'armor', cursed:true });
   addToInv(cursed);
   equipItem(0,0);
   assert.strictEqual(mem.equip.armor.name,'Mask');
@@ -206,7 +206,6 @@ test('uncursed gear can be removed and triggers unequip effects', () => {
     id: 'helm',
     name: 'Helm',
     type: 'armor',
-    slot: 'armor',
     cursed: true,
     unequip: { teleport: { map: 'office', x: 1, y: 1 }, msg: 'back' }
   });
@@ -234,7 +233,7 @@ test('equipping teleport item moves party and logs message', () => {
   party.x = 0; party.y = 0;
   const mem = new Character('t2','Tele','Role');
   party.join(mem);
-  const tp = normalizeItem({ id:'warp_ring', name:'Warp Ring', type:'trinket', slot:'trinket', equip:{ teleport:{ map:'world', x:5, y:6 }, msg:'whoosh' } });
+  const tp = normalizeItem({ id:'warp_ring', name:'Warp Ring', type:'trinket', equip:{ teleport:{ map:'world', x:5, y:6 }, msg:'whoosh' } });
   addToInv(tp);
   equipItem(0,0);
   assert.strictEqual(party.x,5);
@@ -340,7 +339,7 @@ test('movement delay improves with agility and equipment', async () => {
   const baseDelay = getMoveDelay();
   await firstMove;
 
-  addToInv({ id:'agi_charm', name:'AGI Charm', type:'trinket', slot:'trinket', mods:{ AGI:2 } });
+  addToInv({ id:'agi_charm', name:'AGI Charm', type:'trinket', mods:{ AGI:2 } });
   equipItem(0,0);
 
   const secondMove = move(1,0);
@@ -367,7 +366,7 @@ test('movement delay respects move_delay_mod equipment', async () => {
   const baseDelay = getMoveDelay();
   await firstMove;
 
-  addToInv({ id:'speed_charm', name:'Speed Charm', type:'trinket', slot:'trinket', mods:{ move_delay_mod:0.5 } });
+  addToInv({ id:'speed_charm', name:'Speed Charm', type:'trinket', mods:{ move_delay_mod:0.5 } });
   equipItem(0,0);
 
   const secondMove = move(1,0);
@@ -603,7 +602,7 @@ test('advanceDialog respects goto with costItem', () => {
 
 test('advanceDialog respects costSlot', () => {
   player.inv.length = 0;
-  const trinket = registerItem({ id: 'river_trinket', name: 'Trinket', slot: 'trinket', type: 'trinket' });
+  const trinket = registerItem({ id: 'river_trinket', name: 'Trinket', type: 'trinket' });
   addToInv(trinket);
   const tree = {
     start: { text: '', next: [ { label: 'Pay', costSlot: 'trinket', to: 'end' } ] },
@@ -612,12 +611,12 @@ test('advanceDialog respects costSlot', () => {
   const dialog = { tree, node: 'start' };
   const res = advanceDialog(dialog, 0);
   assert.ok(res.success);
-  assert.ok(!player.inv.some(it => it.slot === 'trinket'));
+  assert.ok(!player.inv.some(it => it.type === 'trinket'));
 });
 
 test('advanceDialog honours reqSlot', () => {
   player.inv.length = 0;
-  const token = registerItem({ id: 'fae_token', name: 'Fae Token', slot: 'trinket', type: 'trinket' });
+  const token = registerItem({ id: 'fae_token', name: 'Fae Token', type: 'trinket' });
   const tree = {
     start: { text: '', next: [ { label: 'Enter', reqSlot: 'trinket', success: 'ok', to: 'end' }, { label: 'Leave', to: 'end' } ] },
     end: { text: '' }
@@ -631,7 +630,7 @@ test('advanceDialog honours reqSlot', () => {
   dialog = { tree, node: 'start' };
   res = advanceDialog(dialog, 0);
   assert.ok(res.success);
-  assert.ok(player.inv.some(it => it.slot === 'trinket'));
+  assert.ok(player.inv.some(it => it.type === 'trinket'));
 });
 
 test('advanceDialog uses reqItem without consuming and allows goto', () => {
@@ -764,7 +763,7 @@ test('placeHut uses custom grid and door', () => {
 test('quest turn-in grants reward item', () => {
   player.inv.length = 0;
   NPCS.length = 0;
-  registerItem({ id: 'cursed_vr_helmet', name: 'Cursed VR Helmet', type: 'armor', slot: 'armor' });
+  registerItem({ id: 'cursed_vr_helmet', name: 'Cursed VR Helmet', type: 'armor' });
   const quest = new Quest('q_reward', 'Quest', '', { reward: 'cursed_vr_helmet' });
   quest.status = 'active';
   const tree = {
@@ -1966,8 +1965,8 @@ test('combat uses stats and equipment', () => {
 
   const hero = new Character('h', 'Hero', 'fighter');
   hero.stats.STR = 6;
-  hero.equip.weapon = { id: 'club', slot: 'weapon', mods: { ATK: 2 } };
-  hero.equip.armor = { id: 'vest', slot: 'armor', mods: { DEF: 2 } };
+  hero.equip.weapon = { id: 'club', type: 'weapon', mods: { ATK: 2 } };
+  hero.equip.armor = { id: 'vest', type: 'armor', mods: { DEF: 2 } };
   hero.applyEquipmentStats();
 
   const dummy = { name: 'Dummy', hp: 10, DEF: 1 };

--- a/test/creator-perks.test.js
+++ b/test/creator-perks.test.js
@@ -26,7 +26,7 @@ function setup(){
   vm.runInContext(code,context);
   const inv=context.player.inv;
   context.addToInv=i=>{ inv.push(i); };
-  context.equipItem=(mi,ii)=>{ const m=party[mi]; m.equip=m.equip||{weapon:null,armor:null,trinket:null}; m.equip[inv[ii].slot]=inv[ii]; inv.splice(ii,1); };
+  context.equipItem=(mi,ii)=>{ const m=party[mi]; m.equip=m.equip||{weapon:null,armor:null,trinket:null}; m.equip[inv[ii].type]=inv[ii]; inv.splice(ii,1); };
   return {context,inv};
 }
 

--- a/test/cursed-helmet-ui.test.js
+++ b/test/cursed-helmet-ui.test.js
@@ -14,7 +14,7 @@ test('cursed equipment keeps label after failed unequip', async () => {
   vm.runInContext(invCode, context);
   const mem = new context.Character('hero', 'Hero', 'Role');
   context.party.join(mem);
-  context.registerItem({ id: 'helm', name: 'VR Helmet', type: 'armor', slot: 'armor', cursed: true });
+  context.registerItem({ id: 'helm', name: 'VR Helmet', type: 'armor', cursed: true });
   context.addToInv('helm');
   context.equipItem(0, 0);
   context.renderParty();

--- a/test/inventory-highlight.test.js
+++ b/test/inventory-highlight.test.js
@@ -30,7 +30,7 @@ function setup(items, equipped){
     const m = ctx.party[memberIndex];
     const it = ctx.player.inv[invIndex];
     if(!m || !it) return;
-    m.equip[it.slot] = it;
+    m.equip[it.type] = it;
     ctx.player.inv.splice(invIndex,1);
   };
   vm.createContext(ctx);
@@ -53,10 +53,10 @@ async function loadSetLeader(ctx){
 
 test('better items are highlighted', async () => {
   const items = [
-    { name: 'Shiny Blade', slot: 'weapon', value: 3, mods: { ATK: 2 } },
-    { name: 'Old Stick', slot: 'weapon', value: 1, mods: { ATK: 0 } }
+    { name: 'Shiny Blade', type: 'weapon', value: 3, mods: { ATK: 2 } },
+    { name: 'Old Stick', type: 'weapon', value: 1, mods: { ATK: 0 } }
   ];
-  const eq = { weapon: { name: 'Dull Knife', slot: 'weapon', value: 1, mods: { ATK: 1 } } };
+  const eq = { weapon: { name: 'Dull Knife', type: 'weapon', value: 1, mods: { ATK: 1 } } };
   const ctx = setup(items, eq);
   await loadRender(ctx);
   ctx.renderInv();
@@ -68,11 +68,11 @@ test('better items are highlighted', async () => {
 
 test('leader change re-evaluates highlights', async () => {
   const items = [
-    { name: 'Bronze Sword', slot: 'weapon', value: 3 }
+    { name: 'Bronze Sword', type: 'weapon', value: 3 }
   ];
   const eqs = [
-    { weapon: { name: 'Steel Sword', slot: 'weapon', value: 4 } },
-    { weapon: { name: 'Rusty Sword', slot: 'weapon', value: 1 } }
+    { weapon: { name: 'Steel Sword', type: 'weapon', value: 4 } },
+    { weapon: { name: 'Rusty Sword', type: 'weapon', value: 1 } }
   ];
   const ctx = setup(items, eqs);
   await loadRender(ctx);
@@ -89,11 +89,11 @@ test('leader change re-evaluates highlights', async () => {
 
 test('party selection refreshes item highlights', async () => {
   const items = [
-    { name: 'Bronze Sword', slot: 'weapon', value: 3 }
+    { name: 'Bronze Sword', type: 'weapon', value: 3 }
   ];
   const eqs = [
-    { weapon: { name: 'Steel Sword', slot: 'weapon', value: 4 } },
-    { weapon: { name: 'Rusty Sword', slot: 'weapon', value: 1 } }
+    { weapon: { name: 'Steel Sword', type: 'weapon', value: 4 } },
+    { weapon: { name: 'Rusty Sword', type: 'weapon', value: 1 } }
   ];
   const ctx = setup(items, eqs);
   await loadRender(ctx);
@@ -108,13 +108,13 @@ test('party selection refreshes item highlights', async () => {
 
 test('setLeader equips missing gear and suggests a single upgrade per slot', async () => {
   const items = [
-    { name: 'Axe', slot: 'weapon', value: 2 },
-    { name: 'Chain', slot: 'armor', value: 2 },
-    { name: 'Scale', slot: 'armor', value: 2 }
+    { name: 'Axe', type: 'weapon', value: 2 },
+    { name: 'Chain', type: 'armor', value: 2 },
+    { name: 'Scale', type: 'armor', value: 2 }
   ];
   const eqs = [
-    { weapon: { name: 'Spear', slot: 'weapon', value: 3 }, armor: { name: 'Cloth', slot: 'armor', value: 1 } },
-    { weapon: null, armor: { name: 'Tunic', slot: 'armor', value: 1 } }
+    { weapon: { name: 'Spear', type: 'weapon', value: 3 }, armor: { name: 'Cloth', type: 'armor', value: 1 } },
+    { weapon: null, armor: { name: 'Tunic', type: 'armor', value: 1 } }
   ];
   const ctx = setup(items, eqs);
   await loadRender(ctx);

--- a/test/true-dust.module.test.js
+++ b/test/true-dust.module.test.js
@@ -38,7 +38,7 @@ test('true dust module defines safe zone and spawns', () => {
   assert.strictEqual(note.x, 7);
   assert.strictEqual(note.y, 3);
   const radio = data.items.find(i => i.id === 'cracked_radio');
-  assert.ok(radio && radio.slot === 'trinket');
+  assert.ok(radio && radio.type === 'trinket');
   const caches = data.items.filter(i => i.id.startsWith('scrap_cache'));
   assert.strictEqual(caches.length, 3);
   const ganton = data.npcs.find(n => n.id === 'ganton');


### PR DESCRIPTION
## Summary
- replace Adventure Kit slot picker with a type dropdown
- treat item `type` as the equipment slot and drop the dedicated `slot` field
- merge legacy `slot` values into `type` when loading module JSON

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a37645188328b8ac98557ec388cb