### PR TITLE
fix: apply zone dimension changes immediately

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2870,6 +2870,21 @@ function renderZoneList() {
   Array.from(list.children).forEach(div => div.onclick = () => editZone(parseInt(div.dataset.idx, 10)));
 }
 
+function updateZoneDims() {
+  if (editZoneIdx < 0) return;
+  const z = moduleData.zones[editZoneIdx];
+  z.x = parseInt(document.getElementById('zoneX').value, 10) || 0;
+  z.y = parseInt(document.getElementById('zoneY').value, 10) || 0;
+  z.w = Math.max(1, parseInt(document.getElementById('zoneW').value, 10) || 1);
+  z.h = Math.max(1, parseInt(document.getElementById('zoneH').value, 10) || 1);
+  renderZoneList();
+  drawWorld();
+}
+
+['zoneX', 'zoneY', 'zoneW', 'zoneH'].forEach(id => {
+  document.getElementById(id).addEventListener('input', updateZoneDims);
+});
+
 function deleteZone() {
   if (editZoneIdx < 0) return;
   moduleData.zones.splice(editZoneIdx, 1);

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -185,6 +185,26 @@ test('playtestModule includes zones', () => {
   global.open = origOpen;
 });
 
+test('zone field updates apply immediately', () => {
+  applyLoadedModule({ seed: 1, zones: [{ map: 'world', x: 0, y: 0, w: 1, h: 1 }] });
+  editZone(0);
+  const z = moduleData.zones[0];
+  let renders = 0;
+  const origDraw = global.drawWorld;
+  global.drawWorld = () => { renders++; };
+  const zx = document.getElementById('zoneX');
+  zx.value = 2;
+  zx._listeners.input[0]();
+  assert.strictEqual(z.x, 2);
+  const zw = document.getElementById('zoneW');
+  zw.value = 3;
+  zw._listeners.input[0]();
+  assert.strictEqual(z.w, 3);
+  assert.ok(renders >= 2);
+  assert.ok(document.getElementById('zoneList').innerHTML.includes('(2,0,3x1)'));
+  global.drawWorld = origDraw;
+});
+
 test('custom item tags update tag options', () => {
   const dl = document.getElementById('tagOptions');
   assert.ok(dl.innerHTML.includes('value="key"'));


### PR DESCRIPTION
## Summary
- update zone coordinate and size inputs to modify data instantly and redraw the world
- add regression test verifying zone field changes rerender without using Update Zone

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc3400f6688328a8f45a05c4b542e0