### PR TITLE
feat: document core data structures

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
     "es2021": true
   },
   "extends": "eslint:recommended",
+  "plugins": ["jsdoc"],
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module"
@@ -14,6 +15,7 @@
     "no-unused-vars": "off",
     "no-inner-declarations": "off",
     "no-cond-assign": "off",
-    "semi": ["error", "always"]
+    "semi": ["error", "always"],
+    "jsdoc/check-types": "error"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "dustland",
-  "version": "0.63.0",
+  "version": "0.80.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dustland",
-      "version": "0.63.0",
+      "version": "0.80.0",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",
+        "eslint-plugin-jsdoc": "^48.0.3",
         "http-server": "^14.1.1",
         "jsdom": "^26.1.0",
         "puppeteer": "^24.17.0",
@@ -171,6 +172,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.46.0.tgz",
+      "integrity": "sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
@@ -310,6 +326,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+      "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.10.7",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.7.tgz",
@@ -442,6 +471,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -736,6 +775,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1005,6 +1054,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1115,6 +1171,63 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "48.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.11.0.tgz",
+      "integrity": "sha512-d12JHJDPNo7IFwTOAItCeJY1hcqoIxE0lHA8infQByLilQ9xkqrRa6laWCnsuCrf+8rUnvxXY1XuTbibRBNylA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.46.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.6.0",
+        "parse-imports": "^2.1.1",
+        "semver": "^7.6.3",
+        "spdx-expression-parse": "^4.0.0",
+        "synckit": "^0.9.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1948,6 +2061,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsdom": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
@@ -2370,6 +2493,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-imports": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.2.1.tgz",
+      "integrity": "sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==",
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "dependencies": {
+        "es-module-lexer": "^1.5.3",
+        "slashes": "^3.0.12"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/parse-json": {
@@ -2889,6 +3026,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/slashes": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
+      "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -2940,6 +3084,31 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/streamx": {
       "version": "2.22.1",
@@ -3015,6 +3184,23 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/synckit": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.3.tgz",
+      "integrity": "sha512-JJoOEKTfL1urb1mDoEblhD9NhEbWmq9jHEMEnxoC4ujUaZ4itA8vKgwkFAyNClgxplLi9tsUKX+EduK0p/l7sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
     },
     "node_modules/tar-fs": {
       "version": "3.1.0",
@@ -3158,6 +3344,22 @@
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.10.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "jsdom": "^26.1.0",
     "puppeteer": "^24.17.0",
     "ws": "^8.18.3",
-    "yaml-lint": "^1.7.0"
+    "yaml-lint": "^1.7.0",
+    "eslint-plugin-jsdoc": "^48.0.3"
   }
 }

--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -1,9 +1,39 @@
+/** @typedef {import('./inventory.js').GameItem} GameItem */
+
+/**
+ * @typedef {object} PartyMember
+ * @property {string} id
+ * @property {string} name
+ * @property {string} role
+ * @property {boolean} permanent
+ * @property {string|null} portraitSheet
+ * @property {number} lvl
+ * @property {number} xp
+ * @property {number} skillPoints
+ * @property {Record<string, number>} stats
+ * @property {{weapon:GameItem|null, armor:GameItem|null, trinket:GameItem|null}} equip
+ * @property {number} maxHp
+ * @property {number} hp
+ * @property {number} ap
+ * @property {number} maxAdr
+ * @property {number} adr
+ * @property {Record<string, number>} _bonus
+ * @property {Array<string|object>} special
+ * @property {number} adrGenMod
+ * @property {number} adrDmgMod
+ * @property {{[key:string]: number}} cooldowns
+ * @property {boolean} guard
+ * @property {object[]} statusEffects
+ * @property {string} [persona]
+ */
+
 const baseStats = () => ({STR:4, AGI:4, INT:4, PER:4, LCK:4, CHA:4});
 
 const xpCurve = [0,100,200,300,400,500,700,900,1100,1300,1500,1900,2300,2700,3100,3500,4300,5100,5900,6700];
 
 var bus = (globalThis.Dustland && globalThis.Dustland.eventBus) || globalThis.EventBus;
 
+/** @implements {PartyMember} */
 class Character {
   constructor(id, name, role, opts={}){
     this.id=id; this.name=name; this.role=role;

--- a/scripts/core/quests.js
+++ b/scripts/core/quests.js
@@ -1,5 +1,31 @@
 // ===== Quests =====
+
+/* global renderQuests, log, toast, EventBus, queueNanoDialogForNPCs, flagValue, textEl */
+/** @typedef {import('./inventory.js').GameItem} GameItem */
+
+/**
+ * @typedef {object} QuestData
+ * @property {string} id
+ * @property {string} title
+ * @property {string} desc
+ * @property {'available'|'active'|'completed'} status
+ * @property {boolean} [pinned]
+ * @property {string} [item]
+ * @property {number} [count]
+ * @property {string} [reqFlag]
+ * @property {string|GameItem} [reward]
+ * @property {number} [xp]
+ * @property {{x:number,y:number}} [moveTo]
+ * @property {Quest[]} [quests]
+ */
+
 class Quest {
+  /**
+   * @param {string} id
+   * @param {string} title
+   * @param {string} desc
+   * @param {QuestData} [meta]
+   */
   constructor(id, title, desc, meta = {}) {
     this.id = id;
     this.title = title;
@@ -21,7 +47,8 @@ class Quest {
 }
 
 class QuestLog {
-  constructor() { this.quests = {}; }
+  constructor() { /** @type {Record<string, Quest>} */ this.quests = {}; }
+  /** @param {Quest} quest */
   add(quest) {
     const existing = this.quests[quest.id];
     if (existing) {
@@ -39,10 +66,12 @@ class QuestLog {
     log('Quest added: ' + quest.title);
     queueNanoDialogForNPCs?.('start', 'quest update');
   }
+  /** @param {string} id */
   complete(id) {
     const q = this.quests[id];
     if (q) q.complete();
   }
+  /** @param {string} id */
   pin(id) {
     const q = this.quests[id];
     if (q && !q.pinned) {
@@ -50,6 +79,7 @@ class QuestLog {
       renderQuests();
     }
   }
+  /** @param {string} id */
   unpin(id) {
     const q = this.quests[id];
     if (q && q.pinned) {

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -1,24 +1,40 @@
+/* global toast, log, EventBus */
 const { on } = globalThis.EventBus;
 
 /**
- * @typedef {Object} Item
+ * @typedef {object} GameItem
+ * @property {string} id
  * @property {string} name
  * @property {string} type
- * @property {Object<string, number>} [mods]
- * @property {{type:string, amount?:number, onUse?:Function}} [use]
+ * @property {{[key:string]: number}} [mods]
+ * @property {{type:string, amount?:number, duration?:number, stat?:string, text?:string, onUse?:Function}} [use]
  * @property {string} [desc]
  * @property {number} [rarity]
  * @property {number} [value]
  */
 
 /**
- * @typedef {Object} QuestState
+ * A party member character.
+ * @typedef {object} PartyMember
+ * @property {string} id
+ * @property {string} name
+ * @property {number} hp
+ * @property {number} maxHp
+ * @property {number} lvl
+ * @property {Record<string, number>} stats
+ * @property {{weapon:GameItem|null, armor:GameItem|null, trinket:GameItem|null}} equip
+ * @property {string} [origin]
+ * @property {string} [quirk]
+ */
+
+/**
+ * @typedef {object} QuestState
  * @property {string} id
  * @property {'available'|'active'|'completed'} status
  */
 
 /**
- * @typedef {Object} NPC
+ * @typedef {object} NPC
  * @property {string} id
  * @property {string} map
  * @property {number} x
@@ -26,12 +42,12 @@ const { on } = globalThis.EventBus;
  * @property {string} color
  * @property {string} name
  * @property {string} title
- * @property {Object<string, any>} tree
+ * @property {{[key:string]: any}} tree
  * @property {Quest} [quest]
  */
 
 /**
- * @typedef {Object} Quest
+ * @typedef {object} Quest
  * @property {string} id
  * @property {string} name
  * @property {'available'|'active'|'completed'} status
@@ -41,7 +57,7 @@ const { on } = globalThis.EventBus;
  */
 
 /**
- * @typedef {Object} Map
+ * @typedef {object} Map
  * @property {string} id
  * @property {number} w
  * @property {number} h
@@ -53,7 +69,7 @@ const { on } = globalThis.EventBus;
  */
 
 /**
- * @typedef {Object} Check
+ * @typedef {object} Check
  * @property {string} stat
  * @property {number} dc
  * @property {Function[]} [onSuccess]
@@ -109,7 +125,7 @@ class Dice {
  * Launch the menu-based combat interface. In non-browser environments the
  * player automatically flees. Nearby combat-enabled NPCs within two tiles
  * will join the defender.
- * @param {{HP?:number,DEF:number,loot?:Item,name?:string,npc?:NPC}} defender
+ * @param {{HP?:number,DEF:number,loot?:GameItem,name?:string,npc?:NPC}} defender
  * @returns {Promise<{result:'bruise'|'loot'|'flee'}>}
  */
 async function startCombat(defender){

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -168,6 +168,10 @@ test('createRNG produces deterministic sequences', () => {
     assert.ok(player.inv.some(it=>it.id==='apple'));
   });
 
+  test('registerItem requires an id', () => {
+    assert.throws(() => registerItem({ name:'Nameless', type:'weapon' }), /id/);
+  });
+
   test('picking up an item logs once', () => {
     player.inv.length = 0;
     party.length = 0;


### PR DESCRIPTION
## Summary
- add JSDoc typedefs for items, party members, and quests
- enforce JSDoc type checks via eslint-plugin-jsdoc
- cover missing registerItem id validation in tests

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc5a17d84083289b8c7bd27b6cac54