### PR TITLE
feat: add multiplayer lobby shortcut

### DIFF
--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -144,6 +144,14 @@ function showModulePicker(){
   ackBtn.onclick = () => { window.location.href = 'adventure-kit.html'; };
   overlay.appendChild(ackBtn);
 
+  const mpBtn = document.createElement('div');
+  mpBtn.id = 'mpGlyph';
+  mpBtn.textContent = '⇆';
+  mpBtn.title = 'Multiplayer';
+  mpBtn.style = 'position:absolute;top:44px;right:10px;z-index:1;color:#0f0;font-size:24px;cursor:pointer';
+  mpBtn.onclick = () => { window.location.href = 'multiplayer.html'; };
+  overlay.appendChild(mpBtn);
+
   const canvas = document.createElement('canvas');
   canvas.id = 'dustParticles';
   // Background dust layer; z-index keeps UI elements in front.

--- a/scripts/supporting/multiplayer-lobby.js
+++ b/scripts/supporting/multiplayer-lobby.js
@@ -3,7 +3,7 @@
   const refreshBtn = document.getElementById('refresh');
 
   function join(sess) {
-    alert('Joining ' + sess.name + ' at ' + sess.host + ':' + sess.port);
+    window.location.href = `dustland.html?host=${encodeURIComponent(sess.host)}&port=${sess.port}`;
   }
 
   function refresh() {


### PR DESCRIPTION
## Summary
- add a multiplayer icon to the module picker overlay
- link lobby session joins to the game with host/port params

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c29c61e3ec8328ba406f9c2953908e