### PR TITLE
feat: add chest creation wizard

### DIFF
--- a/components/wizard/chest-wizard.js
+++ b/components/wizard/chest-wizard.js
@@ -1,0 +1,77 @@
+(function(){
+  const ChestWizard = {
+    title: 'Chest Wizard',
+    steps: [
+      Dustland.WizardSteps.text('Chest Name', 'name'),
+      Dustland.WizardSteps.text('Key Name', 'keyName'),
+      Dustland.WizardSteps.text('Loot Name', 'lootName'),
+      Dustland.WizardSteps.mapPlacement('chestPos'),
+      Dustland.WizardSteps.mapPlacement('keyPos'),
+      Dustland.WizardSteps.confirm('Done')
+    ],
+    commit(state) {
+      const baseId = state.name.toLowerCase().replace(/\s+/g, '_');
+      const chestId = baseId;
+      const keyId = baseId + '_key';
+      const lootId = baseId + '_loot';
+      const key = {
+        map: 'world',
+        x: state.keyPos?.x,
+        y: state.keyPos?.y,
+        id: keyId,
+        name: state.keyName,
+        type: 'quest',
+        tags: ['key']
+      };
+      const loot = {
+        id: lootId,
+        name: state.lootName,
+        type: 'quest'
+      };
+      const chest = {
+        id: chestId,
+        map: 'world',
+        x: state.chestPos?.x,
+        y: state.chestPos?.y,
+        color: '#ddf',
+        name: state.name,
+        symbol: '?',
+        locked: true,
+        tree: {
+          locked: {
+            text: 'A locked chest sits here.',
+            choices: [
+              { label: '(Use Key)', to: 'open', once: true, reqItem: keyId, effects: [ { effect: 'unlockNPC', npcId: chestId } ] },
+              { label: '(Leave)', to: 'bye' }
+            ]
+          },
+          open: {
+            text: 'The chest creaks open, revealing ' + state.lootName + '.',
+            choices: [
+              { label: '(Take ' + state.lootName + ')', to: 'empty', reward: lootId, effects: [ { effect: 'addFlag', flag: chestId + '_looted' } ] }
+            ]
+          },
+          empty: {
+            text: 'The chest is empty.',
+            choices: [
+              { label: '(Lock Chest)', to: 'locked_empty', reqItem: keyId, effects: [ { effect: 'lockNPC', npcId: chestId } ] },
+              { label: '(Leave)', to: 'bye' }
+            ]
+          },
+          locked_empty: {
+            text: 'The chest is empty and locked.',
+            choices: [
+              { label: '(Leave)', to: 'bye' }
+            ]
+          }
+        }
+      };
+      return { items: [key, loot], npcs: [chest] };
+    }
+  };
+
+  globalThis.Dustland = globalThis.Dustland || {};
+  Dustland.ChestWizard = ChestWizard;
+  Dustland.wizards = Dustland.wizards || {};
+  Dustland.wizards.chest = ChestWizard;
+})();

--- a/test/chest-wizard.commit.test.js
+++ b/test/chest-wizard.commit.test.js
@@ -1,0 +1,76 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+test('ChestWizard commit builds module data', async () => {
+  const document = makeDocument();
+  const container = document.getElementById('w');
+  document.body.appendChild(container);
+  const context = { window: { document }, document };
+  vm.createContext(context);
+  const wizCode = await fs.readFile(new URL('../components/wizard/wizard.js', import.meta.url), 'utf8');
+  vm.runInContext(wizCode, context);
+  const stepFiles = ['text.js', 'map-placement.js', 'confirm.js'];
+  for (const f of stepFiles) {
+    const code = await fs.readFile(new URL('../components/wizard/steps/' + f, import.meta.url), 'utf8');
+    vm.runInContext(code, context);
+  }
+  const chestCode = await fs.readFile(new URL('../components/wizard/chest-wizard.js', import.meta.url), 'utf8');
+  vm.runInContext(chestCode, context);
+  const cfg = context.Dustland.ChestWizard;
+  const mod = JSON.parse(JSON.stringify(cfg.commit({
+    name: 'Dusty Chest',
+    keyName: 'Chest Key',
+    lootName: 'Gold Coin',
+    chestPos: { x: 1, y: 2 },
+    keyPos: { x: 3, y: 4 }
+  })));
+  assert.deepStrictEqual(mod, {
+    items: [
+      { map: 'world', x: 3, y: 4, id: 'dusty_chest_key', name: 'Chest Key', type: 'quest', tags: ['key'] },
+      { id: 'dusty_chest_loot', name: 'Gold Coin', type: 'quest' }
+    ],
+    npcs: [
+      {
+        id: 'dusty_chest',
+        map: 'world',
+        x: 1,
+        y: 2,
+        color: '#ddf',
+        name: 'Dusty Chest',
+        symbol: '?',
+        locked: true,
+        tree: {
+          locked: {
+            text: 'A locked chest sits here.',
+            choices: [
+              { label: '(Use Key)', to: 'open', once: true, reqItem: 'dusty_chest_key', effects: [ { effect: 'unlockNPC', npcId: 'dusty_chest' } ] },
+              { label: '(Leave)', to: 'bye' }
+            ]
+          },
+          open: {
+            text: 'The chest creaks open, revealing Gold Coin.',
+            choices: [
+              { label: '(Take Gold Coin)', to: 'empty', reward: 'dusty_chest_loot', effects: [ { effect: 'addFlag', flag: 'dusty_chest_looted' } ] }
+            ]
+          },
+          empty: {
+            text: 'The chest is empty.',
+            choices: [
+              { label: '(Lock Chest)', to: 'locked_empty', reqItem: 'dusty_chest_key', effects: [ { effect: 'lockNPC', npcId: 'dusty_chest' } ] },
+              { label: '(Leave)', to: 'bye' }
+            ]
+          },
+          locked_empty: {
+            text: 'The chest is empty and locked.',
+            choices: [
+              { label: '(Leave)', to: 'bye' }
+            ]
+          }
+        }
+      }
+    ]
+  });
+});

--- a/test/chest-wizard.config.test.js
+++ b/test/chest-wizard.config.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+test('ChestWizard config wires steps', async () => {
+  const document = makeDocument();
+  const container = document.getElementById('w');
+  document.body.appendChild(container);
+  const context = { window: { document }, document };
+  vm.createContext(context);
+  const wizCode = await fs.readFile(new URL('../components/wizard/wizard.js', import.meta.url), 'utf8');
+  vm.runInContext(wizCode, context);
+  const stepFiles = ['text.js', 'map-placement.js', 'confirm.js'];
+  for (const f of stepFiles) {
+    const code = await fs.readFile(new URL('../components/wizard/steps/' + f, import.meta.url), 'utf8');
+    vm.runInContext(code, context);
+  }
+  const chestCode = await fs.readFile(new URL('../components/wizard/chest-wizard.js', import.meta.url), 'utf8');
+  vm.runInContext(chestCode, context);
+  const cfg = context.Dustland.ChestWizard;
+  assert.ok(cfg && cfg.steps && cfg.steps.length);
+  assert.strictEqual(context.Dustland.wizards.chest, cfg);
+  const wiz = context.Dustland.Wizard(container, cfg.steps);
+  document.querySelector('input').value = 'Chest';
+  wiz.next();
+  document.querySelector('input').value = 'Key';
+  wiz.next();
+  document.querySelector('input').value = 'Loot';
+  wiz.next();
+  wiz.getState().chestPos = { x: 0, y: 0 };
+  wiz.next();
+  wiz.getState().keyPos = { x: 1, y: 1 };
+  wiz.next();
+  wiz.next();
+  assert.strictEqual(wiz.getState().lootName, 'Loot');
+});


### PR DESCRIPTION
## Summary
- add wizard to create a key, chest, and loot items wired together
- test chest wizard configuration and commit output

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9b51b5334832894fa2fc50a18ca99