### PR TITLE
feat: add bunker travel map thumbnails

### DIFF
--- a/modules/world-one.module.js
+++ b/modules/world-one.module.js
@@ -4,18 +4,28 @@ const DATA = `
 {
   "seed": "world-one",
   "start": { "map": "world", "x": 2, "y": 2 },
+  "world": [
+    [0,0,0,0,0],
+    [0,0,0,0,0],
+    [0,0,0,0,0],
+    [0,0,0,0,0],
+    [0,0,0,0,0]
+  ],
   "items": [
     { "id": "fuel_cell", "name": "Fuel Cell", "type": "quest" },
     { "id": "rusty_gear", "name": "Rusty Gear", "type": "quest", "map": "world", "x": 3, "y": 2 }
   ],
+  "buildings": [
+    { "x": 4, "y": 2, "w": 1, "h": 1, "doorX": 4, "doorY": 2, "boarded": true, "bunker": true, "bunkerId": "alpha" }
+  ],
   "npcs": [
     {
-      "id": "gear_seeker",
+      "id": "npc_a",
       "map": "world",
       "x": 1,
       "y": 2,
       "color": "#cfa",
-      "name": "Gear Seeker",
+      "name": "NPC A",
       "desc": "Needs a rusty gear.",
       "prompt": "Wanderer fiddling with broken machine",
       "tree": {

--- a/modules/world-two.module.js
+++ b/modules/world-two.module.js
@@ -4,18 +4,28 @@ const DATA = `
 {
   "seed": "world-two",
   "start": { "map": "world", "x": 2, "y": 2 },
+  "world": [
+    [0,0,0,0,0],
+    [0,0,0,0,0],
+    [0,0,0,0,0],
+    [0,0,0,0,0],
+    [0,0,0,0,0]
+  ],
   "items": [
     { "id": "fuel_cell", "name": "Fuel Cell", "type": "quest" },
     { "id": "shiny_cog", "name": "Shiny Cog", "type": "quest", "map": "world", "x": 2, "y": 3 }
   ],
+  "buildings": [
+    { "x": 4, "y": 2, "w": 1, "h": 1, "doorX": 4, "doorY": 2, "boarded": true, "bunker": true, "bunkerId": "beta" }
+  ],
   "npcs": [
     {
-      "id": "cog_hunter",
+      "id": "npc_b",
       "map": "world",
       "x": 2,
       "y": 1,
       "color": "#acf",
-      "name": "Cog Hunter",
+      "name": "NPC B",
       "desc": "Looking for a shiny cog.",
       "prompt": "Scavenger eyeing a broken robot",
       "tree": {

--- a/scripts/ui/world-map.js
+++ b/scripts/ui/world-map.js
@@ -33,19 +33,14 @@
     list.style.display = 'flex';
     bunkers.filter(b => b.active && b.id !== fromId).forEach(b => {
       const info = moduleMap[b.id] || {};
-      const wrap = document.createElement('div');
-      wrap.style.margin = '4px';
-      const btn = document.createElement('button');
-      btn.textContent = info.name || b.id;
-      btn.style.display = 'block';
-      btn.style.marginTop = '4px';
-      btn.onclick = () => travel(fromId, b.id);
       ensureModule(b.id, moduleData => {
-        const thumb = renderThumb(moduleData);
-        wrap.appendChild(thumb);
-        wrap.appendChild(btn);
+        const thumb = renderThumb(moduleData, info);
+        thumb.style.margin = '4px';
+        thumb.style.cursor = 'pointer';
+        thumb.title = info.name || b.id;
+        thumb.onclick = () => travel(fromId, b.id);
+        list.appendChild(thumb);
       });
-      list.appendChild(wrap);
     });
     const cancel = document.createElement('button');
     cancel.textContent = 'Cancel';
@@ -67,7 +62,7 @@
     if(ft?.loadSlot?.(toId)){ close(); return; }
     ensureModule(toId, moduleData => {
       moduleData.postLoad?.(moduleData);
-      applyModule(moduleData, { fullReset: false });
+      applyModule(moduleData);
       const info = moduleMap[toId];
       if(info){
         setMap(info.map, info.name);
@@ -78,7 +73,7 @@
     });
   }
 
-  function renderThumb(moduleData){
+  function renderThumb(moduleData, info){
     const canvas = document.createElement('canvas');
     const world = moduleData?.world;
     const scale = 4;
@@ -87,9 +82,14 @@
       canvas.height = world.length * scale;
       const ctx = canvas.getContext('2d');
       world.forEach((row, y) => row.forEach((t, x) => {
-        ctx.fillStyle = t ? '#6b8' : '#000';
-        ctx.fillRect(x*scale, y*scale, scale, scale);
+        const hasTile = t !== undefined && t !== null;
+        ctx.fillStyle = hasTile ? '#6b8' : '#000';
+        ctx.fillRect(x * scale, y * scale, scale, scale);
       }));
+      if(info){
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(info.x * scale, info.y * scale, scale, scale);
+      }
     }else{
       canvas.width = canvas.height = 32;
       const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- add bunker buildings and NPC A/B split across two worlds
- render world map thumbnails with bunker markers and clickable fast travel
- reset world state on bunker travel to avoid cross-world NPCs

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2391734188328a56235af0d8b4ef9