### PR TITLE
fix: add NPC dialogue tree in wizard

### DIFF
--- a/components/wizard/npc-wizard.js
+++ b/components/wizard/npc-wizard.js
@@ -18,7 +18,12 @@
         name: state.name,
         portrait: state.portrait,
         prompt: state.prompt,
-        dialogue: state.dialogue,
+        tree: {
+          start: {
+            text: state.dialogue,
+            choices: [ { label: '(Leave)', to: 'bye' } ]
+          }
+        },
         map: 'world',
         x: state.pos?.x,
         y: state.pos?.y

--- a/test/npc-wizard.commit.test.js
+++ b/test/npc-wizard.commit.test.js
@@ -29,7 +29,16 @@ test('NpcWizard commit builds module data', async () => {
     pos: { x: 1, y: 2 }
   })));
   assert.deepStrictEqual(mod, {
-    npcs: [{ id: 'bob', name: 'Bob', portrait: 'p.png', prompt: 'rusted scavenger', dialogue: 'Hi', map: 'world', x: 1, y: 2 }],
+    npcs: [{
+      id: 'bob',
+      name: 'Bob',
+      portrait: 'p.png',
+      prompt: 'rusted scavenger',
+      tree: { start: { text: 'Hi', choices: [ { label: '(Leave)', to: 'bye' } ] } },
+      map: 'world',
+      x: 1,
+      y: 2
+    }],
     quests: [{ id: 'bob_quest', giver: 'bob', item: 'widget' }]
   });
 });


### PR DESCRIPTION
## Summary
- have NPC & Quest Wizard generate a dialogue tree for new NPCs
- test wizard commit output reflects NPC tree

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c18476e364832899f04efd37a22e3f