### PR TITLE
fix: ignore lockfile before version pull

### DIFF
--- a/scripts/supporting/version-bump.js
+++ b/scripts/supporting/version-bump.js
@@ -62,6 +62,9 @@ function main() {
   sh(`git add ${pkgPath} ${enginePath}`);
   sh(`git commit -m "chore: bump version to ${next}"`);
   sh(`git tag v${next}`);
+  // Discard incidental lockfile changes from install steps.
+  // These would otherwise block the rebase pull below.
+  sh('git checkout -- package-lock.json');
   sh('git pull --rebase');
   sh('git push');
   sh('git push --tags');


### PR DESCRIPTION
## Summary
- avoid CI failures when version-bump runs after install steps by resetting package-lock.json before pulling

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bddb2cc1c88328bebf9b8292aa1fa8