### PR TITLE
fix: clear world flags on reset

### DIFF
--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -663,6 +663,7 @@ if (startNew) startNew.onclick = () => { hideStart(); resetAll(); };
 
 function resetAll(){
   party.length=0; player.inv=[]; party.flags={}; player.scrap=0;
+  Object.keys(worldFlags).forEach(k => delete worldFlags[k]);
   state.map='creator'; openCreator();
   log('Reset. Back to character creation.');
   if (typeof toast === 'function') toast('Game reset.');

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1054,6 +1054,16 @@ test('dialog choices can be gated by world flags', () => {
   assert.strictEqual(choicesEl.children.length, 2);
   closeDialog();
 });
+
+test('resetAll clears world flags', () => {
+  Object.keys(worldFlags).forEach(k => delete worldFlags[k]);
+  worldFlags.demo = { count: 1, time: Date.now() };
+  const origOpen = global.openCreator;
+  global.openCreator = () => {};
+  resetAll();
+  global.openCreator = origOpen;
+  assert.strictEqual(Object.keys(worldFlags).length, 0);
+});
 test('dialog choices can be gated by party flags', () => {
   party.flags = {};
   state.map = 'world';


### PR DESCRIPTION
## Summary
- clear global world flags during game reset to avoid leaking state across runs
- test resetAll to ensure world flags are cleared

## Testing
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb73c3b4d883289008b085301e3f83