### PR TITLE
fix: handle item-gated dialog transitions

### DIFF
--- a/scripts/core/dialog.js
+++ b/scripts/core/dialog.js
@@ -200,6 +200,12 @@ function advanceDialog(stateObj, choiceIdx){
       handleGoto(choice.goto);
       res.close=true; res.success=true; stateObj.node=null; return res;
     }
+    const nextId = choice.to || choice.id;
+    if (nextId) {
+      res.next = nextId;
+      stateObj.node = nextId;
+      return res;
+    }
     return finalize(choice.success || '', true);
   }
 
@@ -237,6 +243,12 @@ function advanceDialog(stateObj, choiceIdx){
     if(choice.goto){
       handleGoto(choice.goto);
       res.close=true; res.success=true; stateObj.node=null; return res;
+    }
+    const nextId = choice.to || choice.id;
+    if (nextId) {
+      res.next = nextId;
+      stateObj.node = nextId;
+      return res;
     }
     return finalize(choice.success || '', true);
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -617,6 +617,21 @@ test('advanceDialog respects goto with costItem', () => {
   assert.ok(!player.inv.some(it => it.id === 'key'));
 });
 
+test('advanceDialog costItem transitions to target node', () => {
+  player.inv.length = 0;
+  const coin = registerItem({ id: 'coin', name: 'Coin', type: 'quest' });
+  addToInv(coin);
+  const tree = {
+    start: { text: '', next: [{ label: 'Pay', costItem: 'coin', to: 'next' }] },
+    next: { text: '' }
+  };
+  const dialog = { tree, node: 'start' };
+  const res = advanceDialog(dialog, 0);
+  assert.strictEqual(res.next, 'next');
+  assert.strictEqual(dialog.node, 'next');
+  assert.ok(!player.inv.some(it => it.id === 'coin'));
+});
+
 test('advanceDialog respects costSlot', () => {
   player.inv.length = 0;
   const trinket = registerItem({ id: 'river_trinket', name: 'Trinket', type: 'trinket' });
@@ -679,6 +694,21 @@ test('advanceDialog uses reqItem without consuming and allows goto', () => {
   assert.strictEqual(party.x, 5);
   assert.strictEqual(party.y, 6);
   assert.ok(player.inv.some(it => it.id === 'pass'));
+});
+
+test('advanceDialog reqItem transitions to target node', () => {
+  player.inv.length = 0;
+  const key = registerItem({ id: 'magic_key', name: 'Magic Key', type: 'quest' });
+  addToInv(key);
+  const tree = {
+    locked: { text: '', next: [{ label: 'Unlock', reqItem: 'magic_key', to: 'start' }] },
+    start: { text: 'opened' }
+  };
+  const dialog = { tree, node: 'locked' };
+  const res = advanceDialog(dialog, 0);
+  assert.strictEqual(res.next, 'start');
+  assert.strictEqual(dialog.node, 'start');
+  assert.ok(player.inv.some(it => it.id === 'magic_key'));
 });
 
 test('advanceDialog matches reqItem case-insensitively', () => {


### PR DESCRIPTION
## Summary
- allow dialog choices gated by required or cost items to move to target nodes
- cover item-gated transitions with tests

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb9731547083288614dcc385b45ecf