### PR TITLE
fix: respawn returns players to cavern

### DIFF
--- a/modules/pit-bas.module.js
+++ b/modules/pit-bas.module.js
@@ -1595,6 +1595,6 @@ startGame = function () {
   PIT_BAS_MODULE.postLoad?.(PIT_BAS_MODULE);
   applyModule(PIT_BAS_MODULE);
   const s = PIT_BAS_MODULE.start || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
-  setPartyPos(s.x, s.y);
   setMap(s.map, s.map === 'world' ? 'Wastes' : undefined);
+  setPartyPos(s.x, s.y);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dustland",
-  "version": "0.80.0",
+  "version": "0.81.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dustland",
-      "version": "0.80.0",
+      "version": "0.81.2",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   "license": "MIT",
   "devDependencies": {
     "eslint": "^8.57.1",
+    "eslint-plugin-jsdoc": "^48.0.3",
     "http-server": "^14.1.1",
     "jsdom": "^26.1.0",
     "puppeteer": "^24.17.0",
     "ws": "^8.18.3",
-    "yaml-lint": "^1.7.0",
-    "eslint-plugin-jsdoc": "^48.0.3"
+    "yaml-lint": "^1.7.0"
   }
 }

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -237,9 +237,11 @@ function closeCombat(result = 'flee'){
   party.restore();
 
   if(result === 'bruise' && state.mapEntry){
+    const entry = state.mapEntry;
     log?.('You wake up at the entrance.');
     if(typeof toast==='function') toast('You wake up at the entrance.');
-    setPartyPos?.(state.mapEntry.x, state.mapEntry.y);
+    if(typeof setMap==='function') setMap(entry.map);
+    setPartyPos?.(entry.x, entry.y);
   }
 
   const duration = Date.now() - combatState.startTime;

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -215,7 +215,11 @@ function applyZones(map,x,y){
   if((party||[]).length && party.every(m=>m.hp<=0)){
     log?.('Your party collapses and wakes at the entrance.');
     if(typeof toast==='function') toast('Everyone is down!');
-    if(state.mapEntry) setPartyPos(state.mapEntry.x, state.mapEntry.y);
+    if(state.mapEntry){
+      const entry = state.mapEntry;
+      if(typeof setMap==='function') setMap(entry.map);
+      setPartyPos(entry.x, entry.y);
+    }
     centerCamera?.(party.x, party.y, state.map);
     (party||[]).forEach(m=>{ m.hp = 1; });
     renderParty?.(); updateHUD?.();

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1372,6 +1372,32 @@ test('fallen party members are revived after combat', async () => {
   assert.ok(party[0].hp >= 1);
 });
 
+test('bruise resets map to entry', async () => {
+  party.length = 0;
+  player.inv.length = 0;
+  state.map = 'whistle_room';
+  party.map = 'whistle_room';
+  party.x = 5; party.y = 5;
+  state.mapEntry = { map: 'cavern', x: 2, y: 2 };
+  const m1 = new Character('p1','P1','Role');
+  m1.hp = 1;
+  party.join(m1);
+
+  const resultPromise = openCombat([
+    { name: 'E1', hp: 3 }
+  ]);
+
+  handleCombatKey({ key: 'Enter' });
+  const res = await resultPromise;
+  assert.strictEqual(res.result, 'bruise');
+  assert.strictEqual(state.map, 'cavern');
+  assert.strictEqual(party.x, 2);
+  assert.strictEqual(party.y, 2);
+  state.map = 'world';
+  party.map = 'world';
+  state.mapEntry = null;
+});
+
 test('falling resets adrenaline', async () => {
   party.length = 0;
   player.inv.length = 0;


### PR DESCRIPTION
## Summary
- ensure pit module records cavern entry
- move party back to entry map after combat or hazard wipe
- add regression test for returning to cavern on bruise

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3e6874688328b837e50e2893d581