### PR TITLE
feat: add poison status effect

### DIFF
--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -246,6 +246,19 @@ function useItem(invIndex){
     notifyInventoryChanged();
     return true;
   }
+  if(it.use.type==='cleanse'){
+    const who = (party[selectedMember]||party[0]);
+    if(!who){ log('No party member to cleanse.'); return false; }
+    if(Array.isArray(who.statusEffects)){
+      who.statusEffects.length = 0;
+    }
+    log(`${who.name} feels purified.`);
+    if(typeof toast==='function') toast(`${who.name} is cleansed`);
+    emit('sfx','tick');
+    player.inv.splice(invIndex,1);
+    notifyInventoryChanged();
+    return true;
+  }
   if(typeof it.use.onUse === 'function'){
     const ok = it.use.onUse({player, party, log, toast});
     if(ok!==false){

--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -23,6 +23,7 @@ class Character {
     this.adrDmgMod = 1;
     this.cooldowns = {};
     this.guard = false;
+    this.statusEffects = [];
   }
   xpToNext(){ return xpToNext(this.lvl); }
   awardXP(amt){

--- a/test/poison.effect.test.js
+++ b/test/poison.effect.test.js
@@ -1,0 +1,42 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+global.log = () => {};
+global.toast = () => {};
+global.EventBus = { emit: () => {} };
+
+const dom = new JSDOM(`<div id="combatOverlay"></div><div id="combatEnemies"></div><div id="combatParty"></div><div id="combatCmd"></div><div id="turnIndicator"></div>`);
+global.document = dom.window.document;
+global.window = dom.window;
+
+await import('../scripts/core/party.js');
+await import('../scripts/core/combat.js');
+await import('../scripts/core/inventory.js');
+
+const { addStatus, tickStatuses, registerItem, addToInv, useItem, makeMember, party } = globalThis;
+
+test('poison deals damage over time', () => {
+  const foe = { name: 'Foe', hp: 10, maxHp: 10 };
+  addStatus(foe, { type: 'poison', strength: 2, duration: 3 });
+  tickStatuses(foe);
+  assert.strictEqual(foe.hp, 8);
+  tickStatuses(foe);
+  assert.strictEqual(foe.hp, 6);
+  tickStatuses(foe);
+  assert.strictEqual(foe.hp, 4);
+  assert.strictEqual(foe.statusEffects.length, 0);
+});
+
+test('cleanse item clears poison', () => {
+  party.length = 0;
+  globalThis.player = { inv: [] };
+  const m1 = makeMember('p1', 'P1', 'Role');
+  party.push(m1);
+  addStatus(m1, { type: 'poison', strength: 1, duration: 5 });
+  registerItem({ id: 'antidote', name: 'Antidote', type: 'misc', use: { type: 'cleanse' } });
+  addToInv('antidote');
+  assert.ok(m1.statusEffects.length > 0);
+  useItem(0);
+  assert.strictEqual(m1.statusEffects.length, 0);
+});


### PR DESCRIPTION
## Summary
- add combat status effects with poison damage over time
- allow cleanse items to remove negative status effects
- cover poison application and cleansing with tests

## Testing
- `npm test -- test/poison.effect.test.js`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `npm test` *(fails: command terminated early due to environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7b3708608328886fbf876fa7ab36