### PR TITLE
feat: remove action point stat

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -36,7 +36,6 @@
             <div class="label">Adrenaline</div>
             <div class="hudbar adr" id="adrBar"><div class="fill" id="adrFill"></div></div>
           </div>
-          <div class="badge">AP: <span id="ap">2</span></div>
           <div class="badge">Scrap: <span id="scrap">0</span></div>
           <div class="badge">Map: <span id="mapname">—</span></div>
         </div>

--- a/dustland.html
+++ b/dustland.html
@@ -36,7 +36,6 @@
             <div class="label">Adrenaline</div>
             <div class="hudbar adr" id="adrBar" role="progressbar" aria-label="Adrenaline" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="fill" id="adrFill"></div></div>
           </div>
-          <div class="badge">AP: <span id="ap">2</span></div>
           <div class="badge">Scrap: <span id="scrap">0</span></div>
           <div class="badge">Map: <span id="mapname">—</span></div>
         </div>

--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -14,7 +14,6 @@ class Character {
     this.equip={weapon:null, armor:null, trinket:null};
     this.maxHp=10;
     this.hp=this.maxHp;
-    this.ap=2;
     this.maxAdr=100;
     this.adr=0;
     this._bonus={ATK:0, DEF:0, LCK:0};

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -158,8 +158,6 @@ async function startCombat(defender){
   }
 
   if(attacker){
-    attacker.ap = Math.max(0,(attacker.ap||0)-1);
-    player.ap = attacker.ap;
     player.hp = attacker.hp;
   }
   refreshUI();
@@ -255,7 +253,7 @@ function registerZoneEffects(list){
   });
 }
 const state = { map:'world', mapFlags: {} }; // default map
-const player = { hp:10, ap:2, inv:[], scrap:0 };
+const player = { hp:10, inv:[], scrap:0 };
 if (typeof registerItem === 'function') {
   registerItem({
     id: 'memory_worm',
@@ -618,7 +616,7 @@ function save(){
     questData[k]={title:q.title,desc:q.desc,status:q.status,pinned:!!q.pinned};
   });
   const partyData = Array.from(party, p => ({
-    id:p.id,name:p.name,role:p.role,lvl:p.lvl,xp:p.xp,skillPoints:p.skillPoints,stats:p.stats,equip:p.equip,hp:p.hp,ap:p.ap,map:p.map,x:p.x,y:p.y,maxHp:p.maxHp,portraitSheet:p.portraitSheet
+    id:p.id,name:p.name,role:p.role,lvl:p.lvl,xp:p.xp,skillPoints:p.skillPoints,stats:p.stats,equip:p.equip,hp:p.hp,map:p.map,x:p.x,y:p.y,maxHp:p.maxHp,portraitSheet:p.portraitSheet
   }));
   const data={worldSeed, world, player, state, buildings, interiors, itemDrops, npcs:npcData, quests:questData, party:partyData};
   localStorage.setItem('dustland_crt', JSON.stringify(data));

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -7,7 +7,6 @@ const ENGINE_VERSION = '0.79.3';
 
 const logEl = document.getElementById('log');
 const hpEl = document.getElementById('hp');
-const apEl = document.getElementById('ap');
 const scrEl = document.getElementById('scrap');
 const hpBar = document.getElementById('hpBar');
 const hpFill = document.getElementById('hpFill');
@@ -271,12 +270,12 @@ function playFX(type){
   playFX._t=setTimeout(()=>{ fxOverlay.style.opacity='0'; },200);
 }
 function hudBadge(msg){
-  const ap=document.getElementById('ap');
-  if(!ap) return;
+  const target = hpEl;
+  if(!target) return;
   const span=document.createElement('span');
   span.className='hudBadge';
   span.textContent=msg;
-  ap.parentElement.appendChild(span);
+  target.parentElement.appendChild(span);
   setTimeout(()=>span.remove(),1000);
 }
 
@@ -528,7 +527,6 @@ let activeTab = 'inv';
 function updateHUD(){
   const prevHp = updateHUD._lastHpVal ?? player.hp;
   hpEl.textContent = player.hp;
-  apEl.textContent = player.ap;
   if(scrEl) scrEl.textContent = player.scrap;
   const lead = typeof leader === 'function' ? leader() : null;
   const fx = globalThis.fxConfig;
@@ -864,7 +862,7 @@ party.forEach((m,i)=>{
   const portraitSrc = persona?.portrait || m.portraitSheet;
   c.innerHTML = `<div class='row'><div class='portrait'></div><div><b>${label}</b> — ${m.role} (Lv ${m.lvl})</div></div>`+
 `<div class='row small'>${statLine(m.stats)}</div>`+
-`<div class='row stats'>HP ${m.hp}/${m.maxHp}  ADR ${m.adr}  AP ${m.ap}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div>`+
+`<div class='row stats'>HP ${m.hp}/${m.maxHp}  ADR ${m.adr}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div>`+
 `<div class='row'><div class='xpbar' data-xp='${m.xp}/${nextXP}'><div class='fill' style='width:${pct}%'></div></div></div>`+
 `<div class='row small'>
   <span class='equip-line'>WPN: ${wLabel}${wEq?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}</span>

--- a/scripts/supporting/balance-tester-agent.js
+++ b/scripts/supporting/balance-tester-agent.js
@@ -13,7 +13,6 @@ if (typeof window === 'undefined') {
     const html = `<!DOCTYPE html><body>
       <div id="log"></div>
       <div id="hp"></div>
-      <div id="ap"></div>
       <div id="scrap"></div>
       <canvas id="game"></canvas>
       <div id="mapname"></div>

--- a/test/ack-player.playtest.test.js
+++ b/test/ack-player.playtest.test.js
@@ -10,7 +10,6 @@ test('engine skips start when ack-player param present', () => {
   const html = `<!DOCTYPE html><body>
     <div id="log"></div>
     <div id="hp"></div>
-    <div id="ap"></div>
     <div id="scrap"></div>
     <canvas id="game"></canvas>
   </body>`;

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -42,7 +42,7 @@ function setup(html){
     setTimeout,
     clearTimeout,
     console,
-    player: { hp: 10, ap: 2, scrap: 0 },
+    player: { hp: 10, scrap: 0 },
     leader: () => ({ maxHp: 10, adr: 0, maxAdr: 100 }),
     buffs: []
   };
@@ -52,7 +52,7 @@ function setup(html){
   return context;
 }
 
-const HUD_HTML = `<body><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div><div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar" class="hudbar adr"><div id="adrFill"></div></div><div id="statusIcons"></div></body>`;
+const HUD_HTML = `<body><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="scrap"></div><div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar" class="hudbar adr"><div id="adrFill"></div></div><div id="statusIcons"></div></body>`;
 
 test('hp bar flashes, updates aria values, and body gains critical/out classes', async () => {
   const ctx = setup(HUD_HTML);

--- a/test/panel-toggle.test.js
+++ b/test/panel-toggle.test.js
@@ -20,7 +20,6 @@ test('panel toggle shows and hides panel', async () => {
   canvas.id = 'game';
   document.body.appendChild(document.getElementById('log'));
   document.body.appendChild(document.getElementById('hp'));
-  document.body.appendChild(document.getElementById('ap'));
   document.body.appendChild(document.getElementById('scrap'));
   document.body.appendChild(canvas);
   const panel = document.createElement('div');
@@ -72,7 +71,6 @@ test('b key closes panel on mobile', async () => {
   canvas.id = 'game';
   document.body.appendChild(document.getElementById('log'));
   document.body.appendChild(document.getElementById('hp'));
-  document.body.appendChild(document.getElementById('ap'));
   document.body.appendChild(document.getElementById('scrap'));
   document.body.appendChild(canvas);
   const panel = document.createElement('div');

--- a/test/party-selection.test.js
+++ b/test/party-selection.test.js
@@ -4,8 +4,8 @@ import { createGameProxy } from './test-harness.js';
 
 test('party panels handle click and focus selection', async () => {
   const party = [
-    { name:'A', role:'Hero', lvl:1, hp:5, maxHp:5, ap:2, skillPoints:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null}, _bonus:{}, portraitSheet:null, xp:0 },
-    { name:'B', role:'Mage', lvl:1, hp:5, maxHp:5, ap:2, skillPoints:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null}, _bonus:{}, portraitSheet:null, xp:0 }
+    { name:'A', role:'Hero', lvl:1, hp:5, maxHp:5, skillPoints:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null}, _bonus:{}, portraitSheet:null, xp:0 },
+    { name:'B', role:'Mage', lvl:1, hp:5, maxHp:5, skillPoints:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null}, _bonus:{}, portraitSheet:null, xp:0 }
   ];
   const { context, document } = createGameProxy(party);
   let selectedEvt = -1;
@@ -28,7 +28,7 @@ test('party panels handle click and focus selection', async () => {
 
 test('renderParty shows single frame from sprite sheet', () => {
   const party = [
-    { name:'Grin', role:'NPC', lvl:1, hp:5, maxHp:5, ap:2, skillPoints:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null}, _bonus:{}, portraitSheet:'assets/portraits/grin_4.png', xp:0 }
+    { name:'Grin', role:'NPC', lvl:1, hp:5, maxHp:5, skillPoints:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null}, _bonus:{}, portraitSheet:'assets/portraits/grin_4.png', xp:0 }
   ];
   const { context, document } = createGameProxy(party);
   context.renderParty();

--- a/test/persist-llm-button.test.js
+++ b/test/persist-llm-button.test.js
@@ -13,7 +13,6 @@ test('Persist LLM button hidden until Nano is ready', async () => {
   canvas.id = 'game';
   document.body.appendChild(document.getElementById('log'));
   document.body.appendChild(document.getElementById('hp'));
-  document.body.appendChild(document.getElementById('ap'));
   document.body.appendChild(document.getElementById('scrap'));
   document.body.appendChild(canvas);
   const panel = document.createElement('div');

--- a/test/persona-hud.test.js
+++ b/test/persona-hud.test.js
@@ -6,7 +6,7 @@ import { createGameProxy } from './test-harness.js';
 
 test('renderParty reflects persona portrait and label', async () => {
   const party = [
-    { id:'mara', name:'Mara', role:'Scout', lvl:1, hp:5, maxHp:5, adr:0, ap:2, stats:{}, equip:{ weapon:null, armor:null, trinket:null }, _bonus:{}, portraitSheet:'assets/portraits/portrait_1000.png', xp:0 }
+    { id:'mara', name:'Mara', role:'Scout', lvl:1, hp:5, maxHp:5, adr:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null }, _bonus:{}, portraitSheet:'assets/portraits/portrait_1000.png', xp:0 }
   ];
   const { context, document } = createGameProxy(party);
   const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');

--- a/test/profile-runtime.test.js
+++ b/test/profile-runtime.test.js
@@ -5,7 +5,7 @@ import vm from 'node:vm';
 import { createGameProxy } from './test-harness.js';
 
 test('applyPersona uses profile runtime service', async () => {
-  const party = [{ id:'m1', name:'M', role:'', lvl:1, hp:5, maxHp:5, adr:0, ap:2, stats:{}, equip:{weapon:null,armor:null,trinket:null}, _bonus:{} }];
+  const party = [{ id:'m1', name:'M', role:'', lvl:1, hp:5, maxHp:5, adr:0, stats:{}, equip:{weapon:null,armor:null,trinket:null}, _bonus:{} }];
   const { context } = createGameProxy(party);
   const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
   vm.runInContext(gs, context);

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -12,7 +12,7 @@ test('screenshot button downloads image', async () => {
   const canvas = document.getElementById('game');
   let captured = false;
   canvas.toDataURL = () => { captured = true; return 'data:image/png;base64,x'; };
-  ['log','hp','ap','scrap','saveBtn','loadBtn','resetBtn','settingsBtn','screenshotBtn','settingsClose'].forEach(id => {
+  ['log','hp','scrap','saveBtn','loadBtn','resetBtn','settingsBtn','screenshotBtn','settingsClose'].forEach(id => {
     document.body.appendChild(document.getElementById(id));
   });
   const panel = document.createElement('div');

--- a/test/sfx.test.js
+++ b/test/sfx.test.js
@@ -14,7 +14,6 @@ async function setup(playImpl = () => Promise.resolve()) {
     <div id="quests"></div>
     <div id="log"></div>
     <div id="hp"></div>
-    <div id="ap"></div>
     <div id="scrap"></div>
     <canvas id="game" width="64" height="64"></canvas>
   </body>`, { pretendToBeVisual: true });

--- a/test/skill-badge.test.js
+++ b/test/skill-badge.test.js
@@ -9,7 +9,7 @@ const partyCode = await fs.readFile(new URL('../scripts/core/party.js', import.m
 function setup(){
   const party=[];
   const { context, document } = createGameProxy(party);
-  const ids=['log','hp','ap','scrap','inv','party','quests','tabInv','tabParty','tabQuests','game'];
+  const ids=['log','hp','scrap','inv','party','quests','tabInv','tabParty','tabQuests','game'];
   ids.forEach(id=>document.body.appendChild(document.getElementById(id)));
   document.body.appendChild(document.querySelector('.tabs'));
   vm.runInContext(partyCode, context);

--- a/test/test-harness.js
+++ b/test/test-harness.js
@@ -148,7 +148,7 @@ export function createGameProxy(party){
     party,
     selectedMember:0,
     state:{ map:'world' },
-    player:{ hp:10, ap:2, scrap:0 },
+    player:{ hp:10, scrap:0 },
     save:()=>{},
     load:()=>{},
     resetAll:()=>{},

--- a/test/weather-banner.test.js
+++ b/test/weather-banner.test.js
@@ -7,7 +7,7 @@ import { JSDOM } from 'jsdom';
 test('weather banner updates on weather change', async () => {
   const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
   const code = full.split('// ===== Boot =====')[0];
-  const dom = new JSDOM('<body><div id="weatherBanner" hidden></div><div id="log"></div><div id="hp"></div><div id="ap"></div><div id="scrap"></div><div id="hpBar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar"><div id="adrFill"></div></div><div id="statusIcons"></div><canvas id="game"></canvas></body>');
+  const dom = new JSDOM('<body><div id="weatherBanner" hidden></div><div id="log"></div><div id="hp"></div><div id="scrap"></div><div id="hpBar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar"><div id="adrFill"></div></div><div id="statusIcons"></div><canvas id="game"></canvas></body>');
   const bus = { handlers:{}, on(evt,fn){ (this.handlers[evt]=this.handlers[evt]||[]).push(fn); }, emit(evt,p){ (this.handlers[evt]||[]).forEach(fn=>fn(p)); } };
   function AudioCtx(){}
   dom.window.AudioContext = AudioCtx;
@@ -23,7 +23,7 @@ test('weather banner updates on weather change', async () => {
     requestAnimationFrame: fn => fn(),
     console,
     Audio: AudioStub,
-    player: { hp: 10, ap: 2, scrap: 0 },
+    player: { hp: 10, scrap: 0 },
     leader: () => ({ maxHp:10, adr:0, maxAdr:100 }),
     Dustland: { weather: { getWeather: () => ({ state: 'clear', icon: '☀️', desc: 'Clear' }) } },
     NanoDialog: { enabled: true }


### PR DESCRIPTION
## Summary
- drop Action Point mechanic from characters and player state
- clean up HUD and party rendering to omit AP
- update tests and balance tools for AP removal

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc5262e3dc8328a764eeebbcf0ae94