### PR TITLE
fix: allow stepping on items and render portals

### DIFF
--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -137,7 +137,8 @@ function queryTile(x,y,map=mapIdForState()){
   const items=itemDrops.filter(it=> it.map===map && it.x===x && it.y===y);
   // doors allow passage when unlocked
   const blocking=entities.some(e=> !(e.door && !e.locked));
-  const walkableFlag=!!(walkable[tile] && !blocking && items.length===0);
+  // Ground items no longer block movement; allow walking onto item tiles
+  const walkableFlag=!!(walkable[tile] && !blocking);
   return {tile, walkable:walkableFlag, entities, items};
 }
 // Find nearest free, walkable, unoccupied (and not water on world)

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -409,7 +409,7 @@ function centerCamera(x,y,map){
 }
 
 // ===== Drawing Pipeline =====
-const renderOrder = ['tiles', 'items', 'entitiesBelow', 'player', 'entitiesAbove'];
+const renderOrder = ['tiles', 'items', 'portals', 'entitiesBelow', 'player', 'entitiesAbove'];
 
 function render(gameState=state, dt){
   const ctx = sctx;
@@ -423,6 +423,7 @@ function render(gameState=state, dt){
   const offY = Math.max(0, Math.floor((vH - H) / 2));
 
   const items = gameState.itemDrops || itemDrops;
+  const ps = gameState.portals || portals;
   const entities = gameState.entities || (typeof NPCS !== 'undefined' ? NPCS : []);
   const pos = gameState.party || party;
 
@@ -481,6 +482,16 @@ function render(gameState=state, dt){
             ctx.fillStyle='#c8ffbf';
             ctx.fillRect(vx+4,vy+4,TS-8,TS-8);
           }
+        }
+      }
+    }
+    else if(layer==='portals'){
+      for(const p of ps){
+        if(p.map!==activeMap) continue;
+        if(p.x>=camX&&p.y>=camY&&p.x<camX+vW&&p.y<camY+vH){
+          const vx=(p.x-camX+offX)*TS, vy=(p.y-camY+offY)*TS;
+          ctx.strokeStyle='#f0f';
+          ctx.strokeRect(vx+2,vy+2,TS-4,TS-4);
         }
       }
     }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -413,7 +413,7 @@ test('queryTile reports entities and items', () => {
   assert.strictEqual(q.walkable,false);
   assert.strictEqual(q.entities.length,1);
   q=queryTile(2,0);
-  assert.strictEqual(q.walkable,false);
+  assert.strictEqual(q.walkable,true);
   assert.strictEqual(q.items.length,1);
 });
 

--- a/test/portal-render.test.js
+++ b/test/portal-render.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('portal layer renders above items', async () => {
+  const code = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
+  const orderSnippet = code.match(/const renderOrder = \[[^\]]+\]/)[0];
+  const renderOrder = vm.runInNewContext(orderSnippet + '; renderOrder;');
+  assert.ok(renderOrder.includes('portals'));
+  assert.ok(renderOrder.indexOf('portals') > renderOrder.indexOf('items'));
+  assert.match(code, /layer==='portals'/);
+});


### PR DESCRIPTION
## Summary
- allow movement onto tiles containing items
- draw portal overlays above items to make entrances visible
- add tests for walkability and portal rendering

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf133ecc483289463a6df12174fa5