### PR TITLE
fix: bump version during Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  page_build:
 
 permissions:
   contents: write
@@ -15,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    if: "!startsWith(github.event.head_commit.message, 'chore: bump version')"
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: bump version')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,4 +31,4 @@ jobs:
       - run: node scripts/presubmit.js
       - run: npm run lint
       - run: node scripts/version-bump.js
-        if: github.event_name == 'push'
+        if: github.event_name == 'page_build'


### PR DESCRIPTION
## Summary
- trigger CI on `page_build` events
- run version bump only when GitHub Pages publishes

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bae2be67fc8328b3b929b60f3d4c4c