### PR TITLE
feat: carve jittered roads in procedural maps

### DIFF
--- a/docs/design/procedural-map-generator.md
+++ b/docs/design/procedural-map-generator.md
@@ -69,7 +69,7 @@ Insights pulled from accessible community tutorials and open-source repos:
 
 ### Road Graph
 - [x] Connect region centers with a minimum spanning tree.
-- [ ] Carve jittered paths via midpoint displacement or random walk and convert to road tiles.
+- [x] Carve jittered paths via midpoint displacement or random walk and convert to road tiles.
 
 ### Ruin Placement
 - [ ] Use Poisson-disk sampling to scatter ruin tiles while honoring spacing and terrain rules.

--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -204,9 +204,50 @@ function connectRegionCenters(centers) {
   return edges;
 }
 
+function carveRoads(tiles, centers, edges, seed = 1) {
+  const rand = mulberry32(typeof seed === 'string' ? hashString(seed) : seed);
+  const h = tiles.length;
+  const w = tiles[0].length;
+  for (const [ai, bi] of edges) {
+    let x0 = Math.round(centers[ai].x);
+    let y0 = Math.round(centers[ai].y);
+    const x1 = Math.round(centers[bi].x);
+    const y1 = Math.round(centers[bi].y);
+    let dx = Math.abs(x1 - x0);
+    let sx = x0 < x1 ? 1 : -1;
+    let dy = -Math.abs(y1 - y0);
+    let sy = y0 < y1 ? 1 : -1;
+    let err = dx + dy;
+    while (x0 !== x1 || y0 !== y1) {
+      tiles[y0][x0] = TILE.ROAD;
+      if (rand() < 0.3) {
+        const jx = Math.max(0, Math.min(w - 1, x0 + (rand() < 0.5 ? -1 : 1)));
+        const jy = Math.max(0, Math.min(h - 1, y0 + (rand() < 0.5 ? -1 : 1)));
+        tiles[jy][jx] = TILE.ROAD;
+      }
+      const e2 = 2 * err;
+      const px = x0;
+      const py = y0;
+      if (e2 >= dy) { err += dy; x0 += sx; }
+      if (e2 <= dx) { err += dx; y0 += sy; }
+      if (px !== x0 && py !== y0) {
+        tiles[py][x0] = TILE.ROAD;
+      }
+    }
+    tiles[y0][x0] = TILE.ROAD;
+    if (rand() < 0.3) {
+      const jx = Math.max(0, Math.min(w - 1, x0 + (rand() < 0.5 ? -1 : 1)));
+      const jy = Math.max(0, Math.min(h - 1, y0 + (rand() < 0.5 ? -1 : 1)));
+      tiles[jy][jx] = TILE.ROAD;
+    }
+  }
+  return tiles;
+}
+
 globalThis.generateHeightField = generateHeightField;
 globalThis.heightFieldToTiles = heightFieldToTiles;
 globalThis.refineTiles = refineTiles;
 globalThis.markWalls = markWalls;
 globalThis.connectRegionCenters = connectRegionCenters;
+globalThis.carveRoads = carveRoads;
 

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -94,3 +94,33 @@ test('connectRegionCenters handles single region', () => {
   const edges = globalThis.connectRegionCenters([{ x: 1, y: 1 }]);
   assert.deepEqual(edges, []);
 });
+
+test('carveRoads draws road between centers', () => {
+  globalThis.TILE = { SAND: 0, ROAD: 4 };
+  const size = 5;
+  const tiles = Array.from({ length: size }, () => Array(size).fill(0));
+  const centers = [{ x: 0, y: 0 }, { x: 4, y: 4 }];
+  const edges = [[0, 1]];
+  const roaded = globalThis.carveRoads(tiles, centers, edges, 1);
+  assert.equal(roaded[0][0], 4);
+  assert.equal(roaded[4][4], 4);
+  const queue = [[0, 0]];
+  const seen = new Set(['0,0']);
+  let found = false;
+  const dirs = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+  while (queue.length) {
+    const [x, y] = queue.shift();
+    if (x === 4 && y === 4) { found = true; break; }
+    for (const [dx, dy] of dirs) {
+      const nx = x + dx;
+      const ny = y + dy;
+      if (nx >= 0 && nx < size && ny >= 0 && ny < size) {
+        if (roaded[ny][nx] === 4 && !seen.has(`${nx},${ny}`)) {
+          seen.add(`${nx},${ny}`);
+          queue.push([nx, ny]);
+        }
+      }
+    }
+  }
+  assert.ok(found);
+});


### PR DESCRIPTION
## Summary
- add `carveRoads` to plot jittered paths between region centers
- test road carving connectivity
- mark road-carving task complete in procedural map design doc

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bad89c1e148328bee39ea1e65d43ca