### PR TITLE
fix: guard tab selection against missing elements

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -630,15 +630,16 @@ function showTab(which){
   const tInv=document.getElementById('tabInv'), tP=document.getElementById('tabParty'), tQ=document.getElementById('tabQuests');
   if (!inv) return;
   inv.style.display=(which==='inv'?'grid':'none');
-  partyEl.style.display=(which==='party'?'grid':'none');
-  q.style.display=(which==='quests'?'grid':'none');
+  if(partyEl) partyEl.style.display=(which==='party'?'grid':'none');
+  if(q) q.style.display=(which==='quests'?'grid':'none');
   for(const el of [tInv,tP,tQ]){
+    if(!el) continue;
     el.classList.remove('active');
     if(el.setAttribute) el.setAttribute('aria-selected','false');
   }
-  if(which==='inv'){ tInv.classList.add('active'); if(tInv.setAttribute) tInv.setAttribute('aria-selected','true'); }
-  if(which==='party'){ tP.classList.add('active'); if(tP.setAttribute) tP.setAttribute('aria-selected','true'); }
-  if(which==='quests'){ tQ.classList.add('active'); if(tQ.setAttribute) tQ.setAttribute('aria-selected','true'); }
+  if(which==='inv' && tInv){ tInv.classList.add('active'); if(tInv.setAttribute) tInv.setAttribute('aria-selected','true'); }
+  if(which==='party' && tP){ tP.classList.add('active'); if(tP.setAttribute) tP.setAttribute('aria-selected','true'); }
+  if(which==='quests' && tQ){ tQ.classList.add('active'); if(tQ.setAttribute) tQ.setAttribute('aria-selected','true'); }
 }
 
 function updateTabsLayout(){


### PR DESCRIPTION
## Summary
- avoid `classList` errors when tab elements are missing by skipping nulls in `showTab`

## Testing
- `./install-deps.sh`
- `node scripts/supporting/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf18ab3d1c8328b0242acfac136ce0