### PR TITLE
fix: refresh zone effects in movement

### DIFF
--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -8,7 +8,6 @@ bus?.on?.('combat:ended', () => { combatActive = false; });
 const buffs = [];              // 2c342c / 313831
 const tileColors = {0:'#1e271d',1:'#313831',2:'#1573ff',3:'#203320',4:'#777777',5:'#304326',6:'#4d5f4d',7:'#233223',8:'#8bd98d',9:'#000000'};// 2B382B / 203320
 let moveDelay = 0;
-const zones = (globalThis.Dustland && globalThis.Dustland.zoneEffects) || [];
 let encounterCooldown = 0;
 let weatherSpeed = 1;
 let encounterBias = null;
@@ -23,6 +22,7 @@ function zoneAttrs(map,x,y){
   let spawns = null;
   let minSteps = null;
   let maxSteps = null;
+  const zones = globalThis.Dustland?.zoneEffects || [];
   for(const z of zones){
     if((z.map||'world')!==map) continue;
     if(x<z.x || y<z.y || x>=z.x+(z.w||0) || y>=z.y+(z.h||0)) continue;
@@ -187,6 +187,7 @@ function wait(){
 }
 
 function applyZones(map,x,y){
+  const zones = globalThis.Dustland?.zoneEffects || [];
   for(const z of zones){
     if((z.map||'world')!==map) continue;
     if(x<z.x || y<z.y || x>=z.x+(z.w||0) || y>=z.y+(z.h||0)) continue;

--- a/test/movement-zones-late.test.js
+++ b/test/movement-zones-late.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('movement reads zones added after load', async () => {
+  const code = await fs.readFile(new URL('../scripts/core/movement.js', import.meta.url), 'utf8');
+  const context = { Dustland: {}, state: {}, party: [] };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  context.Dustland.zoneEffects = [ { map: 'world', x: 0, y: 0, w: 1, h: 1, healMult: 2 } ];
+  const attrs = context.zoneAttrs('world', 0, 0);
+  assert.strictEqual(attrs.healMult, 2);
+});


### PR DESCRIPTION
## Summary
- fetch zoneEffects dynamically in movement system
- add test ensuring zones added post-load are respected

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba007d59e88328819f67fe0a857e5a