### PR TITLE
fix: persist dialog item rewards

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1247,17 +1247,17 @@ function addChoiceRow(container, ch = {}) {
     if (type) { addAdv(type); sel.value = ''; }
   });
 
+  let rewardTypeSel;
   if (reward) {
     addAdv('reward');
-    const rt = row.querySelector('.choiceRewardType');
+    rewardTypeSel = row.querySelector('.choiceRewardType');
     const xp = row.querySelector('.choiceRewardXP');
     const sc = row.querySelector('.choiceRewardScrap');
     const ri = row.querySelector('.choiceRewardItem');
-    if (rt) rt.value = isXP ? 'xp' : isScrap ? 'scrap' : 'item';
+    if (rewardTypeSel) rewardTypeSel.value = isXP ? 'xp' : isScrap ? 'scrap' : 'item';
     if (xp) xp.value = xpVal;
     if (sc) sc.value = scrapVal;
     if (ri) ri.value = itemVal;
-    if (rt) rt.dispatchEvent(new Event('change'));
   }
   if (stat || dc || success || failure) {
     addAdv('stat');
@@ -1346,6 +1346,7 @@ function addChoiceRow(container, ch = {}) {
   row.querySelectorAll('input[type=checkbox]').forEach(el => el.addEventListener('change', updateTreeData));
   row.querySelector('.delChoice').addEventListener('click', () => { row.remove(); updateTreeData(); });
   refreshChoiceDropdowns();
+  if (reward && rewardTypeSel) rewardTypeSel.dispatchEvent(new Event('change'));
 }
 
 function populateChoiceDropdown(sel, selected = '') {

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -748,6 +748,7 @@ test('renderTreeEditor reflects NPC-specific tree updates', () => {
   globalThis.updateTreeData = origUpdate2;
 });
 test('advanced dialog choices persist after reopening editor', () => {
+  moduleData.items = [{ id: 'reward' }];
   moduleData.npcs = [{
     id: 'npc1', name: 'NPC', color: '#fff', map: 'world', x: 0, y: 0,
     tree: { start: { text: 'hi', choices: [{ label: '(Leave)', to: 'bye' }] } }
@@ -758,23 +759,25 @@ test('advanced dialog choices persist after reopening editor', () => {
       text: 'hi',
       choices: [{
         label: 'Go', to: 'end',
-        reward: 'XP 5',
+        reward: 'reward',
         goto: { map: 'world', x: 2, y: 1 }
       }]
     },
     end: { text: '', choices: [{ label: '(Leave)', to: 'bye' }] }
   };
-  treeData = newTree;
+  setTreeData(newTree);
   document.getElementById('npcTree').value = JSON.stringify(newTree);
   const origUpdate = globalThis.updateTreeData;
   globalThis.updateTreeData = () => {};
   closeDialogEditor();
   globalThis.updateTreeData = origUpdate;
   openDialogEditor();
-  assert.strictEqual(treeData.start.choices[0].reward, 'XP 5');
-  assert.strictEqual(treeData.start.choices[0].goto.x, 2);
+  const tree = getTreeData();
+  assert.strictEqual(tree.start.choices[0].reward, 'reward');
+  assert.strictEqual(tree.start.choices[0].goto.x, 2);
   closeDialogEditor();
   closeNPCEditor();
+  moduleData.items = [];
 });
 
 test('editNPC expands short hex colors', () => {


### PR DESCRIPTION
## Summary
- ensure item rewards remain selected by dispatching updates after dropdowns refresh
- cover dialog editor round-trip for advanced choices with an item reward

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb791087288328b5a4a61a7d21d661