### PR TITLE
feat: add bunker fast travel overlay

### DIFF
--- a/docs/design/in-progress/bunker-fast-travel.md
+++ b/docs/design/in-progress/bunker-fast-travel.md
@@ -6,7 +6,7 @@
 *Status: Draft*
 
 ## Status update
-As of 2025-09-07, `data/bunkers.js` and core travel logic with events exist. UI hooks remain unimplemented.
+As of 2025-09-07, `data/bunkers.js` and core travel logic with events exist. A basic world map overlay now opens from bunkers, but thumbnails and deeper state persistence remain.
 
 ### Open questions
 - Mechanics 2 mentions distance-based fuel costs; how will the system compute distance between bunkers?
@@ -23,8 +23,8 @@ As of 2025-09-07, `data/bunkers.js` and core travel logic with events exist. UI 
     - [x] in world two: add an NPC with item & item fetch quest
     - [x] add a bunker in each world
     - [x] in both worlds, add a relatively simple monster you can randomly encounter in order to grind on collecting power cells to have the fuel to get between worlds
-    - [ ] finishing the world 1 item fetch quest should unlock fast travel to world two (and back again)
-    - [ ] going into the bunker and choosing to fast travel should trigger a newly implemented scripts/ui/world-map.js
+    - [x] finishing the world 1 item fetch quest should unlock fast travel to world two (and back again)
+    - [x] going into the bunker and choosing to fast travel should trigger a newly implemented scripts/ui/world-map.js
     - [ ] scripts/ui/world-map.js should be able to thumbnail a module's overworld (all modules unlocked for fast travel) and display them and allow for selection
     - [ ] fast travelling between worlds should load the new map world, party and open quests should be retained across the module load boundary
     - [ ] travelling back to the other world, completed quests/chosen dialog/taken item state should be preserved. perhaps a mechanism for this should be to generate a saved game when moving between maps and you travel back to a save of that map rather than a raw reload of the module from the JS file?
@@ -48,7 +48,7 @@ As of 2025-09-07, `data/bunkers.js` and core travel logic with events exist. UI 
 ## Implementation Sketch
 - [x] Add `data/bunkers.js` with coordinates and activation flags.
 - [x] Create `scripts/core/fast-travel.js` handling node graphs and fuel costs.
-- [ ] Hook into map UI in `scripts/ui/world-map.js` to select destinations.
+- [x] Hook into map UI in `scripts/ui/world-map.js` to select destinations.
 - [x] Emit `travel:start` and `travel:end` events for mods.
 
 > **Wing:** Make sure fuel costs scale with distance so speedrunners can't warp past the curve.

--- a/dustland.html
+++ b/dustland.html
@@ -251,7 +251,10 @@
     <script defer src="./components/dial.js"></script>
     <script defer src="./data/skills/trainer-upgrades.js"></script>
     <script defer src="./scripts/trainer-ui.js"></script>
+    <script defer src="./data/bunkers.js"></script>
+    <script defer src="./scripts/core/fast-travel.js"></script>
     <script defer src="./scripts/dustland-core.js"></script>
+    <script defer src="./scripts/ui/world-map.js"></script>
     <script defer src="./scripts/core/event-flags.js"></script>
     <script defer src="./scripts/dustland-path.js"></script>
     <script defer src="./scripts/dustland-nano.js"></script>

--- a/modules/world-one.module.js
+++ b/modules/world-one.module.js
@@ -28,6 +28,7 @@ const DATA = `
         },
         "turnin": {
           "text": "Perfect fit! Thanks.",
+          "effects": [ { "effect": "activateBunker", "id": "beta" } ],
           "choices": [ { "label": "(Leave)", "to": "bye" } ]
         }
       }
@@ -46,6 +47,7 @@ const DATA = `
           "text": "Power hums faintly behind the panel.",
           "choices": [
             { "label": "(Activate)", "to": "activate" },
+            { "label": "(Fast travel)", "effects": [ { "effect": "openWorldMap", "id": "alpha" } ], "to": "bye" },
             { "label": "(Leave)", "to": "bye" }
           ]
         },
@@ -73,6 +75,9 @@ function postLoad(module){
   const handle = list => (list || []).map(e => {
     if (e && e.effect === 'activateBunker') {
       return () => Dustland.fastTravel?.activateBunker?.(e.id);
+    }
+    if (e && e.effect === 'openWorldMap') {
+      return () => Dustland.worldMap?.open?.(e.id);
     }
     return e;
   });

--- a/modules/world-two.module.js
+++ b/modules/world-two.module.js
@@ -46,6 +46,7 @@ const DATA = `
           "text": "Power hums faintly behind the panel.",
           "choices": [
             { "label": "(Activate)", "to": "activate" },
+            { "label": "(Fast travel)", "effects": [ { "effect": "openWorldMap", "id": "beta" } ], "to": "bye" },
             { "label": "(Leave)", "to": "bye" }
           ]
         },
@@ -73,6 +74,9 @@ function postLoad(module){
   const handle = list => (list || []).map(e => {
     if (e && e.effect === 'activateBunker') {
       return () => Dustland.fastTravel?.activateBunker?.(e.id);
+    }
+    if (e && e.effect === 'openWorldMap') {
+      return () => Dustland.worldMap?.open?.(e.id);
     }
     return e;
   });

--- a/scripts/ui/world-map.js
+++ b/scripts/ui/world-map.js
@@ -1,0 +1,70 @@
+(function(){
+  const bunkers = globalThis.Dustland?.bunkers || [];
+  const moduleMap = {
+    alpha: { script: 'modules/world-one.module.js', global: 'WORLD_ONE_MODULE', name: 'World One', map: 'world', x: 4, y: 2 },
+    beta: { script: 'modules/world-two.module.js', global: 'WORLD_TWO_MODULE', name: 'World Two', map: 'world', x: 4, y: 2 }
+  };
+
+  function ensureModule(id, cb){
+    const info = moduleMap[id];
+    if(!info) return;
+    if(globalThis[info.global]){ cb(globalThis[info.global]); return; }
+    const script = document.createElement('script');
+    script.src = info.script;
+    script.onload = () => cb(globalThis[info.global]);
+    document.head.appendChild(script);
+  }
+
+  function open(fromId){
+    const overlay = document.createElement('div');
+    overlay.id = 'worldMap';
+    overlay.style.position = 'fixed';
+    overlay.style.left = '0';
+    overlay.style.top = '0';
+    overlay.style.right = '0';
+    overlay.style.bottom = '0';
+    overlay.style.background = 'rgba(0,0,0,0.8)';
+    overlay.style.color = '#fff';
+    overlay.style.display = 'flex';
+    overlay.style.flexDirection = 'column';
+    overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'center';
+    const list = document.createElement('div');
+    bunkers.filter(b => b.active && b.id !== fromId).forEach(b => {
+      const info = moduleMap[b.id] || {};
+      const btn = document.createElement('button');
+      btn.textContent = info.name || b.id;
+      btn.style.margin = '4px';
+      btn.onclick = () => travel(fromId, b.id);
+      list.appendChild(btn);
+    });
+    const cancel = document.createElement('button');
+    cancel.textContent = 'Cancel';
+    cancel.style.marginTop = '8px';
+    cancel.onclick = close;
+    overlay.appendChild(list);
+    overlay.appendChild(cancel);
+    document.body.appendChild(overlay);
+  }
+
+  function close(){
+    document.getElementById('worldMap')?.remove();
+  }
+
+  function travel(fromId, toId){
+    if(!globalThis.Dustland?.fastTravel?.travel(fromId, toId)) return;
+    ensureModule(toId, moduleData => {
+      moduleData.postLoad?.(moduleData);
+      applyModule(moduleData, { fullReset: false });
+      const info = moduleMap[toId];
+      if(info){
+        setMap(info.map, info.name);
+        setPartyPos(info.x, info.y);
+      }
+    });
+    close();
+  }
+
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.worldMap = { open, close };
+})();


### PR DESCRIPTION
## Summary
- hook bunkers into a new world map overlay for fast travel
- unlock Beta bunker after completing gear quest
- document and wire up initial cross-world fast travel

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c21d532c908328af7a6198423ad2da