### PR TITLE
feat: cluster procedural ruins

### DIFF
--- a/docs/design/procedural-map-generator.md
+++ b/docs/design/procedural-map-generator.md
@@ -30,7 +30,7 @@ Seeded 2D map generator that layers noise and region growth to draw terrain, wat
 1. **Height field** – Generate a Simplex-noise height map, optionally subtracting a radial falloff to bias edges toward water, then convert elevations into water, sand, brush, or rock tiles.
 2. **Tile refinement** – Grow land regions and smooth stray cells with cellular automata.
 3. **Road graph** – Connect region centers with a minimum spanning tree; jitter paths with midpoint displacement or a random-walk carve. If only one land region exists, split the map into quadrants to seed multiple centers so roads still appear on contiguous terrain.
-4. **Ruin placement** – Scatter ruin tiles using Poisson-disk sampling and eligibility rules.
+4. **Ruin placement** – Seed ruin clusters with Poisson-disk sampling and fill nearby tiles to form small forts.
 5. **Export** – Emit a JSON tile map plus road and feature metadata.
 
 ## Data Flow

--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -243,26 +243,38 @@ function carveRoads(tiles, centers, edges, field, seed = 1) {
   return tiles;
 }
 
-function scatterRuins(tiles, seed = 1, radius = 3) {
+function scatterRuins(tiles, seed = 1, radius = 6) {
   const rand = mulberry32(typeof seed === 'string' ? hashString(seed) : seed);
   const h = tiles.length;
   const w = tiles[0].length;
+  const centers = [];
   const ruins = [];
   const r2 = radius * radius;
   for (let i = 0; i < w * h; i++) {
     const x = Math.floor(rand() * w);
     const y = Math.floor(rand() * h);
     const t = tiles[y][x];
-    if (t === TILE.WATER || t === TILE.ROAD) continue;
+    if (t === TILE.WATER || t === TILE.ROAD || t === TILE.RUIN) continue;
     let ok = true;
-    for (const r of ruins) {
-      const dx = r.x - x;
-      const dy = r.y - y;
+    for (const c of centers) {
+      const dx = c.x - x;
+      const dy = c.y - y;
       if (dx * dx + dy * dy < r2) { ok = false; break; }
     }
     if (!ok) continue;
     tiles[y][x] = TILE.RUIN;
+    centers.push({ x, y });
     ruins.push({ x, y });
+    const extra = 1 + Math.floor(rand() * 3);
+    for (let n = 0; n < extra; n++) {
+      const nx = x + Math.floor(rand() * 3) - 1;
+      const ny = y + Math.floor(rand() * 3) - 1;
+      if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
+      const tt = tiles[ny][nx];
+      if (tt === TILE.WATER || tt === TILE.ROAD || tt === TILE.RUIN) continue;
+      tiles[ny][nx] = TILE.RUIN;
+      ruins.push({ x: nx, y: ny });
+    }
   }
   return { tiles, ruins };
 }

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -150,15 +150,19 @@ test('scatterRuins respects spacing and terrain', () => {
   assert.equal(a.tiles[0][0], 2);
   assert.equal(a.tiles[1][1], 4);
   assert.ok(a.ruins.length > 0);
+  let clustered = false;
   for (let i = 0; i < a.ruins.length; i++) {
     const r1 = a.ruins[i];
     for (let j = i + 1; j < a.ruins.length; j++) {
       const r2 = a.ruins[j];
       const dx = r1.x - r2.x;
       const dy = r1.y - r2.y;
-      assert.ok(dx * dx + dy * dy >= 9);
+      const d2 = dx * dx + dy * dy;
+      if (d2 <= 2) { clustered = true; break; }
     }
+    if (clustered) break;
   }
+  assert.ok(clustered);
 });
 
 test('generateProceduralMap returns grid of requested size', () => {


### PR DESCRIPTION
## Summary
- group procedural ruins into clustered forts
- document ruin clustering in design spec
- test for adjacent ruin tiles

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb176b58908328b2fe5ad64c46752b