### PR TITLE
feat: allow unplaced items in ACK

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -480,8 +480,8 @@
           <label>Description<textarea id="itemDesc" rows="2"></textarea></label>
           <label>Tags<input id="itemTags" list="tagOptions" /></label>
           <datalist id="tagOptions"></datalist>
-          <label>Map<input id="itemMap" value="world" /></label>
-          <div class="xy">
+          <label>Map<input id="itemMap" placeholder="world" /></label>
+          <div class="xy" id="itemXY">
             <label>X<input id="itemX" type="number" min="0" /></label>
             <label>Y<input id="itemY" type="number" min="0" /></label>
           </div>

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -171,6 +171,18 @@ test('custom item tags update tag options', () => {
   moduleData.items = [];
 });
 
+test('can add item without map placement', () => {
+  moduleData.items = [];
+  startNewItem();
+  document.getElementById('itemName').value = 'Reward';
+  document.getElementById('itemId').value = 'reward';
+  document.getElementById('itemMap').value = '';
+  addItem();
+  assert.strictEqual(moduleData.items.length, 1);
+  assert.ok(!('map' in moduleData.items[0]));
+  moduleData.items = [];
+});
+
 test('world paint persists through save/load', () => {
   genWorld(1);
   clearWorld();


### PR DESCRIPTION
## Summary
- allow adding items without placing them on a map in Adventure Kit
- hide item coordinate controls when no map is provided
- test quest reward items that skip map placement

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e7e3f3f8832883dad0a018276986