### PR TITLE
feat: display enemy prompt when portrait missing

### DIFF
--- a/docs/module-json-workflow.md
+++ b/docs/module-json-workflow.md
@@ -39,6 +39,9 @@ default portrait index:
 { "portraitSheet": "assets/portraits/my_npc.png" }
 ```
 
+If an enemy lacks a `portraitSheet`, include a `prompt` field describing the desired art. The prompt text displays in game and helps track missing portraits.
+
+
 ## postLoad hooks
 Adventure Kit loads a module script when the JSON includes a `module` path. After the script loads, it calls the script's `postLoad(module)` method to apply procedural logic:
 

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -105,7 +105,13 @@ function setPortraitDiv(el, obj){
       el.style.backgroundPosition = 'center';
     }
   } else {
-    el.textContent = obj && obj.portrait ? obj.portrait : '@';
+    if (obj && obj.prompt) {
+      el.textContent = obj.prompt;
+    } else if (obj && obj.portrait) {
+      el.textContent = obj.portrait;
+    } else {
+      el.textContent = '@';
+    }
   }
 }
 

--- a/scripts/core/npc.js
+++ b/scripts/core/npc.js
@@ -3,8 +3,8 @@ var Dustland = globalThis.Dustland;
 const NPC_COLOR = '#9ef7a0';
 const OBJECT_COLOR = '#225a20';
 class NPC {
-  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null,portraitLock=true,symbol='!',door=false,locked=false}) {
-    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet,portraitLock,symbol,door,locked});
+  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null,portraitLock=true,symbol='!',door=false,locked=false,prompt=null}) {
+    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,combat,shop,portraitSheet,portraitLock,symbol,door,locked,prompt});
     // `door` marks an NPC tile as passable when unlocked
     const capNode = (node) => {
       if (this.combat && node === 'do_fight') {
@@ -117,6 +117,7 @@ function createNpcFactory(defs) {
       if (n.shop) opts.shop = n.shop;
       if (n.portraitSheet) opts.portraitSheet = n.portraitSheet;
       if (n.portraitLock === false) opts.portraitLock = false;
+      if (n.prompt) opts.prompt = n.prompt;
       if (n.symbol) opts.symbol = n.symbol;
       if (n.door) opts.door = n.door;
       if (typeof n.locked === 'boolean') opts.locked = n.locked;

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -119,7 +119,7 @@ async function startCombat(defender){
   }
 
   const toEnemy = (def) => {
-    const { HP, portraitSheet, npc, name, ...rest } = def || {};
+    const { HP, portraitSheet, prompt, npc, name, ...rest } = def || {};
     return {
       ...rest,
       id: def.id || def.name,
@@ -127,6 +127,7 @@ async function startCombat(defender){
       hp: def.hp ?? HP ?? 5,
       npc,
       portraitSheet: portraitSheet || npc?.portraitSheet,
+      prompt: prompt || npc?.prompt,
       special: rest.special
     };
   };

--- a/test/module-json.tools.test.js
+++ b/test/module-json.tools.test.js
@@ -18,7 +18,7 @@ test('module-json export/import round trip', () => {
   try {
     const moduleFile = path.join(tmp, 'sample.module.js');
     const jsonFile = path.join(tmp, 'data', 'modules', 'sample.json');
-    const original = { hello: 'world', portraitSheet: 'assets/portraits/custom.png', world: [[0,1],[2,3]] };
+    const original = { hello: 'world', portraitSheet: 'assets/portraits/custom.png', prompt: 'rusted bot', world: [[0,1],[2,3]] };
     const moduleContent = `const DATA = \`\n${JSON.stringify(original, null, 2)}\n\`;\nexport function postLoad() {}`;
     fs.writeFileSync(moduleFile, moduleContent);
     runScript(['export', moduleFile], tmp);
@@ -27,6 +27,7 @@ test('module-json export/import round trip', () => {
     assert.strictEqual(exported.name, 'sample-module');
     const { name } = exported;
     assert.strictEqual(exported.portraitSheet, 'assets/portraits/custom.png');
+    assert.strictEqual(exported.prompt, 'rusted bot');
     assert.deepStrictEqual(exported.world, ['🏝🪨', '🌊🌿']);
     delete exported.module;
     delete exported.name;
@@ -42,6 +43,7 @@ test('module-json export/import round trip', () => {
     const obj = JSON.parse(match[1]);
     assert.strictEqual(obj.hello, 'mars');
     assert.strictEqual(obj.portraitSheet, 'assets/portraits/custom.png');
+    assert.strictEqual(obj.prompt, 'rusted bot');
     assert.deepStrictEqual(obj.world, [[0,1],[2,3]]);
     assert.strictEqual(obj.module, undefined);
     assert.strictEqual(obj.name, 'sample-module');

--- a/test/portraits.test.js
+++ b/test/portraits.test.js
@@ -88,3 +88,10 @@ test('generic portrait keeps frame once chosen', () => {
   context.setPortraitDiv(el2, npc);
   assert.strictEqual(el2.style.backgroundPosition, firstPos);
 });
+
+test('setPortraitDiv shows prompt when missing portrait', () => {
+  const {context,dom} = setup();
+  const el = dom.window.document.createElement('div');
+  context.setPortraitDiv(el, { prompt: 'rusted mech' });
+  assert.strictEqual(el.textContent, 'rusted mech');
+});


### PR DESCRIPTION
## Summary
- show an enemy's prompt text whenever no portrait image is set
- carry `prompt` through NPC and enemy creation
- document and test prompt handling in module JSON tools and portraits

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb84baaff483288c2f52308486f6b4