### PR TITLE
feat: scaffold two-worlds fast travel modules

### DIFF
--- a/docs/design/in-progress/bunker-fast-travel.md
+++ b/docs/design/in-progress/bunker-fast-travel.md
@@ -14,11 +14,11 @@ As of 2025-09-07, `data/bunkers.js` and core travel logic with events exist. UI 
   - Is there meant to be a world above the main map? are there a connected set of regions you can travel between that load entirely new modules and the "world map" is the map that connects them? perhaps a world map can be a bunch of thumbnail world maps shown on a.. perhaps a mercator projection or else just a stylized pixel art something.. but each module's world map could be a bunker travel location once unlocked.. it would be cool to load the js file, parse out the map data and render it as a thumbnail though.. then travelling to the new location would load in that new map world.. we have to make sure that world state transfers and is preserved across module changes.
   - let's build a POC module called two-worlds to verify everything works in the engine to support this:
   - Tasks:
-    - [ ] create a two worlds module added to module select
-    - [ ] create a world one module (not added to module select)
-    - [ ] create a world two module (not added to module select)
-    - [ ] in world one: add an NPC with item & item fetch quest
-    - [ ] in world two: add an NPC with item & item fetch quest
+    - [x] create a two worlds module added to module select
+    - [x] create a world one module (not added to module select)
+    - [x] create a world two module (not added to module select)
+    - [x] in world one: add an NPC with item & item fetch quest
+    - [x] in world two: add an NPC with item & item fetch quest
     - [ ] add a bunker in each world
     - [ ] in both worlds, add a relatively simple monster you can randomly encounter in order to grind on collecting power cells to have the fuel to get between worlds
     - [ ] finishing the world 1 item fetch quest should unlock fast travel to world two (and back again)

--- a/modules/two-worlds.module.js
+++ b/modules/two-worlds.module.js
@@ -1,0 +1,7 @@
+// Entry module that loads World One.
+(function(){
+  const script = document.createElement('script');
+  script.src = 'modules/world-one.module.js';
+  script.onload = () => startGame();
+  document.head.appendChild(script);
+})();

--- a/modules/world-one.module.js
+++ b/modules/world-one.module.js
@@ -1,0 +1,45 @@
+function seedWorldContent() {}
+
+const DATA = `
+{
+  "seed": "world-one",
+  "start": { "map": "world", "x": 2, "y": 2 },
+  "items": [
+    { "id": "rusty_gear", "name": "Rusty Gear", "type": "quest", "map": "world", "x": 3, "y": 2 }
+  ],
+  "npcs": [
+    {
+      "id": "gear_seeker",
+      "map": "world",
+      "x": 1,
+      "y": 2,
+      "color": "#cfa",
+      "name": "Gear Seeker",
+      "desc": "Needs a rusty gear.",
+      "prompt": "Wanderer fiddling with broken machine",
+      "tree": {
+        "start": {
+          "text": "My rig is missing a rusty gear. Seen one?",
+          "choices": [
+            { "label": "(Give gear)", "to": "turnin", "reqItem": "rusty_gear" },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "turnin": {
+          "text": "Perfect fit! Thanks.",
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        }
+      }
+    }
+  ]
+}
+`;
+
+globalThis.WORLD_ONE_MODULE = JSON.parse(DATA);
+
+startGame = function(){
+  applyModule(WORLD_ONE_MODULE);
+  const s = WORLD_ONE_MODULE.start;
+  setPartyPos(s.x, s.y);
+  setMap(s.map, 'World One');
+};

--- a/modules/world-two.module.js
+++ b/modules/world-two.module.js
@@ -1,0 +1,45 @@
+function seedWorldContent() {}
+
+const DATA = `
+{
+  "seed": "world-two",
+  "start": { "map": "world", "x": 2, "y": 2 },
+  "items": [
+    { "id": "shiny_cog", "name": "Shiny Cog", "type": "quest", "map": "world", "x": 2, "y": 3 }
+  ],
+  "npcs": [
+    {
+      "id": "cog_hunter",
+      "map": "world",
+      "x": 2,
+      "y": 1,
+      "color": "#acf",
+      "name": "Cog Hunter",
+      "desc": "Looking for a shiny cog.",
+      "prompt": "Scavenger eyeing a broken robot",
+      "tree": {
+        "start": {
+          "text": "I could use a shiny cog.",
+          "choices": [
+            { "label": "(Give cog)", "to": "turnin", "reqItem": "shiny_cog" },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "turnin": {
+          "text": "Great, thanks.",
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        }
+      }
+    }
+  ]
+}
+`;
+
+globalThis.WORLD_TWO_MODULE = JSON.parse(DATA);
+
+startGame = function(){
+  applyModule(WORLD_TWO_MODULE);
+  const s = WORLD_TWO_MODULE.start;
+  setPartyPos(s.x, s.y);
+  setMap(s.map, 'World Two');
+};

--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -7,6 +7,7 @@ const MODULES = [
   { id: 'broadcast', name: 'Broadcast Story', file: 'modules/broadcast-fragment-1.module.js' },
   { id: 'pit', name: 'PIT.BAS', file: 'modules/pit-bas.module.js' },
   { id: 'other', name: 'OTHER.BAS', file: 'modules/other-bas.module.js' },
+  { id: 'two-worlds', name: 'Two Worlds', file: 'modules/two-worlds.module.js' },
   { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' }
 ];
 

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -132,6 +132,12 @@ test('other module points to other-bas', () => {
   assert.strictEqual(other.file, 'modules/other-bas.module.js');
 });
 
+test('two-worlds module points to entry script', () => {
+  const tw = MODULES.find(m => m.id === 'two-worlds');
+  assert.ok(tw);
+  assert.strictEqual(tw.file, 'modules/two-worlds.module.js');
+});
+
 test('enter key loads selected module', () => {
   loadModule(MODULES[MODULES.length - 1]);
   assert.ok(global.location.href.includes('golden.module.json'));


### PR DESCRIPTION
## Summary
- add placeholder world-one and world-two modules with simple item quests
- expose two-worlds entry module in module picker
- record progress in bunker fast travel design doc

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c208e38d1c8328b87c0978b7071ec7