### PR TITLE
fix: loop patrol NPC paths

### DIFF
--- a/scripts/dustland-path.js
+++ b/scripts/dustland-path.js
@@ -111,7 +111,12 @@
       if(st.path.length){
         const step=st.path.shift();
         if(step){ n.x=step.x; n.y=step.y; n._lastMove=now; }
-        if(!st.path.length){ st.idx=(st.idx+1)%pts.length; }
+        if(!st.path.length){
+          st.idx=(st.idx+1)%pts.length;
+          const target=pts[st.idx];
+          // queue the next leg so patrols loop without pausing at endpoints
+          st.job=queue(n.map,{x:n.x,y:n.y},target,n.id);
+        }
         continue;
       }
       if(st.job){
@@ -122,7 +127,16 @@
           if(st.path.length){
             const step=st.path.shift();
             if(step){ n.x=step.x; n.y=step.y; n._lastMove=now; }
-            if(!st.path.length){ st.idx=(st.idx+1)%pts.length; }
+            if(!st.path.length){
+              st.idx=(st.idx+1)%pts.length;
+              const target=pts[st.idx];
+              // queue the next leg so patrols loop without pausing at endpoints
+              st.job=queue(n.map,{x:n.x,y:n.y},target,n.id);
+            }
+          } else {
+            st.idx=(st.idx+1)%pts.length;
+            const target=pts[st.idx];
+            st.job=queue(n.map,{x:n.x,y:n.y},target,n.id);
           }
         }
         continue;

--- a/test/npc-path.test.js
+++ b/test/npc-path.test.js
@@ -66,3 +66,22 @@ test('NPC re-pathfinds after being moved', async () => {
   assert.deepStrictEqual(st.path, []);
   assert.strictEqual(st.job, null);
 });
+
+test('NPC loops back to start after final waypoint', async () => {
+  NPCS.length = 0;
+  NPCS.push({ id:'n3', map:'world', x:0, y:0, loop:[{x:0,y:0},{x:2,y:0}] });
+  party.x = 5; party.y = 5;
+  await import('../scripts/dustland-path.js');
+  window.Dustland.path.tickPathAI();
+  await Promise.resolve();
+  window.Dustland.path.tickPathAI();
+  NPCS[0]._lastMove = Date.now() - 211;
+  window.Dustland.path.tickPathAI();
+  await Promise.resolve();
+  NPCS[0]._lastMove = Date.now() - 211;
+  window.Dustland.path.tickPathAI();
+  await Promise.resolve();
+  NPCS[0]._lastMove = Date.now() - 211;
+  window.Dustland.path.tickPathAI();
+  assert.strictEqual(NPCS[0].x, 0);
+});


### PR DESCRIPTION
## Summary
- ensure patrol NPCs queue a new path once they hit a waypoint so routes loop smoothly
- test NPCs looping back to their starting point

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba27a2e0748328a1b0c2572a9d2fc9