### PR TITLE
system: separate version bump from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ name: CI
     branches: [main]
   pull_request:
     branches: [main]
-  page_build:
 
 permissions:
   contents: write
@@ -16,22 +15,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  event-info:
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "event_name=${{ github.event_name }}"
-          echo "head_commit_message=${{ github.event.head_commit.message || '' }}"
-
   build:
-    needs: event-info
     if: >-
-      ${{ github.event_name != 'page_build' &&
-          (github.event_name != 'push' ||
-           !startsWith(
-             github.event.head_commit.message,
-             'chore: bump version'
-           )) }}
+      ${{ github.event_name != 'push' ||
+          !startsWith(
+            github.event.head_commit.message,
+            'chore: bump version'
+          ) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,14 +36,3 @@ jobs:
       - run: node scripts/supporting/presubmit.js
       - run: npm run lint
 
-  version-bump:
-    if: github.event_name == 'page_build'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - run: node scripts/supporting/version-bump.js

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,7 +11,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -31,6 +31,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Bump version
+        run: node scripts/supporting/version-bump.js
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- simplify CI to run only for non-version-bump commits
- bump version during static deployment before publishing to pages

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bedec5871883289cab0c6a5bbb092b