### PR TITLE
feat: mark walls along region borders

### DIFF
--- a/docs/design/procedural-map-generator.md
+++ b/docs/design/procedural-map-generator.md
@@ -65,7 +65,7 @@ Insights pulled from accessible community tutorials and open-source repos:
 
 ### Tile Refinement
 - [x] Smooth stray cells and grow land regions with cellular automata.
-- [ ] Mark walls along region borders.
+- [x] Mark walls along region borders.
 
 ### Road Graph
 - [ ] Connect region centers with a minimum spanning tree.

--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -149,7 +149,29 @@ function refineTiles(tiles, iterations = 1) {
   return current;
 }
 
+function markWalls(tiles) {
+  const out = tiles.map(r => r.slice());
+  for (let y = 0; y < tiles.length; y++) {
+    for (let x = 0; x < tiles[y].length; x++) {
+      if (tiles[y][x] !== TILE.SAND) continue;
+      const dirs = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+      for (const d of dirs) {
+        const nx = x + d[0];
+        const ny = y + d[1];
+        if (ny >= 0 && ny < tiles.length && nx >= 0 && nx < tiles[y].length) {
+          if (tiles[ny][nx] === TILE.WATER) {
+            out[y][x] = TILE.WALL;
+            break;
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
 globalThis.generateHeightField = generateHeightField;
 globalThis.heightFieldToTiles = heightFieldToTiles;
 globalThis.refineTiles = refineTiles;
+globalThis.markWalls = markWalls;
 

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -53,3 +53,25 @@ test('refineTiles removes isolated land', () => {
     [2, 2, 2]
   ]);
 });
+
+test('markWalls marks coast tiles', () => {
+  globalThis.TILE = { SAND: 0, WATER: 2, WALL: 6 };
+  const grid = [
+    [2, 2, 2],
+    [2, 0, 2],
+    [2, 2, 2]
+  ];
+  const withWalls = globalThis.markWalls(grid);
+  assert.equal(withWalls[1][1], 6);
+});
+
+test('markWalls leaves interior land as sand', () => {
+  globalThis.TILE = { SAND: 0, WATER: 2, WALL: 6 };
+  const grid = [
+    [0, 0, 0],
+    [0, 0, 0],
+    [0, 0, 0]
+  ];
+  const withWalls = globalThis.markWalls(grid);
+  assert.deepEqual(withWalls, grid);
+});


### PR DESCRIPTION
## Summary
- mark coastline sand tiles as walls in procedural map generator
- add tests for wall marking and update design doc task

## Testing
- `./install-deps.sh` (fails: mise.jdx.dev repo unreachable; disabling and retrying)
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bac8c26d1883289c18be71382e1491