### PR TITLE
feat: color warnings yellow and add icons

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -701,7 +701,7 @@
         <button class="btn" type="button" id="closeDialogModal">Close</button>
       </div>
       <div id="treeEditor"></div>
-      <div id="treeWarning" style="color:#f66;font-size:12px;margin-top:4px"></div>
+      <div id="treeWarning" style="color:#fc0;font-size:12px;margin-top:4px"></div>
       <button class="btn" type="button" id="addNode">Add Node</button>
       <datalist id="choiceFlagList"></datalist>
     </div>

--- a/dustland.css
+++ b/dustland.css
@@ -573,7 +573,7 @@ input[type="range"] {
     crtDistort var(--telegraphDuration) ease-in-out;
   --shakeMag:calc(var(--telegraphIntensity)*2px);
 }
-@keyframes bossWarn { 50% { background:rgba(80,0,0,.8); } }
+@keyframes bossWarn { 50% { background:rgba(80,80,0,.8); } }
 @keyframes screenShake {
   0%,100% { transform:translate(0,0); }
   25% { transform:translate(var(--shakeMag),var(--shakeMag)); }

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1703,7 +1703,7 @@ function updateTreeData() {
   });
 
   const warnEl = document.getElementById('treeWarning');
-  if (warnEl) warnEl.textContent = orphans.length ? `Orphan nodes: ${orphans.join(', ')}` : '';
+  if (warnEl) warnEl.textContent = orphans.length ? `⚠️ Orphan nodes: ${orphans.join(', ')}` : '';
 }
 
 function loadTreeEditor() {
@@ -3572,7 +3572,11 @@ function renderProblems(issues){
     return;
   }
   card.style.display='block';
-  const html = issues.map((p,i)=>`<div data-idx="${i}">${p.msg}</div>`).join('');
+  const html = issues.map((p,i)=>{
+    const icon = p.warn ? '⚠️' : '🛑';
+    const color = p.warn ? '#fc0' : '#f33';
+    return `<div data-idx="${i}" style="color:${color}">${icon} ${p.msg}</div>`;
+  }).join('');
   if(list.innerHTML !== html){
     list.innerHTML = html;
     Array.from(list.children).forEach(div=>div.onclick=onProblemClick);

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -17,15 +17,28 @@ const adrFill = document.getElementById('adrFill');
 const statusIcons = document.getElementById('statusIcons');
 const weatherBanner = document.getElementById('weatherBanner');
 
-function log(msg){
+function log(msg, type){
   if (logEl) {
-    const p=document.createElement('div');
-    p.textContent=msg;
+    const p = document.createElement('div');
+    p.textContent = msg;
+    if (type === 'warn') p.style.color = '#fc0';
+    else if (type === 'error') p.style.color = '#f33';
     logEl.prepend(p);
   } else {
     console.log("Log: " + msg);
   }
 }
+
+const origWarn = console.warn;
+console.warn = function(...args) {
+  origWarn.apply(console, args);
+  log('⚠️ ' + args.join(' '), 'warn');
+};
+const origError = console.error;
+console.error = function(...args) {
+  origError.apply(console, args);
+  log('🛑 ' + args.join(' '), 'error');
+};
 
 // --- Toasts (lightweight) ---
 const toastHost = document.createElement('div');
@@ -1022,7 +1035,13 @@ const engineExports = { log, updateHUD, renderInv, renderQuests, renderParty, fo
 Object.assign(globalThis, engineExports);
 
 // ===== Minimal Unit Tests (#test) =====
-function assert(name, cond){ const msg = (cond? '✅ ':'❌ ') + name; log(msg); if(!cond) console.error('Test failed:', name); }
+function assert(name, cond){
+  if (cond) {
+    log('✅ ' + name);
+  } else {
+    console.error('Test failed: ' + name);
+  }
+}
 function runTests(){
   openCreator(); assert('Creator visible', creator.style.display==='flex');
   step=2; renderStep(); assert('Stat + buttons exist', ccRight.querySelectorAll('button[data-d="1"]').length>0);


### PR DESCRIPTION
## Summary
- show ⚠️ and 🛑 icons next to warnings and errors
- color warnings yellow in dialogs and problem lists
- tint combat warning flashes yellow

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc47c87e148328a49d5f353411fc7f