### PR TITLE
fix: mark vertical portals in append-room

### DIFF
--- a/scripts/supporting/append-room.js
+++ b/scripts/supporting/append-room.js
@@ -34,7 +34,7 @@ const w = 5;
 const h = 5;
 const grid = Array.from({ length: h }, (_, y) =>
   Array.from({ length: w }, (_, x) =>
-    y === 0 || y === h - 1 || x === 0 || x === w - 1 ? '🧱' : '🏝'
+    y === 0 || y === h - 1 || x === 0 || x === w - 1 ? '🧱' : '⬜'
   )
 );
 
@@ -42,8 +42,8 @@ if (links.N) grid[0][2] = '🚪';
 if (links.E) grid[2][4] = '🚪';
 if (links.S) grid[4][2] = '🚪';
 if (links.W) grid[2][0] = '🚪';
-if (links.U) grid[1][2] = '⬆️';
-if (links.D) grid[3][2] = '⬇️';
+if (links.U) grid[1][2] = 'U';
+if (links.D) grid[3][2] = 'D';
 
 mod.interiors.push({ id, w, h, grid: grid.map(r => r.join('')), entryX: 2, entryY: 2 });
 

--- a/test/append-room.helper.test.js
+++ b/test/append-room.helper.test.js
@@ -5,24 +5,26 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
-test.skip('append-room inserts and replaces directional exits', async () => {
+test('append-room visualizes vertical portals and walls', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'append-room-'));
   const file = path.join(dir, 'mod.json');
-  const init = {
-    interiors: [{ id: 'start', w: 3, h: 3, grid: ['🧱🧱🧱', '🧱🏝🧱', '🧱🧱🧱'], entryX: 1, entryY: 1 }],
-    portals: []
-  };
+  const init = { interiors: [], portals: [] };
   await fs.writeFile(file, JSON.stringify(init, null, 2));
   const script = path.join('scripts', 'supporting', 'append-room.js');
 
-  let res = spawnSync('node', [script, file, 'new', 'xxpxx,x   x,x   x,x   x,xxxxx', 'start']);
+  const res = spawnSync('node', [script, file, 'shaft', 'U:upper', 'D:lower']);
   assert.strictEqual(res.status, 0);
-  let data = JSON.parse(await fs.readFile(file, 'utf8'));
-  assert.ok(data.portals.find(p => p.map === 'new' && p.x === 2 && p.y === 0 && p.toMap === 'start'));
 
-  res = spawnSync('node', [script, file, 'new', 'xxxxx,x   x,x   x,x   x,xxpxx', '', '', 'start']);
-  assert.strictEqual(res.status, 0);
-  data = JSON.parse(await fs.readFile(file, 'utf8'));
-  assert.ok(data.portals.find(p => p.map === 'new' && p.x === 2 && p.y === 4 && p.toMap === 'start'));
-  assert.ok(!data.portals.find(p => p.map === 'new' && p.y === 0));
+  const data = JSON.parse(await fs.readFile(file, 'utf8'));
+  const room = data.interiors.find(r => r.id === 'shaft');
+  assert.ok(room);
+  assert.deepStrictEqual(room.grid, [
+    '🧱🧱🧱🧱🧱',
+    '🧱⬜U⬜🧱',
+    '🧱⬜⬜⬜🧱',
+    '🧱⬜D⬜🧱',
+    '🧱🧱🧱🧱🧱'
+  ]);
+  assert.ok(data.portals.some(p => p.map === 'shaft' && p.x === 2 && p.y === 1 && p.toMap === 'upper'));
+  assert.ok(data.portals.some(p => p.map === 'shaft' && p.x === 2 && p.y === 3 && p.toMap === 'lower'));
 });


### PR DESCRIPTION
## Summary
- render up and down portals with "U" and "D"
- use indoor floor tiles and keep walls around generated rooms
- test append-room visualizes vertical portals and walls

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd604bd308328a09f7f1299739a05