### PR TITLE
fix: load radio tower interior

### DIFF
--- a/modules/radio-tower.module.js
+++ b/modules/radio-tower.module.js
@@ -1,8 +1,8 @@
 const DATA = `{
   "name": "Radio Tower",
   "start": { "map": "tower", "x": 1, "y": 1 },
-  "maps": [
-    { "id": "tower", "w": 3, "h": 3, "grid": ["⬜⬜⬜","⬜🎚⬜","⬜⬜⬜"] }
+  "interiors": [
+    { "id": "tower", "w": 3, "h": 3, "grid": ["🧱🧱🧱","🧱⬜🧱","🧱🧱🧱"], "entryX": 1, "entryY": 1 }
   ],
   "events": [
     { "map": "tower", "x": 1, "y": 1, "events": [ { "when": "enter", "effect": "openRadio" } ] }

--- a/test/radio-tower.module.test.js
+++ b/test/radio-tower.module.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+test('radio tower module registers interior map', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'radio-tower.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const context = {
+    interiors: {},
+    openRadioPuzzle: () => {},
+    setPartyPos: () => {},
+    setMap: () => {},
+    log: () => {}
+  };
+  context.applyModule = mod => {
+    (mod.interiors || []).forEach(i => { context.interiors[i.id] = i; });
+  };
+  context.globalThis = context;
+  vm.runInNewContext(src, context);
+  context.startGame();
+  assert.ok(context.interiors.tower, 'tower interior registered');
+  assert.strictEqual(context.RADIO_TOWER.maps, undefined);
+});


### PR DESCRIPTION
## Summary
- rewrite radio tower module to register its map as an interior
- add a regression test ensuring the tower map loads

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc40f30b0c8328bfc06147c5724511