### PR TITLE
feat: trigger zone effects from item usage

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -643,6 +643,9 @@
           <label>Negate<input id="zoneNegate" /></label>
           <label>Heal Mult<input id="zoneHealMult" type="number" step="0.1" min="0" /></label>
           <label><input type="checkbox" id="zoneNoEnc" />No Encounters</label>
+          <label>Use Item<input id="zoneUseItem" /></label>
+          <label>Reward<input id="zoneReward" /></label>
+          <label><input type="checkbox" id="zoneOnce" />Once</label>
           <button class="btn" id="addZone">Add Zone</button>
           <button class="btn" id="delZone" style="display:none">Delete Zone</button>
         </div>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2745,6 +2745,9 @@ function startNewZone() {
   document.getElementById('zoneNegate').value = '';
   document.getElementById('zoneHealMult').value = '';
   document.getElementById('zoneNoEnc').checked = false;
+  document.getElementById('zoneUseItem').value = '';
+  document.getElementById('zoneReward').value = '';
+  document.getElementById('zoneOnce').checked = false;
   document.getElementById('addZone').textContent = 'Add Zone';
   document.getElementById('delZone').style.display = 'none';
   showZoneEditor(true);
@@ -2763,6 +2766,9 @@ function collectZone() {
   const negate = document.getElementById('zoneNegate').value.trim();
   const healMult = parseFloat(document.getElementById('zoneHealMult').value);
   const noEnc = document.getElementById('zoneNoEnc').checked;
+  const useItemId = document.getElementById('zoneUseItem').value.trim();
+  const reward = document.getElementById('zoneReward').value.trim();
+  const once = document.getElementById('zoneOnce').checked;
   const entry = { map, x, y, w, h };
   if (hp || msg) {
     entry.perStep = {};
@@ -2772,6 +2778,11 @@ function collectZone() {
   if (negate) entry.negate = negate;
   if (!isNaN(healMult)) entry.healMult = healMult;
   if (noEnc) entry.noEncounters = true;
+  if (useItemId) {
+    entry.useItem = { id: useItemId };
+    if (reward) entry.useItem.reward = reward;
+    if (once) entry.useItem.once = true;
+  }
   return entry;
 }
 
@@ -2806,6 +2817,9 @@ function editZone(i) {
   document.getElementById('zoneNegate').value = z.negate || '';
   document.getElementById('zoneHealMult').value = z.healMult ?? '';
   document.getElementById('zoneNoEnc').checked = !!z.noEncounters;
+  document.getElementById('zoneUseItem').value = z.useItem?.id || '';
+  document.getElementById('zoneReward').value = z.useItem?.reward || '';
+  document.getElementById('zoneOnce').checked = !!z.useItem?.once;
   document.getElementById('addZone').textContent = 'Update Zone';
   document.getElementById('delZone').style.display = 'block';
   showZoneEditor(true);

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -253,14 +253,16 @@ function useItem(invIndex){
     const before = who.hp;
     who.hp = Math.min(who.hp + base + bonus, who.maxHp);
     const healed = who.hp - before;
-    log(`${who.name} drinks ${it.name} (+${healed} HP).`);
-    if (bonus > 0) log('Lucky boost!');
-    if (typeof toast === 'function') toast(`${who.name} +${healed} HP`);
+    const msg = it.use.text || `${who.name} drinks ${it.name} (+${healed} HP).`;
+    log(msg);
+    if (bonus > 0 && !it.use.text) log('Lucky boost!');
+    if (typeof toast === 'function') toast(it.use.text || `${who.name} +${healed} HP`);
     emit('sfx','tick');
     player.inv.splice(invIndex,1);
     notifyInventoryChanged();
     player.hp = party[0] ? party[0].hp : player.hp;
     if(typeof updateHUD === 'function') updateHUD();
+    emit(`used:${it.id}`, { item: it });
     return true;
   }
   if(it.use.type==='boost'){
@@ -274,6 +276,7 @@ function useItem(invIndex){
     emit('sfx','tick');
     player.inv.splice(invIndex,1);
     notifyInventoryChanged();
+    emit(`used:${it.id}`, { item: it });
     return true;
   }
   if(it.use.type==='cleanse'){
@@ -282,11 +285,13 @@ function useItem(invIndex){
     if(Array.isArray(who.statusEffects)){
       who.statusEffects.length = 0;
     }
-    log(`${who.name} feels purified.`);
-    if(typeof toast==='function') toast(`${who.name} is cleansed`);
+    const msg = it.use.text || `${who.name} feels purified.`;
+    log(msg);
+    if(typeof toast==='function') toast(it.use.text || `${who.name} is cleansed`);
     emit('sfx','tick');
     player.inv.splice(invIndex,1);
     notifyInventoryChanged();
+    emit(`used:${it.id}`, { item: it });
     return true;
   }
   if(typeof it.use.onUse === 'function'){
@@ -294,8 +299,11 @@ function useItem(invIndex){
     if(ok!==false){
         player.inv.splice(invIndex,1);
         notifyInventoryChanged();
-        if(typeof toast==='function') toast(`Used ${it.name}`);
+        const msg = it.use.text || `Used ${it.name}`;
+        log(msg);
+        if(typeof toast==='function') toast(msg);
         emit('sfx','tick');
+        emit(`used:${it.id}`, { item: it });
     }
     return !!ok;
   }

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -235,7 +235,25 @@ const tileEvents = [];
 const zoneEffects = [];
 const enemyBanks = {};
 function registerTileEvents(list){ (list||[]).forEach(e => tileEvents.push(e)); }
-function registerZoneEffects(list){ (list||[]).forEach(z => zoneEffects.push(z)); }
+function registerZoneEffects(list){
+  (list||[]).forEach(z => {
+    zoneEffects.push(z);
+    const id = z.useItem?.id;
+    if(id && globalThis.EventBus?.on){
+      globalThis.EventBus.on(`used:${id}`, () => {
+        const map = z.map || 'world';
+        if(party.map !== map) return;
+        const { x, y } = party;
+        if(x < z.x || y < z.y || x >= z.x + (z.w || 0) || y >= z.y + (z.h || 0)) return;
+        if(z.useItem.once && z.useItem._used) return;
+        if(z.useItem.reward){
+          globalThis.Dustland?.actions?.applyQuestReward(z.useItem.reward);
+        }
+        if(z.useItem.once) z.useItem._used = true;
+      });
+    }
+  });
+}
 const state = { map:'world', mapFlags: {} }; // default map
 const player = { hp:10, ap:2, inv:[], scrap:0 };
 if (typeof registerItem === 'function') {

--- a/test/zone-use-item-event.test.js
+++ b/test/zone-use-item-event.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const invCode = await fs.readFile(new URL('../scripts/core/inventory.js', import.meta.url), 'utf8');
+
+const zoneEffects = [];
+function registerZoneEffects(list){
+  (list||[]).forEach(z => {
+    zoneEffects.push(z);
+    const id = z.useItem?.id;
+    if(id){
+      EventBus.on(`used:${id}`, () => {
+        const map = z.map || 'world';
+        if(party.map !== map) return;
+        const { x, y } = party;
+        if(x < z.x || y < z.y || x >= z.x + (z.w || 0) || y >= z.y + (z.h || 0)) return;
+        if(z.useItem.once && z.useItem._used) return;
+        if(z.useItem.reward){
+          Dustland.actions.applyQuestReward(z.useItem.reward);
+        }
+        if(z.useItem.once) z.useItem._used = true;
+      });
+    }
+  });
+}
+
+const logs = [];
+const bus = { listeners:{}, on(evt,fn){ (bus.listeners[evt]=bus.listeners[evt]||[]).push(fn); }, emit(evt,p){ (bus.listeners[evt]||[]).forEach(f=>f(p)); } };
+
+global.EventBus = bus;
+global.Dustland = { actions:{ applyQuestReward(r){ if(/^scrap\s+/i.test(r)) player.scrap += parseInt(r.replace(/[^0-9]/g,''),10); } } };
+const party = [];
+party.x = 0; party.y = 0; party.map = 'world';
+party.push({ name:'Hero', hp:1, maxHp:1, stats:{}, _bonus:{} });
+global.party = party;
+global.player = { inv:[], scrap:0, hp:1 };
+global.log = m => logs.push(m);
+global.toast = () => {};
+global.selectedMember = 0;
+global.updateHUD = () => {};
+
+vm.runInThisContext(invCode, { filename: 'core/inventory.js' });
+
+registerItem({ id:'mystic_key', name:'Mystic Key', type:'consumable', use:{ type:'heal', amount:0, text:'The key glows.' } });
+registerZoneEffects([{ map:'world', x:0, y:0, w:1, h:1, useItem:{ id:'mystic_key', reward:'scrap 5', once:true } }]);
+
+test('zone rewards on item use and only once', () => {
+  player.inv = [getItem('mystic_key')];
+  useItem(0);
+  assert.strictEqual(player.scrap, 5);
+  assert.ok(logs.includes('The key glows.'));
+  player.inv = [getItem('mystic_key')];
+  useItem(0);
+  assert.strictEqual(player.scrap, 5);
+  zoneEffects[0].useItem._used = false;
+  party.x = 2; party.y = 2;
+  player.inv = [getItem('mystic_key')];
+  useItem(0);
+  assert.strictEqual(player.scrap, 5);
+});


### PR DESCRIPTION
## Summary
- emit `used:{item}` events with custom messages when items are consumed
- allow zones to listen for item usage and grant rewards once
- add editor fields for zone item-use triggers and cover with tests

## Testing
- `node scripts/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc1a50866883289dd18b467e5f3f72