### PR TITLE
feat: add dungeon link from whistle room and label interiors

### DIFF
--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -29,6 +29,33 @@ const DATA = `
   ],
   "quests": [],
   "npcs": [],
+  "mapLabels": {
+    "cavern": "Cavern",
+    "whistle_room": "Whistle Room",
+    "small_cavern": "Small Cavern",
+    "large_cavern": "Large Cavern",
+    "golden_gate": "Golden Gate",
+    "dungeon": "Dungeon",
+    "river_room": "River Room",
+    "glass_room": "Glass Room",
+    "bandit_room": "Bandit Room",
+    "green_house": "Green House",
+    "river_bed": "River Bed",
+    "troll_room": "Troll Room",
+    "trophy_room": "Trophy Room",
+    "rag_room": "Rag Room",
+    "bright_room": "Bright Room",
+    "pointless_room": "Pointless Room",
+    "white_room": "White Room",
+    "whisper_room": "Whisper Room",
+    "wizard_room": "Wizard Room",
+    "alice_room": "Alice Room",
+    "lightning_room": "Lightning Room",
+    "magician_book_room": "Magician Book Room",
+    "air_room": "Air Room",
+    "maze_small_room": "Maze Small Room",
+    "bee_room": "Bee Room"
+  },
   "portals": [
     {
       "map": "cavern",
@@ -44,6 +71,22 @@ const DATA = `
       "y": 1,
       "toMap": "cavern",
       "toX": 3,
+      "toY": 1
+    },
+    {
+      "map": "whistle_room",
+      "x": 2,
+      "y": 1,
+      "toMap": "dungeon",
+      "toX": 4,
+      "toY": 1
+    },
+    {
+      "map": "dungeon",
+      "x": 4,
+      "y": 1,
+      "toMap": "whistle_room",
+      "toX": 2,
       "toY": 1
     },
     {
@@ -438,7 +481,7 @@ const DATA = `
       "h": 4,
       "grid": [
         "🧱🧱🧱🧱",
-        "🧱🚪🏝🧱",
+        "🧱🚪🚪🧱",
         "🧱🏝🏝🧱",
         "🧱🧱🧱🧱"
       ],
@@ -784,5 +827,5 @@ startGame = function () {
   applyModule(PIT_BAS_MODULE);
   const s = PIT_BAS_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   setPartyPos(s.x, s.y);
-  setMap(s.map, s.map === 'world' ? 'Wastes' : 'PIT.BAS');
+  setMap(s.map, s.map === 'world' ? 'Wastes' : undefined);
 };

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -393,6 +393,11 @@ function applyModule(data = {}, options = {}) {
     npcTemplates.length = 0;
     Object.keys(enemyBanks).forEach(k => delete enemyBanks[k]);
 
+    // Reset custom map labels
+    Object.keys(mapLabels).forEach(k => {
+      if (k !== 'world' && k !== 'creator') delete mapLabels[k];
+    });
+
     // Generate terrain based on config
     let generated = false;
     if (moduleData.worldGen) {
@@ -422,6 +427,9 @@ function applyModule(data = {}, options = {}) {
     const g = grid && typeof grid[0] === 'string' ? gridFromEmoji(grid) : grid;
     interiors[id] = { ...rest, grid: g };
   });
+
+  // Map labels
+  if (moduleData.mapLabels) Object.assign(mapLabels, moduleData.mapLabels);
 
   // Buildings
   if (moduleData.buildings) {

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -13,16 +13,22 @@ test('pit bas module initializes rooms and items', () => {
   const calls = [];
   const context = { Math };
   context.globalThis = context;
-  context.applyModule = () => { calls.push('apply'); };
+  context.mapLabels = { world: 'Wastes' };
+  context.applyModule = data => {
+    calls.push('apply');
+    if (data.mapLabels) Object.assign(context.mapLabels, data.mapLabels);
+  };
   context.setPartyPos = (x, y) => { context.pos = { x, y }; };
-  context.setMap = (map, name) => { context.mapName = name; };
+  context.setMap = (map, name) => {
+    context.mapName = name || context.mapLabels[map] || 'Interior';
+  };
   context.log = () => { calls.push('log'); };
   vm.runInNewContext(src, context);
   context.PIT_BAS_MODULE.postLoad = () => { calls.push('post'); };
   context.startGame();
   assert.deepStrictEqual(calls, ['post', 'apply']);
   assert.deepStrictEqual(context.pos, { x: 3, y: 5 });
-  assert.strictEqual(context.mapName, 'PIT.BAS');
+  assert.strictEqual(context.mapName, 'Cavern');
   assert.strictEqual(
     context.PIT_BAS_MODULE.items[0].id,
     'magic_lightbulb'
@@ -44,6 +50,11 @@ test('pit bas module initializes rooms and items', () => {
   assert.ok(
     context.PIT_BAS_MODULE.portals.find(
       p => p.map === 'cavern' && p.toMap === 'small_cavern'
+    )
+  );
+  assert.ok(
+    context.PIT_BAS_MODULE.portals.find(
+      p => p.map === 'whistle_room' && p.toMap === 'dungeon'
     )
   );
   const smallReturn = context.PIT_BAS_MODULE.portals.find(
@@ -106,6 +117,10 @@ test('pit bas module initializes rooms and items', () => {
     context.PIT_BAS_MODULE.portals.find(
       p => p.map === 'maze_small_room' && p.toMap === 'bee_room'
     )
+  );
+  assert.strictEqual(
+    context.PIT_BAS_MODULE.mapLabels.whistle_room,
+    'Whistle Room'
   );
 });
 


### PR DESCRIPTION
## Summary
- connect whistle room directly to the dungeon
- display proper room names via module mapLabels

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd883eb7888328b0a8e736a13e5d47