### PR TITLE
feat: add inventory item effects

### DIFF
--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -128,6 +128,34 @@
               }
             }
             break; }
+          case 'addItem': {
+            if ((eff.id || eff.item) && typeof addToInv === 'function') {
+              addToInv(eff.id || eff.item);
+            }
+            break; }
+          case 'removeItem': {
+            if (eff.id && typeof findItemIndex === 'function' && typeof removeFromInv === 'function') {
+              const idx = findItemIndex(eff.id);
+              if (idx !== -1) removeFromInv(idx);
+            }
+            break; }
+          case 'removeItemsByTag': {
+            if (eff.tag && Array.isArray(player?.inv) && typeof removeFromInv === 'function') {
+              for (let i = player.inv.length - 1; i >= 0; i--) {
+                const it = player.inv[i];
+                if (it.tags && it.tags.map(t => t.toLowerCase()).includes(eff.tag.toLowerCase())) {
+                  removeFromInv(i);
+                }
+              }
+            }
+            break; }
+          case 'replaceItem': {
+            if (eff.remove && typeof findItemIndex === 'function' && typeof removeFromInv === 'function') {
+              const idx = findItemIndex(eff.remove);
+              if (idx !== -1) removeFromInv(idx);
+            }
+            if (eff.add && typeof addToInv === 'function') addToInv(eff.add);
+            break; }
           case 'modStat': {
             const target = ctx.actor || ctx.player;
             if (target && target.stats && eff.stat) {

--- a/test/inventory-effects.test.js
+++ b/test/inventory-effects.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+// Test inventory-related effects
+
+const setup = async () => {
+  global.EventBus = { emit() {} };
+  global.player = { inv: [], stats: {} };
+  global.party = { length: 1, map: 'cavern', x: 0, y: 0 };
+  global.log = () => {};
+  global.toast = () => {};
+  await import('../scripts/core/inventory.js');
+  await import('../scripts/core/effects.js');
+  return globalThis.Dustland.effects;
+};
+
+test('inventory add/remove effects', async () => {
+  const effects = await setup();
+  effects.apply([{ effect: 'addItem', item: { id: 'coin', name: 'Coin', type: 'quest', tags: ['treasure'] } }]);
+  effects.apply([{ effect: 'addItem', item: { id: 'stone', name: 'Stone', type: 'quest' } }]);
+  assert.strictEqual(player.inv.length, 2);
+
+  effects.apply([{ effect: 'replaceItem', remove: 'stone', add: { id: 'rock', name: 'Rock', type: 'quest' } }]);
+  assert.strictEqual(player.inv.length, 2);
+  assert.ok(player.inv.some(it => it.id === 'rock'));
+
+  effects.apply([{ effect: 'removeItemsByTag', tag: 'treasure' }]);
+  assert.strictEqual(player.inv.length, 1);
+  assert.strictEqual(player.inv[0].id, 'rock');
+
+  effects.apply([{ effect: 'removeItem', id: 'rock' }]);
+  assert.strictEqual(player.inv.length, 0);
+});


### PR DESCRIPTION
## Summary
- add Effects cases to add, remove, replace items by tag or id
- cover inventory Effects with tests

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0d448e6248328a6721e9c102201e9