### PR TITLE
fix: restore valid dustland module JSON

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -601,7 +601,7 @@ const DATA = `
     },
     {
       "id": "exitdoor",
-      "map": "hall",buried
+      "map": "hall",
       "x": 15,
       "y": 17,
       "color": "#a9f59f",


### PR DESCRIPTION
## Summary
- remove stray text from `exitdoor` NPC entry

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c179a17f3083288ab0b5af19674500