### PR TITLE
feat: seed bunkers and scrap rats in prototype worlds

### DIFF
--- a/docs/design/in-progress/bunker-fast-travel.md
+++ b/docs/design/in-progress/bunker-fast-travel.md
@@ -21,8 +21,8 @@ As of 2025-09-07, `data/bunkers.js` and core travel logic with events exist. UI 
     - [x] create a world two module (not added to module select)
     - [x] in world one: add an NPC with item & item fetch quest
     - [x] in world two: add an NPC with item & item fetch quest
-    - [ ] add a bunker in each world
-    - [ ] in both worlds, add a relatively simple monster you can randomly encounter in order to grind on collecting power cells to have the fuel to get between worlds
+    - [x] add a bunker in each world
+    - [x] in both worlds, add a relatively simple monster you can randomly encounter in order to grind on collecting power cells to have the fuel to get between worlds
     - [ ] finishing the world 1 item fetch quest should unlock fast travel to world two (and back again)
     - [ ] going into the bunker and choosing to fast travel should trigger a newly implemented scripts/ui/world-map.js
     - [ ] scripts/ui/world-map.js should be able to thumbnail a module's overworld (all modules unlocked for fast travel) and display them and allow for selection

--- a/modules/world-one.module.js
+++ b/modules/world-one.module.js
@@ -5,6 +5,7 @@ const DATA = `
   "seed": "world-one",
   "start": { "map": "world", "x": 2, "y": 2 },
   "items": [
+    { "id": "fuel_cell", "name": "Fuel Cell", "type": "quest" },
     { "id": "rusty_gear", "name": "Rusty Gear", "type": "quest", "map": "world", "x": 3, "y": 2 }
   ],
   "npcs": [
@@ -30,14 +31,64 @@ const DATA = `
           "choices": [ { "label": "(Leave)", "to": "bye" } ]
         }
       }
+    },
+    {
+      "id": "bunker_alpha",
+      "map": "world",
+      "x": 4,
+      "y": 2,
+      "color": "#aaa",
+      "name": "Bunker Alpha",
+      "desc": "A flickering terminal awaits activation.",
+      "prompt": "Dusty bunker terminal",
+      "tree": {
+        "start": {
+          "text": "Power hums faintly behind the panel.",
+          "choices": [
+            { "label": "(Activate)", "to": "activate" },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "activate": {
+          "text": "Alpha bunker added to network.",
+          "effects": [ { "effect": "activateBunker", "id": "alpha" } ],
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        }
+      }
     }
-  ]
+  ],
+  "templates": [
+    { "id": "scrap_rat", "name": "Scrap Rat", "combat": { "HP": 3, "ATK": 1, "DEF": 0 } }
+  ],
+  "encounters": {
+    "world": [
+      { "templateId": "scrap_rat", "loot": "fuel_cell", "maxDist": 5 }
+    ]
+  }
 }
 `;
 
 globalThis.WORLD_ONE_MODULE = JSON.parse(DATA);
+function postLoad(module){
+  const handle = list => (list || []).map(e => {
+    if (e && e.effect === 'activateBunker') {
+      return () => Dustland.fastTravel?.activateBunker?.(e.id);
+    }
+    return e;
+  });
+  module.npcs?.forEach(n => {
+    Object.values(n.tree || {}).forEach(node => {
+      if (node.effects) node.effects = handle(node.effects);
+      node.choices?.forEach(c => {
+        if (c.effects) c.effects = handle(c.effects);
+      });
+    });
+  });
+}
+globalThis.WORLD_ONE_MODULE.postLoad = postLoad;
 
 startGame = function(){
+  WORLD_ONE_MODULE.postLoad?.(WORLD_ONE_MODULE);
   applyModule(WORLD_ONE_MODULE);
   const s = WORLD_ONE_MODULE.start;
   setPartyPos(s.x, s.y);

--- a/modules/world-two.module.js
+++ b/modules/world-two.module.js
@@ -5,6 +5,7 @@ const DATA = `
   "seed": "world-two",
   "start": { "map": "world", "x": 2, "y": 2 },
   "items": [
+    { "id": "fuel_cell", "name": "Fuel Cell", "type": "quest" },
     { "id": "shiny_cog", "name": "Shiny Cog", "type": "quest", "map": "world", "x": 2, "y": 3 }
   ],
   "npcs": [
@@ -30,14 +31,64 @@ const DATA = `
           "choices": [ { "label": "(Leave)", "to": "bye" } ]
         }
       }
+    },
+    {
+      "id": "bunker_beta",
+      "map": "world",
+      "x": 4,
+      "y": 2,
+      "color": "#aaa",
+      "name": "Bunker Beta",
+      "desc": "A flickering terminal awaits activation.",
+      "prompt": "Dusty bunker terminal",
+      "tree": {
+        "start": {
+          "text": "Power hums faintly behind the panel.",
+          "choices": [
+            { "label": "(Activate)", "to": "activate" },
+            { "label": "(Leave)", "to": "bye" }
+          ]
+        },
+        "activate": {
+          "text": "Beta bunker added to network.",
+          "effects": [ { "effect": "activateBunker", "id": "beta" } ],
+          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+        }
+      }
     }
-  ]
+  ],
+  "templates": [
+    { "id": "scrap_rat", "name": "Scrap Rat", "combat": { "HP": 3, "ATK": 1, "DEF": 0 } }
+  ],
+  "encounters": {
+    "world": [
+      { "templateId": "scrap_rat", "loot": "fuel_cell", "maxDist": 5 }
+    ]
+  }
 }
 `;
 
 globalThis.WORLD_TWO_MODULE = JSON.parse(DATA);
+function postLoad(module){
+  const handle = list => (list || []).map(e => {
+    if (e && e.effect === 'activateBunker') {
+      return () => Dustland.fastTravel?.activateBunker?.(e.id);
+    }
+    return e;
+  });
+  module.npcs?.forEach(n => {
+    Object.values(n.tree || {}).forEach(node => {
+      if (node.effects) node.effects = handle(node.effects);
+      node.choices?.forEach(c => {
+        if (c.effects) c.effects = handle(c.effects);
+      });
+    });
+  });
+}
+globalThis.WORLD_TWO_MODULE.postLoad = postLoad;
 
 startGame = function(){
+  WORLD_TWO_MODULE.postLoad?.(WORLD_TWO_MODULE);
   applyModule(WORLD_TWO_MODULE);
   const s = WORLD_TWO_MODULE.start;
   setPartyPos(s.x, s.y);

--- a/scripts/core/fast-travel.js
+++ b/scripts/core/fast-travel.js
@@ -38,6 +38,14 @@
     return true;
   }
 
+  function activateBunker(id){
+    const bunker = bunkers.find(b => b.id === id);
+    if (bunker) {
+      bunker.active = true;
+      if (typeof log === 'function') log(`Bunker ${id} activated.`);
+    }
+  }
+
   globalThis.Dustland = globalThis.Dustland || {};
-  globalThis.Dustland.fastTravel = { fuelCost, travel };
+  globalThis.Dustland.fastTravel = { fuelCost, travel, activateBunker };
 })();


### PR DESCRIPTION
## Summary
- Add bunker terminals and fuel-drop encounters to world-one and world-two modules
- Expose `activateBunker` in fast-travel core utility
- Check off completed tasks in bunker fast travel design doc

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c21077889883288b43592bf941cedd