### PR TITLE
fix: style adventure kit checkboxes

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -81,9 +81,27 @@
     }
 
     input[type=checkbox] {
-      width: auto;
+      appearance: none;
+      width: 14px;
+      height: 14px;
       margin-top: 0;
       display: inline-block;
+      border: 1px solid #9ef7a0;
+      border-radius: 2px;
+      background: #1a2f1a;
+      position: relative;
+    }
+
+    input[type=checkbox]:checked::after {
+      content: '';
+      position: absolute;
+      top: 1px;
+      left: 4px;
+      width: 3px;
+      height: 7px;
+      border: solid #9ef7a0;
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg);
     }
 
     .xy {
@@ -247,7 +265,8 @@
     }
 
     #treeEditor .choices details input[type=checkbox] {
-      width: auto;
+      width: 14px;
+      height: 14px;
     }
 
     #treeEditor .nodeHeader {


### PR DESCRIPTION
## Summary
- style adventure kit checkboxes as light green boxes with dark green fill and custom check mark

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b25c34bc8328844293f681d67d09