### PR TITLE
fix: move Mira to world map

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -677,9 +677,9 @@ const DATA = `
     },
     {
       "id": "party_mira",
-      "map": "hall",
-      "x": 15,
-      "y": 21,
+      "map": "world",
+      "x": 16,
+      "y": 45,
       "color": "#f66",
       "name": "Mira",
       "title": "Blade Dancer",


### PR DESCRIPTION
## Summary
- Spawn party member Mira on the world map instead of the test hall

## Testing
- `node scripts/presubmit.js`
- `npm test`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb886b65048328b953b11f0ceaa2b8