### PR TITLE
fix: add scrap reward to NPC wizard

### DIFF
--- a/components/wizard/npc-wizard.js
+++ b/components/wizard/npc-wizard.js
@@ -7,7 +7,7 @@
       // Notes for artists to craft a portrait if one is missing
       Dustland.WizardSteps.text('Portrait Prompt', 'prompt'),
       Dustland.WizardSteps.text('Dialogue', 'dialogue'),
-      Dustland.WizardSteps.itemPicker('Fetch Item', ['tuned_crystal', 'signal_fragment_1'], 'questItem'),
+      Dustland.WizardSteps.itemPicker('Fetch Item', ['tuned_crystal', 'signal_fragment_1'], 'questItem', 'scrapReward'),
       Dustland.WizardSteps.mapPlacement('pos'),
       Dustland.WizardSteps.confirm('Done')
     ],
@@ -26,7 +26,8 @@
       const quest = {
         id: id + '_quest',
         giver: id,
-        item: state.questItem
+        item: state.questItem,
+        reward: 'SCRAP ' + state.scrapReward
       };
       return { npcs: [npc], quests: [quest] };
     }

--- a/components/wizard/steps/item-picker.js
+++ b/components/wizard/steps/item-picker.js
@@ -1,5 +1,5 @@
 (function(){
-  function itemPickerStep(label, options, key){
+  function itemPickerStep(label, options, key, rewardKey){
     return {
       render(container, state){
         const labelEl = document.createElement('label');
@@ -25,12 +25,26 @@
         container.appendChild(labelEl);
         container.appendChild(select);
         this.select = select;
+        if (rewardKey) {
+          const rewardLabel = document.createElement('label');
+          rewardLabel.textContent = 'Scrap Reward';
+          const rewardInput = document.createElement('input');
+          rewardInput.type = 'number';
+          rewardInput.min = '0';
+          rewardInput.value = state[rewardKey] || '';
+          container.appendChild(rewardLabel);
+          container.appendChild(rewardInput);
+          this.rewardInput = rewardInput;
+        }
       },
       validate(){
-        return this.select && this.select.value;
+        if (!this.select || !this.select.value) return false;
+        if (rewardKey) return this.rewardInput && this.rewardInput.value;
+        return true;
       },
       onComplete(state){
         state[key] = this.select.value;
+        if (rewardKey) state[rewardKey] = parseInt(this.rewardInput.value, 10);
       }
     };
   }
@@ -39,3 +53,4 @@
   globalThis.Dustland.WizardSteps = globalThis.Dustland.WizardSteps || {};
   globalThis.Dustland.WizardSteps.itemPicker = itemPickerStep;
 })();
+

--- a/test/npc-wizard.commit.test.js
+++ b/test/npc-wizard.commit.test.js
@@ -26,10 +26,11 @@ test('NpcWizard commit builds module data', async () => {
     prompt: 'rusted scavenger',
     dialogue: 'Hi',
     questItem: 'widget',
+    scrapReward: 5,
     pos: { x: 1, y: 2 }
   })));
   assert.deepStrictEqual(mod, {
     npcs: [{ id: 'bob', name: 'Bob', portrait: 'p.png', prompt: 'rusted scavenger', dialogue: 'Hi', map: 'world', x: 1, y: 2 }],
-    quests: [{ id: 'bob_quest', giver: 'bob', item: 'widget' }]
+    quests: [{ id: 'bob_quest', giver: 'bob', item: 'widget', reward: 'SCRAP 5' }]
   });
 });

--- a/test/wizard.test.js
+++ b/test/wizard.test.js
@@ -56,3 +56,26 @@ test('asset picker step stores selection', async () => {
   wizard.next();
   assert.strictEqual(wizard.getState().portrait, 'b.png');
 });
+
+test('item picker step captures reward', async () => {
+  const document = makeDocument();
+  const containerEl = document.getElementById('w');
+  document.body.appendChild(containerEl);
+  const context = { window: { document }, document };
+  vm.createContext(context);
+  const wizCode = await fs.readFile(new URL('../components/wizard/wizard.js', import.meta.url), 'utf8');
+  vm.runInContext(wizCode, context);
+  const itemCode = await fs.readFile(new URL('../components/wizard/steps/item-picker.js', import.meta.url), 'utf8');
+  vm.runInContext(itemCode, context);
+  const wizard = context.Dustland.Wizard(containerEl, [
+    context.Dustland.WizardSteps.itemPicker('Fetch Item', ['a', 'b'], 'item', 'scrap')
+  ], {});
+  const sel = document.querySelector('select');
+  sel.value = 'b';
+  const input = document.querySelector('input');
+  input.value = '7';
+  wizard.next();
+  const state = wizard.getState();
+  assert.strictEqual(state.item, 'b');
+  assert.strictEqual(state.scrap, 7);
+});


### PR DESCRIPTION
## Summary
- allow NPC & Quest wizard to specify scrap reward
- validate reward in item picker step
- test NPC wizard reward handling

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c18388fcdc83288d1b6171514d7d27