### PR TITLE
feat: add whistle room to pit module

### DIFF
--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -13,10 +13,22 @@ const DATA = `
       "map": "cavern",
       "x": 3,
       "y": 3
+    },
+    {
+      "id": "whistle",
+      "name": "Whistle",
+      "type": "quest",
+      "map": "whistle_room",
+      "x": 2,
+      "y": 2
     }
   ],
   "quests": [],
   "npcs": [],
+  "portals": [
+    { "map": "cavern", "x": 3, "y": 1, "toMap": "whistle_room", "toX": 1, "toY": 1 },
+    { "map": "whistle_room", "x": 1, "y": 1, "toMap": "cavern", "toX": 3, "toY": 1 }
+  ],
   "interiors": [
     {
       "id": "cavern",
@@ -33,6 +45,19 @@ const DATA = `
       ],
       "entryX": 3,
       "entryY": 5
+    },
+    {
+      "id": "whistle_room",
+      "w": 4,
+      "h": 4,
+      "grid": [
+        "🧱🧱🧱🧱",
+        "🧱🚪🏝🧱",
+        "🧱🏝🏝🧱",
+        "🧱🧱🧱🧱"
+      ],
+      "entryX": 1,
+      "entryY": 1
     }
   ],
   "buildings": []

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -9,7 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const file = path.join(__dirname, '..', 'modules', 'pit-bas.module.js');
 const src = fs.readFileSync(file, 'utf8');
 
-test('pit bas module initializes cavern and lightbulb', () => {
+test('pit bas module initializes rooms and items', () => {
   const calls = [];
   const context = { Math };
   context.globalThis = context;
@@ -23,7 +23,18 @@ test('pit bas module initializes cavern and lightbulb', () => {
   assert.deepStrictEqual(calls, ['post', 'apply']);
   assert.deepStrictEqual(context.pos, { x: 3, y: 5 });
   assert.strictEqual(context.mapName, 'PIT.BAS');
-  assert.strictEqual(context.PIT_BAS_MODULE.items[0].id, 'magic_lightbulb');
+  assert.strictEqual(
+    context.PIT_BAS_MODULE.items[0].id,
+    'magic_lightbulb'
+  );
+  assert.ok(
+    context.PIT_BAS_MODULE.items.find(i => i.id === 'whistle')
+  );
+  assert.ok(
+    context.PIT_BAS_MODULE.portals.find(
+      p => p.map === 'cavern' && p.toMap === 'whistle_room'
+    )
+  );
 });
 
 test('pit bas module logs entry message', () => {


### PR DESCRIPTION
## Summary
- connect cavern to a new whistle room
- add whistle quest item to new room
- test pit module initialization and portal wiring

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68bd69c1a49c8328838008a6662073e8