### PR TITLE
fix: repopulate required item dropdown

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1481,6 +1481,7 @@ function renderTreeEditor() {
   wrap.querySelectorAll('input,textarea,select').forEach(el => el.addEventListener('input', updateTreeData));
   wrap.querySelectorAll('select').forEach(el => el.addEventListener('change', updateTreeData));
   wrap.querySelectorAll('input[type=checkbox]').forEach(el => el.addEventListener('change', updateTreeData));
+  refreshChoiceDropdowns();
 }
 
 function updateTreeData() {


### PR DESCRIPTION
## Summary
- refresh dialog editor dropdowns after rendering so required items persist
- test required item dropdown repopulates on render

## Testing
- `npm test`
- `node scripts/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb8c6b87f0832885570728403180d9