### PR TITLE
feat: add wistful tone to dustland module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-09-11
+- Added poetic greeting and enriched Archivist dialogue in Dustland module.
+
 ## 2025-09-08
 - Added bunker flag for buildings, enabling fast travel via world map.
 

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -590,11 +590,11 @@ const DATA = `
       "title": "Memory Keeper",
       "portraitSheet": "assets/portraits/dustland-module/archivist_4.png",
       "portraitLock": false,
-      "desc": "Curious about recorded tales.",
+      "desc": "Guardian of whispers, archiving the last songs of a fading world.",
       "prompt": "Elder hunched over reels of magnetic tape",
       "tree": {
         "start": {
-          "text": "Got anything on tape?",
+          "text": "The Archivist's eyes glimmer. 'Do you carry any memories worth saving?'",
           "choices": [ { "label": "(Leave)", "to": "bye" } ]
         }
       }
@@ -2683,4 +2683,5 @@ startGame = function () {
   const loc = s || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };
   setMap(loc.map, loc.map === 'world' ? 'Wastes' : 'Test Hall');
   setPartyPos(loc.x, loc.y);
+  log('The wind carries a lone melody, bittersweet and fading.');
 };


### PR DESCRIPTION
## Summary
- Enrich the Archivist NPC with a reflective question and history-keeping flair
- Whisper a melancholy greeting when Dustland loads

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2989efd608328ac8141163e7a9464