### PR TITLE
fix: subdivide land to ensure roads

### DIFF
--- a/docs/design/procedural-map-generator.md
+++ b/docs/design/procedural-map-generator.md
@@ -29,7 +29,7 @@ Seeded 2D map generator that layers noise and region growth to draw terrain, wat
 
 1. **Height field** – Generate a Simplex-noise height map, optionally subtracting a radial falloff to bias edges toward water, then convert elevations into water, sand, brush, or rock tiles.
 2. **Tile refinement** – Grow land regions and smooth stray cells with cellular automata.
-3. **Road graph** – Connect region centers with a minimum spanning tree; jitter paths with midpoint displacement or a random-walk carve.
+3. **Road graph** – Connect region centers with a minimum spanning tree; jitter paths with midpoint displacement or a random-walk carve. If only one land region exists, split the map into quadrants to seed multiple centers so roads still appear on contiguous terrain.
 4. **Ruin placement** – Scatter ruin tiles using Poisson-disk sampling and eligibility rules.
 5. **Export** – Emit a JSON tile map plus road and feature metadata.
 
@@ -72,6 +72,7 @@ Insights pulled from accessible community tutorials and open-source repos:
 ### Road Graph
 - [x] Connect region centers with a minimum spanning tree.
 - [x] Carve jittered paths via midpoint displacement or random walk and convert to road tiles.
+- [x] When only one land region is detected, subdivide it into quadrants so roads generate even on fully connected land.
 
 ### Ruin Placement
 - [ ] Use Poisson-disk sampling to scatter ruin tiles while honoring spacing and terrain rules.

--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -235,7 +235,7 @@ function findRegionCenters(tiles) {
   const h = tiles.length;
   const w = tiles[0].length;
   const seen = Array.from({ length: h }, () => Array(w).fill(false));
-  const centers = [];
+  let centers = [];
   for (let y = 0; y < h; y++) {
     for (let x = 0; x < w; x++) {
       if (tiles[y][x] === TILE.WATER || seen[y][x]) continue;
@@ -257,6 +257,29 @@ function findRegionCenters(tiles) {
       centers.push({ x: sx / count, y: sy / count });
     }
   }
+  if (centers.length < 2) {
+    const hw = Math.floor(w / 2);
+    const hh = Math.floor(h / 2);
+    const quads = [
+      [0, 0, hw, hh],
+      [hw, 0, w, hh],
+      [0, hh, hw, h],
+      [hw, hh, w, h]
+    ];
+    const extra = [];
+    for (const [x0, y0, x1, y1] of quads) {
+      let sx = 0, sy = 0, count = 0;
+      for (let yy = y0; yy < y1; yy++) {
+        for (let xx = x0; xx < x1; xx++) {
+          if (tiles[yy][xx] !== TILE.WATER) {
+            sx += xx; sy += yy; count++;
+          }
+        }
+      }
+      if (count > 0) extra.push({ x: sx / count, y: sy / count });
+    }
+    if (extra.length > 1) centers = extra;
+  }
   return centers;
 }
 
@@ -274,6 +297,7 @@ function generateProceduralMap(seed, width, height, scale = 4, falloff = 0) {
 globalThis.generateHeightField = generateHeightField;
 globalThis.heightFieldToTiles = heightFieldToTiles;
 globalThis.refineTiles = refineTiles;
+globalThis.findRegionCenters = findRegionCenters;
 globalThis.connectRegionCenters = connectRegionCenters;
 globalThis.carveRoads = carveRoads;
 globalThis.generateProceduralMap = generateProceduralMap;

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -76,6 +76,13 @@ test('connectRegionCenters handles single region', () => {
   assert.deepEqual(edges, []);
 });
 
+test('findRegionCenters subdivides large landmass', () => {
+  globalThis.TILE = { WATER: 2 };
+  const tiles = Array.from({ length: 4 }, () => Array(4).fill(1));
+  const centers = globalThis.findRegionCenters(tiles);
+  assert.ok(centers.length > 1);
+});
+
 test('carveRoads draws road between centers', () => {
   globalThis.TILE = { SAND: 0, ROAD: 4 };
   const size = 5;
@@ -118,4 +125,16 @@ test('generateProceduralMap is deterministic', () => {
   const a = globalThis.generateProceduralMap(42, 12, 12);
   const b = globalThis.generateProceduralMap(42, 12, 12);
   assert.deepEqual(a, b);
+});
+
+test('generateProceduralMap adds roads on single land region', () => {
+  globalThis.TILE = { SAND: 0, WATER: 2, BRUSH: 3, ROCK: 5, ROAD: 4 };
+  const grid = globalThis.generateProceduralMap(2, 16, 16, 4, 0);
+  let roads = 0;
+  for (const row of grid) {
+    for (const t of row) {
+      if (t === 4) roads++;
+    }
+  }
+  assert.ok(roads > 0);
 });


### PR DESCRIPTION
## Summary
- split single land regions into quadrants so MST has multiple centers and roads form on contiguous terrain
- document quadrant subdivision in map generator design doc
- test that region finder and map generator create roads without water breaks

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bae76098b48328b5a97bec545da2b3