### PR TITLE
fix: use not sign emoji for unequip button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2025-09-06
 - Removed hub city module.
+- Replaced unequip text button with 🚫 emoji.
 
 ## 2025-09-05
 - Added configurable procedural map generation with regeneration support.

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -899,9 +899,9 @@ party.forEach((m,i)=>{
 `<div class='row stats'>HP ${m.hp}/${m.maxHp}  ADR ${m.adr}  ATK ${fmt(bonus.ATK||0)}  DEF ${fmt(bonus.DEF||0)}  LCK ${fmt(bonus.LCK||0)}</div>`+
 `<div class='row'><div class='xpbar' data-xp='${m.xp}/${nextXP}'><div class='fill' style='width:${pct}%'></div></div></div>`+
 `<div class='row small'>
-  <span class='equip-line'>WPN: ${wLabel}${wEq?` <button class="btn" data-a="unequip" data-slot="weapon">Unequip</button>`:''}</span>
-  <span class='equip-line'>ARM: ${aLabel}${aEq?` <button class="btn" data-a="unequip" data-slot="armor">Unequip</button>`:''}</span>
-  <span class='equip-line'>TRK: ${tLabel}${tEq?` <button class="btn" data-a="unequip" data-slot="trinket">Unequip</button>`:''}</span>
+  <span class='equip-line'>WPN: ${wLabel}${wEq?` <button class="btn" data-a="unequip" data-slot="weapon" title="Unequip" aria-label="Unequip">🚫</button>`:''}</span>
+  <span class='equip-line'>ARM: ${aLabel}${aEq?` <button class="btn" data-a="unequip" data-slot="armor" title="Unequip" aria-label="Unequip">🚫</button>`:''}</span>
+  <span class='equip-line'>TRK: ${tLabel}${tEq?` <button class="btn" data-a="unequip" data-slot="trinket" title="Unequip" aria-label="Unequip">🚫</button>`:''}</span>
 </div>`;
   const portrait=c.querySelector('.portrait');
   if (typeof setPortraitDiv === 'function') {


### PR DESCRIPTION
## Summary
- Replace "Unequip" text in party menu with 🚫 button using accessible labels
- Document new unequip icon in changelog

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf8e2867e8832894b5e6cb508ce201