### PR TITLE
feat: camp heals party

### DIFF
--- a/scripts/camp-persona.js
+++ b/scripts/camp-persona.js
@@ -5,6 +5,27 @@
   const btn = document.getElementById('campBtn');
   if (btn) btn.addEventListener('click', () => bus.emit('camp:open'));
   bus.on('camp:open', () => {
+    const pos = globalThis.party;
+    const map = globalThis.state?.map || 'world';
+    const zones = globalThis.Dustland?.zoneEffects || [];
+    if (pos) {
+      for (const z of zones) {
+        if ((z.map || 'world') !== map) continue;
+        if (pos.x < z.x || pos.y < z.y || pos.x >= z.x + (z.w || 0) || pos.y >= z.y + (z.h || 0)) continue;
+        if (z.dry || (z.perStep?.hp < 0) || (z.step?.hp < 0)) {
+          globalThis.log?.("You can't camp here.");
+          return;
+        }
+      }
+    }
+    globalThis.healAll?.();
+    if (Array.isArray(pos)) {
+      for (const m of pos) {
+        if (typeof m.hydration === 'number') m.hydration = 2;
+      }
+    }
+    globalThis.updateHUD?.();
+    globalThis.log?.('You rest until healed.');
     const state = gs.getState?.() || {};
     const member = state.party && state.party[0];
     if (!member) return;

--- a/test/camp.test.js
+++ b/test/camp.test.js
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { EventEmitter } from 'node:events';
+
+test('camp:open heals party and refills hydration', async () => {
+  const bus = new EventEmitter();
+  let healed = false;
+  let msg = '';
+  const healAll = () => { healed = true; };
+  const log = m => { msg = m; };
+  const gs = {
+    getState: () => ({ party: [{ id: 'p1', name: 'Hero' }], personas: { a: {} } }),
+    applyPersona: () => {}
+  };
+  const party = [{ id: 'p1', name: 'Hero', hydration: 0 }];
+  party.x = 0; party.y = 0;
+  const state = { map: 'world' };
+  const sandbox = {
+    EventBus: bus,
+    Dustland: { gameState: gs, zoneEffects: [] },
+    document: { getElementById: () => null },
+    healAll,
+    log,
+    prompt: () => null,
+    party,
+    state,
+    updateHUD: () => {}
+  };
+  sandbox.globalThis = sandbox;
+  const code = await fs.readFile(new URL('../scripts/camp-persona.js', import.meta.url), 'utf8');
+  vm.runInNewContext(code, sandbox);
+  bus.emit('camp:open');
+  assert.ok(healed);
+  assert.equal(party[0].hydration, 2);
+  assert.equal(msg, 'You rest until healed.');
+});
+
+test('camp:open blocked in dry or damaging zones', async () => {
+  const bus = new EventEmitter();
+  let healed = false;
+  let msg = '';
+  const healAll = () => { healed = true; };
+  const log = m => { msg = m; };
+  const gs = {
+    getState: () => ({ party: [{ id: 'p1', name: 'Hero' }], personas: {} }),
+    applyPersona: () => {}
+  };
+  const party = [{ id: 'p1', name: 'Hero', hydration: 1 }];
+  party.x = 0; party.y = 0;
+  const state = { map: 'world' };
+  const sandbox = {
+    EventBus: bus,
+    Dustland: { gameState: gs, zoneEffects: [] },
+    document: { getElementById: () => null },
+    healAll,
+    log,
+    prompt: () => null,
+    party,
+    state,
+    updateHUD: () => {}
+  };
+  sandbox.globalThis = sandbox;
+  const code = await fs.readFile(new URL('../scripts/camp-persona.js', import.meta.url), 'utf8');
+  vm.runInNewContext(code, sandbox);
+  const zones = sandbox.Dustland.zoneEffects;
+
+  zones.push({ map: 'world', x: 0, y: 0, w: 1, h: 1, dry: true });
+  bus.emit('camp:open');
+  assert.ok(!healed);
+  assert.equal(party[0].hydration, 1);
+  assert.equal(msg, "You can't camp here.");
+
+  zones[0] = { map: 'world', x: 0, y: 0, w: 1, h: 1, perStep: { hp: -1 } };
+  healed = false; msg = '';
+  bus.emit('camp:open');
+  assert.ok(!healed);
+  assert.equal(party[0].hydration, 1);
+  assert.equal(msg, "You can't camp here.");
+});


### PR DESCRIPTION
## Summary
- block camping in dry or damaging zones
- refill hydration when camping
- cover safe/unsafe camp behavior with tests

## Testing
- `./install-deps.sh`
- `node scripts/supporting/presubmit.js`
- `npm test`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc3e67d1a08328a9968023540e4fb1