### PR TITLE
fix: randomize encounter portraits

### DIFF
--- a/scripts/core/dialog.js
+++ b/scripts/core/dialog.js
@@ -288,7 +288,11 @@ function advanceDialog(stateObj, choiceIdx){
         combat.HP = choice.spawn.challenge;
         combat.challenge = choice.spawn.challenge;
       }
-      const npc = makeNPC(id, state.map, x, y, template.color, template.name, '', template.desc, {}, null, null, null, { combat });
+      const npc = makeNPC(id, state.map, x, y, template.color, template.name, '', template.desc, {}, null, null, null, {
+        combat,
+        portraitSheet: template.portraitSheet,
+        portraitLock: template.portraitLock
+      });
       if (typeof NPCS !== 'undefined') NPCS.push(npc);
     }
   }

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -354,7 +354,7 @@ function checkRandomEncounter(){
     let def;
     if(base.templateId && typeof npcTemplates !== 'undefined'){
       const t = npcTemplates.find(t => t.id === base.templateId);
-      def = { ...(t?.combat||{}), name: t?.name, portraitSheet: t?.portraitSheet, ...base };
+      def = { ...(t?.combat||{}), name: t?.name, portraitSheet: t?.portraitSheet, portraitLock: t?.portraitLock, ...base };
     } else {
       def = { ...base };
     }

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -135,7 +135,7 @@ async function startCombat(defender){
   }
 
   const toEnemy = (def) => {
-    const { HP, portraitSheet, prompt, npc, name, ...rest } = def || {};
+    const { HP, portraitSheet, portraitLock, prompt, npc, name, ...rest } = def || {};
     return {
       ...rest,
       id: def.id || def.name,
@@ -143,6 +143,7 @@ async function startCombat(defender){
       hp: def.hp ?? HP ?? 5,
       npc,
       portraitSheet: portraitSheet || npc?.portraitSheet,
+      portraitLock: portraitLock ?? npc?.portraitLock,
       prompt: prompt || npc?.prompt,
       special: rest.special
     };
@@ -157,7 +158,7 @@ async function startCombat(defender){
     if (n.map !== map) continue;
     const dist = Math.abs(n.x - px) + Math.abs(n.y - py);
     if (dist <= 2 && (!defender?.npc || n !== defender.npc)) {
-      enemies.push(toEnemy({ ...n.combat, npc: n, name: n.name, portraitSheet: n.portraitSheet }));
+      enemies.push(toEnemy({ ...n.combat, npc: n, name: n.name, portraitSheet: n.portraitSheet, portraitLock: n.portraitLock }));
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure encounter templates pass along `portraitLock`
- forward NPC portrait fields to combat
- test that combat and encounters respect random portraits

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c05011edfc83289ab63ea34e4ff4a4