### PR TITLE
feat: add usable wand and zone reward

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -343,6 +343,19 @@ const DATA = `
       "use": {
         "effect": "vision"
       }
+    },
+    {
+      "map": "hall",
+      "x": 16,
+      "y": 18,
+      "id": "wand",
+      "name": "Wand",
+      "type": "quest",
+      "use": {
+        "type": "heal",
+        "amount": 0,
+        "text": "You wave the wand."
+      }
     }
   ],
   "quests": [
@@ -1991,6 +2004,18 @@ const DATA = `
         "msg": "Nanite swarm!"
       },
       "negate": "mask"
+    },
+    {
+      "map": "hall",
+      "x": 16,
+      "y": 18,
+      "w": 2,
+      "h": 1,
+      "useItem": {
+        "id": "wand",
+        "reward": "scrap 5",
+        "once": true
+      }
     }
   ],
   "name": "dustland-module",
@@ -2328,6 +2353,7 @@ function postLoad(module) {
       }
     };
   }
+
 
   // expose procedural map action for Adventure Kit
   module.generateMap = regen => globalThis.generateProceduralWorld?.(regen);

--- a/test/zone-use-item-event.test.js
+++ b/test/zone-use-item-event.test.js
@@ -46,6 +46,9 @@ vm.runInThisContext(invCode, { filename: 'core/inventory.js' });
 registerItem({ id:'mystic_key', name:'Mystic Key', type:'consumable', use:{ type:'heal', amount:0, text:'The key glows.' } });
 registerZoneEffects([{ map:'world', x:0, y:0, w:1, h:1, useItem:{ id:'mystic_key', reward:'scrap 5', once:true } }]);
 
+registerItem({ id:'wand', name:'Wand', type:'consumable', use:{ type:'heal', amount:0, text:'You wave the wand.' } });
+registerZoneEffects([{ map:'world', x:1, y:0, w:1, h:1, useItem:{ id:'wand', reward:'scrap 5', once:true } }]);
+
 test('zone rewards on item use and only once', () => {
   player.inv = [getItem('mystic_key')];
   useItem(0);
@@ -59,4 +62,14 @@ test('zone rewards on item use and only once', () => {
   player.inv = [getItem('mystic_key')];
   useItem(0);
   assert.strictEqual(player.scrap, 5);
+});
+
+test('wand triggers zone reward and logs use', () => {
+  logs.length = 0;
+  player.scrap = 0;
+  party.x = 1; party.y = 0;
+  player.inv = [getItem('wand')];
+  useItem(0);
+  assert.strictEqual(player.scrap, 5);
+  assert.ok(logs.includes('You wave the wand.'));
 });


### PR DESCRIPTION
## Summary
- add consumable wand item that logs when waved
- introduce hall zone reacting to wand use with a scrap reward
- test item-use event wiring for the wand

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdd6349d688328b28c17cb1e63f271