### PR TITLE
fix: guard interior resize with missing rows

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -717,7 +717,7 @@ function resizeInterior(){
   const w=parseInt(document.getElementById('intW').value,10)||I.w;
   const h=parseInt(document.getElementById('intH').value,10)||I.h;
   const ng=Array.from({length:h},(_,y)=>Array.from({length:w},(_,x)=>{
-    if(y<I.h && x<I.w) return I.grid[y][x];
+    if(y<I.h && x<I.w && I.grid[y]) return I.grid[y][x];
     const edge=y===0||y===h-1||x===0||x===w-1; return edge?TILE.WALL:TILE.FLOOR;
   }));
   I.w=w; I.h=h; I.grid=ng;


### PR DESCRIPTION
## Summary
- Avoid accessing undefined rows when resizing interiors

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc4e0ca8d88328bf628dd42bcabb45