### PR TITLE
docs: add portraits to team bios

### DIFF
--- a/docs/team/bios.md
+++ b/docs/team/bios.md
@@ -1,24 +1,28 @@
 # Team Bios
 
 ## Riley "Clown" Morgan
+![Portrait of Riley "Clown" Morgan](clown.png)
 - **Background:** Hacker-artist steering our neon wasteland carnival.
 - **Skills:** Mod-friendly coding, quick sketches, collaborative worldbuilding.
 - **Interests:** Cyberpunk runs, doppelgängers, open-source mischief.
 - **Contributions:** Drafted the Spoils Caches loot system for post-fight rewards.
 
 ## Alex "Echo" Johnson
+![Portrait of Alex "Echo" Johnson](echo.png)
 - **Background:** Former indie comics writer who migrated to games to build interactive stories.
 - **Skills:** World-building, character arcs, moody dialogue.
 - **Interests:** Dystopian caravans, synth music, dusty sunsets.
 - **Contributions:** Shaped fast-travel bunkers, dynamic weather, persona masks, the True Dust module, and plot outlines.
 
 ## Priya "Gizmo" Sharma
+![Portrait of Priya "Gizmo" Sharma](gizmo.png)
 - **Background:** Tools engineer obsessed with clean pipelines and happy teammates.
 - **Skills:** Debugging, editor automation, modular architecture.
 - **Interests:** Accessible UIs, open-source gadgets, spicy snacks.
 - **Contributions:** Planned multiplayer sessions, trader economy tweaks, HUD and trainer UI passes, creator wizards, and tech-debt cleanup.
 
 ## Mateo "Wing" Alvarez
+![Portrait of Mateo "Wing" Alvarez](wing.png)
 - **Background:** Ex-speedrunner who designs encounters with a stopwatch in hand.
 - **Skills:** Combat tuning, user testing, rapid iteration.
 - **Interests:** High-tempo action, fair challenges, retro mechs.


### PR DESCRIPTION
## Summary
- display portraits for each member on the team bios page

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd74c89ce08328b239a39529e99198