### PR TITLE
feat: connect region centers with MST

### DIFF
--- a/docs/design/procedural-map-generator.md
+++ b/docs/design/procedural-map-generator.md
@@ -68,7 +68,7 @@ Insights pulled from accessible community tutorials and open-source repos:
 - [x] Mark walls along region borders.
 
 ### Road Graph
-- [ ] Connect region centers with a minimum spanning tree.
+- [x] Connect region centers with a minimum spanning tree.
 - [ ] Carve jittered paths via midpoint displacement or random walk and convert to road tiles.
 
 ### Ruin Placement

--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -170,8 +170,43 @@ function markWalls(tiles) {
   return out;
 }
 
+function connectRegionCenters(centers) {
+  const edges = [];
+  if (!centers || centers.length < 2) return edges;
+  const connected = new Set([0]);
+  const remaining = new Set();
+  for (let i = 1; i < centers.length; i++) {
+    remaining.add(i);
+  }
+  function dist(a, b) {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+  while (connected.size < centers.length) {
+    let bestA = -1;
+    let bestB = -1;
+    let bestDist = Infinity;
+    for (const a of connected) {
+      for (const b of remaining) {
+        const d = dist(centers[a], centers[b]);
+        if (d < bestDist) {
+          bestDist = d;
+          bestA = a;
+          bestB = b;
+        }
+      }
+    }
+    edges.push([bestA, bestB]);
+    connected.add(bestB);
+    remaining.delete(bestB);
+  }
+  return edges;
+}
+
 globalThis.generateHeightField = generateHeightField;
 globalThis.heightFieldToTiles = heightFieldToTiles;
 globalThis.refineTiles = refineTiles;
 globalThis.markWalls = markWalls;
+globalThis.connectRegionCenters = connectRegionCenters;
 

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -75,3 +75,22 @@ test('markWalls leaves interior land as sand', () => {
   const withWalls = globalThis.markWalls(grid);
   assert.deepEqual(withWalls, grid);
 });
+
+test('connectRegionCenters builds MST', () => {
+  const centers = [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 0, y: 10 }
+  ];
+  const edges = globalThis.connectRegionCenters(centers);
+  edges.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  assert.deepEqual(edges, [
+    [0, 1],
+    [0, 2]
+  ]);
+});
+
+test('connectRegionCenters handles single region', () => {
+  const edges = globalThis.connectRegionCenters([{ x: 1, y: 1 }]);
+  assert.deepEqual(edges, []);
+});


### PR DESCRIPTION
## Summary
- add `connectRegionCenters` to link region centers with a minimum spanning tree
- cover MST logic with tests
- mark road graph task complete in design doc

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bacad8e6fc83288b5d8386a1ce9a3f