### PR TITLE
feat: add prompts for portraitless NPCs

### DIFF
--- a/modules/broadcast-fragment-1.module.js
+++ b/modules/broadcast-fragment-1.module.js
@@ -40,6 +40,7 @@ const DATA = `
       "name": "Sparks",
       "title": "Wasteland Listener",
       "desc": "An old man hunched over a crackling radio, his eyes wide with a strange light.",
+      "prompt": "A wiry scavenger hunched over a battered radio",
       "questId": "q_first_echo",
       "tree": {
         "start": {
@@ -105,6 +106,7 @@ const DATA = `
       "name": "Collapsed Hut",
       "title": "",
       "desc": "A pile of rubble. Something glints within.",
+      "prompt": "Collapsed hut with a crystal glinting in the rubble",
       "tree": {
         "start": {
           "text": "A collapsed hut. It looks like it was recently scavenged.",

--- a/modules/broadcast-fragment-2.module.js
+++ b/modules/broadcast-fragment-2.module.js
@@ -38,6 +38,7 @@ const DATA = `
       "name": "Echo",
       "title": "Tech Scavenger",
       "desc": "A young woman tinkering with a rusty control panel at the base of a huge comms tower.",
+      "prompt": "Young tinkerer repairing a rusted comm tower base",
       "questId": "q_silent_tower",
       "tree": {
         "start": {
@@ -106,6 +107,7 @@ const DATA = `
       "color": "#9ef7a0",
       "name": "Service Depot",
       "desc": "A rusty service depot.",
+      "prompt": "Rusty service depot littered with wires",
       "tree": {
         "start": {
           "text": "You find a Power Cell inside.",
@@ -128,6 +130,7 @@ const DATA = `
       "color": "#9ef7a0",
       "name": "Service Depot",
       "desc": "A rusty service depot.",
+      "prompt": "Rusty service depot littered with wires",
       "tree": {
         "start": {
           "text": "You find a Power Cell inside.",
@@ -150,6 +153,7 @@ const DATA = `
       "color": "#9ef7a0",
       "name": "Service Depot",
       "desc": "A rusty service depot.",
+      "prompt": "Rusty service depot littered with wires",
       "tree": {
         "start": {
           "text": "You find a Power Cell inside.",

--- a/modules/broadcast-fragment-3.module.js
+++ b/modules/broadcast-fragment-3.module.js
@@ -35,6 +35,7 @@ const DATA = `
       "name": "The Hermit",
       "title": "Cave Dweller",
       "desc": "A man with eyes that seem to look through you, not at you.",
+      "prompt": "Gaunt hermit in a humming cavern",
       "questId": "q_resonant_cave",
       "tree": {
         "start": {
@@ -86,6 +87,7 @@ const DATA = `
       "y": 5,
       "color": "#f88",
       "name": "Red Crystal",
+      "prompt": "Glowing red crystal pulsing with energy",
       "tree": {
         "start": {
           "text": "A large, red crystal hums faintly.",
@@ -111,6 +113,7 @@ const DATA = `
       "y": 5,
       "color": "#88f",
       "name": "Blue Crystal",
+      "prompt": "Glowing blue crystal humming softly",
       "tree": {
         "start": {
           "text": "A large, blue crystal hums faintly.",
@@ -132,8 +135,8 @@ const DATA = `
         }
       }
     },
-    { "id": "red_crystal", "map": "resonant_cave", "x": 2, "y": 5, "color": "#f88", "name": "Red Crystal", "tree": { "start": { "text": "A large, red crystal hums faintly.", "choices": [ { "label": "(Touch it)", "to": "bye", "effects": [ { "effect": "addFlag", "flag": "crystal_1_red" } ] } ] } } },
-    { "id": "blue_crystal", "map": "resonant_cave", "x": 8, "y": 5, "color": "#88f", "name": "Blue Crystal", "tree": { "start": { "text": "A large, blue crystal hums faintly.", "choices": [ { "label": "(Touch it)", "to": "bye", "if": { "flag": "crystal_1_red" }, "effects": [ { "effect": "addFlag", "flag": "crystal_2_blue" } ] } ] } } },
+    { "id": "red_crystal", "map": "resonant_cave", "x": 2, "y": 5, "color": "#f88", "name": "Red Crystal", "prompt": "Glowing red crystal pulsing with energy", "tree": { "start": { "text": "A large, red crystal hums faintly.", "choices": [ { "label": "(Touch it)", "to": "bye", "effects": [ { "effect": "addFlag", "flag": "crystal_1_red" } ] } ] } } },
+    { "id": "blue_crystal", "map": "resonant_cave", "x": 8, "y": 5, "color": "#88f", "name": "Blue Crystal", "prompt": "Glowing blue crystal humming softly", "tree": { "start": { "text": "A large, blue crystal hums faintly.", "choices": [ { "label": "(Touch it)", "to": "bye", "if": { "flag": "crystal_1_red" }, "effects": [ { "effect": "addFlag", "flag": "crystal_2_blue" } ] } ] } } },
     {
       "id": "green_crystal",
       "map": "resonant_cave",
@@ -141,6 +144,7 @@ const DATA = `
       "y": 8,
       "color": "#8f8",
       "name": "Green Crystal",
+      "prompt": "Glowing green crystal thrumming in the dark",
       "tree": {
         "start": {
           "text": "A large, green crystal hums faintly.",

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -468,6 +468,7 @@ const DATA = `
       "color": "#c8bba0",
       "name": "Buried Crate",
       "desc": "Sand conceals a supply crate.",
+      "prompt": "Crate half-buried under shifting sand",
       "hintSound": true,
       "tree": {
         "start": {
@@ -498,6 +499,7 @@ const DATA = `
       "name": "Archivist",
       "title": "Memory Keeper",
       "desc": "Curious about recorded tales.",
+      "prompt": "Elder hunched over reels of magnetic tape",
       "tree": {
         "start": {
           "text": "Got anything on tape?",
@@ -1223,6 +1225,7 @@ const DATA = `
       "name": "Signal Tech",
       "title": "Tinkerer",
       "desc": "Fiddles with a busted radio.",
+      "prompt": "Grease-streaked tinkerer fixing a busted radio",
       "questId": "q_signal",
       "tree": {
         "start": {
@@ -1880,6 +1883,7 @@ const DATA = `
       "name": "Workbench",
       "title": "Crafter",
       "desc": "Tools litter the surface.",
+      "prompt": "Cluttered workbench stacked with tools",
       "tree": {
         "start": {
           "text": "The workbench awaits projects.",

--- a/modules/echoes.module.js
+++ b/modules/echoes.module.js
@@ -26,6 +26,7 @@ const DATA = `
       "color": "#9ef7a0",
       "name": "Sparking Crate",
       "desc": "Faint humming echoes from inside.",
+      "prompt": "Crate sparking with bottled energy",
       "tree": {
         "start": {
           "text": "A crate vibrates with energy.",
@@ -47,6 +48,7 @@ const DATA = `
       "name": "Humming Door",
       "title": "To Workshop",
       "desc": "Its lock crackles for a Spark Key.",
+      "prompt": "Metal door glowing with static lock",
       "questId": "q_spark",
       "tree": {
         "start": {
@@ -69,6 +71,7 @@ const DATA = `
       "color": "#9ef7a0",
       "name": "Gear Crate",
       "desc": "Loose gears rattle within.",
+      "prompt": "Heavy crate packed with gears",
       "tree": {
         "start": {
           "text": "The crate is heavy with metal.",
@@ -90,6 +93,7 @@ const DATA = `
       "name": "Rust Door",
       "title": "To Archive",
       "desc": "Its hinges await a Cog Key.",
+      "prompt": "Rusted door with cracked hinges",
       "questId": "q_cog",
       "tree": {
         "start": {
@@ -113,6 +117,7 @@ const DATA = `
       "name": "Dust Rat",
       "title": "Menace",
       "desc": "A rat swollen with dust.",
+      "prompt": "Dust-swollen rat baring teeth",
       "tree": { "start": { "text": "The rat bares its teeth.", "choices": [ { "label": "(Leave)", "to": "bye" } ] } },
       "combat": { "HP": 5, "ATK": 2, "DEF": 1, "loot": "rat_tail" }
     },
@@ -125,6 +130,7 @@ const DATA = `
       "name": "Gear Ghoul",
       "title": "Guardian",
       "desc": "A whirring husk hungry for scraps.",
+      "prompt": "Whirring metal ghoul hungry for scrap",
       "questId": "q_beacon",
       "tree": { "start": { "text": "The ghoul clanks forward.", "choices": [ { "label": "(Fight)", "to": "do_fight", "q": "turnin" }, { "label": "(Leave)", "to": "bye" } ] } },
       "combat": { "HP": 8, "ATK": 3, "DEF": 2, "loot": "copper_cog" }
@@ -138,6 +144,7 @@ const DATA = `
       "name": "Hope Beacon",
       "title": "Lightbringer",
       "desc": "A small lamp pulsing warmly.",
+      "prompt": "Warm lamp shining hope",
       "tree": {
         "start": {
           "text": "The beacon glows, promising brighter days.",

--- a/modules/golden.module.json
+++ b/modules/golden.module.json
@@ -79,6 +79,7 @@
       "color": "#cfa",
       "name": "Worried Villager",
       "desc": "Lost a coin in the cabin.",
+      "prompt": "Anxious villager clutching an empty coin pouch",
       "questId": "q_fetch",
       "tree": {
         "start": {
@@ -148,6 +149,7 @@
       "color": "#ddf",
       "name": "Dusty Chest",
       "desc": "Maybe it holds the coin.",
+      "prompt": "Dusty wooden chest bound by a metal lock",
       "symbol": "?",
       "locked": true,
       "tree": {
@@ -196,6 +198,7 @@
       "name": "Big Rat",
       "title": "Pest",
       "desc": "It guards the cabin.",
+      "prompt": "Large cabin rat with matted fur",
       "tree": {
         "start": {
           "text": "The rat snarls.",
@@ -223,6 +226,7 @@
       "color": "#f66",
       "name": "Sneaky Bandit",
       "desc": "Blocks the path.",
+      "prompt": "Sneaky bandit with a crooked dagger",
       "tree": {
         "start": {
           "text": "Hand over your loot!",
@@ -250,6 +254,7 @@
       "color": "#afa",
       "name": "Friendly Scout",
       "desc": "Offers to join your journey.",
+      "prompt": "Friendly scout with travel gear",
       "tree": {
         "start": {
           "text": "Need a companion?",
@@ -288,6 +293,7 @@
       "color": "#caffc6",
       "name": "Traveling Trader",
       "desc": "Sells basic goods.",
+      "prompt": "Traveling trader carrying a pack of goods",
       "shop": {
         "markup": 2,
         "inv": [
@@ -317,6 +323,7 @@
       "color": "#b8ffb6",
       "name": "Mysterious Wanderer",
       "desc": "Appears after you linger.",
+      "prompt": "Cloaked wanderer emerging from the dust",
       "tree": {
         "start": {
           "text": "You finally noticed me.",
@@ -342,6 +349,7 @@
       "color": "#fcc",
       "name": "Dialog Tester",
       "desc": "Demonstrates advanced dialog options.",
+      "prompt": "Curious tester with a worn notebook",
       "tree": {
         "start": {
           "text": "Pick a feature to test.",
@@ -447,6 +455,7 @@
       "color": "#ccf",
       "name": "Nyx",
       "desc": "A wanderer with layered stories.",
+      "prompt": "Story-laden wanderer with a calm gaze",
       "tree": {
         "start": {
           "text": "Greetings, traveler. What do you seek?",
@@ -527,6 +536,7 @@
       "color": "#fac",
       "name": "Mara",
       "desc": "Steely-eyed survivor.",
+      "prompt": "Steely survivor with determined eyes",
       "tree": {
         "start": {
           "text": "The dust never settles, does it?",
@@ -550,6 +560,7 @@
       "color": "#acf",
       "name": "Jax",
       "desc": "Tinker with a grin.",
+      "prompt": "Grinning tinkerer holding a spare fuse",
       "tree": {
         "start": {
           "text": "Got a spare fuse?",

--- a/modules/graffiti-puzzle.module.js
+++ b/modules/graffiti-puzzle.module.js
@@ -13,6 +13,7 @@ const DATA = `{
       "y": 3,
       "color": "#f5e79f",
       "name": "Graffiti Wall",
+      "prompt": "Wall layered with faded graffiti and hidden marks",
       "tree": {
         "start": {
           "text": "Layers of paint hide a message.",

--- a/modules/hub-city.module.js
+++ b/modules/hub-city.module.js
@@ -14,6 +14,7 @@ const DATA = `
       "color": "#9ef7a0",
       "name": "Quartermaster",
       "desc": "Stocks basic supplies for caravans.",
+      "prompt": "Rugged quartermaster with a grease-stained apron",
       "tree": { "start": { "text": "Need gear?", "choices": [ { "label": "(Leave)", "to": "bye" } ] } }
     }
   ],

--- a/modules/lootbox-demo.module.js
+++ b/modules/lootbox-demo.module.js
@@ -13,6 +13,7 @@ const DATA = `
       "color": "#a9f59f",
       "name": "Cache Guide",
       "desc": "An eager scavenger itching to teach you about spoils caches.",
+      "prompt": "Eager scavenger waving toward a loot cache",
       "tree": {
         "start": {
           "jump": [

--- a/modules/mara-memory.module.js
+++ b/modules/mara-memory.module.js
@@ -19,6 +19,7 @@ const DATA = `{
       "y": 2,
       "color": "#ffa",
       "name": "Flicker of Mara",
+      "prompt": "Shimmering memory of a masked survivor",
       "tree": {
         "start": {
           "text": "The mask stirs with a buried memory.",

--- a/modules/nyx-tuning.module.js
+++ b/modules/nyx-tuning.module.js
@@ -12,6 +12,7 @@ const DATA = `{
       "color": "#f9f",
       "name": "Nyx",
       "desc": "Listens to static for hidden verses.",
+      "prompt": "Wanderer with headphones listening to static",
       "tree": {
         "start": {
           "text": "The static hums. Can you find the note?",

--- a/modules/silencer-encounter.module.js
+++ b/modules/silencer-encounter.module.js
@@ -13,6 +13,7 @@ const DATA = `{
       "y": 2,
       "name": "Silencer Scout",
       "desc": "A rival drifter watches your moves.",
+      "prompt": "Hooded drifter with goggles and a muffled scarf",
       "tree": {
         "start": {
           "text": "The Silencer narrows his eyes. You're after the signal too.",

--- a/modules/true-dust.module.js
+++ b/modules/true-dust.module.js
@@ -106,6 +106,7 @@ const DATA = `{
       "name": "Rygar",
       "title": "Gatewatch",
       "desc": "Keeps watch over Stonegate's gate.",
+      "prompt": "Weathered gate guard with a copper pendant",
       "tree": {
         "start": {
           "text": "Stay sharp. The wastes bite.",
@@ -122,6 +123,7 @@ const DATA = `{
       "name": "Settler",
       "title": "Gossip",
       "desc": "Whispers about Mira's radio obsession.",
+      "prompt": "Chatty settler whispering rumors",
       "tree": {
         "start": {
           "text": [
@@ -141,6 +143,7 @@ const DATA = `{
       "name": "Mayor Ganton",
       "title": "Rustwater",
       "desc": "Rustwater's mayor eyes you shiftily.",
+      "prompt": "Shifty mayor in a rusted coat",
       "questId": "bandit_purge",
       "tree": {
         "start": {
@@ -170,6 +173,7 @@ const DATA = `{
       "name": "Dockhand",
       "title": "Lakeside",
       "desc": "A dockhand watching the shore.",
+      "prompt": "Weathered dockhand staring at the water",
       "tree": {
         "start": {
           "text": "The dockhand studies the waves.",
@@ -196,6 +200,7 @@ const DATA = `{
       "color": "#f55",
       "name": "Bandit Leader",
       "desc": "A bandit blocks the road.",
+      "prompt": "Road bandit in crude armor",
       "tree": { "start": { "text": "A bandit steps out, weapons drawn." } },
       "combat": { "HP": 10, "ATK": 3, "DEF": 1, "loot": "scrap" }
     }


### PR DESCRIPTION
## Summary
- add descriptive prompt strings to NPCs without portraits across modules
- ensure every portraitless character displays an art hint

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb86565c848328a15d544ee8b84163