### PR TITLE
feat: refine tile smoothing

### DIFF
--- a/docs/design/procedural-map-generator.md
+++ b/docs/design/procedural-map-generator.md
@@ -64,7 +64,7 @@ Insights pulled from accessible community tutorials and open-source repos:
 - [x] Convert heights to water or land tiles based on thresholds.
 
 ### Tile Refinement
-- [ ] Smooth stray cells and grow land regions with cellular automata.
+- [x] Smooth stray cells and grow land regions with cellular automata.
 - [ ] Mark walls along region borders.
 
 ### Road Graph

--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -122,6 +122,34 @@ function heightFieldToTiles(field, waterLevel) {
   return tiles;
 }
 
+function refineTiles(tiles, iterations = 1) {
+  let current = tiles.map(r => r.slice());
+  for (let i = 0; i < iterations; i++) {
+    const next = current.map(r => r.slice());
+    for (let y = 0; y < current.length; y++) {
+      for (let x = 0; x < current[y].length; x++) {
+        let land = 0;
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dx = -1; dx <= 1; dx++) {
+            if (dx === 0 && dy === 0) continue;
+            const ny = y + dy;
+            const nx = x + dx;
+            if (ny >= 0 && ny < current.length && nx >= 0 && nx < current[y].length) {
+              if (current[ny][nx] === TILE.SAND) land++;
+            }
+          }
+        }
+        if (land >= 5) next[y][x] = TILE.SAND;
+        else if (land <= 3) next[y][x] = TILE.WATER;
+        else next[y][x] = current[y][x];
+      }
+    }
+    current = next;
+  }
+  return current;
+}
+
 globalThis.generateHeightField = generateHeightField;
 globalThis.heightFieldToTiles = heightFieldToTiles;
+globalThis.refineTiles = refineTiles;
 

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -25,3 +25,31 @@ test('heightFieldToTiles maps heights to tiles', () => {
     [2, 0]
   ]);
 });
+
+test('refineTiles smooths stray cells', () => {
+  globalThis.TILE = { SAND: 0, WATER: 2 };
+  const grid = [
+    [2, 2, 2, 2, 2],
+    [2, 0, 0, 0, 2],
+    [2, 0, 2, 0, 2],
+    [2, 0, 0, 0, 2],
+    [2, 2, 2, 2, 2]
+  ];
+  const refined = globalThis.refineTiles(grid, 1);
+  assert.equal(refined[2][2], 0);
+});
+
+test('refineTiles removes isolated land', () => {
+  globalThis.TILE = { SAND: 0, WATER: 2 };
+  const grid = [
+    [2, 2, 2],
+    [2, 0, 2],
+    [2, 2, 2]
+  ];
+  const refined = globalThis.refineTiles(grid, 1);
+  assert.deepEqual(refined, [
+    [2, 2, 2],
+    [2, 2, 2],
+    [2, 2, 2]
+  ]);
+});


### PR DESCRIPTION
## Summary
- smooth stray tiles with cellular automata
- add tests for tile refinement
- mark refinement task complete in design doc

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bac205556c83288d19d0bf55f8aad0