### PR TITLE
fix: pin inventory buttons to right

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -783,8 +783,9 @@ function renderInv(){
     row.className='slot';
     row.style.display='flex';
     row.style.alignItems='center';
-    row.style.justifyContent='space-between';
+    row.style.justifyContent='flex-start';
     row.style.gap='8px';
+    row.style.paddingRight='4px';
     if(['weapon','armor','trinket'].includes(it.type) && suggestions[it.type]===it){
       row.classList.add('better');
     }
@@ -795,6 +796,7 @@ function renderInv(){
     const btnWrap=document.createElement('span');
     btnWrap.style.display='flex';
     btnWrap.style.gap='6px';
+    btnWrap.style.marginLeft='auto';
     if(['weapon','armor','trinket'].includes(it.type)){
       const equipBtn=document.createElement('button');
       equipBtn.className='btn';


### PR DESCRIPTION
## Summary
- keep inventory equip/use buttons aligned flush to the right of each slot

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf71c1adf48328ba12f9e3629d8504