### PR TITLE
system: separate version bump job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,12 @@ concurrency:
 jobs:
   build:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(
-            github.event.head_commit.message,
-            'chore: bump version'
-          ) }}
+      ${{ github.event_name != 'page_build' &&
+          (github.event_name != 'push' ||
+           !startsWith(
+             github.event.head_commit.message,
+             'chore: bump version'
+           )) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,5 +37,15 @@ jobs:
       - run: npm test
       - run: node scripts/supporting/presubmit.js
       - run: npm run lint
+
+  version-bump:
+    if: github.event_name == 'page_build'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - run: node scripts/supporting/version-bump.js
-        if: github.event_name == 'page_build'


### PR DESCRIPTION
## Summary
- run regular CI steps only for push and PR events
- add standalone job to bump versions on page builds

## Testing
- `npm ci`
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bec9a8db84832896abd3b6e09dff6e