### PR TITLE
fix: evict old paths when cache exceeds limit

### DIFF
--- a/scripts/dustland-path.js
+++ b/scripts/dustland-path.js
@@ -2,7 +2,8 @@
 // Simple A* pathfinding with async queue for Dustland
 (function(){
   console.log('[Path] Script loaded');
-  const state = { queue: [], busy:false, cache:new Map() };
+  const MAX_CACHE = 256;
+  const state = { queue: [], busy:false, cache:new Map(), order: [] };
 
   function queue(map, start, goal, ignoreId){
     const key = `${map}@${start.x},${start.y}->${goal.x},${goal.y}`;
@@ -24,7 +25,12 @@
       const t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
       const p=aStar(job.map, job.start, job.goal, job.ignoreId);
       if(globalThis.perfStats) globalThis.perfStats.path += ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - t0;
+      if(state.cache.size >= MAX_CACHE){
+        const oldest=state.order.shift();
+        if(oldest) state.cache.delete(oldest);
+      }
       state.cache.set(job.key, p);
+      state.order.push(job.key);
       state.busy=false;
       process();
     },0);
@@ -147,5 +153,5 @@
     if(globalThis.perfStats) globalThis.perfStats.ai += ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - t0;
   }
   globalThis.Dustland = globalThis.Dustland || {};
-  globalThis.Dustland.path = { queue, pathFor, tickPathAI };
+  globalThis.Dustland.path = { queue, pathFor, tickPathAI, MAX_CACHE };
 })();

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -20,12 +20,43 @@ global.queryTile = (x,y,map='world') => {
 
 global.NPCS = [];
 
+await import('../scripts/dustland-path.js');
+const { queue, pathFor, MAX_CACHE } = window.Dustland.path;
+
+async function waitFor(key){
+  for(let i=0;i<1000;i++){
+    const p = pathFor(key);
+    if(p) return p;
+    await new Promise(r=>setTimeout(r,0));
+  }
+  throw new Error('timeout waiting for path');
+}
+
 test('PathQueue finds a path', async () => {
-  await import('../scripts/dustland-path.js');
-  const key = window.Dustland.path.queue('world',{x:0,y:0},{x:2,y:2});
-  await new Promise(r => setTimeout(r,20));
-  const path = window.Dustland.path.pathFor(key);
+  const key = queue('world',{x:0,y:0},{x:2,y:2});
+  const path = await waitFor(key);
   assert.ok(path && path.length > 0, 'path exists');
   assert.deepStrictEqual(path[0], {x:0,y:0});
   assert.deepStrictEqual(path[path.length-1], {x:2,y:2});
+});
+
+test('PathQueue reuses cached paths', async () => {
+  const key = queue('reuse',{x:0,y:0},{x:2,y:2});
+  const path = await waitFor(key);
+  const again = queue('reuse',{x:0,y:0},{x:2,y:2});
+  assert.strictEqual(again, key);
+  assert.deepStrictEqual(pathFor(again), path);
+});
+
+test('PathQueue evicts oldest cache entries', async () => {
+  const keys=[];
+  for(let i=0;i<MAX_CACHE;i++){
+    keys.push(queue('m'+i,{x:0,y:0},{x:2,y:2}));
+  }
+  await waitFor(keys[keys.length-1]);
+  assert.ok(pathFor(keys[0]));
+  const extra=queue('extra',{x:0,y:0},{x:2,y:2});
+  await waitFor(extra);
+  assert.strictEqual(pathFor(keys[0]), null);
+  assert.ok(pathFor(extra));
 });


### PR DESCRIPTION
## Summary
- cap path cache with a MAX_CACHE limit and oldest-entry eviction
- test cache reuse and eviction behavior for path queue

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc59b9c2cc8328bd46247bce8007db