### PR TITLE
fix: preserve choice requirements

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1259,7 +1259,7 @@ function addChoiceRow(container, ch = {}) {
     if (rewardTypeSel) rewardTypeSel.value = isXP ? 'xp' : isScrap ? 'scrap' : 'item';
     if (xp) xp.value = xpVal;
     if (sc) sc.value = scrapVal;
-    if (ri) ri.value = itemVal;
+    if (ri) (ri.dataset || (ri.dataset = {})).sel = itemVal;
   }
   if (stat || dc || success || failure) {
     addAdv('stat');
@@ -1270,14 +1270,26 @@ function addChoiceRow(container, ch = {}) {
   }
   if (costItem || costSlot || costTag) {
     addAdv('cost');
-    if (costItem) row.querySelector('.choiceCostItem').value = costItem;
-    if (costSlot) row.querySelector('.choiceCostSlot').value = costSlot;
+    if (costItem) {
+      const el = row.querySelector('.choiceCostItem');
+      if (el) (el.dataset || (el.dataset = {})).sel = costItem;
+    }
+    if (costSlot) {
+      const el = row.querySelector('.choiceCostSlot');
+      if (el) (el.dataset || (el.dataset = {})).sel = costSlot;
+    }
     if (costTag) row.querySelector('.choiceCostTag').value = costTag;
   }
   if (reqItem || reqSlot || reqTag) {
     addAdv('req');
-    if (reqItem) row.querySelector('.choiceReqItem').value = reqItem;
-    if (reqSlot) row.querySelector('.choiceReqSlot').value = reqSlot;
+    if (reqItem) {
+      const el = row.querySelector('.choiceReqItem');
+      if (el) (el.dataset || (el.dataset = {})).sel = reqItem;
+    }
+    if (reqSlot) {
+      const el = row.querySelector('.choiceReqSlot');
+      if (el) (el.dataset || (el.dataset = {})).sel = reqSlot;
+    }
     if (reqTag) row.querySelector('.choiceReqTag').value = reqTag;
   }
   if (joinId || joinName || joinRole) {
@@ -1415,14 +1427,14 @@ function populateTemplateDropdown(sel, selected = '') {
 function refreshChoiceDropdowns() {
   document.querySelectorAll('.choiceTo').forEach(sel => populateChoiceDropdown(sel, sel.value));
   document.querySelectorAll('.choiceStat').forEach(sel => populateStatDropdown(sel, sel.value));
-  document.querySelectorAll('.choiceCostSlot').forEach(sel => populateSlotDropdown(sel, sel.value));
-  document.querySelectorAll('.choiceReqSlot').forEach(sel => populateSlotDropdown(sel, sel.value));
-  document.querySelectorAll('.choiceCostItem').forEach(sel => populateItemDropdown(sel, sel.value));
-  document.querySelectorAll('.choiceReqItem').forEach(sel => populateItemDropdown(sel, sel.value));
+  document.querySelectorAll('.choiceCostSlot').forEach(sel => populateSlotDropdown(sel, sel.dataset.sel || sel.value));
+  document.querySelectorAll('.choiceReqSlot').forEach(sel => populateSlotDropdown(sel, sel.dataset.sel || sel.value));
+  document.querySelectorAll('.choiceCostItem').forEach(sel => populateItemDropdown(sel, sel.dataset.sel || sel.value));
+  document.querySelectorAll('.choiceReqItem').forEach(sel => populateItemDropdown(sel, sel.dataset.sel || sel.value));
   document.querySelectorAll('.choiceJoinId').forEach(sel => populateNPCDropdown(sel, sel.value));
   document.querySelectorAll('.choiceJoinRole').forEach(sel => populateRoleDropdown(sel, sel.value));
   document.querySelectorAll('.choiceGotoMap').forEach(sel => populateMapDropdown(sel, sel.value));
-  document.querySelectorAll('.choiceRewardItem').forEach(sel => populateItemDropdown(sel, sel.value));
+  document.querySelectorAll('.choiceRewardItem').forEach(sel => populateItemDropdown(sel, sel.dataset.sel || sel.value));
   document.querySelectorAll('.choiceBoard').forEach(sel => populateInteriorDropdown(sel, sel.value));
   document.querySelectorAll('.choiceUnboard').forEach(sel => populateInteriorDropdown(sel, sel.value));
   document.querySelectorAll('.choiceLockNPC').forEach(sel => populateNPCDropdown(sel, sel.value));

--- a/test/require-dropdown.persist.test.js
+++ b/test/require-dropdown.persist.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+function extract(fnName) {
+  const start = code.indexOf(`function ${fnName}`);
+  let depth = 0; let end = start;
+  for (; end < code.length; end++) {
+    if (code[end] === '{') depth++;
+    else if (code[end] === '}') { depth--; if (!depth) { end++; break; } }
+  }
+  return code.slice(start, end);
+}
+const popItemCode = extract('populateItemDropdown');
+const refreshCode = extract('refreshChoiceDropdowns');
+
+test('refreshChoiceDropdowns restores preset required item', () => {
+  const dom = new JSDOM('<select class="choiceReqItem"></select>');
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    moduleData: { items: [{ id: 'key' }] },
+    populateChoiceDropdown: () => {},
+    populateStatDropdown: () => {},
+    populateSlotDropdown: () => {},
+    populateNPCDropdown: () => {},
+    populateRoleDropdown: () => {},
+    populateMapDropdown: () => {},
+    populateInteriorDropdown: () => {}
+  };
+  vm.createContext(context);
+  vm.runInContext(popItemCode + refreshCode, context);
+  const sel = context.document.querySelector('select');
+  sel.dataset.sel = 'key';
+  context.refreshChoiceDropdowns();
+  assert.strictEqual(sel.value, 'key');
+});


### PR DESCRIPTION
## Summary
- store choice item/slot selections in data attributes so editor reloads preserve them
- repopulate dialog dropdowns from stored data selections
- add test ensuring required items survive dropdown refresh

## Testing
- `npm test`
- `node scripts/presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68bb7bd76cf083288863066041add317