### PR TITLE
fix: prevent CRLF changes to image assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.png binary


### PR DESCRIPTION
## Summary
- mark PNG files as binary so Git skips EOL normalization

## Testing
- `npm test` *(fails: 7 tests)*
- `node scripts/supporting/presubmit.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bf1601968c8328b10a19ed0925047a