### PR TITLE
fix: allow tests to exit promptly

### DIFF
--- a/scripts/dustland-nano.js
+++ b/scripts/dustland-nano.js
@@ -206,14 +206,15 @@
         };
         _state.cache.set(key, merged);
         // allow re-enqueue later for fresh variants
-        setTimeout(()=> _state.seenKeys.delete(key), 10000);
+        const t=setTimeout(()=> _state.seenKeys.delete(key), 10000);
+        t.unref?.();
         if (typeof toast === 'function') toast(`New dialog for ${job.npcId}`);
       }
     } catch(err){
       console.warn('[Nano] generation error', err);
     } finally{
       _setBusy(false);
-      setTimeout(_pump, 50);
+      setTimeout(_pump, 50).unref?.();
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent Nano dialog timers from keeping Node's event loop alive

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc4791c24c832889f1257ccd8f083d