### PR TITLE
fix: return to door tile when exiting buildings

### DIFF
--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -465,7 +465,7 @@ function interactAt(x, y) {
       }
       const b=buildings.find(b=> b.interiorId===state.map);
       if(b){
-        setPartyPos(b.doorX, b.doorY-1);
+        setPartyPos(b.doorX, b.doorY);
         setMap('world');
         log('You step back outside.');
         updateHUD();

--- a/test/building-exit-position.test.js
+++ b/test/building-exit-position.test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+const TILE = { FLOOR: 0, DOOR: 1 };
+const walkable = { 0: true, 1: true };
+
+function makeGrid(w, h, fill) {
+  return Array.from({ length: h }, () => Array(w).fill(fill));
+}
+
+test('exiting building returns party to door tile', async () => {
+  global.TILE = TILE;
+  global.walkable = walkable;
+  global.WORLD_W = 5;
+  global.WORLD_H = 5;
+  const world = makeGrid(5, 5, TILE.FLOOR);
+  const interiors = { hut: { grid: [[TILE.FLOOR, TILE.FLOOR], [TILE.FLOOR, TILE.DOOR]], w: 2, h: 2 } };
+  const party = { x: 1, y: 1 };
+  const state = { map: 'hut' };
+  global.world = world;
+  global.interiors = interiors;
+  global.portals = [];
+  global.buildings = [{ interiorId: 'hut', doorX: 3, doorY: 4 }];
+  global.party = party;
+  global.state = state;
+  global.NPCS = [];
+  global.itemDrops = [];
+  global.log = () => {};
+  global.updateHUD = () => {};
+  global.EventBus = { on: () => {}, emit: () => {} };
+  global.Dustland = { eventBus: global.EventBus };
+  global.getTile = (map, x, y) => (map === 'world' ? world[y][x] : interiors[map].grid[y][x]);
+  global.setPartyPos = (x, y) => { party.x = x; party.y = y; };
+  global.setMap = (m) => { state.map = m; };
+
+  const fs = await import('node:fs');
+  const vm = await import('node:vm');
+  const src = fs.readFileSync(new URL('../scripts/core/movement.js', import.meta.url), 'utf8');
+  vm.runInThisContext(src);
+
+  interactAt(1, 1);
+
+  assert.strictEqual(state.map, 'world');
+  assert.strictEqual(party.x, 3);
+  assert.strictEqual(party.y, 4);
+});


### PR DESCRIPTION
## Summary
- keep party on doorway when leaving building interiors
- cover exiting building spawns with new test

## Testing
- `./install-deps.sh`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc36fc1f508328b8ffb5cf528b9073