### PR TITLE
fix: include timers in multiplayer tests

### DIFF
--- a/test/multiplayer-combat.test.js
+++ b/test/multiplayer-combat.test.js
@@ -19,7 +19,17 @@ test('combat events propagate between clients', async () => {
 
   function ctx(){
     const b = bus();
-    const env = { EventBus: b, Dustland: { eventBus: b }, setTimeout, clearTimeout, console, WebSocket: ws.WebSocket, WebSocketServer: ws.WebSocketServer };
+    const env = {
+      EventBus: b,
+      Dustland: { eventBus: b },
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval,
+      console,
+      WebSocket: ws.WebSocket,
+      WebSocketServer: ws.WebSocketServer
+    };
     vm.createContext(env);
     vm.runInContext(gs, env);
     vm.runInContext(sync, env);

--- a/test/multiplayer-movement.test.js
+++ b/test/multiplayer-movement.test.js
@@ -19,7 +19,17 @@ test('movement events propagate between clients', async () => {
 
   function ctx(){
     const b = bus();
-    const env = { EventBus: b, Dustland: { eventBus: b }, setTimeout, clearTimeout, console, WebSocket: ws.WebSocket, WebSocketServer: ws.WebSocketServer };
+    const env = {
+      EventBus: b,
+      Dustland: { eventBus: b },
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval,
+      console,
+      WebSocket: ws.WebSocket,
+      WebSocketServer: ws.WebSocketServer
+    };
     vm.createContext(env);
     vm.runInContext(gs, env);
     vm.runInContext(sync, env);


### PR DESCRIPTION
## Summary
- ensure multiplayer movement and combat tests provide setInterval/clearInterval timers

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8355921c8328a33520ffab55948f