### PR TITLE
fix: populate item map dropdown on select

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -3743,7 +3743,7 @@ document.getElementById('npcFlagPick').onclick = () => { coordTarget = { x: 'npc
 document.getElementById('portalPick').onclick = () => { coordTarget = { x: 'portalX', y: 'portalY' }; };
 document.getElementById('portalDestPick').onclick = () => { coordTarget = { x: 'portalToX', y: 'portalToY' }; };
 document.getElementById('npcPick').onclick = () => { coordTarget = { x: 'npcX', y: 'npcY', map: 'npcMap' }; };
-document.getElementById('itemPick').onclick = () => { coordTarget = { x: 'itemX', y: 'itemY' }; };
+document.getElementById('itemPick').onclick = () => { coordTarget = { x: 'itemX', y: 'itemY', map: 'itemMap' }; };
 document.getElementById('save').onclick = saveModule;
 document.getElementById('load').onclick = () => document.getElementById('loadFile').click();
 document.getElementById('loadFile').addEventListener('change', e => {

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -253,6 +253,18 @@ test('map fields use dropdown options', () => {
   assert.ok(document.getElementById('encMap').innerHTML.includes('<option value="world">world</option>'));
 });
 
+test('item select on map populates map dropdown', () => {
+  genWorld(1);
+  moduleData.items = [];
+  startNewItem();
+  document.getElementById('itemOnMap').checked = true;
+  updateItemMapWrap();
+  document.getElementById('itemPick').onclick();
+  canvasEl._listeners.mousedown[0]({ clientX:3, clientY:2, button:0 });
+  assert.strictEqual(document.getElementById('itemMap').value, 'world');
+  moduleData.items = [];
+});
+
 test('world paint persists through save/load', () => {
   genWorld(1);
   clearWorld();


### PR DESCRIPTION
## Summary
- ensure item "Select on Map" populates item map dropdown
- test item map selection updates dropdown

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1845a8c9483288ea236792bd6f2a7