### PR TITLE
fix: persist item rewards without type

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1485,7 +1485,7 @@ function updateTreeData() {
       let reward = '';
       if (rewardType === 'xp' && xpTxt) reward = `XP ${parseInt(xpTxt, 10)}`;
       else if (rewardType === 'scrap' && scrapTxt) reward = `SCRAP ${parseInt(scrapTxt, 10)}`;
-      else if (rewardType === 'item' && itemReward) reward = itemReward;
+      else if ((rewardType === 'item' || (!rewardType && itemReward)) && itemReward) reward = itemReward;
       const stat = chEl.querySelector('.choiceStat')?.value.trim() || '';
       const dcTxt = chEl.querySelector('.choiceDC')?.value.trim() || '';
       const dc = dcTxt ? parseInt(dcTxt, 10) : undefined;

--- a/test/dialog.effects.test.js
+++ b/test/dialog.effects.test.js
@@ -197,6 +197,70 @@ test('updateTreeData captures scrap reward', () => {
   assert.strictEqual(treeData.start.choices[0].reward, 'SCRAP 2');
 });
 
+test('updateTreeData captures item reward without explicit type', () => {
+  treeData = {};
+  const choiceEl = {
+    querySelector(sel){
+      switch(sel){
+        case '.choiceLabel': return { value: 'take items' };
+        case '.choiceTo': return { value: 'bye', style:{} };
+        case '.choiceRewardType': return { value: '' };
+        case '.choiceRewardXP': return { value: '' };
+        case '.choiceRewardScrap': return { value: '' };
+        case '.choiceRewardItem': return { value: 'Reward' };
+        case '.choiceStat':
+        case '.choiceDC':
+        case '.choiceSuccess':
+        case '.choiceFailure':
+        case '.choiceCostItem':
+        case '.choiceCostSlot':
+        case '.choiceCostTag':
+        case '.choiceReqItem':
+        case '.choiceReqSlot':
+        case '.choiceReqTag':
+        case '.choiceJoinId':
+        case '.choiceJoinName':
+        case '.choiceJoinRole':
+        case '.choiceGotoMap':
+        case '.choiceGotoX':
+        case '.choiceGotoY':
+        case '.choiceQ':
+        case '.choiceFlag':
+        case '.choiceOp':
+        case '.choiceVal':
+          return { value: '' };
+        case '.choiceOnce':
+          return { checked: true };
+        case '.choiceBoard':
+        case '.choiceUnboard':
+          return { value: '' };
+        default:
+          return { value: '' };
+      }
+    }
+  };
+  const nodeEl = {
+    querySelector(sel){
+      switch(sel){
+        case '.nodeId': return { value: 'start' };
+        case '.nodeText': return { value: 'hi' };
+        default: return { value: '' };
+      }
+    },
+    querySelectorAll(sel){ return sel === '.choices > div' ? [choiceEl] : []; },
+    classList:{ contains(){ return false; } },
+    style:{},
+  };
+  elements['treeEditor'] = {
+    querySelectorAll(sel){ return sel === '.node' ? [nodeEl] : []; }
+  };
+  elements['npcTree'] = { value: '' };
+  elements['treeWarning'] = { textContent: '' };
+
+  updateTreeData();
+  assert.strictEqual(treeData.start.choices[0].reward, 'Reward');
+});
+
 test('updateTreeData removes deleted nodes', () => {
   treeData = { start: { text: '', choices: [] }, node1: { text: '', choices: [] } };
   const nodeEl = {


### PR DESCRIPTION
## Summary
- ensure dialog choices retain item rewards even when reward type is omitted
- add regression test for implicit item rewards

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb1a59470883288b65b60206e31b79