### PR TITLE
feat: add small and large caverns

### DIFF
--- a/docs/design/notes/pit-bas-module.md
+++ b/docs/design/notes/pit-bas-module.md
@@ -86,6 +86,39 @@ This document sketches how to port that script into a Dustland module so the pit
 4. **UI Layer** – Use existing dialog panels; no bespoke UI widgets.
 5. **Save Hooks** – Store minimal progress flags so players can retry without replaying the intro.
 
+## Room Layout
+Rooms are sketched on a 5×5 grid using `x` for walls and `p` for portals. For example:
+
+```
+xxpxx
+x   x
+p   x
+x   x
+xxxx
+```
+
+The above layout yields exits to the west and north.
+
+Small cavern layout:
+
+```
+xxpxx
+x   x
+p   x
+x   x
+xxxx
+```
+
+Large cavern layout:
+
+```
+xxxxx
+x   p
+x   x
+x   x
+xxxxx
+```
+
 ## Pipeline Notes
  - Hand-build the JSON map based on the room/item/NPC list. Use `node scripts/supporting/append-room.js` to quickly append rooms and wire portal exits.
 

--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -27,7 +27,11 @@ const DATA = `
   "npcs": [],
   "portals": [
     { "map": "cavern", "x": 3, "y": 1, "toMap": "whistle_room", "toX": 1, "toY": 1 },
-    { "map": "whistle_room", "x": 1, "y": 1, "toMap": "cavern", "toX": 3, "toY": 1 }
+    { "map": "whistle_room", "x": 1, "y": 1, "toMap": "cavern", "toX": 3, "toY": 1 },
+    { "map": "cavern", "x": 3, "y": 5, "toMap": "small_cavern", "toX": 2, "toY": 1 },
+    { "map": "small_cavern", "x": 2, "y": 0, "toMap": "cavern", "toX": 3, "toY": 5 },
+    { "map": "small_cavern", "x": 0, "y": 2, "toMap": "large_cavern", "toX": 3, "toY": 1 },
+    { "map": "large_cavern", "x": 4, "y": 1, "toMap": "small_cavern", "toX": 1, "toY": 2 }
   ],
   "interiors": [
     {
@@ -58,6 +62,34 @@ const DATA = `
       ],
       "entryX": 1,
       "entryY": 1
+    },
+    {
+      "id": "small_cavern",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🚪🧱🧱",
+        "🧱🏝🏝🏝🧱",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 3
+    },
+    {
+      "id": "large_cavern",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🧱🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
     }
   ],
   "buildings": []

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -35,6 +35,38 @@ test('pit bas module initializes rooms and items', () => {
       p => p.map === 'cavern' && p.toMap === 'whistle_room'
     )
   );
+  assert.ok(
+    context.PIT_BAS_MODULE.interiors.find(r => r.id === 'small_cavern')
+  );
+  assert.ok(
+    context.PIT_BAS_MODULE.interiors.find(r => r.id === 'large_cavern')
+  );
+  assert.ok(
+    context.PIT_BAS_MODULE.portals.find(
+      p => p.map === 'cavern' && p.toMap === 'small_cavern'
+    )
+  );
+  const smallReturn = context.PIT_BAS_MODULE.portals.find(
+    p => p.map === 'small_cavern' && p.toMap === 'cavern'
+  );
+  assert.deepStrictEqual(
+    { x: smallReturn.x, y: smallReturn.y },
+    { x: 2, y: 0 }
+  );
+  const smallToLarge = context.PIT_BAS_MODULE.portals.find(
+    p => p.map === 'small_cavern' && p.toMap === 'large_cavern'
+  );
+  assert.deepStrictEqual(
+    { x: smallToLarge.x, y: smallToLarge.y },
+    { x: 0, y: 2 }
+  );
+  const largeToSmall = context.PIT_BAS_MODULE.portals.find(
+    p => p.map === 'large_cavern' && p.toMap === 'small_cavern'
+  );
+  assert.deepStrictEqual(
+    { x: largeToSmall.x, y: largeToSmall.y },
+    { x: 4, y: 1 }
+  );
 });
 
 test('pit bas module logs entry message', () => {


### PR DESCRIPTION
## Summary
- embed pit cavern portals within boundary walls
- document small and large cavern room layouts
- verify portal coordinates stay on map edges

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bd6e0fab70832890d9d0261c02c2c5