### PR TITLE
fix: check leader equipment for zone negation

### DIFF
--- a/docs/design/notes/zones.md
+++ b/docs/design/notes/zones.md
@@ -13,7 +13,7 @@ Zones mark rectangular regions on a map that apply special effects while the par
 - `healMult`: multiplier for passive HP regen
 - `noEncounters`: disable random combat
 - `require`: item id needed for the effect
-- `negate`: item id that cancels the effect
+- `negate`: item id that cancels the effect if in inventory or equipped to the leader
 
 ## Example
 ```json

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -187,18 +187,28 @@ function wait(){
   return move(0,0);
 }
 
+function hasItemOrEquipped(idOrTag){
+  const tag = typeof idOrTag === 'string' ? idOrTag.toLowerCase() : '';
+  if(typeof hasItem === 'function' && hasItem(idOrTag)) return true;
+  if(typeof leader === 'function'){
+    const l = leader();
+    if(l && l.equip){
+      for(const sl of ['weapon','armor','trinket']){
+        const it = l.equip[sl];
+        if(it && (it.id === idOrTag || (it.tags||[]).map(t=>t.toLowerCase()).includes(tag))) return true;
+      }
+    }
+  }
+  return false;
+}
+
 function applyZones(map,x,y){
   const zones = globalThis.Dustland?.zoneEffects || [];
   for(const z of zones){
     if((z.map||'world')!==map) continue;
     if(x<z.x || y<z.y || x>=z.x+(z.w||0) || y>=z.y+(z.h||0)) continue;
-    if(typeof hasItem==='function'){
-      if(z.require && !hasItem(z.require)) continue;
-      if(z.negate && hasItem(z.negate)) continue;
-    } else {
-      if(z.require) continue;
-      if(z.negate) { /* cannot verify inventory */ }
-    }
+    if(z.require && !hasItemOrEquipped(z.require)) continue;
+    if(z.negate && hasItemOrEquipped(z.negate)) continue;
     const step = z.perStep || z.step;
     if(step && typeof step.hp==='number'){
       const delta = step.hp;

--- a/test/nanite-zone.test.js
+++ b/test/nanite-zone.test.js
@@ -67,3 +67,11 @@ test('mask negates zone damage', async () => {
   await ctx.move(1,0);
   assert.strictEqual(ctx.party[0].hp, 5);
 });
+
+test('equipped mask negates zone damage', async () => {
+  const ctx = await setupContext();
+  ctx.party[0].equip.armor = { id:'scrap_mask', tags:['mask'], type:'armor' };
+  ctx.party[0].hp = 5; ctx.party[0].maxHp = 5;
+  await ctx.move(1,0);
+  assert.strictEqual(ctx.party[0].hp, 5);
+});


### PR DESCRIPTION
## Summary
- check leader gear alongside inventory for zone item gates
- document that negate items can be equipped
- test that equipped items cancel zone effects

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c054bb7b088328a8dc32bc323279eb