### PR TITLE
fix: validate locked NPCs require unlock

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -3427,6 +3427,17 @@ function validateSpawns(){
   if(!walkable[world[s.y][s.x]]) issues.push({ msg:'Player start on blocked tile', type:'start' });
   moduleData.npcs.forEach((n,i)=>{ if(n.map==='world' && !walkable[world[n.y][n.x]]) issues.push({ msg:'NPC '+(n.id||'')+' on blocked tile', type:'npc', idx:i }); });
   moduleData.items.forEach((it,i)=>{ if(it.map==='world' && !walkable[world[it.y][it.x]]) issues.push({ msg:'Item '+it.id+' on blocked tile', type:'item', idx:i }); });
+  const unlocks=new Set();
+  moduleData.npcs.forEach(n=>{
+    Object.values(n.tree||{}).forEach(node=>{
+      (node.choices||[]).forEach(ch=>{
+        (ch.effects||[]).forEach(e=>{ if(e.effect==='unlockNPC' && e.npcId) unlocks.add(e.npcId); });
+      });
+    });
+  });
+  moduleData.npcs.forEach((n,i)=>{
+    if(n.locked && n.id && !unlocks.has(n.id)) issues.push({ msg:'Locked NPC '+n.id+' has no unlock', type:'npc', idx:i });
+  });
   return issues;
 }
 

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -316,6 +316,18 @@ test('validateSpawns lists blocked spawns', () => {
   assert.strictEqual(issues[1].type,'npc');
 });
 
+test('validateSpawns flags locked NPC without unlock', () => {
+  genWorld(1);
+  moduleData.start = { map:'world', x:0, y:0 };
+  moduleData.items = [];
+  moduleData.npcs = [{ id:'door', map:'world', x:1, y:0, locked:true, tree:{ locked:{ text:'', choices:[{ label:'(Leave)', to:'bye' }] }, start:{ text:'', choices:[{ label:'(Leave)', to:'bye' }] }, bye:{ text:'', choices:[] } } }];
+  const issues = validateSpawns();
+  assert.strictEqual(issues.length,1);
+  assert.strictEqual(issues[0].msg,'Locked NPC door has no unlock');
+  assert.strictEqual(issues[0].type,'npc');
+  assert.strictEqual(issues[0].idx,0);
+});
+
 test('addTerrainFeature sprinkles noise', () => {
   genWorld(1);
   for (let dy=-1; dy<=1; dy++) {


### PR DESCRIPTION
## Summary
- flag locked NPCs missing unlock effects during save validation
- add test covering locked NPC validation

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb99858f40832897f82a9ad7fa847d