### PR TITLE
fix: delay two-worlds module start until world loads

### DIFF
--- a/modules/two-worlds.module.js
+++ b/modules/two-worlds.module.js
@@ -1,8 +1,15 @@
 // Entry module that loads World One with a brief tutorial dialog.
 (function(){
+  let worldOneStart;
+  function startWrapper(){
+    worldOneStart?.();
+  }
+  startGame = startWrapper;
   const script = document.createElement('script');
   script.src = 'modules/world-one.module.js';
   script.onload = () => {
+    worldOneStart = startGame;
+    startGame = startWrapper;
     const heart = {
       name: 'Wistful Heart',
       tree: {
@@ -11,7 +18,7 @@
           choices: [
             { label: 'What are bunkers?', to: 'bunkers' },
             { label: 'How do I travel quickly?', to: 'travel' },
-            { label: '(Step into the wastes)', to: 'bye', effects: [ startGame ] }
+            { label: '(Step into the wastes)', to: 'bye', effects: [ startWrapper ] }
           ]
         },
         bunkers: {

--- a/test/two-worlds-init.test.js
+++ b/test/two-worlds-init.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+test('two-worlds module defers start until world one loads', () => {
+  let addedScript = null;
+  const origDoc = global.document;
+  const origOpen = global.openDialog;
+  const origStart = global.startGame;
+  const doc = {
+    createElement: () => ({ onload: null, src: '' }),
+    head: { appendChild(el) { addedScript = el; } }
+  };
+  global.document = doc;
+  let dialogOpened = false;
+  global.openDialog = () => { dialogOpened = true; };
+  const src = fs.readFileSync(new URL('../modules/two-worlds.module.js', import.meta.url), 'utf8');
+  vm.runInThisContext(src);
+  assert.strictEqual(typeof startGame, 'function');
+  let started = false;
+  startGame = () => { started = true; };
+  addedScript.onload();
+  assert.ok(dialogOpened);
+  startGame();
+  assert.ok(started);
+  if (origDoc === undefined) delete global.document; else global.document = origDoc;
+  if (origOpen === undefined) delete global.openDialog; else global.openDialog = origOpen;
+  if (origStart === undefined) delete global.startGame; else global.startGame = origStart;
+});


### PR DESCRIPTION
## Summary
- keep `startGame` defined while loading world one in two-worlds module
- add regression test for two-worlds initialization

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c29d0f39208328bdaff6c05345d286