### PR TITLE
fix: handle missing portrait element in dialogs

### DIFF
--- a/scripts/core/dialog.js
+++ b/scripts/core/dialog.js
@@ -320,6 +320,7 @@ function advanceDialog(stateObj, choiceIdx){
 const onceChoices = globalThis.usedOnceChoices || (globalThis.usedOnceChoices = new Set());
 
 function setPortrait(portEl, npc){
+  if(!portEl) return;
   if(!npc.portraitSheet){
     portEl.style.backgroundImage = '';
     portEl.style.background = npc.color || '#274227';

--- a/test/dialog.missing-port.test.js
+++ b/test/dialog.missing-port.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const dialogCode = await fs.readFile(new URL('../scripts/core/dialog.js', import.meta.url), 'utf8');
+
+test('openDialog tolerates missing portrait element', () => {
+  const html = `<body><div id="overlay"></div><div id="choices"></div><div id="dialogText"></div><div id="npcName"></div><div id="npcTitle"></div></body>`;
+  const dom = new JSDOM(html);
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    runEffects: () => {},
+    checkFlagCondition: () => true,
+    setGameState: () => {},
+    GAME_STATE: {},
+  };
+  vm.createContext(context);
+  vm.runInContext(dialogCode, context);
+  const npc = { name: 'NPC', title: '', color: '#000', tree: { start: { text: 'hi', choices: [] } } };
+  assert.doesNotThrow(() => context.openDialog(npc, 'start'));
+});


### PR DESCRIPTION
## Summary
- avoid errors when dialog portrait container is missing
- add regression test for dialog rendering without portrait div

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9bc7acf1c8328a3f9009cad8e4a96