### PR TITLE
feat: support door NPCs

### DIFF
--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -135,7 +135,9 @@ function queryTile(x,y,map=mapIdForState()){
   if(tile===null) return {tile:null, walkable:false, entities:[], items:[]};
   const entities=(typeof NPCS !== 'undefined' ? NPCS : []).filter(n=> n.map===map && n.x===x && n.y===y);
   const items=itemDrops.filter(it=> it.map===map && it.x===x && it.y===y);
-  const walkableFlag=!!(walkable[tile] && entities.length===0 && items.length===0);
+  // doors allow passage when unlocked
+  const blocking=entities.some(e=> !(e.door && !e.locked));
+  const walkableFlag=!!(walkable[tile] && !blocking && items.length===0);
   return {tile, walkable:walkableFlag, entities, items};
 }
 // Find nearest free, walkable, unoccupied (and not water on world)

--- a/scripts/core/npc.js
+++ b/scripts/core/npc.js
@@ -3,8 +3,9 @@ var Dustland = globalThis.Dustland;
 const NPC_COLOR = '#9ef7a0';
 const OBJECT_COLOR = '#225a20';
 class NPC {
-  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null,portraitLock=true,symbol='!'}) {
-    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet,portraitLock,symbol});
+  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null,portraitLock=true,symbol='!',door=false,locked=false}) {
+    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet,portraitLock,symbol,door,locked});
+    // `door` marks an NPC tile as passable when unlocked
     const capNode = (node) => {
       if (this.combat && node === 'do_fight') {
         closeDialog();
@@ -117,6 +118,8 @@ function createNpcFactory(defs) {
       if (n.portraitSheet) opts.portraitSheet = n.portraitSheet;
       if (n.portraitLock === false) opts.portraitLock = false;
       if (n.symbol) opts.symbol = n.symbol;
+      if (n.door) opts.door = n.door;
+      if (typeof n.locked === 'boolean') opts.locked = n.locked;
       const npc = makeNPC(
         n.id,
         n.map || 'world',

--- a/scripts/dustland-path.js
+++ b/scripts/dustland-path.js
@@ -73,7 +73,8 @@
     const info=queryTile(x,y,map);
     if(info.tile===null) return false;
     if(!walkable[info.tile]) return false;
-    return info.entities.every(e=>e.id===ignoreId);
+    // treat unlocked doors as non-blocking
+    return info.entities.every(e=> e.id===ignoreId || (e.door && !e.locked));
   }
 
   function heuristic(a,b){

--- a/test/npc-door.test.js
+++ b/test/npc-door.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+// minimal globals
+global.window = globalThis;
+global.TILE = { FLOOR:0 };
+global.walkable = { 0:true };
+global.itemDrops = [];
+global.NPCS = [];
+global.state = { map:'world' };
+global.EventBus = { on(){}, emit(){} };
+global.Dustland = { eventBus: EventBus };
+
+import './fast-timeouts.js';
+
+await import('../scripts/core/movement.js');
+await import('../scripts/dustland-path.js');
+
+test('locked door blocks movement and path', async () => {
+  global.world = [
+    [0,0,0],
+    [1,1,1]
+  ];
+  global.NPCS = [{ id:'doorL', map:'world', x:1, y:0, door:true, locked:true }];
+  assert.strictEqual(canWalk(1,0), false);
+  const key = window.Dustland.path.queue('world',{x:0,y:0},{x:2,y:0});
+  await Promise.resolve();
+  const path = window.Dustland.path.pathFor(key);
+  assert.deepStrictEqual(path, []);
+});
+
+test('unlocked door allows movement and path', async () => {
+  global.world = [
+    [1,1,1],
+    [0,0,0]
+  ];
+  global.NPCS = [{ id:'doorU', map:'world', x:1, y:1, door:true, locked:false }];
+  assert.strictEqual(canWalk(1,1), true);
+  const key = window.Dustland.path.queue('world',{x:0,y:1},{x:2,y:1});
+  await Promise.resolve();
+  const path = window.Dustland.path.pathFor(key);
+  assert.deepStrictEqual(path, [{x:0,y:1},{x:1,y:1},{x:2,y:1}]);
+});
+


### PR DESCRIPTION
## Summary
- allow NPCs to function as doors with lockable pass-through
- make movement and pathfinding treat unlocked door NPCs as walkable
- add tests for locked vs unlocked door NPC interactions

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9abbad0bc8328afec2f3b93bd00a3