### PR TITLE
docs: clarify pit.bas design layout

### DIFF
--- a/docs/design/notes/pit-bas-module.md
+++ b/docs/design/notes/pit-bas-module.md
@@ -13,32 +13,35 @@ This document sketches how to port that script into a Dustland module so the pit
 
 ## Room, Item, and NPC List
 
-**Rooms**
-- Cavern (start)
-- Large Cavern
-- Small Cavern
-- Whistle Room
-- Golden Gate
-- Dungeon
-- River Room
-- Glass Room
-- Bandit Room
-- Green House
-- River Bed
-- Troll Room
-- Trophy Room
-- Rag Room
-- Bright Room
-- Pointless Room
-- White Room
-- Whisper Room
-- Wizard Room
-- Alice Room
-- Lightning Room
-- Magician's Book Room
-- Air Room
-- Maze: Small Room
-- Bee Room
+**Rooms (BASIC line number)**
+- 10 Cavern (start)
+- 100 Large Cavern
+- 200 Small Cavern
+- 300 Whistle Room
+- 400 Golden Gate
+- 500 Dungeon
+- 600 River Room
+- 700 Glass Room
+- 800 Bandit Room
+- 900 Green House
+- 1000 River Bed
+- 1100 Troll Room
+- 1200 Trophy Room
+- 1300 Drain
+- 1400 Rag Room
+- 1500 Bright Room
+- 1700 Pointless Room
+- 1800 White Room
+- 1900 Shore
+- 2000 Whisper Room
+- 2100 Wizard Room
+- 2200 Roof of House
+- 2300 Alice Room
+- 2400 Lightning Room
+- 2700 Magician's Book Room
+- 3100 Air Room
+- 3600 Maze: Small Room
+- 3900 Bee Room
 
 **Items**
 - Magic lightbulb
@@ -121,31 +124,35 @@ xxxxx
 
 ## Room Connections
 
-- Cavern: north to Large Cavern; east to Whistle Room; south to Small Cavern
-- Large Cavern: south to Cavern; east to Small Cavern
-- Whistle Room: west to Cavern; east to Dungeon
-- Small Cavern: north to Cavern; west to Large Cavern; east to Golden Gate
-- Golden Gate: west to Small Cavern; east to Dungeon
-- Dungeon: west to Golden Gate and Whistle Room; east to River Room
-- River Room: west to Dungeon; east to Glass Room
-- Glass Room: west to River Room; east to Bandit Room
-- Bandit Room: west to Glass Room; east to Green House
-- Green House: west to Bandit Room; east to River Bed
-- River Bed: west to Green House; east to Troll Room
-- Troll Room: west to River Bed; east to Trophy Room
-- Trophy Room: west to Troll Room; east to Rag Room
-- Rag Room: west to Trophy Room; east to Bright Room
-- Bright Room: west to Rag Room; east to Pointless Room
-- Pointless Room: west to Bright Room; east to White Room
-- White Room: west to Pointless Room; east to Whisper Room
-- Whisper Room: west to White Room; east to Wizard Room
-- Wizard Room: west to Whisper Room; east to Alice Room
-- Alice Room: west to Wizard Room; east to Lightning Room
-- Lightning Room: west to Alice Room; east to Magician's Book Room
-- Magician's Book Room: west to Lightning Room; east to Air Room
-- Air Room: west to Magician's Book Room; east to Maze: Small Room
-- Maze: Small Room: west to Air Room; east to Bee Room
-- Bee Room: west to Maze: Small Room
+- Cavern: north to Large Cavern; south to Small Cavern; down to Whistle Room
+- Large Cavern: south to Cavern; east to Golden Gate
+- Small Cavern: north to Cavern
+- Whistle Room: up to Cavern; east to Dungeon
+- Golden Gate: west to Large Cavern
+- Dungeon: north to River Room; south to Glass Room; west to Whistle Room
+- River Room: north to Bandit Room; east to Green House; south to Dungeon; west to River Bed (requires air tanks)
+- Glass Room: east to Dungeon; down to Troll Room
+- Bandit Room: south to River Room; east to Trophy Room
+- Green House: west to River Room
+- River Bed: north to Drain; east to River Room
+- Troll Room: up to Glass Room; east to Rag Room; west to Bright Room
+- Trophy Room: west to Bandit Room
+- Drain: south to River Bed; west to Rapid Water
+- Rag Room: north to Troll Room; east to Whisper Room
+- Bright Room: east to Troll Room; north to White Room; up to Pointless Room
+- Rapid Water: west to Shore; east to Drain
+- Pointless Room: down to Bright Room
+- White Room: south to Bright Room; west to Wizard Room
+- Shore: east to Rapid Water; up to Roof of House; west to Alice Room
+- Whisper Room: west to Rag Room; north to Maze; northeast to Maze
+- Wizard Room: east to White Room; west to North/South Passage; up to Lightning Room; south to In-A-Box
+- Roof of House: up to Lightning Room; west to North/South Passage; down to Shore
+- Alice Room: east to Shore; west to Mirror Alice Room
+- Lightning Room: north to Roof of House; down to Wizard Room
+- Magician's Book Room: west to Air Room; down to 5800
+- Air Room: east to Magician's Book Room; northwest to West Hall
+- Maze: Small Room: north to Dead End; east to Maze; west to Maze
+- Bee Room: north to Maze; east to Merchant Room; southwest to Flute Room
 
 ## Pipeline Notes
  - Hand-build the JSON map based on the room/item/NPC list. Use `node scripts/supporting/append-room.js` to quickly insert rooms and wire portal exits.
@@ -165,4 +172,53 @@ xxxxx
 
 ## Open Questions
 - Once the original map ships, should we add optional side tunnels or alternate endings?
+
+## Scaffolding Commands
+
+```sh
+# Rooms
+node scripts/supporting/append-room.js modules/pit-bas.module.js cavern '<layout>' large_cavern '' small_cavern ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js large_cavern '<layout>' '' golden_gate cavern ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js small_cavern '<layout>' cavern '' '' ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js whistle_room '<layout>' '' dungeon cavern ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js golden_gate '<layout>' '' '' '' large_cavern
+node scripts/supporting/append-room.js modules/pit-bas.module.js dungeon '<layout>' river_room '' glass_room whistle_room
+node scripts/supporting/append-room.js modules/pit-bas.module.js river_room '<layout>' bandit_room green_house dungeon river_bed
+node scripts/supporting/append-room.js modules/pit-bas.module.js glass_room '<layout>' '' dungeon troll_room ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js bandit_room '<layout>' '' trophy_room river_room ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js green_house '<layout>' '' '' river_room ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js river_bed '<layout>' drain river_room '' ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js troll_room '<layout>' glass_room rag_room '' bright_room
+node scripts/supporting/append-room.js modules/pit-bas.module.js trophy_room '<layout>' '' '' '' bandit_room
+node scripts/supporting/append-room.js modules/pit-bas.module.js drain '<layout>' '' rapid_water river_bed ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js rag_room '<layout>' troll_room whisper_room '' ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js bright_room '<layout>' white_room troll_room pointless_room ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js rapid_water '<layout>' '' drain '' shore
+node scripts/supporting/append-room.js modules/pit-bas.module.js pointless_room '<layout>' '' '' bright_room ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js white_room '<layout>' '' wizard_room bright_room ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js shore '<layout>' roof_of_house rapid_water '' alice_room
+node scripts/supporting/append-room.js modules/pit-bas.module.js whisper_room '<layout>' maze_2800 maze_2900 '' rag_room
+node scripts/supporting/append-room.js modules/pit-bas.module.js wizard_room '<layout>' lightning_room north_south_passage in_a_box white_room
+node scripts/supporting/append-room.js modules/pit-bas.module.js roof_of_house '<layout>' lightning_room north_south_passage shore ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js alice_room '<layout>' '' shore '' mirror_alice_room
+node scripts/supporting/append-room.js modules/pit-bas.module.js lightning_room '<layout>' roof_of_house '' wizard_room ''
+node scripts/supporting/append-room.js modules/pit-bas.module.js magician_book_room '<layout>' '' '' '5800' air_room
+node scripts/supporting/append-room.js modules/pit-bas.module.js air_room '<layout>' '' magician_book_room '' west_hall
+node scripts/supporting/append-room.js modules/pit-bas.module.js maze_small_room '<layout>' dead_end maze_3700 '' maze_3500
+node scripts/supporting/append-room.js modules/pit-bas.module.js bee_room '<layout>' maze_2900 merchant_room '' flute_room
+
+# Items
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'magic_lightbulb',name:'Magic Lightbulb',type:'quest',map:'cavern',x:3,y:3});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'whistle',name:'Whistle',type:'quest',map:'whistle_room',x:2,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'silver_medallion',name:'Silver Medallion',type:'quest',map:'dungeon',x:2,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'mace',name:'Mace',type:'quest',map:'dungeon',x:3,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'axe',name:'Axe',type:'quest',map:'dungeon',x:1,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'canteen',name:'Canteen',type:'quest',map:'river_room',x:2,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'diamond_ring',name:'Diamond Ring',type:'quest',map:'river_bed',x:2,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'key',name:'Key',type:'quest',map:'merchant_room',x:2,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'air_tanks',name:'Air Tanks',type:'quest',map:'air_room',x:2,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'sunglasses',name:'Sunglasses',type:'quest',map:'rag_room',x:2,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'bright_sphere',name:'Bright Sphere',type:'quest',map:'bright_room',x:2,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+node -e "import fs from 'node:fs';const m=JSON.parse(fs.readFileSync('modules/pit-bas.module.js','utf8'));m.items.push({id:'lightning_rod',name:'Lightning Rod',type:'quest',map:'roof_of_house',x:2,y:2});fs.writeFileSync('modules/pit-bas.module.js',JSON.stringify(m,null,2));"
+```
 


### PR DESCRIPTION
## Summary
- note BASIC line numbers for each PIT.BAS room
- fix room connection list to match source, including Green House link
- add command block for building rooms and items in the module

## Testing
- `npm test` *(failed: terminated early)*
- `node scripts/supporting/presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68bd9c8fed048328bd9c93ad7e2d9005