### PR TITLE
test: share DOM fixture

### DIFF
--- a/test/ack-player.playtest.test.js
+++ b/test/ack-player.playtest.test.js
@@ -4,13 +4,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
+import { basicDom } from './dom-fixture.js';
 
 test('engine skips start when ack-player param present', () => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const html = `<!DOCTYPE html><body>
-    <div id="log"></div>
-    <div id="hp"></div>
-    <div id="scrap"></div>
+  const html = `<!DOCTYPE html><body>${basicDom}
     <canvas id="game"></canvas>
   </body>`;
   const dom = new JSDOM(html, { url: 'http://localhost/dustland.html?ack-player=1' });

--- a/test/dom-fixture.js
+++ b/test/dom-fixture.js
@@ -1,0 +1,8 @@
+export const basicDom = `
+  <div id="inv"></div>
+  <div id="party"></div>
+  <div id="quests"></div>
+  <div id="log"></div>
+  <div id="hp"></div>
+  <div id="scrap"></div>
+`;

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
 import { JSDOM } from 'jsdom';
+import { basicDom } from './dom-fixture.js';
 
 const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
 const code = full.split('// ===== Boot =====')[0];
@@ -52,7 +53,7 @@ function setup(html){
   return context;
 }
 
-const HUD_HTML = `<body><canvas id="game"></canvas><div id="log"></div><div id="hp"></div><div id="scrap"></div><div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar" class="hudbar adr"><div id="adrFill"></div></div><div id="statusIcons"></div></body>`;
+const HUD_HTML = `<body><canvas id="game"></canvas>${basicDom}<div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar" class="hudbar adr"><div id="adrFill"></div></div><div id="statusIcons"></div></body>`;
 
 test('hp bar flashes, updates aria values, and body gains critical/out classes', async () => {
   const ctx = setup(HUD_HTML);

--- a/test/inventory-highlight.test.js
+++ b/test/inventory-highlight.test.js
@@ -3,9 +3,10 @@ import { test } from 'node:test';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
 import { JSDOM } from 'jsdom';
+import { basicDom } from './dom-fixture.js';
 
 function setup(items, equipped){
-  const dom = new JSDOM('<div id="inv"></div><div id="party"></div>');
+  const dom = new JSDOM(`<body>${basicDom}</body>`);
   const equips = Array.isArray(equipped) ? equipped : [equipped];
   const bus = { emit: () => {} };
   const ctx = {

--- a/test/sfx.test.js
+++ b/test/sfx.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
 import { JSDOM } from 'jsdom';
+import { basicDom } from './dom-fixture.js';
 
 async function setup(playImpl = () => Promise.resolve()) {
   const dom = new JSDOM(`<!doctype html><body>
@@ -9,12 +10,7 @@ async function setup(playImpl = () => Promise.resolve()) {
       <button id="tabParty"></button>
       <button id="tabQuests"></button>
     </div>
-    <div id="inv"></div>
-    <div id="party"></div>
-    <div id="quests"></div>
-    <div id="log"></div>
-    <div id="hp"></div>
-    <div id="scrap"></div>
+${basicDom}
     <canvas id="game" width="64" height="64"></canvas>
   </body>`, { pretendToBeVisual: true });
   const { window } = dom;

--- a/test/weather-banner.test.js
+++ b/test/weather-banner.test.js
@@ -3,11 +3,12 @@ import { test } from 'node:test';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
 import { JSDOM } from 'jsdom';
+import { basicDom } from './dom-fixture.js';
 
 test('weather banner updates on weather change', async () => {
   const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
   const code = full.split('// ===== Boot =====')[0];
-  const dom = new JSDOM('<body><div id="weatherBanner" hidden></div><div id="log"></div><div id="hp"></div><div id="scrap"></div><div id="hpBar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar"><div id="adrFill"></div></div><div id="statusIcons"></div><canvas id="game"></canvas></body>');
+  const dom = new JSDOM(`<body><div id="weatherBanner" hidden></div>${basicDom}<div id="hpBar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar"><div id="adrFill"></div></div><div id="statusIcons"></div><canvas id="game"></canvas></body>`);
   const bus = { handlers:{}, on(evt,fn){ (this.handlers[evt]=this.handlers[evt]||[]).push(fn); }, emit(evt,p){ (this.handlers[evt]||[]).forEach(fn=>fn(p)); } };
   function AudioCtx(){}
   dom.window.AudioContext = AudioCtx;


### PR DESCRIPTION
## Summary
- centralize repeated HUD elements in `basicDom`
- reuse shared DOM markup across affected tests

## Testing
- `npm test` *(fails: 6)*
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68befc2b94f88328be1bd00ba19a9f06