### PR TITLE
feat: place power cell in workshop

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -28,7 +28,10 @@ const DATA = `
     {
       "id": "power_cell",
       "name": "Power Cell",
-      "type": "quest"
+      "type": "quest",
+      "map": "workshop",
+      "x": 3,
+      "y": 2
     },
     {
       "id": "signal_beacon",

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -89,6 +89,13 @@ test('workshop building includes workbench NPC', () => {
   assert.ok(hasCraft);
 });
 
+test('power cell can be found in the workshop', () => {
+  const data = loadModuleData();
+  const cell = data.items.find(i => i.id === 'power_cell');
+  assert.ok(cell);
+  assert.strictEqual(cell.map, 'workshop');
+});
+
 test('medkit heals for 10 HP', () => {
   const data = loadModuleData();
   const med = data.items.find(i => i.id === 'medkit');


### PR DESCRIPTION
## Summary
- spawn a power cell inside the workshop so players can craft signal beacons
- cover workshop power cell with a regression test

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc3d740c98832892a12c5d8e48720f