### PR TITLE
test: ensure advanced dialog choices persist in ACK editor

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1654,6 +1654,7 @@ function openDialogEditor() {
 }
 
 function closeDialogEditor() {
+  updateTreeData();
   document.getElementById('dialogModal').classList.remove('shown');
   const dlgEl = document.getElementById('npcDialog');
   if (!dlgEl.value.trim()) dlgEl.value = treeData.start?.text || '';
@@ -1924,7 +1925,6 @@ function collectNPCFromForm() {
   const flag = getRevealFlag();
   const op = document.getElementById('npcOp').value;
   const val = parseInt(document.getElementById('npcVal').value, 10) || 0;
-  updateTreeData();
   let tree = null;
   const treeTxt = document.getElementById('npcTree').value.trim();
   if (treeTxt) { try { tree = JSON.parse(treeTxt); } catch (e) { tree = null; } }

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -36,6 +36,7 @@ function stubEl(){
     parentElement:{ style:{}, appendChild(){}, querySelectorAll(){ return []; } },
     setAttribute(){},
     click(){},
+    dispatchEvent(){},
     focus(){ document.activeElement = el; },
   };
   Object.defineProperty(el,'innerHTML',{ get(){return this._innerHTML;}, set(v){ this._innerHTML=v; this.children=[]; }});
@@ -660,6 +661,36 @@ test('dialog text edited in tree editor is preserved', () => {
   globalThis.updateTreeData = origUpdate;
   closeNPCEditor();
   assert.strictEqual(moduleData.npcs[0].tree.start.text, 'welcome');
+});
+
+test('advanced dialog choices persist after reopening editor', () => {
+  moduleData.npcs = [{
+    id: 'npc1', name: 'NPC', color: '#fff', map: 'world', x: 0, y: 0,
+    tree: { start: { text: 'hi', choices: [{ label: '(Leave)', to: 'bye' }] } }
+  }];
+  editNPC(0);
+  const newTree = {
+    start: {
+      text: 'hi',
+      choices: [{
+        label: 'Go', to: 'end',
+        reward: 'XP 5',
+        goto: { map: 'world', x: 2, y: 1 }
+      }]
+    },
+    end: { text: '', choices: [{ label: '(Leave)', to: 'bye' }] }
+  };
+  treeData = newTree;
+  document.getElementById('npcTree').value = JSON.stringify(newTree);
+  const origUpdate = globalThis.updateTreeData;
+  globalThis.updateTreeData = () => {};
+  closeDialogEditor();
+  globalThis.updateTreeData = origUpdate;
+  openDialogEditor();
+  assert.strictEqual(treeData.start.choices[0].reward, 'XP 5');
+  assert.strictEqual(treeData.start.choices[0].goto.x, 2);
+  closeDialogEditor();
+  closeNPCEditor();
 });
 
 test('editNPC expands short hex colors', () => {


### PR DESCRIPTION
## Summary
- add regression test ensuring advanced dialog choices survive closing and reopening the ACK dialog editor
- call `updateTreeData` before hiding dialog editor so edited choices persist
- avoid redundant tree rebuild when saving NPCs

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb1e9de85083288468b22f26355254