### PR TITLE
feat: add multiplayer heartbeat and diffing

### DIFF
--- a/scripts/supporting/multiplayer-sync.js
+++ b/scripts/supporting/multiplayer-sync.js
@@ -6,25 +6,69 @@
     async startHost({ port = 7777 } = {}) {
       const WSS = globalThis.WebSocketServer || (await import('ws')).WebSocketServer;
       const wss = new WSS({ port });
+      let last = {};
       const broadcast = () => {
-        const data = JSON.stringify(globalThis.Dustland.gameState?.getState?.() || {});
-        wss.clients.forEach(c => { if (c.readyState === 1) c.send(data); });
+        const state = globalThis.Dustland.gameState?.getState?.() || {};
+        const diff = {};
+        for (const k in state) {
+          if (state[k] !== last[k]) diff[k] = state[k];
+        }
+        for (const k in last) {
+          if (!(k in state)) diff[k] = undefined;
+        }
+        if (Object.keys(diff).length) {
+          const data = JSON.stringify(diff);
+          wss.clients.forEach(c => { if (c.readyState === 1) c.send(data); });
+          last = { ...state };
+        }
       };
       bus?.on && bus.on('state:changed', broadcast);
+      const hb = setInterval(() => {
+        wss.clients.forEach(c => {
+          if (!c.isAlive) return c.terminate();
+          c.isAlive = false;
+          if (c.readyState === 1) c.send('{"type":"ping"}');
+        });
+      }, 5000);
       wss.on('connection', ws => {
+        ws.isAlive = true;
+        ws.on('message', msg => {
+          try {
+            const data = JSON.parse(msg);
+            if (data.type === 'pong') ws.isAlive = true;
+          } catch (err) { /* ignore */ }
+        });
         ws.send(JSON.stringify(globalThis.Dustland.gameState?.getState?.() || {}));
       });
+      wss.on('close', () => clearInterval(hb));
       return wss;
     },
     async connect(url){
       const WS = globalThis.WebSocket || (await import('ws')).WebSocket;
-      const ws = new WS(url);
-      ws.onmessage = ev => {
-        try {
-          const data = JSON.parse(ev.data);
-          globalThis.Dustland.gameState?.updateState?.(s => Object.assign(s, data));
-        } catch (err) { /* ignore */ }
+      let ws;
+      const connect = () => {
+        ws = new WS(url);
+        let lastPing = Date.now();
+        const check = setInterval(() => {
+          if (Date.now() - lastPing > 10000) ws.close();
+        }, 2000);
+        ws.onmessage = ev => {
+          try {
+            const data = JSON.parse(ev.data);
+            if (data.type === 'ping') {
+              lastPing = Date.now();
+              ws.readyState === 1 && ws.send('{"type":"pong"}');
+            } else {
+              globalThis.Dustland.gameState?.updateState?.(s => Object.assign(s, data));
+            }
+          } catch (err) { /* ignore */ }
+        };
+        ws.onclose = () => {
+          clearInterval(check);
+          setTimeout(connect, 100);
+        };
       };
+      connect();
       return ws;
     }
   };

--- a/test/multiplayer-sync.test.js
+++ b/test/multiplayer-sync.test.js
@@ -11,31 +11,39 @@ function bus(){
   };
 }
 
-test('world state broadcasts to client', async () => {
+test('world state broadcasts and reconnects', async () => {
   const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
   const sync = await fs.readFile(new URL('../scripts/supporting/multiplayer-sync.js', import.meta.url), 'utf8');
   const ws = await import('ws');
 
   const hostBus = bus();
-  const host = { EventBus: hostBus, Dustland:{ eventBus: hostBus }, setTimeout, clearTimeout, console, WebSocket: ws.WebSocket, WebSocketServer: ws.WebSocketServer };
+  const host = { EventBus: hostBus, Dustland:{ eventBus: hostBus }, setTimeout, clearTimeout, setInterval, clearInterval, console, WebSocket: ws.WebSocket, WebSocketServer: ws.WebSocketServer };
   vm.createContext(host);
   vm.runInContext(gs, host);
   vm.runInContext(sync, host);
 
   const clientBus = bus();
-  const client = { EventBus: clientBus, Dustland:{ eventBus: clientBus }, setTimeout, clearTimeout, console, WebSocket: ws.WebSocket, WebSocketServer: ws.WebSocketServer };
+  const client = { EventBus: clientBus, Dustland:{ eventBus: clientBus }, setTimeout, clearTimeout, setInterval, clearInterval, console, WebSocket: ws.WebSocket, WebSocketServer: ws.WebSocketServer };
   vm.createContext(client);
   vm.runInContext(gs, client);
   vm.runInContext(sync, client);
 
   const port = 8090;
-  const server = await host.Dustland.multiplayer.startHost({ port });
+  let server = await host.Dustland.multiplayer.startHost({ port });
   const socket = await client.Dustland.multiplayer.connect(`ws://localhost:${port}`);
   await new Promise(res => socket.on('open', res));
 
-  host.Dustland.gameState.updateState(s => { s.test = 42; });
+  host.Dustland.gameState.updateState(s => { s.test = 1; });
   await new Promise(res => setTimeout(res, 50));
-  assert.equal(client.Dustland.gameState.getState().test, 42);
+  assert.equal(client.Dustland.gameState.getState().test, 1);
+
+  await new Promise(res => server.close(res));
+  await new Promise(res => setTimeout(res, 100));
+  server = await host.Dustland.multiplayer.startHost({ port });
+  await new Promise(res => setTimeout(res, 200));
+  host.Dustland.gameState.updateState(s => { s.test = 2; });
+  await new Promise(res => setTimeout(res, 50));
+  assert.equal(client.Dustland.gameState.getState().test, 2);
   socket.close();
   server.close();
 });


### PR DESCRIPTION
## Summary
- add ping/pong heartbeat and shallow state diffing to multiplayer sync
- reconnect clients on stale connections
- test host/client exchange and reconnection

## Testing
- `./install-deps.sh`
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc59da28a48328bcce8217e603b0eb