### PR TITLE
feat: add multiplayer event relay

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -42,9 +42,11 @@ const combatState = {
   turns: 0
 };
 
-function recordCombatEvent(ev){
+function recordCombatEvent(ev, relay = true){
   combatState.log.push(ev);
+  if(relay) globalThis.EventBus?.emit('combat:event', ev);
 }
+globalThis.EventBus?.on?.('combat:event', ev => recordCombatEvent(ev, false));
 
 function addStatus(target, status){
   if(!target || !status) return;

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -255,6 +255,7 @@ function move(dx,dy){
           }
         });
         setPartyPos(nx, ny);
+        bus.emit('movement:player', { x: nx, y: ny, map: state.map });
         if(typeof footstepBump==='function') footstepBump();
         onEnter(state.map, nx, ny, { player, party, state, actor, buffs });
         applyZones(state.map, nx, ny);
@@ -509,6 +510,7 @@ const movement = {
   checkRandomEncounter,
   distanceToRoad
 };
+bus?.on?.('movement:player', ({ x, y }) => { setPartyPos(x, y); });
 globalThis.Dustland = globalThis.Dustland || {};
 globalThis.Dustland.movement = movement;
 Object.assign(globalThis, movement);

--- a/scripts/multiplayer.js
+++ b/scripts/multiplayer.js
@@ -1,0 +1,60 @@
+(function(){
+  globalThis.Dustland = globalThis.Dustland || {};
+  const bus = globalThis.EventBus;
+  const base = globalThis.Dustland.multiplayer || {};
+  const NET_FLAG = '__fromNet';
+
+  async function startHost(opts){
+    const wss = await base.startHost?.(opts);
+    if(!wss) return wss;
+    const broadcast = (obj, skip)=>{
+      const data = JSON.stringify(obj);
+      wss.clients.forEach(c=>{ if(c.readyState===1 && c!==skip) c.send(data); });
+    };
+    const relay = (evt,data)=>{ if(data && data[NET_FLAG]) return; broadcast({type:'event',evt,data}); };
+    bus?.on?.('movement:player', d=>relay('movement:player',d));
+    bus?.on?.('combat:event', d=>relay('combat:event',d));
+    bus?.on?.('combat:started', d=>relay('combat:started',d));
+    bus?.on?.('combat:ended', d=>relay('combat:ended',d));
+    wss.on('connection', ws=>{
+      ws.on('message', msg=>{
+        try{
+          const obj = JSON.parse(msg);
+          if(obj?.type==='event' && obj.evt){
+            obj.data = obj.data || {}; obj.data[NET_FLAG] = true;
+            bus?.emit?.(obj.evt, obj.data);
+            broadcast(obj, ws);
+          }
+        }catch{/* ignore */}
+      });
+    });
+    return wss;
+  }
+
+  async function connect(url){
+    const ws = await base.connect?.(url);
+    const send = obj=> ws?.send?.(JSON.stringify(obj));
+    const relay = (evt,data)=>{ if(data && data[NET_FLAG]) return; send({type:'event',evt,data}); };
+    bus?.on?.('movement:player', d=>relay('movement:player',d));
+    bus?.on?.('combat:event', d=>relay('combat:event',d));
+    bus?.on?.('combat:started', d=>relay('combat:started',d));
+    bus?.on?.('combat:ended', d=>relay('combat:ended',d));
+    const orig = ws.onmessage;
+    ws.onmessage = ev=>{
+      try{
+        const obj = JSON.parse(ev.data);
+        if(obj?.type==='event' && obj.evt){
+          obj.data = obj.data || {}; obj.data[NET_FLAG] = true;
+          bus?.emit?.(obj.evt, obj.data);
+        } else {
+          globalThis.Dustland.gameState?.updateState?.(s=>Object.assign(s,obj));
+        }
+      }catch{
+        if(typeof orig==='function') orig(ev);
+      }
+    };
+    return ws;
+  }
+
+  globalThis.Dustland.multiplayer = { startHost, connect };
+})();

--- a/test/multiplayer-combat.test.js
+++ b/test/multiplayer-combat.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function bus(){
+  const listeners = {};
+  return {
+    on(evt, fn){ (listeners[evt]=listeners[evt]||[]).push(fn); },
+    emit(evt, payload){ (listeners[evt]||[]).forEach(f=>f(payload)); }
+  };
+}
+
+test('combat events propagate between clients', async () => {
+  const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
+  const sync = await fs.readFile(new URL('../scripts/supporting/multiplayer-sync.js', import.meta.url), 'utf8');
+  const mp = await fs.readFile(new URL('../scripts/multiplayer.js', import.meta.url), 'utf8');
+  const ws = await import('ws');
+
+  function ctx(){
+    const b = bus();
+    const env = { EventBus: b, Dustland: { eventBus: b }, setTimeout, clearTimeout, console, WebSocket: ws.WebSocket, WebSocketServer: ws.WebSocketServer };
+    vm.createContext(env);
+    vm.runInContext(gs, env);
+    vm.runInContext(sync, env);
+    vm.runInContext(mp, env);
+    return { env, bus: b };
+  }
+
+  const { env: host } = ctx();
+  const { env: c1, bus: b1 } = ctx();
+  const { env: c2, bus: b2 } = ctx();
+
+  const port = 8132;
+  const server = await host.Dustland.multiplayer.startHost({ port });
+  const s1 = await c1.Dustland.multiplayer.connect(`ws://localhost:${port}`);
+  const s2 = await c2.Dustland.multiplayer.connect(`ws://localhost:${port}`);
+  await Promise.all([new Promise(r=>s1.on('open',r)), new Promise(r=>s2.on('open',r))]);
+
+  const received = new Promise(res => b2.on('combat:event', ev => { if(ev.type==='attack') res(); }));
+  b1.emit('combat:event', { type:'attack' });
+  await received;
+
+  s1.close();
+  s2.close();
+  server.close();
+});

--- a/test/multiplayer-movement.test.js
+++ b/test/multiplayer-movement.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function bus(){
+  const listeners = {};
+  return {
+    on(evt, fn){ (listeners[evt]=listeners[evt]||[]).push(fn); },
+    emit(evt, payload){ (listeners[evt]||[]).forEach(f=>f(payload)); }
+  };
+}
+
+test('movement events propagate between clients', async () => {
+  const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
+  const sync = await fs.readFile(new URL('../scripts/supporting/multiplayer-sync.js', import.meta.url), 'utf8');
+  const mp = await fs.readFile(new URL('../scripts/multiplayer.js', import.meta.url), 'utf8');
+  const ws = await import('ws');
+
+  function ctx(){
+    const b = bus();
+    const env = { EventBus: b, Dustland: { eventBus: b }, setTimeout, clearTimeout, console, WebSocket: ws.WebSocket, WebSocketServer: ws.WebSocketServer };
+    vm.createContext(env);
+    vm.runInContext(gs, env);
+    vm.runInContext(sync, env);
+    vm.runInContext(mp, env);
+    return { env, bus: b };
+  }
+
+  const { env: host } = ctx();
+  const { env: c1, bus: b1 } = ctx();
+  const { env: c2, bus: b2 } = ctx();
+
+  const port = 8131;
+  const server = await host.Dustland.multiplayer.startHost({ port });
+  const s1 = await c1.Dustland.multiplayer.connect(`ws://localhost:${port}`);
+  const s2 = await c2.Dustland.multiplayer.connect(`ws://localhost:${port}`);
+  await Promise.all([new Promise(r=>s1.on('open',r)), new Promise(r=>s2.on('open',r))]);
+
+  const received = new Promise(res => b2.on('movement:player', ev => { if(ev.x===5 && ev.y===6) res(); }));
+  b1.emit('movement:player', { x:5, y:6 });
+  await received;
+
+  s1.close();
+  s2.close();
+  server.close();
+});


### PR DESCRIPTION
## Summary
- wrap WebSocket host/sync utilities with multiplayer module that relays EventBus updates
- broadcast player movement and combat events across connected clients
- add tests simulating movement and combat sync between two clients

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5a4ab5a483289478d9f089a43d26