### PR TITLE
fix: allow NPC placement in interiors

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -3872,7 +3872,7 @@ canvas.addEventListener('mousedown', ev => {
     updateCursor(x, y);
     return;
   }
-  if (currentMap !== 'world' && !coordTarget && !(overNpc || overItem || overEvent || overPortal || overZone)) {
+  if (currentMap !== 'world' && !coordTarget && !placingType && !(overNpc || overItem || overEvent || overPortal || overZone)) {
     hoverTile = { x, y };
     const I = moduleData.interiors.find(i => i.id === currentMap);
     if (I) {


### PR DESCRIPTION
## Summary
- avoid interior paint mode when placing NPCs

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`
- `./install-deps.sh` *(fails: Invalid response from proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc58728b7c8328a139fbe31ac18291