### PR TITLE
fix: parse module data on windows

### DIFF
--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -13,10 +13,10 @@ function loadModuleSrc() {
 
 function loadModuleData() {
   const src = loadModuleSrc();
-  const DATA_START = 'const DATA = `\n';
-  const start = src.indexOf(DATA_START) + DATA_START.length;
-  const end = src.indexOf('`', start);
-  return JSON.parse(src.slice(start, end));
+  const MARKER = 'const DATA = `';
+  const start = src.indexOf(MARKER);
+  const end = src.indexOf('`', start + MARKER.length);
+  return JSON.parse(src.slice(start + MARKER.length, end));
 }
 
 test('dustland module includes patrolling enemy', () => {

--- a/test/respec-vendor.test.js
+++ b/test/respec-vendor.test.js
@@ -8,10 +8,10 @@ function loadModuleData() {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const file = path.join(__dirname, '..', 'modules', 'dustland.module.js');
   const src = fs.readFileSync(file, 'utf8');
-  const DATA_START = 'const DATA = `\n';
-  const start = src.indexOf(DATA_START) + DATA_START.length;
-  const end = src.indexOf('`', start);
-  return JSON.parse(src.slice(start, end));
+  const MARKER = 'const DATA = `';
+  const start = src.indexOf(MARKER);
+  const end = src.indexOf('`', start + MARKER.length);
+  return JSON.parse(src.slice(start + MARKER.length, end));
 }
 
 test('dustland module includes respec vendor', () => {

--- a/test/slot-machine.module.test.js
+++ b/test/slot-machine.module.test.js
@@ -9,10 +9,10 @@ function loadModuleData() {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const file = path.join(__dirname, '..', 'modules', 'dustland.module.js');
   const src = fs.readFileSync(file, 'utf8');
-  const DATA_START = 'const DATA = `\n';
-  const start = src.indexOf(DATA_START) + DATA_START.length;
-  const end = src.indexOf('`', start);
-  return JSON.parse(src.slice(start, end));
+  const MARKER = 'const DATA = `';
+  const start = src.indexOf(MARKER);
+  const end = src.indexOf('`', start + MARKER.length);
+  return JSON.parse(src.slice(start + MARKER.length, end));
 }
 
 test('dustland module adds slot shack with gambling options', () => {

--- a/test/trainer-npcs.test.js
+++ b/test/trainer-npcs.test.js
@@ -20,10 +20,10 @@ function setupParty(){
 }
 
 const moduleSrc = await fs.readFile(new URL('../modules/dustland.module.js', import.meta.url), 'utf8');
-const DATA_START = 'const DATA = `\n';
-const start = moduleSrc.indexOf(DATA_START) + DATA_START.length;
-const end = moduleSrc.indexOf('`', start);
-const moduleData = JSON.parse(moduleSrc.slice(start, end));
+const MARKER = 'const DATA = `';
+const start = moduleSrc.indexOf(MARKER);
+const end = moduleSrc.indexOf('`', start + MARKER.length);
+const moduleData = JSON.parse(moduleSrc.slice(start + MARKER.length, end));
 
 test('trainStat spends a point and raises stat', () => {
   const ctx = setupParty();


### PR DESCRIPTION
## Summary
- make module-data tests robust to CRLF line endings

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdc47028948328ba3941e54703b211