### PR TITLE
feat: require air tanks in pit module river

### DIFF
--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -1019,6 +1019,18 @@ const DATA = `
       "x": 2,
       "y": 2,
       "events": [ { "when": "enter", "effect": "lightningZap" } ]
+    },
+    {
+      "map": "river_bed",
+      "x": 4,
+      "y": 2,
+      "events": [ { "when": "enter", "effect": "requireAirTanks" } ]
+    },
+    {
+      "map": "river_bed",
+      "x": 2,
+      "y": 0,
+      "events": [ { "when": "enter", "effect": "requireAirTanks" } ]
     }
   ],
   "interiors": [
@@ -1584,6 +1596,13 @@ function postLoad(module) {
       log('A lightning bolt strikes! You tumble back to the cavern.');
       setMap('cavern', 'Cavern');
       setPartyPos(2, 2);
+    }
+  };
+  module.effects.requireAirTanks = () => {
+    if (!hasItem('air_tanks')) {
+      log('You need air tanks to go underwater.');
+      setMap('river_room', 'River Room');
+      setPartyPos(0, 2);
     }
   };
 }

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -276,3 +276,27 @@ test('lightning rod deflects bolt', () => {
     'The lightning rod hums and deflects the bolt.'
   ]);
 });
+
+test('river bed requires air tanks', () => {
+  const logs = [];
+  const context = { Math };
+  context.globalThis = context;
+  context.applyModule = () => {};
+  context.setPartyPos = (x, y) => { context.pos = { x, y }; };
+  context.setMap = map => { context.map = map; };
+  context.log = msg => logs.push(msg);
+  context.hasItem = () => false;
+  vm.runInNewContext(src, context);
+  context.PIT_BAS_MODULE.postLoad(context.PIT_BAS_MODULE);
+  logs.length = 0;
+  context.PIT_BAS_MODULE.effects.requireAirTanks();
+  assert.deepStrictEqual(logs, ['You need air tanks to go underwater.']);
+  assert.strictEqual(context.map, 'river_room');
+  assert.deepStrictEqual(context.pos, { x: 0, y: 2 });
+  const entries = context.PIT_BAS_MODULE.events.filter(e => e.map === 'river_bed');
+  assert.ok(entries.some(e => e.x === 4 && e.y === 2));
+  assert.ok(entries.some(e => e.x === 2 && e.y === 0));
+  entries.forEach(e => {
+    assert.ok(e.events.some(ev => ev.effect === 'requireAirTanks'));
+  });
+});


### PR DESCRIPTION
## Summary
- block entry to the river bed unless the party has air tanks
- add unit test covering the air tank requirement

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68be3e3d73cc8328801b1f31ebeffaf7