### PR TITLE
feat: convert height fields to tiles

### DIFF
--- a/docs/design/procedural-map-generator.md
+++ b/docs/design/procedural-map-generator.md
@@ -61,7 +61,7 @@ Insights pulled from accessible community tutorials and open-source repos:
 
 ### Height Field
 - [x] Implement `generateHeightField(seed, size, scale)` using Simplex noise with radial falloff.
-- [ ] Convert heights to water or land tiles based on thresholds.
+- [x] Convert heights to water or land tiles based on thresholds.
 
 ### Tile Refinement
 - [ ] Smooth stray cells and grow land regions with cellular automata.

--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -110,5 +110,18 @@ function generateHeightField(seed, size, scale) {
   return grid;
 }
 
+function heightFieldToTiles(field, waterLevel) {
+  const tiles = [];
+  for (let y = 0; y < field.length; y++) {
+    const row = [];
+    for (let x = 0; x < field[y].length; x++) {
+      row.push(field[y][x] < waterLevel ? TILE.WATER : TILE.SAND);
+    }
+    tiles.push(row);
+  }
+  return tiles;
+}
+
 globalThis.generateHeightField = generateHeightField;
+globalThis.heightFieldToTiles = heightFieldToTiles;
 

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -12,3 +12,16 @@ test('generateHeightField applies radial falloff', () => {
   const field = globalThis.generateHeightField(1, 3, 1);
   assert(field[1][1] > field[0][0]);
 });
+
+test('heightFieldToTiles maps heights to tiles', () => {
+  globalThis.TILE = { SAND: 0, WATER: 2 };
+  const field = [
+    [0.1, 0.6],
+    [0.4, 0.8]
+  ];
+  const tiles = globalThis.heightFieldToTiles(field, 0.5);
+  assert.deepEqual(tiles, [
+    [2, 0],
+    [2, 0]
+  ]);
+});


### PR DESCRIPTION
## Summary
- add `heightFieldToTiles` to convert height values into water or land tiles
- cover tile conversion with a new procedural map test
- mark tile conversion task complete in procedural map design doc

## Testing
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba5a9be1588328ab46c36931d4f5ec