### PR TITLE
docs: note pit helper wiring automation

### DIFF
--- a/docs/design/notes/pit-bas-module.md
+++ b/docs/design/notes/pit-bas-module.md
@@ -87,6 +87,8 @@ This document sketches how to port that script into a Dustland module so the pit
 5. **Save Hooks** – Store minimal progress flags so players can retry without replaying the intro.
 
 ## Pipeline Notes
+> **Gizmo:** No one should hand-wire thirty rooms; let the helper script solder the lines.
+- Port chunks of the pit build helper script to automate repetitive wiring.
 - Hand-build the JSON map based on the room/item/NPC list.
 - Include the `docs/examples/PIT.BAS` listing as an optional in-game artifact.
 - Validate the JSON with existing module tests before hand-tuning encounters.


### PR DESCRIPTION
## Summary
- flag pit build helper as a tool to automate repetitive wiring

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68bcfdf6b0f48328bec2fba652cf228e