### PR TITLE
feat: append-room directional portals

### DIFF
--- a/docs/design/notes/pit-bas-module.md
+++ b/docs/design/notes/pit-bas-module.md
@@ -120,11 +120,15 @@ xxxxx
 ```
 
 ## Pipeline Notes
- - Hand-build the JSON map based on the room/item/NPC list. Use `node scripts/supporting/append-room.js` to quickly append rooms and wire portal exits.
+ - Hand-build the JSON map based on the room/item/NPC list. Use `node scripts/supporting/append-room.js` to quickly insert rooms and wire portal exits.
+   - The layout argument is a comma-separated list of rows using `x` for walls, `p` for portals, and spaces for floor tiles.
+   - Portals on the top row connect north, the left column west, the right column east, and the bottom row south.
+   - Example: `node scripts/supporting/append-room.js modules/pit-bas.module.js small_cavern 'xxpxx,x   x,p   x,x   x,xxxx' cavern '' '' large_cavern`.
+   - Invoking the script again with the same room name replaces its layout and portals.
 
 > **Gizmo:** No one should hand-wire thirty rooms; let the helper script solder the lines.
-- Port chunks of the pit build helper script to automate repetitive wiring.
-- Hand-build the JSON map based on the room/item/NPC list.
+ - Port chunks of the pit build helper script to automate repetitive wiring.
+ - Hand-build the JSON map based on the room/item/NPC list.
 
 - Include the `docs/examples/PIT.BAS` listing as an optional in-game artifact.
 - Validate the JSON with existing module tests before hand-tuning encounters.

--- a/scripts/supporting/append-room.js
+++ b/scripts/supporting/append-room.js
@@ -3,27 +3,79 @@ import path from 'node:path';
 
 if (process.argv.length < 5) {
   console.log('Usage: node scripts/supporting/append-room.js <file> <roomId> <targetRoom>');
+  console.log('   or: node scripts/supporting/append-room.js <file> <roomId> <layout> [north] [east] [south] [west]');
   process.exit(1);
 }
 
-const [file, id, target] = process.argv.slice(2);
+const args = process.argv.slice(2);
+const file = args[0];
+const id = args[1];
 const filePath = path.resolve(file);
 const mod = JSON.parse(fs.readFileSync(filePath, 'utf8'));
 
 mod.interiors = mod.interiors || [];
 mod.portals = mod.portals || [];
 
-mod.interiors.push({
-  id,
-  w: 4,
-  h: 4,
-  grid: ['🧱🧱🧱🧱', '🧱🚪🧱🧱', '🧱🧱🧱🧱', '🧱🧱🧱🧱'],
-  entryX: 1,
-  entryY: 1
+function clearExisting() {
+  mod.interiors = mod.interiors.filter(r => r.id !== id);
+  mod.portals = mod.portals.filter(p => p.map !== id && p.toMap !== id);
+}
+
+if (args.length === 3) {
+  const target = args[2];
+  clearExisting();
+  mod.interiors.push({
+    id,
+    w: 4,
+    h: 4,
+    grid: ['🧱🧱🧱🧱', '🧱🚪🧱🧱', '🧱🧱🧱🧱', '🧱🧱🧱🧱'],
+    entryX: 1,
+    entryY: 1
+  });
+  mod.portals.push({ map: target, x: 1, y: 1, toMap: id, toX: 1, toY: 1 });
+  mod.portals.push({ map: id, x: 1, y: 1, toMap: target, toX: 1, toY: 1 });
+  fs.writeFileSync(filePath, JSON.stringify(mod, null, 2));
+  console.log(`Appended room ${id} linked with ${target}`);
+  process.exit(0);
+}
+
+const layout = args[2];
+const north = args[3];
+const east = args[4];
+const south = args[5];
+const west = args[6];
+
+const rows = layout.split(',');
+const h = rows.length;
+const w = rows[0].length;
+const grid = rows.map(r => r.split('').map(c => c === 'x' ? '🧱' : c === 'p' ? '🚪' : '🏝').join(''));
+
+clearExisting();
+mod.interiors.push({ id, w, h, grid, entryX: 1, entryY: 1 });
+
+const exits = { north: [], east: [], south: [], west: [] };
+rows.forEach((row, y) => {
+  row.split('').forEach((c, x) => {
+    if (c !== 'p') return;
+    if (y === 0) exits.north.push({ x, y });
+    else if (y === h - 1) exits.south.push({ x, y });
+    else if (x === 0) exits.west.push({ x, y });
+    else if (x === w - 1) exits.east.push({ x, y });
+  });
 });
 
-mod.portals.push({ map: target, x: 1, y: 1, toMap: id, toX: 1, toY: 1 });
-mod.portals.push({ map: id, x: 1, y: 1, toMap: target, toX: 1, toY: 1 });
+function addPortal(dir, target) {
+  if (!target) return;
+  exits[dir].forEach(({ x, y }) => {
+    mod.portals.push({ map: id, x, y, toMap: target, toX: 1, toY: 1 });
+    mod.portals.push({ map: target, x: 1, y: 1, toMap: id, toX: x, toY: y });
+  });
+}
+
+addPortal('north', north);
+addPortal('east', east);
+addPortal('south', south);
+addPortal('west', west);
 
 fs.writeFileSync(filePath, JSON.stringify(mod, null, 2));
-console.log(`Appended room ${id} linked with ${target}`);
+console.log(`Inserted room ${id}`);

--- a/test/append-room.helper.test.js
+++ b/test/append-room.helper.test.js
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
-test('append-room adds linked interior', async () => {
+test('append-room inserts and replaces directional exits', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'append-room-'));
   const file = path.join(dir, 'mod.json');
   const init = {
@@ -14,10 +14,15 @@ test('append-room adds linked interior', async () => {
   };
   await fs.writeFile(file, JSON.stringify(init, null, 2));
   const script = path.join('scripts', 'supporting', 'append-room.js');
-  const res = spawnSync('node', [script, file, 'new', 'start']);
+
+  let res = spawnSync('node', [script, file, 'new', 'xxpxx,x   x,x   x,x   x,xxxxx', 'start']);
   assert.strictEqual(res.status, 0);
-  const data = JSON.parse(await fs.readFile(file, 'utf8'));
-  assert.ok(data.interiors.some(r => r.id === 'new'));
-  assert.ok(data.portals.find(p => p.map === 'start' && p.toMap === 'new'));
-  assert.ok(data.portals.find(p => p.map === 'new' && p.toMap === 'start'));
+  let data = JSON.parse(await fs.readFile(file, 'utf8'));
+  assert.ok(data.portals.find(p => p.map === 'new' && p.x === 2 && p.y === 0 && p.toMap === 'start'));
+
+  res = spawnSync('node', [script, file, 'new', 'xxxxx,x   x,x   x,x   x,xxpxx', '', '', 'start']);
+  assert.strictEqual(res.status, 0);
+  data = JSON.parse(await fs.readFile(file, 'utf8'));
+  assert.ok(data.portals.find(p => p.map === 'new' && p.x === 2 && p.y === 4 && p.toMap === 'start'));
+  assert.ok(!data.portals.find(p => p.map === 'new' && p.y === 0));
 });


### PR DESCRIPTION
## Summary
- allow `append-room.js` to replace rooms and add directional exits
- document room insertion workflow for PIT.BAS module
- exercise new helper in tests

## Testing
- `npm test -- test/append-room.helper.test.js`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd96fb34588328aa78d5f7accc4d8f