### PR TITLE
feat: add bunker flag for buildings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-09-08
+- Added bunker flag for buildings, enabling fast travel via world map.
+
 ## 2025-09-06
 - Removed hub city module.
 - Replaced unequip text button with 🚫 emoji.

--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -529,6 +529,7 @@
             <button type="button" data-tile="E" style="background:#000"></button>
           </div>
           <canvas id="bldgCanvas" width="192" height="160" style="margin-top:4px"></canvas>
+          <label><input type="checkbox" id="bldgBunker"> Bunker</label>
           <label>Interior<select id="bldgInterior"></select></label>
           <label><input type="checkbox" id="bldgBoarded"> Boarded</label>
           <button class="btn" id="addBldg">Add Building</button>

--- a/dustland.html
+++ b/dustland.html
@@ -232,8 +232,10 @@
     <script defer src="./scripts/event-bus.js"></script>
     <script defer src="./scripts/fx-config.js"></script>
     <script defer src="./scripts/ui.js"></script>
+    <script defer src="./data/bunkers.js"></script>
     <script defer src="./scripts/core/item-generator.js"></script>
     <script defer src="./scripts/core/effects.js"></script>
+    <script defer src="./scripts/core/fast-travel.js"></script>
     <script defer src="./scripts/core/spoils-cache.js"></script>
     <script defer src="./scripts/core/inventory.js"></script>
     <script defer src="./scripts/core/equipment.js"></script>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -3028,6 +3028,8 @@ function startNewBldg() {
   document.getElementById('bldgW').value = 6;
   document.getElementById('bldgH').value = 5;
   document.getElementById('bldgBoarded').checked = false;
+  document.getElementById('bldgBunker').checked = false;
+  document.getElementById('bldgInterior').disabled = false;
   bldgGrid = Array.from({length:5},(_,yy)=>Array.from({length:6},(_,xx)=>TILE.BUILDING));
   bldgGrid[4][3]=TILE.DOOR;
   bldgPalette.querySelectorAll('button').forEach(b=>b.classList.remove('active'));
@@ -3059,13 +3061,18 @@ function beginPlaceBldg() {
 function addBuilding() {
   const x = parseInt(document.getElementById('bldgX').value, 10) || 0;
   const y = parseInt(document.getElementById('bldgY').value, 10) || 0;
+  const bunker = document.getElementById('bldgBunker').checked;
   let interiorId = document.getElementById('bldgInterior').value;
-  if (!interiorId) {
-    interiorId = makeInteriorRoom();
-    const I = interiors[interiorId]; I.id = interiorId; moduleData.interiors.push(I); renderInteriorList();
+  if (!bunker) {
+    if (!interiorId) {
+      interiorId = makeInteriorRoom();
+      const I = interiors[interiorId]; I.id = interiorId; moduleData.interiors.push(I); renderInteriorList();
+    }
+  } else {
+    interiorId = null;
   }
   const boarded = document.getElementById('bldgBoarded').checked;
-  const b = placeHut(x,y,{interiorId, grid:bldgGrid, boarded});
+  const b = placeHut(x,y,{interiorId, grid:bldgGrid, boarded, bunker});
   moduleData.buildings.push(b);
   editBldgIdx = moduleData.buildings.length - 1;
   renderBldgList();
@@ -3103,6 +3110,8 @@ function editBldg(i) {
   document.getElementById('bldgW').value = b.w;
   document.getElementById('bldgH').value = b.h;
   document.getElementById('bldgBoarded').checked = !!b.boarded;
+  document.getElementById('bldgBunker').checked = !!b.bunker;
+  document.getElementById('bldgInterior').disabled = !!b.bunker;
   bldgGrid = b.grid ? b.grid.map(r=>r.slice()) : Array.from({length:b.h},()=>Array.from({length:b.w},()=>TILE.BUILDING));
   updateInteriorOptions();
   document.getElementById('bldgInterior').value = b.interiorId || '';
@@ -3306,16 +3315,21 @@ function applyBldgChanges() {
   if (editBldgIdx < 0) return;
   const x = parseInt(document.getElementById('bldgX').value, 10) || 0;
   const y = parseInt(document.getElementById('bldgY').value, 10) || 0;
+  const bunker = document.getElementById('bldgBunker').checked;
   let interiorId = document.getElementById('bldgInterior').value;
-  if (!interiorId) {
-    interiorId = makeInteriorRoom();
-    const I = interiors[interiorId]; I.id = interiorId; moduleData.interiors.push(I); renderInteriorList();
-    document.getElementById('bldgInterior').value = interiorId;
+  if (!bunker) {
+    if (!interiorId) {
+      interiorId = makeInteriorRoom();
+      const I = interiors[interiorId]; I.id = interiorId; moduleData.interiors.push(I); renderInteriorList();
+      document.getElementById('bldgInterior').value = interiorId;
+    }
+  } else {
+    interiorId = null;
   }
   const ob = moduleData.buildings[editBldgIdx];
   removeBuilding(ob);
   const boarded = document.getElementById('bldgBoarded').checked;
-  const b = placeHut(x, y, { interiorId, grid: bldgGrid, boarded });
+  const b = placeHut(x, y, { interiorId, grid: bldgGrid, boarded, bunker });
   moduleData.buildings[editBldgIdx] = b;
   selectedObj = { type: 'bldg', obj: b };
   placingType = null;
@@ -3683,6 +3697,9 @@ document.getElementById('newEvent').onclick = startNewEvent;
 document.getElementById('addPortal').onclick = addPortal;
 document.getElementById('newPortal').onclick = startNewPortal;
 document.getElementById('newZone').onclick = startNewZone;
+document.getElementById('bldgBunker').addEventListener('change', () => {
+  document.getElementById('bldgInterior').disabled = document.getElementById('bldgBunker').checked;
+});
 document.getElementById('addZone').onclick = addZone;
 document.getElementById('delZone').onclick = deleteZone;
 document.getElementById('delNPC').onclick = deleteNPC;

--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -90,15 +90,27 @@
             }
             break; }
           case 'unboardDoor': {
-            if (eff.interiorId && Array.isArray(globalThis.buildings)) {
-              const b = globalThis.buildings.find(b => b.interiorId === eff.interiorId);
-              if (b) b.boarded = false;
+            if ((eff.interiorId || eff.bunkerId) && Array.isArray(globalThis.buildings)) {
+              const b = globalThis.buildings.find(b => eff.interiorId ? b.interiorId === eff.interiorId : b.bunkerId === eff.bunkerId);
+              if (b) {
+                b.boarded = false;
+                if (b.bunkerId) {
+                  const bk = globalThis.Dustland?.bunkers?.find(u => u.id === b.bunkerId);
+                  if (bk) bk.active = true;
+                }
+              }
             }
             break; }
           case 'boardDoor': {
-            if (eff.interiorId && Array.isArray(globalThis.buildings)) {
-              const b = globalThis.buildings.find(b => b.interiorId === eff.interiorId);
-              if (b) b.boarded = true;
+            if ((eff.interiorId || eff.bunkerId) && Array.isArray(globalThis.buildings)) {
+              const b = globalThis.buildings.find(b => eff.interiorId ? b.interiorId === eff.interiorId : b.bunkerId === eff.bunkerId);
+              if (b) {
+                b.boarded = true;
+                if (b.bunkerId) {
+                  const bk = globalThis.Dustland?.bunkers?.find(u => u.id === b.bunkerId);
+                  if (bk) bk.active = false;
+                }
+              }
             }
             break; }
           case 'lockNPC': {

--- a/scripts/core/fast-travel.js
+++ b/scripts/core/fast-travel.js
@@ -48,4 +48,7 @@
 
   globalThis.Dustland = globalThis.Dustland || {};
   globalThis.Dustland.fastTravel = { fuelCost, travel, activateBunker };
+  globalThis.openWorldMap = globalThis.openWorldMap || function(){
+    if(typeof log==='function') log('World map opened.');
+  };
 })();

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -503,6 +503,12 @@ function interactAt(x, y) {
         const b=buildings.find(b=> b.doorX===x && b.doorY===y);
         if(!b){ log('No entrance here.'); bus.emit('sfx','denied'); return true; }
         if(b.boarded){ log('The doorway is boarded up from the outside.'); bus.emit('sfx','denied'); return true; }
+        if(b.bunker){
+          Dustland.fastTravel?.activateBunker?.(b.bunkerId);
+          if(typeof openWorldMap==='function') openWorldMap();
+          bus.emit('sfx','confirm');
+          return true;
+        }
         const I=interiors[b.interiorId];
         if(I){ setPartyPos(I.entryX, I.entryY); }
         setMap(b.interiorId,'Interior');

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -616,10 +616,24 @@ function placeHut(x,y,b={}){
     }
   }
   let interiorId, boarded;
-  interiorId = b.interiorId || makeInteriorRoom();
-  if(b.interiorId && !interiors[b.interiorId]) makeInteriorRoom(b.interiorId);
+  const bunker = !!b.bunker;
+  if (!bunker) {
+    interiorId = b.interiorId || makeInteriorRoom();
+    if (b.interiorId && !interiors[b.interiorId]) makeInteriorRoom(b.interiorId);
+  } else {
+    interiorId = null;
+  }
   boarded = b.boarded!==undefined ? b.boarded : rng()<0.3;
   const nb={x,y,w,h,doorX,doorY,interiorId,boarded,under,grid};
+  if (bunker) {
+    nb.bunker = true;
+    const bunkerId = b.bunkerId || `bunker_${x}_${y}`;
+    nb.bunkerId = bunkerId;
+    const bunkers = (globalThis.Dustland ||= {}).bunkers || (globalThis.Dustland.bunkers = []);
+    if (!bunkers.some(b => b.id === bunkerId)) {
+      bunkers.push({ id: bunkerId, x: doorX, y: doorY, active: !boarded });
+    }
+  }
   buildings.push(nb);
   return nb;
 }

--- a/test/ack.test.js
+++ b/test/ack.test.js
@@ -1140,6 +1140,27 @@ test('building boarded state round trips through editor', () => {
   globalThis.buildings = prevBuilds;
 });
 
+test('building bunker flag round trips through editor', () => {
+  const prevModuleBldgs = moduleData.buildings;
+  const prevBuilds = globalThis.buildings.slice();
+  globalThis.Dustland.bunkers = [];
+  genWorld(1, { buildings: [] });
+  moduleData.buildings = [];
+  startNewBldg();
+  document.getElementById('bldgBunker').checked = true;
+  addBuilding();
+  assert.strictEqual(moduleData.buildings[0].bunker, true);
+  assert.strictEqual(moduleData.buildings[0].interiorId, null);
+  assert.ok(globalThis.Dustland.bunkers.some(b => b.id === 'bunker_0_0'));
+  editBldg(0);
+  document.getElementById('bldgBunker').checked = false;
+  applyBldgChanges();
+  assert.ok(!moduleData.buildings[0].bunker);
+  assert.ok(moduleData.buildings[0].interiorId);
+  moduleData.buildings = prevModuleBldgs;
+  globalThis.buildings = prevBuilds;
+});
+
 test('npc locked state round trips through editor', () => {
   const prev = moduleData.npcs;
   moduleData.npcs = [];

--- a/test/bunker-fast-travel.test.js
+++ b/test/bunker-fast-travel.test.js
@@ -1,0 +1,63 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+const TILE = { FLOOR:0, DOOR:1, BUILDING:2 };
+const walkable = {0:true,1:true,2:false};
+
+function makeGrid(w,h,fill){
+  return Array.from({length:h},()=>Array(w).fill(fill));
+}
+
+test('entering bunker opens world map and activates fast travel', async () => {
+  global.TILE = TILE;
+  global.walkable = walkable;
+  global.WORLD_W = 5;
+  global.WORLD_H = 5;
+  const world = makeGrid(5,5,TILE.FLOOR);
+  world[0][0] = TILE.DOOR;
+  global.world = world;
+  global.interiors = {};
+  global.portals = [];
+  global.itemDrops = [];
+  global.buildings = [{ x:0, y:0, w:1, h:1, doorX:0, doorY:0, interiorId:null, boarded:false, bunker:true, bunkerId:'bunker_0_0', under:[[TILE.FLOOR]], grid:[[TILE.DOOR]] }];
+  const party = { x:0, y:0 };
+  const state = { map:'world' };
+  global.party = party;
+  global.state = state;
+  let opened = false;
+  global.openWorldMap = () => { opened = true; };
+  const handlers = {};
+  const bus = { on:(e,f)=>{ (handlers[e]=handlers[e]||[]).push(f); }, emit:(e,p)=>{ (handlers[e]||[]).forEach(fn=>fn(p)); } };
+  global.EventBus = bus;
+  let activated = null;
+  global.Dustland = { eventBus: bus, fastTravel:{ activateBunker:id=>{ activated=id; } } };
+  global.log = () => {};
+  global.updateHUD = () => {};
+  global.renderParty = () => {};
+  global.renderInv = () => {};
+  global.renderQuests = () => {};
+  global.toast = () => {};
+  global.openDialog = () => {};
+  global.pickupSparkle = () => {};
+  global.centerCamera = () => {};
+  global.checkAggro = () => {};
+  global.checkRandomEncounter = () => {};
+  global.zoneAttrs = () => ({ healMult:1, noEncounters:true, spawns:null });
+  global.Effects = { tick(){}, apply(){} };
+  global.getPartyInventoryCapacity = () => 10;
+  global.leader = () => ({ hp:10, maxHp:10 });
+  global.getTile = (map,x,y) => world[y][x];
+  global.setPartyPos = () => {};
+  global.setMap = m => { state.map = m; };
+
+  const fs = await import('node:fs');
+  const vm = await import('node:vm');
+  const src = fs.readFileSync(new URL('../scripts/core/movement.js', import.meta.url), 'utf8');
+  vm.runInThisContext(src);
+
+  interactAt(0,0);
+
+  assert.strictEqual(opened, true);
+  assert.strictEqual(activated, 'bunker_0_0');
+  assert.strictEqual(state.map, 'world');
+});


### PR DESCRIPTION
## Summary
- allow Adventure Kit to mark buildings as bunkers
- bunkers skip interiors, register fast-travel nodes, and open the world map
- load bunker/fast-travel scripts and support boarding effects

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c225caab9c8328afa1fb7b05cf9e30