### PR TITLE
fix: specify output language for Nano API

### DIFF
--- a/scripts/dustland-nano.js
+++ b/scripts/dustland-nano.js
@@ -92,20 +92,20 @@
       return;
     }
     try {
-      const avail = await LanguageModel.availability({ outputLanguage: "en" });
+      const avail = await LanguageModel.availability({ output: { language: "en" } });
       console.log("[Nano] availability() returned:", avail);
 
       if (avail === "available") {
         console.log("[Nano] Creating session (model already available)...");
-        _state.session = await LanguageModel.create({ outputLanguage: "en" });
-        _state.ready = true; _state.failed=false; 
+        _state.session = await LanguageModel.create({ output: { language: "en" } });
+        _state.ready = true; _state.failed=false;
         _updateBadge();
 
       } else if (avail === "downloadable" || avail === "downloading") {
         console.log("[Nano] Downloading on-device model…");
         _showProgress(0);
         _state.session = await LanguageModel.create({
-          outputLanguage: "en",
+          output: { language: "en" },
           monitor(m){
             m.addEventListener("downloadprogress", (e)=>{
               const pct = e.total ? (e.loaded / e.total) * 100 : e.loaded * 100;
@@ -115,7 +115,7 @@
           }
         });
         _hideProgress();
-        _state.ready = true; _state.failed=false; 
+        _state.ready = true; _state.failed=false;
         _updateBadge();
 
       } else {

--- a/test/nano.test.js
+++ b/test/nano.test.js
@@ -32,18 +32,24 @@ global.toast = noop;
 
 let lastPrompt = '';
 global.LanguageModel = {
-  availability: async () => 'available',
-  create: async () => ({
-    prompt: async (p) => {
-      lastPrompt = p;
-      if (p.includes('New 16x16 block')) {
-        const line = '🏝'.repeat(16);
-        const block = Array(16).fill(line).join('\n');
-        return block;
+  availability: async (opts) => {
+    assert.deepStrictEqual(opts, { output: { language: 'en' } });
+    return 'available';
+  },
+  create: async (opts) => {
+    assert.deepStrictEqual(opts, { output: { language: 'en' } });
+    return {
+      prompt: async (p) => {
+        lastPrompt = p;
+        if (p.includes('New 16x16 block')) {
+          const line = '🏝'.repeat(16);
+          const block = Array(16).fill(line).join('\n');
+          return block;
+        }
+        return `Lines:\nRust bites every gear, but we endure.\nKeep your scrap dry.\nNever trade hope for rust.\nChoices:\nAsk about wares|Got anything rare?\nInspect the stall|INT|8|XP 5|You spot a hidden coil.|You find only dust.\n`;
       }
-      return `Lines:\nRust bites every gear, but we endure.\nKeep your scrap dry.\nNever trade hope for rust.\nChoices:\nAsk about wares|Got anything rare?\nInspect the stall|INT|8|XP 5|You spot a hidden coil.|You find only dust.\n`;
-    }
-  })
+    };
+  }
 };
 
 test('NanoDialog generates lines and choices', async () => {


### PR DESCRIPTION
## Summary
- set explicit output language when checking LanguageModel availability and creating sessions
- assert expected output language in Nano tests

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c052d9a36c8328874f55b04ee10974