### PR TITLE
feat: persist pinned quests and hide hidden quest compass

### DIFF
--- a/components/signal-compass.js
+++ b/components/signal-compass.js
@@ -8,6 +8,12 @@
     (parent || document.body).appendChild(el);
     return {
       update(pos, target){
+        const cfg = globalThis.ACK?.config?.navigation || {};
+        if (cfg.enabled === false && target?.hidden) {
+          el.style.display = 'none';
+          return;
+        }
+        el.style.display = '';
         const dx = (target.x || 0) - (pos.x || 0);
         const dy = (target.y || 0) - (pos.y || 0);
         const ang = Math.atan2(dy, dx);

--- a/docs/design/blog-feedback-tasks.md
+++ b/docs/design/blog-feedback-tasks.md
@@ -53,9 +53,9 @@
 - [ ] Let players annotate map grid tiles
 - [ ] Add more defensive structures for outposts beyond turrets
 - [ ] Taper late-game crafting cost spikes in the scrap economy
-- [ ] Stop the compass from pointing to hidden quests when navigation is off
+- [x] Stop the compass from pointing to hidden quests when navigation is off
 - [x] Design additional unique creatures beyond the giant glass scorpion
-- [ ] Persist pinned quests across sessions
+- [x] Persist pinned quests across sessions
 - [x] Publish roadmap blog posts alongside hotfixes
 - [ ] Create craftable protective tarps for solar panels
 - [ ] Make rare-spice cooking recipes worth the effort

--- a/scripts/core/quests.js
+++ b/scripts/core/quests.js
@@ -5,6 +5,7 @@ class Quest {
     this.title = title;
     this.desc = desc;
     this.status = 'available';
+    this.pinned = meta.pinned || false;
     Object.assign(this, meta);
   }
   complete() {
@@ -42,12 +43,28 @@ class QuestLog {
     const q = this.quests[id];
     if (q) q.complete();
   }
+  pin(id) {
+    const q = this.quests[id];
+    if (q && !q.pinned) {
+      q.pinned = true;
+      renderQuests();
+    }
+  }
+  unpin(id) {
+    const q = this.quests[id];
+    if (q && q.pinned) {
+      q.pinned = false;
+      renderQuests();
+    }
+  }
 }
 
 const questLog = new QuestLog();
 const quests = questLog.quests;
 function addQuest(id, title, desc, meta) { questLog.add(new Quest(id, title, desc, meta)); }
 function completeQuest(id) { questLog.complete(id); }
+function pinQuest(id) { questLog.pin(id); }
+function unpinQuest(id) { questLog.unpin(id); }
 
 // minimal core helpers so defaultQuestProcessor works even without content helpers loaded yet
 function defaultQuestProcessor(npc, nodeId) {
@@ -85,5 +102,5 @@ function defaultQuestProcessor(npc, nodeId) {
   }
 }
 
-const questExports = { Quest, QuestLog, questLog, quests, addQuest, completeQuest, defaultQuestProcessor };
+const questExports = { Quest, QuestLog, questLog, quests, addQuest, completeQuest, defaultQuestProcessor, pinQuest, unpinQuest };
 Object.assign(globalThis, questExports);

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -591,7 +591,7 @@ function save(){
   const questData = {};
   Object.keys(quests).forEach(k=>{
     const q=quests[k];
-    questData[k]={title:q.title,desc:q.desc,status:q.status};
+    questData[k]={title:q.title,desc:q.desc,status:q.status,pinned:!!q.pinned};
   });
   const partyData = Array.from(party, p => ({
     id:p.id,name:p.name,role:p.role,lvl:p.lvl,xp:p.xp,skillPoints:p.skillPoints,stats:p.stats,equip:p.equip,hp:p.hp,ap:p.ap,map:p.map,x:p.x,y:p.y,maxHp:p.maxHp,portraitSheet:p.portraitSheet
@@ -616,7 +616,7 @@ function load(){
   Object.keys(quests).forEach(k=> delete quests[k]);
   Object.keys(d.quests||{}).forEach(id=>{
     const qd=d.quests[id];
-    const q=new Quest(id,qd.title,qd.desc); q.status=qd.status; quests[id]=q;
+    const q=new Quest(id,qd.title,qd.desc); q.status=qd.status; q.pinned=qd.pinned||false; quests[id]=q;
   });
 
   const npcFactory = createNpcFactory(d.npcs || []);

--- a/test/quest-pinned.persist.test.js
+++ b/test/quest-pinned.persist.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function noop() {}
+
+async function loadQuestClass() {
+  const code = await fs.readFile(new URL('../scripts/core/quests.js', import.meta.url), 'utf8');
+  const sandbox = { renderQuests: noop, log: noop, EventBus: { emit: noop }, queueNanoDialogForNPCs: noop };
+  vm.runInNewContext(code, sandbox);
+  return sandbox.Quest;
+}
+
+test('pinned quests survive save/load cycle', async () => {
+  const Quest = await loadQuestClass();
+  const quests = { q1: new Quest('q1', 'Quest', '') };
+  quests.q1.pinned = true;
+
+  function save() {
+    const questData = {};
+    Object.keys(quests).forEach(k => {
+      const q = quests[k];
+      questData[k] = { title: q.title, desc: q.desc, status: q.status, pinned: q.pinned };
+    });
+    return JSON.stringify({ quests: questData });
+  }
+
+  function load(str) {
+    const d = JSON.parse(str);
+    const loaded = {};
+    Object.keys(d.quests || {}).forEach(id => {
+      const qd = d.quests[id];
+      const q = new Quest(id, qd.title, qd.desc);
+      q.status = qd.status;
+      q.pinned = qd.pinned;
+      loaded[id] = q;
+    });
+    return loaded;
+  }
+
+  const data = save();
+  const restored = load(data);
+  assert.equal(restored.q1.pinned, true);
+});

--- a/test/signal-compass.test.js
+++ b/test/signal-compass.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+test('signal compass hides for hidden target when navigation disabled', async () => {
+  const code = await fs.readFile(new URL('../components/signal-compass.js', import.meta.url), 'utf8');
+  const document = makeDocument();
+  const window = { document };
+  const ACK = { config: { navigation: { enabled: false } } };
+  const ctx = { document, window, ACK, Dustland: {} };
+  vm.createContext(ctx);
+  vm.runInContext(code, ctx);
+  const compass = ctx.Dustland.createSignalCompass();
+  compass.update({ x: 0, y: 0 }, { x: 10, y: 0, hidden: true });
+  const el = document.querySelector('.signal-compass');
+  assert.equal(el.style.display, 'none');
+});
+
+test('signal compass shows when navigation enabled', async () => {
+  const code = await fs.readFile(new URL('../components/signal-compass.js', import.meta.url), 'utf8');
+  const document = makeDocument();
+  const window = { document };
+  const ACK = { config: { navigation: { enabled: true } } };
+  const ctx = { document, window, ACK, Dustland: {} };
+  vm.createContext(ctx);
+  vm.runInContext(code, ctx);
+  const compass = ctx.Dustland.createSignalCompass();
+  compass.update({ x: 0, y: 0 }, { x: 10, y: 0, hidden: true });
+  const el = document.querySelector('.signal-compass');
+  assert.equal(el.style.display, '');
+});


### PR DESCRIPTION
## Summary
- add navigation guard to signal compass so hidden quests stay hidden when navigation is off
- persist pinned quest state and expose pin/unpin helpers
- document completed tasks in blog feedback design doc

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb90c392b48328a7bf6432e623c9e1