### PR TITLE
fix: wire pit exits and combatants

### DIFF
--- a/data/modules/pit-bas.json
+++ b/data/modules/pit-bas.json
@@ -26,15 +26,14 @@
     {
       "id": "silver_medallion",
       "name": "Silver Medallion",
-      "type": "quest",
-      "map": "dungeon",
-      "x": 2,
-      "y": 2
+      "type": "quest"
     },
     {
       "id": "mace",
       "name": "Mace",
-      "type": "quest",
+      "type": "weapon",
+      "slot": "weapon",
+      "mods": { "ATK": 2, "ADR": 10 },
       "map": "dungeon",
       "x": 3,
       "y": 2
@@ -42,7 +41,9 @@
     {
       "id": "axe",
       "name": "Axe",
-      "type": "quest",
+      "type": "weapon",
+      "slot": "weapon",
+      "mods": { "ATK": 3, "ADR": 10 },
       "map": "dungeon",
       "x": 1,
       "y": 2
@@ -128,12 +129,13 @@
     "white_room": "White Room",
     "shore": "Shore",
     "whisper_room": "Whisper Room",
-    "wizard_room": "Wizard Room",
-    "roof_of_house": "Roof Of House",
-    "alice_room": "Alice Room",
-    "lightning_room": "Lightning Room",
-    "magician_book_room": "Magician Book Room",
-    "air_room": "Air Room",
+      "wizard_room": "Wizard Room",
+      "roof_of_house": "Roof Of House",
+      "alice_room": "Alice Room",
+      "mirror_alice_room": "Mirror Alice Room",
+      "lightning_room": "Lightning Room",
+      "magician_book_room": "Magician Book Room",
+      "air_room": "Air Room",
     "maze_small_room": "Maze Small Room",
     "bee_room": "Bee Room",
     "merchant_room": "Merchant Room",
@@ -300,6 +302,22 @@
       "toMap": "river_bed",
       "toX": 4,
       "toY": 2
+    },
+    {
+      "map": "dungeon",
+      "x": 2,
+      "y": 4,
+      "toMap": "troll_room",
+      "toX": 2,
+      "toY": 0
+    },
+    {
+      "map": "troll_room",
+      "x": 2,
+      "y": 0,
+      "toMap": "dungeon",
+      "toX": 2,
+      "toY": 4
     },
     {
       "map": "troll_room",
@@ -1036,7 +1054,7 @@
         "🧱🏝⬆️🏝🧱",
         "🧱🏝🏝🏝🧱",
         "🧱🏝⬇️🏝🧱",
-        "🧱🧱🧱🧱🧱"
+        "🧱🏝⬇️🏝🧱"
       ],
       "entryX": 2,
       "entryY": 2
@@ -1049,6 +1067,20 @@
         "🧱🧱🧱🧱🧱",
         "🧱🏝🏝🏝🧱",
         "🚪🏝🏝🏝🚪",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "mirror_alice_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🚪",
         "🧱🏝🏝🏝🧱",
         "🧱🧱🧱🧱🧱"
       ],

--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -29,15 +29,14 @@ const DATA = `
     {
       "id": "silver_medallion",
       "name": "Silver Medallion",
-      "type": "quest",
-      "map": "dungeon",
-      "x": 2,
-      "y": 2
+      "type": "quest"
     },
     {
       "id": "mace",
       "name": "Mace",
-      "type": "quest",
+      "type": "weapon",
+      "slot": "weapon",
+      "mods": { "ATK": 2, "ADR": 10 },
       "map": "dungeon",
       "x": 3,
       "y": 2
@@ -45,7 +44,9 @@ const DATA = `
     {
       "id": "axe",
       "name": "Axe",
-      "type": "quest",
+      "type": "weapon",
+      "slot": "weapon",
+      "mods": { "ATK": 3, "ADR": 10 },
       "map": "dungeon",
       "x": 1,
       "y": 2
@@ -117,14 +118,14 @@ const DATA = `
       "color": "#f88",
       "name": "Bandit",
       "prompt": "Tattered bandit eyeing you warily",
+      "desc": "It eyes your coin purse.",
+      "combat": { "HP": 6, "ATK": 2, "DEF": 1 },
       "tree": {
         "start": {
           "text": "The bandit watches your every move.",
           "choices": [
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
+            { "label": "(Fight)", "to": "do_fight" },
+            { "label": "(Leave)", "to": "bye" }
           ]
         }
       }
@@ -137,14 +138,14 @@ const DATA = `
       "color": "#f88",
       "name": "Troll",
       "prompt": "Menacing troll blocking the path",
+      "desc": "A hulking troll blocks the way.",
+      "combat": { "HP": 8, "ATK": 3, "DEF": 2 },
       "tree": {
         "start": {
           "text": "The troll snarls but does not attack.",
           "choices": [
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
+            { "label": "(Fight)", "to": "do_fight" },
+            { "label": "(Leave)", "to": "bye" }
           ]
         }
       }
@@ -181,10 +182,20 @@ const DATA = `
         "start": {
           "text": "The adventurer doesn't respond.",
           "choices": [
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
+            { "label": "(Loot)", "to": "loot" },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "loot": {
+          "text": "You search the body and find a medallion.",
+          "choices": [
+            { "label": "(Take Medallion)", "to": "empty", "reward": "silver_medallion" }
+          ]
+        },
+        "empty": {
+          "text": "The body has nothing else.",
+          "choices": [
+            { "label": "(Leave)", "to": "bye" }
           ]
         }
       }
@@ -197,14 +208,14 @@ const DATA = `
       "color": "#ff0",
       "name": "Bees",
       "prompt": "Swarm of buzzing bees",
+      "desc": "A furious swarm.",
+      "combat": { "HP": 3, "ATK": 1, "DEF": 0 },
       "tree": {
         "start": {
           "text": "The bees buzz around angrily.",
           "choices": [
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
+            { "label": "(Fight)", "to": "do_fight" },
+            { "label": "(Leave)", "to": "bye" }
           ]
         }
       }
@@ -257,14 +268,14 @@ const DATA = `
       "color": "#f88",
       "name": "Grue",
       "prompt": "Hungry grue lurking in the shadows",
+      "desc": "It hungers for light.",
+      "combat": { "HP": 10, "ATK": 4, "DEF": 2 },
       "tree": {
         "start": {
           "text": "It is dark. You are likely to be eaten by a grue.",
           "choices": [
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
+            { "label": "(Fight)", "to": "do_fight" },
+            { "label": "(Leave)", "to": "bye" }
           ]
         }
       }
@@ -295,6 +306,7 @@ const DATA = `
     "wizard_room": "Wizard Room",
     "roof_of_house": "Roof Of House",
     "alice_room": "Alice Room",
+    "mirror_alice_room": "Mirror Alice Room",
     "lightning_room": "Lightning Room",
     "magician_book_room": "Magician Book Room",
     "air_room": "Air Room",
@@ -468,6 +480,22 @@ const DATA = `
       "toMap": "river_bed",
       "toX": 4,
       "toY": 2
+    },
+    {
+      "map": "dungeon",
+      "x": 2,
+      "y": 4,
+      "toMap": "troll_room",
+      "toX": 2,
+      "toY": 0
+    },
+    {
+      "map": "troll_room",
+      "x": 2,
+      "y": 0,
+      "toMap": "dungeon",
+      "toX": 2,
+      "toY": 4
     },
     {
       "map": "troll_room",
@@ -1244,7 +1272,7 @@ const DATA = `
         "🧱🏝⬆️🏝🧱",
         "🧱🏝🏝🏝🧱",
         "🧱🏝⬇️🏝🧱",
-        "🧱🧱🧱🧱🧱"
+        "🧱🏝⬇️🏝🧱"
       ],
       "entryX": 2,
       "entryY": 2
@@ -1257,6 +1285,20 @@ const DATA = `
         "🧱🧱🧱🧱🧱",
         "🧱🏝🏝🏝🧱",
         "🚪🏝🏝🏝🚪",
+        "🧱🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "mirror_alice_room",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🚪",
         "🧱🏝🏝🏝🧱",
         "🧱🧱🧱🧱🧱"
       ],

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -33,13 +33,19 @@ test('pit bas module initializes rooms and items', () => {
     context.PIT_BAS_MODULE.items[0].id,
     'magic_lightbulb'
   );
-  assert.ok(context.PIT_BAS_MODULE.items.find(i => i.id === 'whistle'));
-  assert.ok(context.PIT_BAS_MODULE.items.find(i => i.id === 'key'));
-  assert.ok(
-    context.PIT_BAS_MODULE.portals.find(
-      p => p.map === 'cavern' && p.toMap === 'whistle_room'
-    )
-  );
+    assert.ok(context.PIT_BAS_MODULE.items.find(i => i.id === 'whistle'));
+    assert.ok(context.PIT_BAS_MODULE.items.find(i => i.id === 'key'));
+    const mace = context.PIT_BAS_MODULE.items.find(i => i.id === 'mace');
+    const axe = context.PIT_BAS_MODULE.items.find(i => i.id === 'axe');
+    assert.strictEqual(mace.type, 'weapon');
+    assert.strictEqual(mace.slot, 'weapon');
+    assert.strictEqual(axe.type, 'weapon');
+    assert.strictEqual(axe.slot, 'weapon');
+    assert.ok(
+      context.PIT_BAS_MODULE.portals.find(
+        p => p.map === 'cavern' && p.toMap === 'whistle_room'
+      )
+    );
   assert.ok(
     context.PIT_BAS_MODULE.interiors.find(r => r.id === 'small_cavern')
   );
@@ -56,16 +62,26 @@ test('pit bas module initializes rooms and items', () => {
       p => p.map === 'whistle_room' && p.toMap === 'dungeon'
     )
   );
-  const smallReturn = context.PIT_BAS_MODULE.portals.find(
-    p => p.map === 'small_cavern' && p.toMap === 'cavern'
-  );
-  assert.deepStrictEqual(
-    { x: smallReturn.x, y: smallReturn.y },
-    { x: 2, y: 0 }
-  );
-  const beeToMerchant = context.PIT_BAS_MODULE.portals.find(
-    p => p.map === 'bee_room' && p.toMap === 'merchant_room'
-  );
+    const smallReturn = context.PIT_BAS_MODULE.portals.find(
+      p => p.map === 'small_cavern' && p.toMap === 'cavern'
+    );
+    assert.deepStrictEqual(
+      { x: smallReturn.x, y: smallReturn.y },
+      { x: 2, y: 0 }
+    );
+    assert.ok(
+      context.PIT_BAS_MODULE.portals.find(
+        p => p.map === 'dungeon' && p.toMap === 'troll_room'
+      )
+    );
+    assert.ok(
+      context.PIT_BAS_MODULE.portals.find(
+        p => p.map === 'troll_room' && p.toMap === 'dungeon'
+      )
+    );
+    const beeToMerchant = context.PIT_BAS_MODULE.portals.find(
+      p => p.map === 'bee_room' && p.toMap === 'merchant_room'
+    );
   assert.ok(beeToMerchant);
   const merchantToBee = context.PIT_BAS_MODULE.portals.find(
     p => p.map === 'merchant_room' && p.toMap === 'bee_room'
@@ -99,9 +115,10 @@ test('pit bas module initializes rooms and items', () => {
     'white_room',
     'whisper_room',
     'wizard_room',
-    'alice_room',
-    'lightning_room',
-    'magician_book_room',
+      'alice_room',
+      'mirror_alice_room',
+      'lightning_room',
+      'magician_book_room',
     'air_room',
     'maze_small_room',
     'dead_end',
@@ -130,18 +147,22 @@ test('pit bas module initializes rooms and items', () => {
     context.PIT_BAS_MODULE.mapLabels.merchant_room,
     'Merchant Room'
   );
-  assert.strictEqual(
-    context.PIT_BAS_MODULE.mapLabels.flute_room,
-    'Flute Room'
-  );
-  assert.strictEqual(
-    context.PIT_BAS_MODULE.mapLabels.dead_end,
-    'Dead End'
-  );
-  const listing = Buffer.from(
-    context.PIT_BAS_MODULE.listing,
-    'base64'
-  ).toString();
+    assert.strictEqual(
+      context.PIT_BAS_MODULE.mapLabels.flute_room,
+      'Flute Room'
+    );
+    assert.strictEqual(
+      context.PIT_BAS_MODULE.mapLabels.dead_end,
+      'Dead End'
+    );
+    assert.strictEqual(
+      context.PIT_BAS_MODULE.mapLabels.mirror_alice_room,
+      'Mirror Alice Room'
+    );
+    const listing = Buffer.from(
+      context.PIT_BAS_MODULE.listing,
+      'base64'
+    ).toString();
   assert.ok(listing.startsWith('0 COLOR 15'));
 });
 
@@ -180,6 +201,14 @@ test('pit bas module defines basic npcs', () => {
   expected.forEach(id => {
     assert.ok(ids.includes(id));
   });
+  const bandit = context.PIT_BAS_MODULE.npcs.find(n => n.id === 'bandit');
+  const troll = context.PIT_BAS_MODULE.npcs.find(n => n.id === 'troll');
+  const bees = context.PIT_BAS_MODULE.npcs.find(n => n.id === 'bees');
+  const grue = context.PIT_BAS_MODULE.npcs.find(n => n.id === 'grue');
+  [bandit, troll, bees, grue].forEach(n => assert.ok(n.combat));
+  const dead = context.PIT_BAS_MODULE.npcs.find(n => n.id === 'dead_adventurer');
+  assert.ok(dead.tree.start.choices.some(c => c.label === '(Loot)'));
+  assert.ok(dead.tree.loot.choices.some(c => c.reward === 'silver_medallion'));
 });
 
 test('lightning room zaps without rod', () => {


### PR DESCRIPTION
## Summary
- make bandit, troll, bees, and grue actual combat NPCs
- convert dungeon weapons to equippable gear and hide medallion in loot dialog
- fix pit portal links and add Mirror Alice Room

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68be08657f388328a13b1f954147aec4