### PR TITLE
fix: include zones in playtest module

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -3375,7 +3375,8 @@ function playtestModule() {
     const { map, ...rest } = e;
     (enc[map] ||= []).push(rest);
   });
-  const data = { ...moduleData, encounters: enc, world: gridToEmoji(world), buildings: bldgs, interiors: ints };
+  const zones = moduleData.zones ? moduleData.zones.map(z => ({ ...z })) : [];
+  const data = { ...moduleData, encounters: enc, world: gridToEmoji(world), buildings: bldgs, interiors: ints, zones };
   localStorage.setItem(PLAYTEST_KEY, JSON.stringify(data));
   window.open('dustland.html?ack-player=1#play', '_blank');
 }

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -159,6 +159,26 @@ test('zones round-trip through saveModule', () => {
   globalThis.validateSpawns = origValidate;
 });
 
+test('playtestModule includes zones', () => {
+  applyLoadedModule({ seed: 1 });
+  document.getElementById('zoneMap').value = 'world';
+  document.getElementById('zoneX').value = 0;
+  document.getElementById('zoneY').value = 0;
+  document.getElementById('zoneW').value = 1;
+  document.getElementById('zoneH').value = 1;
+  addZone();
+  let saved = '';
+  const origLS = global.localStorage;
+  global.localStorage = { setItem: (k,v) => { saved = v; }, getItem: () => null, removeItem: () => {} };
+  const origOpen = global.open;
+  global.open = () => {};
+  playtestModule();
+  const json = JSON.parse(saved);
+  assert.deepStrictEqual(json.zones, [{ map: 'world', x: 0, y: 0, w: 1, h: 1 }]);
+  global.localStorage = origLS;
+  global.open = origOpen;
+});
+
 test('custom item tags update tag options', () => {
   const dl = document.getElementById('tagOptions');
   assert.ok(dl.innerHTML.includes('value="key"'));


### PR DESCRIPTION
## Summary
- Ensure ACK playtest builds include defined zones
- Test that playtestModule serializes zones correctly

## Testing
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9fe00d2348328922887f9003d0e22