### PR TITLE
feat: support enter/escape in ACK confirm

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -731,13 +731,23 @@ function confirmDialog(msg, onYes) {
   modal.classList.add('shown');
   const yes = document.getElementById('confirmYes');
   const no = document.getElementById('confirmNo');
+  const tgt = document.addEventListener ? document : document.body;
+  const onKey = e => {
+    if (e.key === 'Enter') {
+      if (yes.onclick) yes.onclick(); else yes.click?.();
+    } else if (e.key === 'Escape') {
+      if (no.onclick) no.onclick(); else no.click?.();
+    }
+  };
   const cleanup = () => {
     modal.classList.remove('shown');
     yes.onclick = null;
     no.onclick = null;
+    tgt.removeEventListener?.('keydown', onKey);
   };
   yes.onclick = () => { cleanup(); onYes(); };
   no.onclick = cleanup;
+  tgt.addEventListener?.('keydown', onKey);
 }
 
 function setupListFilter(inputId, listId) {

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -588,6 +588,16 @@ test('confirm modal renders after dialog modal', async () => {
   assert.ok(confirmIdx > dialogIdx);
 });
 
+test('confirm dialog supports enter/escape shortcuts', () => {
+  let called = 0;
+  confirmDialog('ok?', () => { called++; });
+  document.body._listeners.keydown[0]({ key: 'Enter' });
+  assert.strictEqual(called, 1);
+  confirmDialog('ok?', () => { called++; });
+  document.body._listeners.keydown[0]({ key: 'Escape' });
+  assert.strictEqual(called, 1);
+});
+
 test('closing dialog editor persists dialog changes', () => {
   moduleData.npcs = [{
     id: 'npc1', name: 'NPC', color: '#fff', map: 'world', x: 0, y: 0,


### PR DESCRIPTION
## Summary
- allow Adventure Kit confirm dialogs to accept Enter for yes and Escape for no
- cover keyboard shortcuts in ACK tests

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bae58889488328ad49891adb72fa9d