### PR TITLE
feat: expand pit module with remaining rooms

### DIFF
--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -4,7 +4,11 @@ const DATA = `
 {
   "seed": "pit-bas",
   "name": "pit-bas",
-  "start": { "map": "cavern", "x": 3, "y": 5 },
+  "start": {
+    "map": "cavern",
+    "x": 3,
+    "y": 5
+  },
   "items": [
     {
       "id": "magic_lightbulb",
@@ -26,12 +30,390 @@ const DATA = `
   "quests": [],
   "npcs": [],
   "portals": [
-    { "map": "cavern", "x": 3, "y": 1, "toMap": "whistle_room", "toX": 1, "toY": 1 },
-    { "map": "whistle_room", "x": 1, "y": 1, "toMap": "cavern", "toX": 3, "toY": 1 },
-    { "map": "cavern", "x": 3, "y": 5, "toMap": "small_cavern", "toX": 2, "toY": 1 },
-    { "map": "small_cavern", "x": 2, "y": 0, "toMap": "cavern", "toX": 3, "toY": 5 },
-    { "map": "small_cavern", "x": 0, "y": 2, "toMap": "large_cavern", "toX": 3, "toY": 1 },
-    { "map": "large_cavern", "x": 4, "y": 1, "toMap": "small_cavern", "toX": 1, "toY": 2 }
+    {
+      "map": "cavern",
+      "x": 3,
+      "y": 1,
+      "toMap": "whistle_room",
+      "toX": 1,
+      "toY": 1
+    },
+    {
+      "map": "whistle_room",
+      "x": 1,
+      "y": 1,
+      "toMap": "cavern",
+      "toX": 3,
+      "toY": 1
+    },
+    {
+      "map": "cavern",
+      "x": 3,
+      "y": 5,
+      "toMap": "small_cavern",
+      "toX": 2,
+      "toY": 1
+    },
+    {
+      "map": "small_cavern",
+      "x": 2,
+      "y": 0,
+      "toMap": "cavern",
+      "toX": 3,
+      "toY": 5
+    },
+    {
+      "map": "small_cavern",
+      "x": 0,
+      "y": 2,
+      "toMap": "large_cavern",
+      "toX": 3,
+      "toY": 1
+    },
+    {
+      "map": "large_cavern",
+      "x": 4,
+      "y": 1,
+      "toMap": "small_cavern",
+      "toX": 1,
+      "toY": 2
+    },
+    {
+      "map": "small_cavern",
+      "x": 4,
+      "y": 1,
+      "toMap": "golden_gate",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "golden_gate",
+      "x": 0,
+      "y": 2,
+      "toMap": "small_cavern",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "golden_gate",
+      "x": 4,
+      "y": 1,
+      "toMap": "dungeon",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "dungeon",
+      "x": 0,
+      "y": 2,
+      "toMap": "golden_gate",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "dungeon",
+      "x": 4,
+      "y": 1,
+      "toMap": "river_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "river_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "dungeon",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "river_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "glass_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "glass_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "river_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "glass_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "bandit_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "bandit_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "glass_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "bandit_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "green_house",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "green_house",
+      "x": 0,
+      "y": 2,
+      "toMap": "bandit_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "green_house",
+      "x": 4,
+      "y": 1,
+      "toMap": "river_bed",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "river_bed",
+      "x": 0,
+      "y": 2,
+      "toMap": "green_house",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "river_bed",
+      "x": 4,
+      "y": 1,
+      "toMap": "troll_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "troll_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "river_bed",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "troll_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "trophy_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "trophy_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "troll_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "trophy_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "rag_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "rag_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "trophy_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "rag_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "bright_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "bright_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "rag_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "bright_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "pointless_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "pointless_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "bright_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "pointless_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "white_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "white_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "pointless_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "white_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "whisper_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "whisper_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "white_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "whisper_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "wizard_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "wizard_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "whisper_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "wizard_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "alice_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "alice_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "wizard_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "alice_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "lightning_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "lightning_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "alice_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "lightning_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "magician_book_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "magician_book_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "lightning_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "magician_book_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "air_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "air_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "magician_book_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "air_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "maze_small_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "maze_small_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "air_room",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "maze_small_room",
+      "x": 4,
+      "y": 1,
+      "toMap": "bee_room",
+      "toX": 0,
+      "toY": 2
+    },
+    {
+      "map": "bee_room",
+      "x": 0,
+      "y": 2,
+      "toMap": "maze_small_room",
+      "toX": 4,
+      "toY": 1
+    }
   ],
   "interiors": [
     {
@@ -69,7 +451,7 @@ const DATA = `
       "h": 5,
       "grid": [
         "🧱🧱🚪🧱🧱",
-        "🧱🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🚪",
         "🚪🏝🏝🏝🧱",
         "🧱🏝🏝🏝🧱",
         "🧱🧱🧱🧱🧱"
@@ -85,6 +467,300 @@ const DATA = `
         "🧱🧱🧱🧱🧱",
         "🧱🏝🏝🏝🚪",
         "🧱🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "golden_gate",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "dungeon",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "river_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "glass_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "bandit_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "green_house",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "river_bed",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "troll_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "trophy_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "rag_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "bright_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "pointless_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "white_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "whisper_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "wizard_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "alice_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "lightning_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "magician_book_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "air_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "maze_small_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🚪",
+        "🚪🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "bee_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🧱",
+        "🚪🏝🏝🏝🧱",
         "🧱🏝🏝🏝🧱",
         "🧱🧱🧱🧱🧱"
       ],

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -67,6 +67,46 @@ test('pit bas module initializes rooms and items', () => {
     { x: largeToSmall.x, y: largeToSmall.y },
     { x: 4, y: 1 }
   );
+  const expectedRooms = [
+    'cavern',
+    'whistle_room',
+    'small_cavern',
+    'large_cavern',
+    'golden_gate',
+    'dungeon',
+    'river_room',
+    'glass_room',
+    'bandit_room',
+    'green_house',
+    'river_bed',
+    'troll_room',
+    'trophy_room',
+    'rag_room',
+    'bright_room',
+    'pointless_room',
+    'white_room',
+    'whisper_room',
+    'wizard_room',
+    'alice_room',
+    'lightning_room',
+    'magician_book_room',
+    'air_room',
+    'maze_small_room',
+    'bee_room'
+  ];
+  expectedRooms.forEach(id => {
+    assert.ok(context.PIT_BAS_MODULE.interiors.find(r => r.id === id));
+  });
+  assert.ok(
+    context.PIT_BAS_MODULE.portals.find(
+      p => p.map === 'small_cavern' && p.toMap === 'golden_gate'
+    )
+  );
+  assert.ok(
+    context.PIT_BAS_MODULE.portals.find(
+      p => p.map === 'maze_small_room' && p.toMap === 'bee_room'
+    )
+  );
 });
 
 test('pit bas module logs entry message', () => {


### PR DESCRIPTION
## Summary
- add missing PIT.BAS rooms and wire them into a linear portal chain
- cover new rooms and portals in PIT.BAS module tests

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd796585ec8328ba3c4348432d234a