### PR TITLE
fix: enable arrow portals and adjust whistle entry

### DIFF
--- a/data/modules/pit-bas.json
+++ b/data/modules/pit-bas.json
@@ -184,7 +184,7 @@
       "y": 3,
       "toMap": "whistle_room",
       "toX": 2,
-      "toY": 1
+      "toY": 2
     },
     {
       "map": "golden_gate",

--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -187,7 +187,7 @@ const DATA = `
       "y": 3,
       "toMap": "whistle_room",
       "toX": 2,
-      "toY": 1
+      "toY": 2
     },
     {
       "map": "golden_gate",

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -438,40 +438,42 @@ function interactAt(x, y) {
     bus.emit('sfx', 'pickup');
     return true;
   }
-  if(x===party.x && y===party.y && info.tile===TILE.DOOR){
-    if(state.map==='world'){
-      const b=buildings.find(b=> b.doorX===x && b.doorY===y);
-      if(!b){ log('No entrance here.'); bus.emit('sfx','denied'); return true; }
-      if(b.boarded){ log('The doorway is boarded up from the outside.'); bus.emit('sfx','denied'); return true; }
-      const I=interiors[b.interiorId];
-      if(I){ setPartyPos(I.entryX, I.entryY); }
-      setMap(b.interiorId,'Interior');
-      log('You step inside.'); updateHUD();
+  if(x===party.x && y===party.y){
+    const p=portals.find(p=> p.map===state.map && p.x===x && p.y===y);
+    if(p){
+      const target=p.toMap;
+      const I=interiors[target];
+      const px = (typeof p.toX==='number') ? p.toX : (I?I.entryX:0);
+      const py = (typeof p.toY==='number') ? p.toY : (I?I.entryY:0);
+      setPartyPos(px, py);
+      setMap(target);
+      log(p.desc || 'You move through the doorway.');
+      updateHUD();
       bus.emit('sfx','confirm');
       return true;
     }
-    if(state.map!=='world'){
-      const p=portals.find(p=> p.map===state.map && p.x===x && p.y===y);
-      if(p){
-        const target=p.toMap;
-        const I=interiors[target];
-        const px = (typeof p.toX==='number') ? p.toX : (I?I.entryX:0);
-        const py = (typeof p.toY==='number') ? p.toY : (I?I.entryY:0);
-        setPartyPos(px, py);
-        setMap(target);
-        log(p.desc || 'You move through the doorway.');
-        updateHUD();
+    if(info.tile===TILE.DOOR){
+      if(state.map==='world'){
+        const b=buildings.find(b=> b.doorX===x && b.doorY===y);
+        if(!b){ log('No entrance here.'); bus.emit('sfx','denied'); return true; }
+        if(b.boarded){ log('The doorway is boarded up from the outside.'); bus.emit('sfx','denied'); return true; }
+        const I=interiors[b.interiorId];
+        if(I){ setPartyPos(I.entryX, I.entryY); }
+        setMap(b.interiorId,'Interior');
+        log('You step inside.'); updateHUD();
         bus.emit('sfx','confirm');
         return true;
       }
-      const b=buildings.find(b=> b.interiorId===state.map);
-      if(b){
-        setPartyPos(b.doorX, b.doorY);
-        setMap('world');
-        log('You step back outside.');
-        updateHUD();
-        bus.emit('sfx','confirm');
-        return true;
+      if(state.map!=='world'){
+        const b=buildings.find(b=> b.interiorId===state.map);
+        if(b){
+          setPartyPos(b.doorX, b.doorY);
+          setMap('world');
+          log('You step back outside.');
+          updateHUD();
+          bus.emit('sfx','confirm');
+          return true;
+        }
       }
     }
   }

--- a/test/whistle-room-portal.test.js
+++ b/test/whistle-room-portal.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+global.window = globalThis;
+global.TILE = { FLOOR:0, DOOR:8 };
+global.walkable = { 0:true, 8:true };
+global.itemDrops = [];
+global.NPCS = [];
+global.state = { map:'cavern' };
+const handlers = {};
+const bus = { on:(e,f)=>{ (handlers[e]=handlers[e]||[]).push(f); }, emit:(e,p)=>{ (handlers[e]||[]).forEach(fn=>fn(p)); } };
+global.EventBus = bus;
+global.Dustland = { eventBus: bus };
+
+global.portals = [ { map:'cavern', x:0, y:0, toMap:'whistle_room', toX:1, toY:1 } ];
+global.buildings = [];
+
+global.interiors = {
+  cavern: { grid:[[0]] },
+  whistle_room: { grid:[[0,0],[0,0]] }
+};
+
+global.world = [[0]];
+
+global.player = { inv:[] };
+global.lastInteract = 0;
+function getTile(map,x,y){ return interiors[map].grid[y][x]; }
+function setTile(map,x,y,t){ interiors[map].grid[y][x]=t; }
+function setPartyPos(x,y){ party.x=x; party.y=y; }
+function setMap(map){ state.map=map; party.map=map; }
+
+global.getTile = getTile;
+global.setTile = setTile;
+global.setPartyPos = setPartyPos;
+global.setMap = setMap;
+global.log = () => {};
+global.updateHUD = () => {};
+global.getPartyInventoryCapacity = () => 10;
+
+global.party = [{ hp:10 }];
+party.x = 0; party.y = 0; party.map = 'cavern';
+
+await import('../scripts/core/movement.js');
+
+test('interact moves through portal on floor tile', () => {
+  assert.strictEqual(state.map, 'cavern');
+  interactionSystem.interact();
+  assert.strictEqual(state.map, 'whistle_room');
+  assert.strictEqual(party.x, 1);
+  assert.strictEqual(party.y, 1);
+});


### PR DESCRIPTION
## Summary
- allow interact to follow portals even when standing on non-door tiles
- spawn party on open ground when descending to the whistle room
- add test covering floor-tile portals

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc6f4fba4832892af487719d9cb66