### PR TITLE
fix: preserve quest requirements from modules

### DIFF
--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -466,7 +466,19 @@ function applyModule(data = {}, options = {}) {
   // Quests
   if (typeof quests !== 'undefined' && moduleData.quests) {
     moduleData.quests.forEach(q => {
-      quests[q.id] = new Quest(q.id, q.title, q.desc, { item: q.item, reward: q.reward, xp: q.xp, moveTo: q.moveTo });
+      quests[q.id] = new Quest(
+        q.id,
+        q.title,
+        q.desc,
+        {
+          item: q.item,
+          itemTag: q.itemTag,
+          count: q.count,
+          reward: q.reward,
+          xp: q.xp,
+          moveTo: q.moveTo
+        }
+      );
     });
   }
 


### PR DESCRIPTION
## Summary
- keep quest itemTag and count when applying modules
- ensure pit merchant quest only completes after turning in all treasures

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0598a67f88328ab178531c2bfe26e