### PR TITLE
fix: reposition archivist in test hall

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -474,8 +474,8 @@ const DATA = `
     {
       "id": "tape_sage",
       "map": "hall",
-      "x": 14,
-      "y": 18,
+      "x": 20,
+      "y": 15,
       "color": "#b0c4de",
       "name": "Archivist",
       "title": "Memory Keeper",


### PR DESCRIPTION
## Summary
- move the Archivist NPC away from the player's spawn point in the hall

## Testing
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba15fb830c83289a67fecf35616aa8