### PR TITLE
feat: support quest dialog chains

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -433,9 +433,7 @@
           </div>
           <button class="btn" type="button" id="npcPick" title="Click on the map to choose location">Select on Map</button>
           <label>Dialog<textarea id="npcDialog" rows="2"></textarea></label>
-          <label>Quest<select id="npcQuest">
-              <option value="">(none)</option>
-            </select></label>
+          <label>Quests<select id="npcQuests" multiple size="3"></select></label>
           <button class="btn" type="button" id="genQuestDialog" style="display:none">Generate Quest Dialog</button>
           <div id="questTextWrap" style="display:none">
             <label>Accept Text<textarea id="npcAccept" rows="2">Good luck.</textarea></label>

--- a/scripts/core/quests.js
+++ b/scripts/core/quests.js
@@ -94,6 +94,14 @@ function defaultQuestProcessor(npc, nodeId) {
         const xp = meta.xp ?? 5;
         party.forEach(p => awardXP(p, xp));
         if (meta.moveTo) { npc.x = meta.moveTo.x; npc.y = meta.moveTo.y; }
+        if (Array.isArray(npc.quests)) {
+          npc.questIdx = (npc.questIdx || 0) + 1;
+          npc.quest = npc.quests[npc.questIdx] || null;
+          if (npc.quest && !npc.quest.status) npc.quest.status = 'available';
+          if (Array.isArray(npc.questDialogs)) {
+            npc.tree.start.text = npc.questDialogs[npc.questIdx] || npc.tree.start.text;
+          }
+        }
       } else {
         const def = ITEMS[meta.item];
         textEl.textContent = `You don’t have ${def ? def.name : meta.item}.`;

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -437,8 +437,10 @@ function applyModule(data = {}, options = {}) {
     if (n.hidden && n.reveal) { hiddenNPCs.push(n); return; }
     let tree = n.tree;
     if (typeof tree === 'string') { try { tree = JSON.parse(tree); } catch (e) { tree = null; } }
+    const dlgArr = n.dialogs || (Array.isArray(n.dialog) ? n.dialog : null);
     if (!tree) {
-      tree = { start: { text: n.dialog || '', choices: [{ label: '(Leave)', to: 'bye' }] } };
+      const txt = dlgArr ? dlgArr[0] : (n.dialog || '');
+      tree = { start: { text: txt, choices: [{ label: '(Leave)', to: 'bye' }] } };
     }
     let quest = null;
     if (n.questId && quests[n.questId]) quest = quests[n.questId];
@@ -450,6 +452,10 @@ function applyModule(data = {}, options = {}) {
     if (n.symbol) opts.symbol = n.symbol;
     if (n.door) opts.door = n.door;
     if (typeof n.locked === 'boolean') opts.locked = n.locked;
+    if (Array.isArray(n.quests)) {
+      opts.quests = n.quests.map(id => quests[id]).filter(Boolean);
+    }
+    if (dlgArr) opts.questDialogs = dlgArr;
     const npc = makeNPC(n.id, n.map || 'world', n.x, n.y, n.color, n.name || n.id, n.title || '', n.desc || '', tree, quest, null, null, opts);
     if (Array.isArray(n.loop)) npc.loop = n.loop;
     if (typeof NPCS !== 'undefined') NPCS.push(npc);

--- a/test/npc-patrol.test.js
+++ b/test/npc-patrol.test.js
@@ -12,6 +12,20 @@ function mkInput(document, id, value = '') {
   return el;
 }
 
+function mkSelect(document, id, values = []) {
+  const el = document.createElement('select');
+  el.id = id;
+  el.multiple = true;
+  values.forEach(v => {
+    const opt = document.createElement('option');
+    opt.value = v;
+    opt.selected = true;
+    el.appendChild(opt);
+  });
+  document.body.appendChild(el);
+  return el;
+}
+
 function mkCheckbox(document, id, checked = false) {
   const el = document.createElement('input');
   el.type = 'checkbox';
@@ -42,7 +56,7 @@ test('collectNPCFromForm uses patrol checkbox for loops', async () => {
   mkInput(document, 'npcX', '0');
   mkInput(document, 'npcY', '0');
   mkTextarea(document, 'npcDialog', 'hi');
-  mkInput(document, 'npcQuest', '');
+  mkSelect(document, 'npcQuests', []);
   mkTextarea(document, 'npcAccept', '');
   mkTextarea(document, 'npcTurnin', '');
   mkCheckbox(document, 'npcCombat', false);

--- a/test/npc-quest-chain.test.js
+++ b/test/npc-quest-chain.test.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+test('NPC serves quest list sequentially', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const dir = path.join(__dirname, '..', 'scripts', 'core');
+  const npcSrc = fs.readFileSync(path.join(dir, 'npc.js'), 'utf8');
+  const questSrc = fs.readFileSync(path.join(dir, 'quests.js'), 'utf8');
+  const sandbox = {
+    EventBus: { emit: () => {} },
+    log: () => {},
+    queueNanoDialogForNPCs: () => {},
+    countItems: () => 1,
+    addToInv: () => {},
+    awardXP: () => {},
+    party: [],
+    textEl: { textContent: '' },
+    player: { inv: [], scrap: 0 },
+    ITEMS: {},
+    state: {},
+    CURRENCY: 'sc',
+    renderQuests: () => {},
+    window: {},
+  };
+  vm.runInNewContext(npcSrc, sandbox);
+  sandbox.queueNanoDialogForNPCs = () => {};
+  vm.runInNewContext(questSrc, sandbox);
+  const npc = sandbox.makeNPC('test','world',0,0,'#fff','Test','', '', null, null, null, null, {
+    quests: [
+      new sandbox.Quest('q1', 'Q1', 'd1'),
+      new sandbox.Quest('q2', 'Q2', 'd2')
+    ]
+  });
+  npc.processNode('accept');
+  assert.strictEqual(sandbox.quests.q1.status, 'active');
+  npc.processNode('do_turnin');
+  assert.strictEqual(sandbox.quests.q1.status, 'completed');
+  assert.ok(npc.quest, 'no next quest');
+  assert.strictEqual(npc.quest.id, 'q2');
+  npc.processNode('accept');
+  assert.strictEqual(sandbox.quests.q2.status, 'active');
+});
+
+test('NPC advances quest dialog with quest chain', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const dir = path.join(__dirname, '..', 'scripts', 'core');
+  const npcSrc = fs.readFileSync(path.join(dir, 'npc.js'), 'utf8');
+  const questSrc = fs.readFileSync(path.join(dir, 'quests.js'), 'utf8');
+  const sandbox = {
+    EventBus: { emit: () => {} },
+    log: () => {},
+    queueNanoDialogForNPCs: () => {},
+    countItems: () => 1,
+    addToInv: () => {},
+    awardXP: () => {},
+    party: [],
+    textEl: { textContent: '' },
+    player: { inv: [], scrap: 0 },
+    ITEMS: {},
+    state: {},
+    CURRENCY: 'sc',
+    renderQuests: () => {},
+    window: {},
+  };
+  vm.runInNewContext(npcSrc, sandbox);
+  sandbox.queueNanoDialogForNPCs = () => {};
+  vm.runInNewContext(questSrc, sandbox);
+  const npc = sandbox.makeNPC('test','world',0,0,'#fff','Test','', '', null, null, null, null, {
+    quests: [
+      new sandbox.Quest('q1', 'Q1', 'd1'),
+      new sandbox.Quest('q2', 'Q2', 'd2')
+    ],
+    questDialogs: ['Hello Q1', 'Hello Q2']
+  });
+  assert.strictEqual(npc.tree.start.text, 'Hello Q1');
+  npc.processNode('accept');
+  npc.processNode('do_turnin');
+  assert.strictEqual(npc.tree.start.text, 'Hello Q2');
+});


### PR DESCRIPTION
## Summary
- allow NPCs to cycle dialog alongside sequential quests
- wire module loader and adventure kit UI for multi-quest NPCs
- cover quest dialog advancement and adjust wizard tests

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bbb47943d883289c4eecf3a26bfe3e