### PR TITLE
docs: detail bunker fast travel design

### DIFF
--- a/docs/design/in-progress/bunker-fast-travel.md
+++ b/docs/design/in-progress/bunker-fast-travel.md
@@ -10,9 +10,11 @@ As of 2025-09-07, `data/bunkers.js` and core travel logic with events exist. UI 
 
 ### Open questions
 - Mechanics 2 mentions distance-based fuel costs; how will the system compute distance between bunkers?
+  - Use the Manhattan distance between bunker coordinates in `data/bunkers.js`. Fuel cost scales as `BASE_COST + distance * FUEL_PER_TILE`, keeping math cheap on the grid.
 - Implementation Sketch references `scripts/ui/world-map.js`, but the project currently lacks a world map module—where should destination selection live?
-  - Is there meant to be a world above the main map? are there a connected set of regions you can travel between that load entirely new modules and the "world map" is the map that connects them? perhaps a world map can be a bunch of thumbnail world maps shown on a.. perhaps a mercator projection or else just a stylized pixel art something.. but each module's world map could be a bunker travel location once unlocked.. it would be cool to load the js file, parse out the map data and render it as a thumbnail though.. then travelling to the new location would load in that new map world.. we have to make sure that world state transfers and is preserved across module changes.
-  - let's build a POC module called two-worlds to verify everything works in the engine to support this:
+  - Destination selection lives in a new `scripts/ui/world-map.js` overlay. It renders each unlocked bunker's overworld as a clickable thumbnail built from module map data.
+  - The map functions as a hub above individual modules. Choosing a thumbnail loads that module while preserving party state and active quests.
+  - To verify cross-module travel, build a proof-of-concept `two-worlds` module:
   - Tasks:
     - [x] create a two worlds module added to module select
     - [x] create a world one module (not added to module select)
@@ -24,9 +26,11 @@ As of 2025-09-07, `data/bunkers.js` and core travel logic with events exist. UI 
     - [ ] finishing the world 1 item fetch quest should unlock fast travel to world two (and back again)
     - [ ] going into the bunker and choosing to fast travel should trigger a newly implemented scripts/ui/world-map.js
     - [ ] scripts/ui/world-map.js should be able to thumbnail a module's overworld (all modules unlocked for fast travel) and display them and allow for selection
-    - [ ] fast travelling betweek worlds should load the new map world, party and open quests should be retained across the module load boundary
+    - [ ] fast travelling between worlds should load the new map world, party and open quests should be retained across the module load boundary
     - [ ] travelling back to the other world, completed quests/chosen dialog/taken item state should be preserved. perhaps a mechanism for this should be to generate a saved game when moving between maps and you travel back to a save of that map rather than a raw reload of the module from the JS file?
 - Implementation Sketch calls for `travel:start` and `travel:end` events; what payloads should they carry to support mods?
+  - `travel:start` emits `{ fromId, toId, cost }`.
+  - `travel:end` emits `{ fromId, toId, result }` where `result` captures ambushes or story events.
 
 > **Echo:** The wastes sprawl, but our stories shouldn't drown in dead miles. Bunkers can hum with secret routes if we let them.
 


### PR DESCRIPTION
## Summary
- clarify fuel cost scaling using Manhattan distance
- outline world-map overlay and POC module tasks
- specify payloads for `travel:start` and `travel:end`

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c20d71566c8328b8c68c9addd7e2ae