### PR TITLE
feat: add spread damage weapon mod

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -204,9 +204,10 @@ loopMinus.addEventListener('click', () => {
 
 const moduleData = globalThis.moduleData || (globalThis.moduleData = { seed: Date.now(), name: 'adventure-module', npcs: [], items: [], quests: [], buildings: [], interiors: [], portals: [], events: [], zones: [], encounters: [], templates: [], start: { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) }, module: undefined, moduleVar: undefined });
 const STAT_OPTS = ['ATK', 'DEF', 'LCK', 'INT', 'PER', 'CHA'];
-const MOD_TYPES = ['ATK', 'DEF', 'LCK', 'INT', 'PER', 'CHA', 'STR', 'AGI', 'ADR', 'adrenaline_gen_mod', 'adrenaline_dmg_mod'];
+const MOD_TYPES = ['ATK', 'DEF', 'LCK', 'INT', 'PER', 'CHA', 'STR', 'AGI', 'ADR', 'adrenaline_gen_mod', 'adrenaline_dmg_mod', 'spread'];
 const PRESET_TAGS = ['key', 'pass', 'tool', 'idol', 'signal_fragment', 'mask'];
 const customTags = new Set();
+globalThis.treeData = globalThis.treeData || {};
 
 function allTags() {
   return PRESET_TAGS.concat([...customTags]).sort();

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -456,13 +456,15 @@ function chooseOption(){
 
 function doAttack(dmg, type = 'basic'){
   const attacker = party[combatState.active];
-  const target = combatState.enemies[0];
-  if (!attacker || !target){ nextCombatant?.(); return; }
+  const weapon   = attacker?.equip?.weapon;
+  // Spread attacks hit all enemies for a percentage of base damage.
+  const spread   = weapon?.mods?.spread;
+  const targets  = spread ? [...combatState.enemies] : [combatState.enemies[0]];
+  if (!attacker || targets.length === 0){ nextCombatant?.(); return; }
 
-  const weapon = attacker.equip?.weapon;
   const isRanged = weapon && /rifle|gun|bow|pistol/i.test(weapon.id || weapon.name || '');
   const statName = isRanged ? 'AGI' : 'STR';
-  const statVal = (attacker.stats?.[statName] || 0) + (attacker._bonus?.[statName] || 0);
+  const statVal  = (attacker.stats?.[statName] || 0) + (attacker._bonus?.[statName] || 0);
   const statBonus = Math.max(0, statVal - 4);
   const atkBonus  = attacker._bonus?.ATK || 0;
   const base      = dmg + atkBonus + statBonus;
@@ -473,43 +475,6 @@ function doAttack(dmg, type = 'basic'){
   const mult  = 1 + adrPct * (attacker.adrDmgMod || 1);
   dealt = Math.round(dealt * mult);
 
-  const req = target.requires;
-  if (req && (!weapon || weapon.id !== req)){
-    dealt = 0;
-    log?.(`${attacker.name}'s attacks can't harm ${target.name}. Equip ${req}.`);
-  }
-
-  // Immunity to basic
-  if (type === 'basic' && Array.isArray(target.immune) && target.immune.includes('basic')){
-    dealt = 0;
-    log?.(`${target.name} shrugs off the attack.`);
-  }
-
-  // Target defense
-  const preDef = dealt;
-  dealt = Math.max(0, dealt - (target.DEF || 0));
-  if (preDef > 0 && dealt === 0) {
-    log?.(`${attacker.name}'s attack bounces off ${target.name} harmlessly.`);
-  }
-
-  const luck = (attacker.stats?.LCK || 0) + (attacker._bonus?.LCK || 0);
-  const eff  = Math.max(0, luck - 4);
-  if (Math.random() < eff * 0.05){
-    dealt += 1;
-    log?.('Lucky strike!');
-  }
-
-  target.hp -= dealt;
-
-  recordCombatEvent?.({
-    type: 'player',
-    actor: attacker.name,
-    action: 'attack',
-    target: target.name,
-    damage: dealt,
-    targetHp: target.hp
-  });
-
   // Adrenaline gain (based on weapon mods & generator mod)
   const baseGain = (weapon?.mods?.ADR ?? 10) / 4;
   const gain     = Math.round(baseGain * (attacker.adrGenMod || 1));
@@ -517,61 +482,106 @@ function doAttack(dmg, type = 'basic'){
   if (gain > 0 && typeof playFX === 'function') playFX('adrenaline');
 
   updateHUD?.();
-  if (dealt > 0) log?.(`${attacker.name} hits ${target.name} for ${dealt} damage.`);
 
-  // Enemy counter against basic attacks
-  if (type === 'basic' && target.counterBasic){
-    const cd = target.counterBasic.dmg || 1;
-    attacker.hp -= cd;
-    log?.(`${target.name} counters for ${cd} damage.`);
+  const perTarget = spread ? Math.max(0, Math.round(dealt * spread / 100)) : dealt;
+  const defeated = [];
+  for (const target of targets){
+    let tDmg = perTarget;
+    const req = target.requires;
+    if (req && (!weapon || weapon.id !== req)){
+      tDmg = 0;
+      log?.(`${attacker.name}'s attacks can't harm ${target.name}. Equip ${req}.`);
+    }
+
+    // Immunity to basic
+    if (type === 'basic' && Array.isArray(target.immune) && target.immune.includes('basic')){
+      tDmg = 0;
+      log?.(`${target.name} shrugs off the attack.`);
+    }
+
+    // Target defense
+    const preDef = tDmg;
+    tDmg = Math.max(0, tDmg - (target.DEF || 0));
+    if (preDef > 0 && tDmg === 0) {
+      log?.(`${attacker.name}'s attack bounces off ${target.name} harmlessly.`);
+    }
+
+    const luck = (attacker.stats?.LCK || 0) + (attacker._bonus?.LCK || 0);
+    const eff  = Math.max(0, luck - 4);
+    if (Math.random() < eff * 0.05){
+      tDmg += 1;
+      log?.('Lucky strike!');
+    }
+
+    target.hp -= tDmg;
+
+    recordCombatEvent?.({
+      type: 'player',
+      actor: attacker.name,
+      action: 'attack',
+      target: target.name,
+      damage: tDmg,
+      targetHp: target.hp
+    });
+
+    if (tDmg > 0) log?.(`${attacker.name} hits ${target.name} for ${tDmg} damage.`);
+
+    // Enemy counter against basic attacks
+    if (type === 'basic' && target.counterBasic){
+      const cd = target.counterBasic.dmg || 1;
+      attacker.hp -= cd;
+      log?.(`${target.name} counters for ${cd} damage.`);
+    }
+
+    if (target.hp <= 0){
+      log?.(`${target.name} is defeated!`);
+      recordCombatEvent?.({ type: 'enemy', actor: target.name, action: 'defeated', by: attacker.name });
+      globalThis.EventBus?.emit?.('enemy:defeated', { target });
+      const eid = target.id || target.name;
+      if (eid){
+        const turnsTaken = combatState.turns - (target.spawnTurn || 1) + 1;
+        const stats = enemyTurnStats[eid] || (enemyTurnStats[eid] = { total: 0, count: 0 });
+        stats.total += Math.max(1, turnsTaken);
+        stats.count += 1;
+      }
+      if (target.loot) addToInv?.(target.loot);
+
+      // Bandits sometimes drop scrap
+      if (/bandit/i.test(target.id) && Math.random() < 0.5){
+        player.scrap = (player.scrap || 0) + 1;
+        updateHUD?.();
+        log?.('You find 1 scrap on the bandit.');
+      }
+
+      // Special boss drop chance
+      if (target.boss && Math.random() < 0.1){ addToInv?.('memory_worm'); }
+
+      // Spoils cache system (optional)
+      if (typeof SpoilsCache !== 'undefined'){
+        const cache = SpoilsCache.rollDrop?.(target.challenge);
+        if (cache){
+          const registered = typeof registerItem === 'function' ? registerItem(cache) : cache;
+          itemDrops?.push?.({ id: registered.id, map: party.map, x: party.x, y: party.y });
+          log?.(`The ground coughs up a ${registered.name}.`);
+          globalThis.EventBus?.emit?.('spoils:drop', { cache: registered, target });
+        }
+      }
+
+      if (target.npc) removeNPC?.(target.npc);
+
+      defeated.push(target);
+    }
   }
 
-  // Death & loot
-  if (target.hp <= 0){
-    log?.(`${target.name} is defeated!`);
-    recordCombatEvent?.({ type: 'enemy', actor: target.name, action: 'defeated', by: attacker.name });
-    globalThis.EventBus?.emit?.('enemy:defeated', { target });
-    const eid = target.id || target.name;
-    if (eid){
-      const turnsTaken = combatState.turns - (target.spawnTurn || 1) + 1;
-      const stats = enemyTurnStats[eid] || (enemyTurnStats[eid] = { total: 0, count: 0 });
-      stats.total += Math.max(1, turnsTaken);
-      stats.count += 1;
-    }
-    if (target.loot) addToInv?.(target.loot);
+  if (defeated.length){
+    combatState.enemies = combatState.enemies.filter(e => !defeated.includes(e));
+  }
 
-    // Bandits sometimes drop scrap
-    if (/bandit/i.test(target.id) && Math.random() < 0.5){
-      player.scrap = (player.scrap || 0) + 1;
-      updateHUD?.();
-      log?.('You find 1 scrap on the bandit.');
-    }
-
-    // Special boss drop chance
-    if (target.boss && Math.random() < 0.1){ addToInv?.('memory_worm'); }
-
-    // Spoils cache system (optional)
-    if (typeof SpoilsCache !== 'undefined'){
-      const cache = SpoilsCache.rollDrop?.(target.challenge);
-      if (cache){
-        const registered = typeof registerItem === 'function' ? registerItem(cache) : cache;
-        itemDrops?.push?.({ id: registered.id, map: party.map, x: party.x, y: party.y });
-        log?.(`The ground coughs up a ${registered.name}.`);
-        globalThis.EventBus?.emit?.('spoils:drop', { cache: registered, target });
-      }
-    }
-
-    if (target.npc) removeNPC?.(target.npc);
-
-    combatState.enemies.shift();
-    renderCombat();
-    if (combatState.enemies.length === 0){
-      log?.('Victory!');
-      closeCombat('loot');
-      return;
-    }
-  } else {
-    renderCombat();
+  renderCombat();
+  if (combatState.enemies.length === 0){
+    log?.('Victory!');
+    closeCombat('loot');
+    return;
   }
 
   nextCombatant();
@@ -810,5 +820,5 @@ function getCombatLog(){
   return combatState.log.slice();
 }
 
-const combatExports = { openCombat, closeCombat, handleCombatKey, getCombatLog, __testAttack: testAttack };
+const combatExports = { openCombat, closeCombat, handleCombatKey, getCombatLog, __testAttack: testAttack, __combatState: combatState };
 Object.assign(globalThis, combatExports);

--- a/test/spread-attack.test.js
+++ b/test/spread-attack.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+// minimal DOM for combat module
+const dom = new JSDOM(`<div id="combatOverlay"></div><div id="combatEnemies"></div><div id="combatParty"></div><div id="combatCmd"></div><div id="turnIndicator"></div>`);
+global.window = dom.window;
+global.document = dom.window.document;
+
+await import('../scripts/core/party.js');
+await import('../scripts/core/combat.js');
+
+global.updateHUD = () => {};
+global.player = { hp: 10, inv: [] };
+global.log = () => {};
+
+test('spread mod hits all enemies with reduced damage', async () => {
+  const e1 = { name: 'E1', hp: 5, maxHp: 5, DEF: 0 };
+  const e2 = { name: 'E2', hp: 5, maxHp: 5, DEF: 0 };
+  party.length = 0;
+  const attacker = makeMember('a', 'A', 'Hero');
+  attacker.stats.STR = 8;
+  attacker.equip.weapon = { mods: { ADR: 10, spread: 50 } };
+  party.push(attacker);
+  const r = Math.random; Math.random = () => 0;
+  const p = openCombat([e1, e2]);
+  handleCombatKey({ key: 'Enter' });
+  Math.random = r;
+  const enemies = __combatState.enemies;
+  assert.strictEqual(enemies[0].hp, 4);
+  assert.strictEqual(enemies[1].hp, 4);
+  closeCombat('flee');
+  await p;
+});


### PR DESCRIPTION
## Summary
- add spread weapon modifier to hit all enemies for reduced damage
- expose spread in Adventure Kit mod list and ensure treeData exists
- test spread modifier behavior across multiple foes

## Testing
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb7ad787d88328bd32b426b0744918