### PR TITLE
feat: triple spawns after repeated one-turn kills

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -534,9 +534,10 @@ function doAttack(dmg, type = 'basic'){
     const eid = target.id || target.name;
     if (eid){
       const turnsTaken = combatState.turns - (target.spawnTurn || 1) + 1;
-      const stats = enemyTurnStats[eid] || (enemyTurnStats[eid] = { total: 0, count: 0 });
+      const stats = enemyTurnStats[eid] || (enemyTurnStats[eid] = { total: 0, count: 0, quick: 0 });
       stats.total += Math.max(1, turnsTaken);
       stats.count += 1;
+      if (turnsTaken <= 1) stats.quick += 1;
     }
     if (target.loot) addToInv?.(target.loot);
 

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -353,10 +353,10 @@ function checkRandomEncounter(){
     }
     const id = def.id || def.name;
     const stats = globalThis.enemyTurnStats?.[id];
-    // If this enemy consistently falls in one turn, escalate group size
+    // If this enemy consistently falls in a single turn, spawn them in triples
     let count = 1;
-    if (stats && stats.count >= 3 && (stats.total / stats.count) <= 1){
-      count = 2 + Math.floor(Math.random() * 2);
+    if (stats && stats.quick >= 3){
+      count = 3;
     }
     if (count > 1) def.count = count;
     const min = mods.minSteps ?? 3;

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -764,15 +764,15 @@ test('advanced dialog choices persist after reopening editor', () => {
     },
     end: { text: '', choices: [{ label: '(Leave)', to: 'bye' }] }
   };
-  treeData = newTree;
+  setTreeData(newTree);
   document.getElementById('npcTree').value = JSON.stringify(newTree);
   const origUpdate = globalThis.updateTreeData;
   globalThis.updateTreeData = () => {};
   closeDialogEditor();
   globalThis.updateTreeData = origUpdate;
   openDialogEditor();
-  assert.strictEqual(treeData.start.choices[0].reward, 'XP 5');
-  assert.strictEqual(treeData.start.choices[0].goto.x, 2);
+  assert.strictEqual(getTreeData().start.choices[0].reward, 'XP 5');
+  assert.strictEqual(getTreeData().start.choices[0].goto.x, 2);
   closeDialogEditor();
   closeNPCEditor();
 });

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1697,7 +1697,7 @@ test('trivial enemies appear in groups', () => {
   applyModule({ world: [row], templates:[{ id:'weak', name:'Weak', combat:{ HP:1, ATK:1, DEF:0 }}], encounters: { world: [ { templateId:'weak' } ] } });
   state.map = 'world';
   setPartyPos(5, 0);
-  global.enemyTurnStats = { Weak: { total: 3, count: 3 } };
+  global.enemyTurnStats = { Weak: { total: 3, count: 3, quick: 3 } };
   let captured;
   const origRand = Math.random;
   Math.random = () => 0;
@@ -1708,7 +1708,7 @@ test('trivial enemies appear in groups', () => {
   globalThis.Dustland.actions.startCombat = origStart;
   delete global.enemyTurnStats;
   encounterCooldown = 0;
-  assert.ok(captured.count >= 2);
+  assert.strictEqual(captured.count, 3);
 });
 
 test('distant encounters use hard enemy pool', () => {


### PR DESCRIPTION
## Summary
- track single-turn enemy defeats
- spawn groups of three once an enemy has three quick losses
- align adventure kit tests with tree data helpers

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb7a9877ec83289d00df88ae22c3b8