### PR TITLE
feat: support tag-based cost and require in dialogs

### DIFF
--- a/README.nfo
+++ b/README.nfo
@@ -126,6 +126,7 @@ _______________________________________________________________________________
       * uncurseItem(id)
   - NPC trees can be functions for dynamic dialog.
   - Dialog choices support `goto` targeting the player or NPC with optional relative coordinates.
+  - Dialog choices can require or consume items by ID, slot, or tag.
   - Items support `equip.flag` and `unequip` teleport/message effects.
   - Tiles: see TILE enum + colors[] + walkable[].
   - Maps can be specified as arrays of emoji strings using `tileEmoji` (numeric grids still load).

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1013,9 +1013,11 @@ const ADV_HTML = {
       <label>Success<input class="choiceSuccess"/><span class="small">Shown if check passes.</span></label>
       <label>Failure<input class="choiceFailure"/><span class="small">Shown if check fails.</span></label>`,
   cost: `<label>Cost Item<select class="choiceCostItem"></select></label>
-      <label>Cost Slot<select class="choiceCostSlot"></select></label>`,
+      <label>Cost Slot<select class="choiceCostSlot"></select></label>
+      <label>Cost Tag<input class="choiceCostTag" list="tagOptions"/></label>`,
   req: `<label>Req Item<select class="choiceReqItem"></select></label>
-      <label>Req Slot<select class="choiceReqSlot"></select></label>`,
+      <label>Req Slot<select class="choiceReqSlot"></select></label>
+      <label>Req Tag<input class="choiceReqTag" list="tagOptions"/></label>`,
   join: `<fieldset class="choiceSubGroup"><legend>Join</legend>
         <label>ID<select class="choiceJoinId"></select></label>
         <label>Name<input class="choiceJoinName"/><span class="small">Name shown after joining.</span></label>
@@ -1055,7 +1057,7 @@ const ADV_HTML = {
 };
 
 function addChoiceRow(container, ch = {}) {
-  const { label = '', to = '', reward = '', stat = '', dc = '', success = '', failure = '', once = false, costItem = '', costSlot = '', reqItem = '', reqSlot = '', join = null, q = '', setFlag = null, spawn = null } = ch || {};
+  const { label = '', to = '', reward = '', stat = '', dc = '', success = '', failure = '', once = false, costItem = '', costSlot = '', costTag = '', reqItem = '', reqSlot = '', reqTag = '', join = null, q = '', setFlag = null, spawn = null } = ch || {};
   const cond = ch && ch.if ? ch.if : null;
   const ifOnce = ch && ch.ifOnce ? ch.ifOnce : null;
   const ifOnceNode = ifOnce?.node || '';
@@ -1184,15 +1186,17 @@ function addChoiceRow(container, ch = {}) {
     if (success) row.querySelector('.choiceSuccess').value = success;
     if (failure) row.querySelector('.choiceFailure').value = failure;
   }
-  if (costItem || costSlot) {
+  if (costItem || costSlot || costTag) {
     addAdv('cost');
     if (costItem) row.querySelector('.choiceCostItem').value = costItem;
     if (costSlot) row.querySelector('.choiceCostSlot').value = costSlot;
+    if (costTag) row.querySelector('.choiceCostTag').value = costTag;
   }
-  if (reqItem || reqSlot) {
+  if (reqItem || reqSlot || reqTag) {
     addAdv('req');
     if (reqItem) row.querySelector('.choiceReqItem').value = reqItem;
     if (reqSlot) row.querySelector('.choiceReqSlot').value = reqSlot;
+    if (reqTag) row.querySelector('.choiceReqTag').value = reqTag;
   }
   if (joinId || joinName || joinRole) {
     addAdv('join');
@@ -1414,8 +1418,10 @@ function updateTreeData() {
       const failure = chEl.querySelector('.choiceFailure')?.value.trim() || '';
       const costItem = chEl.querySelector('.choiceCostItem')?.value.trim() || '';
       const costSlot = chEl.querySelector('.choiceCostSlot')?.value.trim() || '';
+      const costTag = chEl.querySelector('.choiceCostTag')?.value.trim() || '';
       const reqItem = chEl.querySelector('.choiceReqItem')?.value.trim() || '';
       const reqSlot = chEl.querySelector('.choiceReqSlot')?.value.trim() || '';
+      const reqTag = chEl.querySelector('.choiceReqTag')?.value.trim() || '';
       const joinId = chEl.querySelector('.choiceJoinId')?.value.trim() || '';
       const joinName = chEl.querySelector('.choiceJoinName')?.value.trim() || '';
       const joinRole = chEl.querySelector('.choiceJoinRole')?.value.trim() || '';
@@ -1459,8 +1465,10 @@ function updateTreeData() {
         if (failure) c.failure = failure;
         if (costItem) c.costItem = costItem;
         if (costSlot) c.costSlot = costSlot;
+        if (costTag) c.costTag = costTag;
         if (reqItem) c.reqItem = reqItem;
         if (reqSlot) c.reqSlot = reqSlot;
+        if (reqTag) c.reqTag = reqTag;
         if (joinId || joinName || joinRole) c.join = { id: joinId, name: joinName, role: joinRole };
         if (gotoMap || gotoXTxt || gotoYTxt || gotoTarget === 'npc' || gotoRel) {
           const go = {};

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -614,6 +614,21 @@ test('advanceDialog respects costSlot', () => {
   assert.ok(!player.inv.some(it => it.type === 'trinket'));
 });
 
+test('advanceDialog handles costTag', () => {
+  player.inv.length = 0;
+  registerItem({ id: 'iron_key', name: 'Iron Key', type: 'quest', tags: ['key'] });
+  registerItem({ id: 'gem', name: 'Gem', type: 'quest' });
+  addToInv({ id: 'iron_key' });
+  const tree = {
+    start: { text: '', next: [{ label: 'Unlock', costTag: 'key', reward: 'gem' }] }
+  };
+  const dialog = { tree, node: 'start' };
+  const res = advanceDialog(dialog, 0);
+  assert.ok(res.success);
+  assert.ok(player.inv.some(it => it.id === 'gem'));
+  assert.ok(!player.inv.some(it => it.tags.includes('key')));
+});
+
 test('advanceDialog honours reqSlot', () => {
   player.inv.length = 0;
   const token = registerItem({ id: 'fae_token', name: 'Fae Token', type: 'trinket' });
@@ -662,6 +677,22 @@ test('advanceDialog matches reqItem case-insensitively', () => {
   advanceDialog(dialog, 0);
   assert.strictEqual(party.x, 7);
   assert.strictEqual(party.y, 8);
+});
+
+test('advanceDialog uses reqTag without consuming and allows goto', () => {
+  player.inv.length = 0;
+  registerItem({ id: 'access_card', name: 'Access Card', type: 'quest', tags: ['pass'] });
+  addToInv({ id: 'access_card' });
+  state.map = 'world';
+  party.x = 0; party.y = 0;
+  const tree = {
+    start: { text: '', next: [{ label: 'Enter', reqTag: 'pass', goto: { map: 'room', x: 9, y: 1 } }] }
+  };
+  const dialog = { tree, node: 'start' };
+  advanceDialog(dialog, 0);
+  assert.strictEqual(party.x, 9);
+  assert.strictEqual(party.y, 1);
+  assert.ok(player.inv.some(it => it.tags.includes('pass')));
 });
 
 test('advanceDialog goto can target NPC', () => {

--- a/test/dialog.effects.test.js
+++ b/test/dialog.effects.test.js
@@ -80,8 +80,10 @@ test('updateTreeData captures door board/unboard effects', () => {
         case '.choiceFailure':
         case '.choiceCostItem':
         case '.choiceCostSlot':
+        case '.choiceCostTag':
         case '.choiceReqItem':
         case '.choiceReqSlot':
+        case '.choiceReqTag':
         case '.choiceJoinId':
         case '.choiceJoinName':
         case '.choiceJoinRole':
@@ -148,8 +150,10 @@ test('updateTreeData captures scrap reward', () => {
         case '.choiceFailure':
         case '.choiceCostItem':
         case '.choiceCostSlot':
+        case '.choiceCostTag':
         case '.choiceReqItem':
         case '.choiceReqSlot':
+        case '.choiceReqTag':
         case '.choiceJoinId':
         case '.choiceJoinName':
         case '.choiceJoinRole':


### PR DESCRIPTION
## Summary
- allow dialog choices to check or consume items by tag via new `reqTag` and `costTag` fields
- wire Adventure Kit to edit tag-based requirements and costs
- document and test tag-driven dialog costs/requirements

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a99c57388328a5a360027dd2753f