### PR TITLE
feat: use dropdowns for map selection

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -417,7 +417,7 @@
           <div id="revealOpts" style="display:none">
             <label>Flag Type<select id="npcFlagType"><option value="visits">Visited Tile</option><option value="party">Party Flag</option></select></label>
             <div id="revealVisit">
-              <label>Map<input id="npcFlagMap" value="world" /></label>
+              <label>Map<select id="npcFlagMap"></select></label>
               <div class="xy">
                 <label>X<input id="npcFlagX" type="number" min="0" /></label>
                 <label>Y<input id="npcFlagY" type="number" min="0" /></label>
@@ -487,7 +487,7 @@
           <label>Tags<input id="itemTags" list="tagOptions" /></label>
           <datalist id="tagOptions"></datalist>
           <label><input id="itemOnMap" type="checkbox"/> On Map</label>
-          <label id="itemMapWrap">Map<input id="itemMap" placeholder="world" /></label>
+          <label id="itemMapWrap">Map<select id="itemMap"></select></label>
           <div class="xy" id="itemXY">
             <label>X<input id="itemX" type="number" min="0" /></label>
             <label>Y<input id="itemY" type="number" min="0" /></label>
@@ -560,13 +560,13 @@
         <div class="list" id="portalList"></div>
         <button class="btn" type="button" id="newPortal">+ Portal</button>
         <div id="portalEditor" style="display:none">
-          <label>Map<input id="portalMap" value="world" /></label>
+          <label>Map<select id="portalMap"></select></label>
           <div class="xy">
             <label>X<input id="portalX" type="number" min="0" /></label>
             <label>Y<input id="portalY" type="number" min="0" /></label>
           </div>
           <button class="btn" type="button" id="portalPick" title="Click on the map to choose location">Select on Map</button>
-          <label>To Map<input id="portalToMap" value="world" /></label>
+          <label>To Map<select id="portalToMap"></select></label>
           <div class="xy">
             <label>To X<input id="portalToX" type="number" min="0" /></label>
             <label>To Y<input id="portalToY" type="number" min="0" /></label>
@@ -601,7 +601,7 @@
         <div class="list" id="eventList"></div>
         <button class="btn" type="button" id="newEvent">+ Event</button>
         <div id="eventEditor" style="display:none">
-          <label>Map<input id="eventMap" value="world" /></label>
+          <label>Map<select id="eventMap"></select></label>
           <div class="xy">
             <label>X<input id="eventX" type="number" min="0" /></label>
             <label>Y<input id="eventY" type="number" min="0" /></label>
@@ -629,7 +629,7 @@
         <div class="list" id="zoneList"></div>
         <button class="btn" type="button" id="newZone">+ Zone</button>
         <div id="zoneEditor" style="display:none">
-          <label>Map<input id="zoneMap" value="world" /></label>
+          <label>Map<select id="zoneMap"></select></label>
           <div class="xy">
             <label>X<input id="zoneX" type="number" min="0" /></label>
             <label>Y<input id="zoneY" type="number" min="0" /></label>
@@ -654,7 +654,7 @@
         <div class="list" id="encounterList"></div>
         <button class="btn" type="button" id="newEncounter">+ Enemy</button>
         <div id="encounterEditor" style="display:none">
-          <label>Map<input id="encMap" value="world" /></label>
+          <label>Map<select id="encMap"></select></label>
           <label>Template<select id="encTemplate"></select></label>
           <label>Min Dist<input id="encMinDist" type="number" min="0" /></label>
           <label>Max Dist<input id="encMaxDist" type="number" min="0" /></label>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -621,20 +621,20 @@ intCanvas.addEventListener('mousedown',e=>{
   if(coordTarget){
     document.getElementById(coordTarget.x).value = x;
     document.getElementById(coordTarget.y).value = y;
-    if(coordTarget.map) document.getElementById(coordTarget.map).value = I.id;
+    if (coordTarget.map) populateMapDropdown(document.getElementById(coordTarget.map), I.id);
     coordTarget = null;
     drawInterior();
     return;
   }
   if(placingType){
     if(placingType==='npc'){
-      document.getElementById('npcMap').value = I.id;
+      populateMapDropdown(document.getElementById('npcMap'), I.id);
       document.getElementById('npcX').value = x;
       document.getElementById('npcY').value = y;
       if(placingCb) placingCb();
       document.getElementById('cancelNPC').style.display = 'none';
     }else if(placingType==='item'){
-      document.getElementById('itemMap').value = I.id;
+      populateMapDropdown(document.getElementById('itemMap'), I.id);
       document.getElementById('itemX').value = x;
       document.getElementById('itemY').value = y;
       if(placingCb) placingCb();
@@ -1923,7 +1923,7 @@ function startNewNPC() {
   document.getElementById('npcHidden').checked = false;
   document.getElementById('npcLocked').checked = false;
   document.getElementById('npcFlagType').value = 'visits';
-  document.getElementById('npcFlagMap').value = 'world';
+  populateMapDropdown(document.getElementById('npcFlagMap'), 'world');
   document.getElementById('npcFlagX').value = 0;
   document.getElementById('npcFlagY').value = 0;
   document.getElementById('npcFlagName').value = '';
@@ -2132,10 +2132,11 @@ function editNPC(i) {
   document.getElementById('npcPortraitLock').checked = n.portraitLock !== false;
   document.getElementById('npcHidden').checked = !!n.hidden;
   document.getElementById('npcLocked').checked = !!n.locked;
+  let flagMap = 'world';
   if (n.reveal?.flag?.startsWith('visits@')) {
     document.getElementById('npcFlagType').value = 'visits';
     const parts = n.reveal.flag.split('@');
-    document.getElementById('npcFlagMap').value = parts[1] || 'world';
+    flagMap = parts[1] || 'world';
     const [fx, fy] = (parts[2] || '0,0').split(',');
     document.getElementById('npcFlagX').value = fx;
     document.getElementById('npcFlagY').value = fy;
@@ -2143,6 +2144,7 @@ function editNPC(i) {
     document.getElementById('npcFlagType').value = 'party';
     document.getElementById('npcFlagName').value = n.reveal?.flag || '';
   }
+  populateMapDropdown(document.getElementById('npcFlagMap'), flagMap);
   document.getElementById('npcOp').value = n.reveal?.op || '>=';
   document.getElementById('npcVal').value = n.reveal?.value ?? 1;
   populateFlagList();
@@ -2253,6 +2255,8 @@ function updateUseWrap() {
 }
 function updateItemMapWrap() {
   const onMap = document.getElementById('itemOnMap').checked;
+  const mapEl = document.getElementById('itemMap');
+  populateMapDropdown(mapEl, mapEl.value || '');
   const mapWrap = document.getElementById('itemMapWrap');
   const xy = document.getElementById('itemXY');
   const pick = document.getElementById('itemPick');
@@ -2261,7 +2265,7 @@ function updateItemMapWrap() {
   if (xy) xy.style.display = onMap ? 'flex' : 'none';
   if (pick) pick.style.display = onMap ? 'inline-block' : 'none';
   if (remove) remove.style.display = onMap ? 'inline-block' : 'none';
-  if (!onMap) document.getElementById('itemMap').value = '';
+  if (!onMap) mapEl.value = '';
 }
 function startNewItem() {
   editItemIdx = -1;
@@ -2496,7 +2500,7 @@ function showEncounterEditor(show){
 }
 function startNewEncounter(){
   editEncounterIdx = -1;
-  document.getElementById('encMap').value = 'world';
+  populateMapDropdown(document.getElementById('encMap'), 'world');
   document.getElementById('encMinDist').value = '';
   document.getElementById('encMaxDist').value = '';
   const tmplSel = document.getElementById('encTemplate');
@@ -2529,7 +2533,7 @@ function addEncounter(){
 function editEncounter(i){
   const e = moduleData.encounters[i];
   editEncounterIdx = i;
-  document.getElementById('encMap').value = e.map;
+  populateMapDropdown(document.getElementById('encMap'), e.map);
   populateTemplateDropdown(document.getElementById('encTemplate'), e.templateId || '');
   document.getElementById('encMinDist').value = e.minDist || '';
   document.getElementById('encMaxDist').value = e.maxDist || '';
@@ -2670,7 +2674,7 @@ function updateEventEffectFields() {
 
 function startNewEvent() {
   editEventIdx = -1;
-  document.getElementById('eventMap').value = 'world';
+  populateMapDropdown(document.getElementById('eventMap'), 'world');
   document.getElementById('eventX').value = 0;
   document.getElementById('eventY').value = 0;
   document.getElementById('eventEffect').value = 'toast';
@@ -2721,7 +2725,7 @@ function addEvent() {
 function editEvent(i) {
   const e = moduleData.events[i];
   editEventIdx = i;
-  document.getElementById('eventMap').value = e.map;
+  populateMapDropdown(document.getElementById('eventMap'), e.map);
   document.getElementById('eventX').value = e.x;
   document.getElementById('eventY').value = e.y;
   const ev = e.events[0] || { effect: 'toast' };
@@ -2770,7 +2774,7 @@ function showZoneEditor(show) {
 
 function startNewZone() {
   editZoneIdx = -1;
-  document.getElementById('zoneMap').value = 'world';
+  populateMapDropdown(document.getElementById('zoneMap'), 'world');
   document.getElementById('zoneX').value = 0;
   document.getElementById('zoneY').value = 0;
   document.getElementById('zoneW').value = 1;
@@ -2842,7 +2846,7 @@ function addZone() {
 function editZone(i) {
   const z = moduleData.zones[i];
   editZoneIdx = i;
-  document.getElementById('zoneMap').value = z.map;
+  populateMapDropdown(document.getElementById('zoneMap'), z.map);
   document.getElementById('zoneX').value = z.x;
   document.getElementById('zoneY').value = z.y;
   document.getElementById('zoneW').value = z.w;
@@ -2889,10 +2893,10 @@ function showPortalEditor(show) {
 
 function startNewPortal() {
   editPortalIdx = -1;
-  document.getElementById('portalMap').value = 'world';
+  populateMapDropdown(document.getElementById('portalMap'), 'world');
   document.getElementById('portalX').value = 0;
   document.getElementById('portalY').value = 0;
-  document.getElementById('portalToMap').value = 'world';
+  populateMapDropdown(document.getElementById('portalToMap'), 'world');
   document.getElementById('portalToX').value = 0;
   document.getElementById('portalToY').value = 0;
   document.getElementById('addPortal').textContent = 'Add Portal';
@@ -2929,10 +2933,10 @@ function addPortal() {
 function editPortal(i) {
   const p = moduleData.portals[i];
   editPortalIdx = i;
-  document.getElementById('portalMap').value = p.map;
+  populateMapDropdown(document.getElementById('portalMap'), p.map);
   document.getElementById('portalX').value = p.x;
   document.getElementById('portalY').value = p.y;
-  document.getElementById('portalToMap').value = p.toMap;
+  populateMapDropdown(document.getElementById('portalToMap'), p.toMap);
   document.getElementById('portalToX').value = p.toX;
   document.getElementById('portalToY').value = p.toY;
   document.getElementById('addPortal').textContent = 'Update Portal';
@@ -3849,7 +3853,7 @@ canvas.addEventListener('mousedown', ev => {
   if (coordTarget) {
     document.getElementById(coordTarget.x).value = x;
     document.getElementById(coordTarget.y).value = y;
-    if (coordTarget.map) document.getElementById(coordTarget.map).value = currentMap;
+    if (coordTarget.map) populateMapDropdown(document.getElementById(coordTarget.map), currentMap);
     coordTarget = null;
     canvas.style.cursor = '';
     drawWorld();
@@ -3857,12 +3861,13 @@ canvas.addEventListener('mousedown', ev => {
   }
   if (placingType) {
     if (placingType === 'npc') {
-      document.getElementById('npcMap').value = currentMap;
+      populateMapDropdown(document.getElementById('npcMap'), currentMap);
       document.getElementById('npcX').value = x;
       document.getElementById('npcY').value = y;
       if (placingCb) placingCb();
       document.getElementById('cancelNPC').style.display = 'none';
     } else if (placingType === 'item') {
+      populateMapDropdown(document.getElementById('itemMap'), currentMap);
       document.getElementById('itemX').value = x;
       document.getElementById('itemY').value = y;
       if (placingCb) placingCb();

--- a/scripts/puzzle-usability-test.js
+++ b/scripts/puzzle-usability-test.js
@@ -1,6 +1,13 @@
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
 globalThis.applyModule = function(){};
 globalThis.state = {};
 globalThis.renderWorld = function(){};
+globalThis.startGame = function(){};
+globalThis.setPartyPos = function(){};
+globalThis.setMap = function(){};
+globalThis.log = function(){};
 
 function load(p){
   const resolved = require.resolve(p);

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -209,6 +209,27 @@ test('can add item without map placement', () => {
   moduleData.items = [];
 });
 
+test('map fields use dropdown options', () => {
+  moduleData.npcs = [];
+  moduleData.items = [];
+  moduleData.interiors = [];
+  startNewNPC();
+  assert.ok(document.getElementById('npcFlagMap').innerHTML.includes('<option value="world">world</option>'));
+  startNewItem();
+  document.getElementById('itemOnMap').checked = true;
+  updateItemMapWrap();
+  assert.ok(document.getElementById('itemMap').innerHTML.includes('<option value="world">world</option>'));
+  startNewPortal();
+  assert.ok(document.getElementById('portalMap').innerHTML.includes('<option value="world">world</option>'));
+  assert.ok(document.getElementById('portalToMap').innerHTML.includes('<option value="world">world</option>'));
+  startNewEvent();
+  assert.ok(document.getElementById('eventMap').innerHTML.includes('<option value="world">world</option>'));
+  startNewZone();
+  assert.ok(document.getElementById('zoneMap').innerHTML.includes('<option value="world">world</option>'));
+  startNewEncounter();
+  assert.ok(document.getElementById('encMap').innerHTML.includes('<option value="world">world</option>'));
+});
+
 test('world paint persists through save/load', () => {
   genWorld(1);
   clearWorld();


### PR DESCRIPTION
## Summary
- replace Adventure Kit map inputs with dropdowns
- populate map dropdowns for new zones, portals, events, items, encounters, and NPC flags
- update puzzle usability test for ESM compatibility

## Testing
- `npm test`
- `node scripts/presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68bc2fdc7de083288de6ca52b5977159