### PR TITLE
feat: add seeded height field generator

### DIFF
--- a/docs/design/procedural-map-generator.md
+++ b/docs/design/procedural-map-generator.md
@@ -60,7 +60,7 @@ Insights pulled from accessible community tutorials and open-source repos:
 ## Implementation Tasks
 
 ### Height Field
-- [ ] Implement `generateHeightField(seed, size, scale)` using Simplex noise with radial falloff.
+- [x] Implement `generateHeightField(seed, size, scale)` using Simplex noise with radial falloff.
 - [ ] Convert heights to water or land tiles based on thresholds.
 
 ### Tile Refinement

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dustland",
-  "version": "0.7.52",
+  "version": "0.46.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dustland",
-      "version": "0.7.52",
+      "version": "0.46.5",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -1,0 +1,114 @@
+// Simplex noise-based height field generator without external deps
+
+function mulberry32(a) {
+  return function() {
+    let t = a += 0x6D2B79F5;
+    t = Math.imul(t ^ t >>> 15, t | 1);
+    t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
+
+function hashString(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(31, h) + str.charCodeAt(i) | 0;
+  }
+  return h >>> 0;
+}
+
+function createNoise2D(seed) {
+  const grad3 = [
+    [1, 1], [-1, 1], [1, -1], [-1, -1],
+    [1, 0], [-1, 0], [0, 1], [0, -1]
+  ];
+  const p = new Uint8Array(256);
+  for (let i = 0; i < 256; i++) {
+    p[i] = i;
+  }
+  const random = mulberry32(seed);
+  for (let i = 255; i > 0; i--) {
+    const r = Math.floor(random() * (i + 1));
+    const t = p[i];
+    p[i] = p[r];
+    p[r] = t;
+  }
+  const perm = new Uint8Array(512);
+  for (let i = 0; i < 512; i++) {
+    perm[i] = p[i & 255];
+  }
+  return function(xin, yin) {
+    const F2 = 0.5 * (Math.sqrt(3) - 1);
+    const G2 = (3 - Math.sqrt(3)) / 6;
+    const s = (xin + yin) * F2;
+    const i = Math.floor(xin + s);
+    const j = Math.floor(yin + s);
+    const t = (i + j) * G2;
+    const X0 = i - t;
+    const Y0 = j - t;
+    const x0 = xin - X0;
+    const y0 = yin - Y0;
+    let i1, j1;
+    if (x0 > y0) {
+      i1 = 1; j1 = 0;
+    } else {
+      i1 = 0; j1 = 1;
+    }
+    const x1 = x0 - i1 + G2;
+    const y1 = y0 - j1 + G2;
+    const x2 = x0 - 1 + 2 * G2;
+    const y2 = y0 - 1 + 2 * G2;
+    const ii = i & 255;
+    const jj = j & 255;
+    const gi0 = perm[ii + perm[jj]] % 8;
+    const gi1 = perm[ii + i1 + perm[jj + j1]] % 8;
+    const gi2 = perm[ii + 1 + perm[jj + 1]] % 8;
+    let n0 = 0, n1 = 0, n2 = 0;
+    let t0 = 0.5 - x0 * x0 - y0 * y0;
+    if (t0 >= 0) {
+      t0 *= t0;
+      const g = grad3[gi0];
+      n0 = t0 * t0 * (g[0] * x0 + g[1] * y0);
+    }
+    let t1 = 0.5 - x1 * x1 - y1 * y1;
+    if (t1 >= 0) {
+      t1 *= t1;
+      const g = grad3[gi1];
+      n1 = t1 * t1 * (g[0] * x1 + g[1] * y1);
+    }
+    let t2 = 0.5 - x2 * x2 - y2 * y2;
+    if (t2 >= 0) {
+      t2 *= t2;
+      const g = grad3[gi2];
+      n2 = t2 * t2 * (g[0] * x2 + g[1] * y2);
+    }
+    return 70 * (n0 + n1 + n2);
+  };
+}
+
+function generateHeightField(seed, size, scale) {
+  const seedNum = typeof seed === 'string' ? hashString(seed) : seed;
+  const noise2D = createNoise2D(seedNum);
+  const grid = [];
+  const half = size / 2;
+  const maxDist = Math.sqrt(2) * half;
+  for (let y = 0; y < size; y++) {
+    const row = [];
+    for (let x = 0; x < size; x++) {
+      const nx = x / size * scale;
+      const ny = y / size * scale;
+      let v = noise2D(nx, ny) * 0.5 + 0.5;
+      const dx = x - half;
+      const dy = y - half;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const falloff = 1 - dist / maxDist;
+      v *= Math.max(0, falloff);
+      row.push(v);
+    }
+    grid.push(row);
+  }
+  return grid;
+}
+
+globalThis.generateHeightField = generateHeightField;
+

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import '../scripts/procedural-map.js';
+
+test('generateHeightField is deterministic', () => {
+  const a = globalThis.generateHeightField(42, 4, 1);
+  const b = globalThis.generateHeightField(42, 4, 1);
+  assert.deepEqual(a, b);
+});
+
+test('generateHeightField applies radial falloff', () => {
+  const field = globalThis.generateHeightField(1, 3, 1);
+  assert(field[1][1] > field[0][0]);
+});


### PR DESCRIPTION
## Summary
- implement `generateHeightField` using built-in Simplex noise and radial falloff
- expose `generateHeightField` globally for local HTML usage
- remove `simplex-noise` dependency

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba5866dba08328a27b7f334ccc3249