### PR TITLE
fix: close renderTreeEditor test

### DIFF
--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -746,7 +746,7 @@ test('renderTreeEditor reflects NPC-specific tree updates', () => {
   editNPC(0);
   assert.strictEqual(getTreeData().start.choices[0].reqItem, 'key');
   globalThis.updateTreeData = origUpdate2;
-);
+});
 test('advanced dialog choices persist after reopening editor', () => {
   moduleData.npcs = [{
     id: 'npc1', name: 'NPC', color: '#fff', map: 'world', x: 0, y: 0,


### PR DESCRIPTION
## Summary
- close test block with curly

## Testing
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb75eabeac832885bfc822928ca519