### PR TITLE
feat: add initial PIT.BAS cavern

### DIFF
--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -4,21 +4,50 @@ const DATA = `
 {
   "seed": "pit-bas",
   "name": "pit-bas",
-  "start": { "map": "cavern", "x": 1, "y": 1 },
-  "items": [],
+  "start": { "map": "cavern", "x": 3, "y": 5 },
+  "items": [
+    {
+      "id": "magic_lightbulb",
+      "name": "Magic Lightbulb",
+      "type": "quest",
+      "map": "cavern",
+      "x": 3,
+      "y": 3
+    }
+  ],
   "quests": [],
   "npcs": [],
-  "interiors": [],
+  "interiors": [
+    {
+      "id": "cavern",
+      "w": 7,
+      "h": 7,
+      "grid": [
+        "🧱🧱🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🚪🏝🏝🧱",
+        "🧱🏝🏝🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🏝🏝🧱",
+        "🧱🏝🏝🚪🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 3,
+      "entryY": 5
+    }
+  ],
   "buildings": []
 }
 `;
 
-function postLoad(module) {}
+function postLoad(module) {
+  log('You land in a shadowy cavern.');
+}
 
 globalThis.PIT_BAS_MODULE = JSON.parse(DATA);
 globalThis.PIT_BAS_MODULE.postLoad = postLoad;
 
 startGame = function () {
+  PIT_BAS_MODULE.postLoad?.(PIT_BAS_MODULE);
   applyModule(PIT_BAS_MODULE);
   const s = PIT_BAS_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   setPartyPos(s.x, s.y);

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+test('pit bas module initializes cavern and lightbulb', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'pit-bas.module.js');
+  const src = fs.readFileSync(file, 'utf8');
+  const calls = [];
+  const context = { Math };
+  context.globalThis = context;
+  context.applyModule = () => { calls.push('apply'); };
+  context.setPartyPos = (x, y) => { context.pos = { x, y }; };
+  context.setMap = (map, name) => { context.mapName = name; };
+  context.log = () => { calls.push('log'); };
+  vm.runInNewContext(src, context);
+  context.PIT_BAS_MODULE.postLoad = () => { calls.push('post'); };
+  context.startGame();
+  assert.deepStrictEqual(calls, ['post', 'apply']);
+  assert.deepStrictEqual(context.pos, { x: 3, y: 5 });
+  assert.strictEqual(context.mapName, 'PIT.BAS');
+  assert.strictEqual(context.PIT_BAS_MODULE.items[0].id, 'magic_lightbulb');
+});


### PR DESCRIPTION
## Summary
- seed PIT.BAS module with starting cavern and lightbulb item
- add test ensuring PIT.BAS startGame hooks run and set starting state

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test -- test/pit-bas.module.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bced7cf4508328a350096114b255a6