### PR TITLE
feat: expose NPC portrait prompt field

### DIFF
--- a/components/wizard/npc-wizard.js
+++ b/components/wizard/npc-wizard.js
@@ -4,6 +4,8 @@
     steps: [
       Dustland.WizardSteps.text('Name', 'name'),
       Dustland.WizardSteps.assetPicker('Portrait', ['portrait_1000.png', 'portrait_1001.png'], 'portrait'),
+      // Notes for artists to craft a portrait if one is missing
+      Dustland.WizardSteps.text('Portrait Prompt', 'prompt'),
       Dustland.WizardSteps.text('Dialogue', 'dialogue'),
       Dustland.WizardSteps.itemPicker('Fetch Item', ['tuned_crystal', 'signal_fragment_1'], 'questItem'),
       Dustland.WizardSteps.mapPlacement('pos'),
@@ -15,6 +17,7 @@
         id,
         name: state.name,
         portrait: state.portrait,
+        prompt: state.prompt,
         dialogue: state.dialogue,
         map: 'world',
         x: state.pos?.x,

--- a/test/npc-wizard.commit.test.js
+++ b/test/npc-wizard.commit.test.js
@@ -23,12 +23,13 @@ test('NpcWizard commit builds module data', async () => {
   const mod = JSON.parse(JSON.stringify(cfg.commit({
     name: 'Bob',
     portrait: 'p.png',
+    prompt: 'rusted scavenger',
     dialogue: 'Hi',
     questItem: 'widget',
     pos: { x: 1, y: 2 }
   })));
   assert.deepStrictEqual(mod, {
-    npcs: [{ id: 'bob', name: 'Bob', portrait: 'p.png', dialogue: 'Hi', map: 'world', x: 1, y: 2 }],
+    npcs: [{ id: 'bob', name: 'Bob', portrait: 'p.png', prompt: 'rusted scavenger', dialogue: 'Hi', map: 'world', x: 1, y: 2 }],
     quests: [{ id: 'bob_quest', giver: 'bob', item: 'widget' }]
   });
 });

--- a/test/npc-wizard.config.test.js
+++ b/test/npc-wizard.config.test.js
@@ -27,6 +27,8 @@ test('NpcWizard config wires steps', async () => {
   wiz.next();
   document.querySelector('select').value = 'portrait_1000.png';
   wiz.next();
+  document.querySelector('input').value = 'rusted scavenger';
+  wiz.next();
   document.querySelector('input').value = 'Hello';
   wiz.next();
   document.querySelector('select').value = 'tuned_crystal';
@@ -34,5 +36,7 @@ test('NpcWizard config wires steps', async () => {
   wiz.getState().pos = { x: 0, y: 0 };
   wiz.next();
   wiz.next();
-  assert.strictEqual(wiz.getState().questItem, 'tuned_crystal');
+  const state = wiz.getState();
+  assert.strictEqual(state.prompt, 'rusted scavenger');
+  assert.strictEqual(state.questItem, 'tuned_crystal');
 });


### PR DESCRIPTION
## Summary
- expose portrait prompt field in NPC wizard so creators can leave art directions
- persist prompt value in generated NPC data
- update NPC wizard tests for new prompt step

## Testing
- `npm test`
- `node scripts/presubmit.js`
- `node scripts/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc3917aae08328a9f7dfa99c5c5254