### PR TITLE
fix: repair CI workflow indentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
+---
 name: CI
 
-on:
+'on':
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   page_build:
 
 permissions:
@@ -15,9 +16,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-    build:
-      if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: bump version') }}"
-      runs-on: ubuntu-latest
+  build:
+    if: >-
+      ${{ github.event_name != 'push' ||
+          !startsWith(
+            github.event.head_commit.message,
+            'chore: bump version'
+          ) }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- fix mis-indented `steps` block and add YAML doc start
- quote `on` key and remove bracket spacing to satisfy yamllint
- wrap long conditional to stay within lint limits

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68baf58014f48328a92151f09545a82e