### PR TITLE
feat: add lightning room hazard

### DIFF
--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -842,6 +842,14 @@ const DATA = `
       "toY": 2
     }
   ],
+  "events": [
+    {
+      "map": "lightning_room",
+      "x": 2,
+      "y": 2,
+      "events": [ { "when": "enter", "effect": "lightningZap" } ]
+    }
+  ],
   "interiors": [
     {
       "id": "cavern",
@@ -1298,6 +1306,16 @@ const DATA = `
 
 function postLoad(module) {
   log('You land in a shadowy cavern.');
+  module.effects = module.effects || {};
+  module.effects.lightningZap = () => {
+    if (hasItem('lightning_rod')) {
+      log('The lightning rod hums and deflects the bolt.');
+    } else {
+      log('A lightning bolt strikes! You tumble back to the cavern.');
+      setMap('cavern', 'Cavern');
+      setPartyPos(2, 2);
+    }
+  };
 }
 
 globalThis.PIT_BAS_MODULE = JSON.parse(DATA);

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -176,3 +176,41 @@ test('pit bas module defines basic npcs', () => {
     assert.ok(ids.includes(id));
   });
 });
+
+test('lightning room zaps without rod', () => {
+  const logs = [];
+  const context = { Math };
+  context.globalThis = context;
+  context.applyModule = () => {};
+  context.setPartyPos = (x, y) => { context.pos = { x, y }; };
+  context.setMap = map => { context.map = map; };
+  context.log = msg => logs.push(msg);
+  context.hasItem = () => false;
+  vm.runInNewContext(src, context);
+  context.PIT_BAS_MODULE.postLoad(context.PIT_BAS_MODULE);
+  logs.length = 0;
+  context.PIT_BAS_MODULE.effects.lightningZap();
+  assert.deepStrictEqual(logs, [
+    'A lightning bolt strikes! You tumble back to the cavern.'
+  ]);
+  assert.strictEqual(context.map, 'cavern');
+  assert.deepStrictEqual(context.pos, { x: 2, y: 2 });
+});
+
+test('lightning rod deflects bolt', () => {
+  const logs = [];
+  const context = { Math };
+  context.globalThis = context;
+  context.applyModule = () => {};
+  context.setPartyPos = () => {};
+  context.setMap = () => {};
+  context.log = msg => logs.push(msg);
+  context.hasItem = id => id === 'lightning_rod';
+  vm.runInNewContext(src, context);
+  context.PIT_BAS_MODULE.postLoad(context.PIT_BAS_MODULE);
+  logs.length = 0;
+  context.PIT_BAS_MODULE.effects.lightningZap();
+  assert.deepStrictEqual(logs, [
+    'The lightning rod hums and deflects the bolt.'
+  ]);
+});


### PR DESCRIPTION
## Summary
- add lightning room enter event that zaps players lacking the lightning rod
- cover lightning room behavior with tests

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf0de96448328ab68ab7873b0e7b5