### PR TITLE
fix: guard interior painting bounds

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -618,8 +618,10 @@ function paintInterior(e){
   if(editInteriorIdx<0||!intPainting) return;
   const I=moduleData.interiors[editInteriorIdx];
   const { x, y } = interiorCanvasPos(e);
-  I.grid[y][x]=intPaint;
-  if(intPaint===TILE.DOOR){ I.entryX=x; I.entryY=y-1; }
+  if(x<0||y<0||x>=I.w||y>=I.h) return;
+  const row = I.grid[y] || (I.grid[y] = Array(I.w).fill(TILE.FLOOR));
+  row[x]=intPaint;
+  if(intPaint===TILE.DOOR){ I.entryX=x; I.entryY=Math.max(0,y-1); }
   drawInterior();
 }
 intCanvas.addEventListener('mousedown', e => {


### PR DESCRIPTION
## Summary
- prevent painting outside interior canvas from causing errors

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc480a44b483288c2e9048319e42b2