### PR TITLE
feat: merchant quest awards golden gate key

### DIFF
--- a/data/modules/pit-bas.json
+++ b/data/modules/pit-bas.json
@@ -13,7 +13,8 @@
       "type": "quest",
       "map": "cavern",
       "x": 3,
-      "y": 3
+      "y": 3,
+      "tags": ["treasure"]
     },
     {
       "id": "whistle",
@@ -21,12 +22,14 @@
       "type": "quest",
       "map": "whistle_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "silver_medallion",
       "name": "Silver Medallion",
-      "type": "quest"
+      "type": "quest",
+      "tags": ["treasure"]
     },
     {
       "id": "mace",
@@ -36,7 +39,8 @@
       "mods": { "ATK": 2, "ADR": 10 },
       "map": "dungeon",
       "x": 3,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "axe",
@@ -46,7 +50,8 @@
       "mods": { "ATK": 3, "ADR": 10 },
       "map": "dungeon",
       "x": 1,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "canteen",
@@ -54,7 +59,8 @@
       "type": "quest",
       "map": "river_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "diamond_ring",
@@ -62,15 +68,14 @@
       "type": "quest",
       "map": "river_bed",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "key",
       "name": "Key",
       "type": "quest",
-      "map": "merchant_room",
-      "x": 2,
-      "y": 2
+      "tags": ["key"]
     },
     {
       "id": "air_tanks",
@@ -78,7 +83,8 @@
       "type": "quest",
       "map": "air_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "sunglasses",
@@ -86,7 +92,8 @@
       "type": "quest",
       "map": "rag_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "bright_sphere",
@@ -94,7 +101,8 @@
       "type": "quest",
       "map": "bright_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "lightning_rod",
@@ -102,10 +110,20 @@
       "type": "quest",
       "map": "roof_of_house",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     }
   ],
-  "quests": [],
+  "quests": [
+    {
+      "id": "q_treasure",
+      "title": "Merchant's Hoard",
+      "desc": "Collect all valuables for the merchant.",
+      "item": "treasure",
+      "count": 11,
+      "reward": "key"
+    }
+  ],
   "npcs": [],
   "mapLabels": {
     "cavern": "Cavern",

--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -16,7 +16,8 @@ const DATA = `
       "type": "quest",
       "map": "cavern",
       "x": 3,
-      "y": 3
+      "y": 3,
+      "tags": ["treasure"]
     },
     {
       "id": "whistle",
@@ -24,12 +25,14 @@ const DATA = `
       "type": "quest",
       "map": "whistle_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "silver_medallion",
       "name": "Silver Medallion",
-      "type": "quest"
+      "type": "quest",
+      "tags": ["treasure"]
     },
     {
       "id": "mace",
@@ -39,7 +42,8 @@ const DATA = `
       "mods": { "ATK": 2, "ADR": 10 },
       "map": "dungeon",
       "x": 3,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "axe",
@@ -49,7 +53,8 @@ const DATA = `
       "mods": { "ATK": 3, "ADR": 10 },
       "map": "dungeon",
       "x": 1,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "canteen",
@@ -57,7 +62,8 @@ const DATA = `
       "type": "quest",
       "map": "river_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "diamond_ring",
@@ -65,15 +71,14 @@ const DATA = `
       "type": "quest",
       "map": "river_bed",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "key",
       "name": "Key",
       "type": "quest",
-      "map": "merchant_room",
-      "x": 2,
-      "y": 2
+      "tags": ["key"]
     },
     {
       "id": "air_tanks",
@@ -81,7 +86,8 @@ const DATA = `
       "type": "quest",
       "map": "air_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "sunglasses",
@@ -89,7 +95,8 @@ const DATA = `
       "type": "quest",
       "map": "rag_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "bright_sphere",
@@ -97,7 +104,8 @@ const DATA = `
       "type": "quest",
       "map": "bright_room",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     },
     {
       "id": "lightning_rod",
@@ -105,10 +113,20 @@ const DATA = `
       "type": "quest",
       "map": "roof_of_house",
       "x": 2,
-      "y": 2
+      "y": 2,
+      "tags": ["treasure"]
     }
   ],
-  "quests": [],
+  "quests": [
+    {
+      "id": "q_treasure",
+      "title": "Merchant's Hoard",
+      "desc": "Collect all valuables for the merchant.",
+      "item": "treasure",
+      "count": 11,
+      "reward": "key"
+    }
+  ],
   "npcs": [
     {
       "id": "bandit",
@@ -158,15 +176,51 @@ const DATA = `
       "color": "#a9f59f",
       "name": "Merchant",
       "prompt": "Wary merchant guarding his wares",
+      "questId": "q_treasure",
       "tree": {
         "start": {
-          "text": "The merchant adjusts his pack.",
+          "text": "Bring me all valuables from the pit and I'll hand over the key.",
           "choices": [
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
+            { "label": "(Accept)", "to": "accept", "q": "accept" },
+            { "label": "(Turn in valuables)", "to": "turnin", "q": "turnin" },
+            { "label": "(Leave)", "to": "bye" }
           ]
+        },
+        "accept": {
+          "text": "I'll be waiting.",
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        },
+        "turnin": {
+          "text": "The merchant counts the haul and hands you a key.",
+          "choices": [ { "label": "(Take Key)", "to": "bye" } ]
+        }
+      }
+    },
+    {
+      "id": "golden_gate_door",
+      "map": "large_cavern",
+      "x": 4,
+      "y": 2,
+      "color": "#a9f59f",
+      "name": "Golden Gate",
+      "prompt": "Gate shimmering with golden light",
+      "door": true,
+      "locked": true,
+      "tree": {
+        "locked": {
+          "text": "The gate is locked.",
+          "choices": [
+            { "label": "(Use Key)", "to": "open", "once": true, "reqItem": "key", "effects": [ { "effect": "unlockNPC", "npcId": "golden_gate_door" } ] },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "open": {
+          "text": "The gate swings open.",
+          "choices": [ { "label": "(Enter)", "to": "enter" } ]
+        },
+        "enter": {
+          "text": "You step through the golden gate.",
+          "choices": [ { "label": "(Continue)", "to": "bye", "goto": { "map": "golden_gate", "x": 2, "y": 2 } } ]
         }
       }
     },

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -34,13 +34,40 @@ test('pit bas module initializes rooms and items', () => {
     'magic_lightbulb'
   );
     assert.ok(context.PIT_BAS_MODULE.items.find(i => i.id === 'whistle'));
-    assert.ok(context.PIT_BAS_MODULE.items.find(i => i.id === 'key'));
+    const key = context.PIT_BAS_MODULE.items.find(i => i.id === 'key');
+    assert.ok(key && key.tags && key.tags.includes('key') && !key.map);
+    const treasureIds = [
+      'magic_lightbulb',
+      'whistle',
+      'silver_medallion',
+      'mace',
+      'axe',
+      'canteen',
+      'diamond_ring',
+      'air_tanks',
+      'sunglasses',
+      'bright_sphere',
+      'lightning_rod'
+    ];
+    treasureIds.forEach(id => {
+      const it = context.PIT_BAS_MODULE.items.find(i => i.id === id);
+      assert.ok(it && it.tags && it.tags.includes('treasure'));
+    });
     const mace = context.PIT_BAS_MODULE.items.find(i => i.id === 'mace');
     const axe = context.PIT_BAS_MODULE.items.find(i => i.id === 'axe');
     assert.strictEqual(mace.type, 'weapon');
     assert.strictEqual(mace.slot, 'weapon');
     assert.strictEqual(axe.type, 'weapon');
     assert.strictEqual(axe.slot, 'weapon');
+    const quest = context.PIT_BAS_MODULE.quests.find(q => q.id === 'q_treasure');
+    assert.ok(quest);
+    assert.strictEqual(quest.item, 'treasure');
+    assert.strictEqual(quest.count, 11);
+    const merchant = context.PIT_BAS_MODULE.npcs.find(n => n.id === 'merchant');
+    assert.strictEqual(merchant.questId, 'q_treasure');
+    assert.ok(merchant.tree.start.choices.some(c => c.q === 'turnin'));
+    const gate = context.PIT_BAS_MODULE.npcs.find(n => n.id === 'golden_gate_door');
+    assert.ok(gate && gate.locked && gate.door);
     assert.ok(
       context.PIT_BAS_MODULE.portals.find(
         p => p.map === 'cavern' && p.toMap === 'whistle_room'
@@ -220,6 +247,7 @@ test('pit bas module defines basic npcs', () => {
     'bandit',
     'troll',
     'merchant',
+    'golden_gate_door',
     'dead_adventurer',
     'bees',
     'wizard',


### PR DESCRIPTION
## Summary
- tag pit treasures as quest items and add merchant quest to trade them for the golden key
- require the key to unlock a new golden gate door
- test treasure tags, merchant quest, and gate door

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`

------
https://chatgpt.com/codex/tasks/task_e_68be3e19e1708328a092c870488a7a25