### PR TITLE
fix: ensure node delete confirmation overlays dialog editor

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -683,15 +683,6 @@
       </div><!-- /.tabpanes -->
     </aside>
   </div><!-- /.ak-layout -->
-  <div id="confirmModal" class="modal">
-    <div class="card" style="padding:12px;text-align:center">
-      <div id="confirmText" style="margin-bottom:8px"></div>
-      <div>
-        <button class="btn" id="confirmYes">Yes</button>
-        <button class="btn" id="confirmNo">Cancel</button>
-      </div>
-    </div>
-  </div>
   <div id="dialogModal" class="modal">
     <div class="card">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
@@ -714,6 +705,15 @@
       <div style="margin-top:8px;text-align:right">
         <button class="btn" type="button" id="wizardPrev">Back</button>
         <button class="btn" type="button" id="wizardNext">Next</button>
+      </div>
+    </div>
+  </div>
+  <div id="confirmModal" class="modal">
+    <div class="card" style="padding:12px;text-align:center">
+      <div id="confirmText" style="margin-bottom:8px"></div>
+      <div>
+        <button class="btn" id="confirmYes">Yes</button>
+        <button class="btn" id="confirmNo">Cancel</button>
       </div>
     </div>
   </div>

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -545,6 +545,13 @@ test('node delete uses confirm dialog', () => {
   globalThis.updateTreeData = origUpdate;
 });
 
+test('confirm modal renders after dialog modal', async () => {
+  const html = await fs.readFile('adventure-kit.html', 'utf8');
+  const confirmIdx = html.indexOf('id="confirmModal"');
+  const dialogIdx = html.indexOf('id="dialogModal"');
+  assert.ok(confirmIdx > dialogIdx);
+});
+
 test('closing dialog editor persists dialog changes', () => {
   moduleData.npcs = [{
     id: 'npc1', name: 'NPC', color: '#fff', map: 'world', x: 0, y: 0,


### PR DESCRIPTION
## Summary
- restore confirmation dialog for deleting nodes
- move confirmation modal after dialog editor so it renders on top
- test for confirmation usage and modal order

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e6fd5d408328ac571773eded1d74