### PR TITLE
feat: host game from multiplayer menu

### DIFF
--- a/docs/guides/multiplayer-firewall-guide.md
+++ b/docs/guides/multiplayer-firewall-guide.md
@@ -1,16 +1,17 @@
 # Multiplayer Firewall Guide
 
-To host or join LAN sessions, ensure TCP and UDP port **7777** are open:
+Use the **Host** button on the multiplayer menu to start a session. By default,
+games listen on TCP and UDP port **9000**, so ensure it is open:
 
 1. **Windows:**
    - Open *Windows Defender Firewall*.
    - Choose *Advanced Settings* → *Inbound Rules* → *New Rule*.
-   - Select *Port*, enter **7777**, and allow connections.
+   - Select *Port*, enter **9000**, and allow connections.
 2. **macOS:**
    - Go to *System Settings* → *Network* → *Firewall*.
-   - Add Dustland to *Allow incoming connections* and specify port **7777**.
+   - Add Dustland to *Allow incoming connections* and specify port **9000**.
 3. **Routers:**
-   - Log in to your router and forward TCP/UDP **7777** to the host machine.
+   - Log in to your router and forward TCP/UDP **9000** to the host machine.
    - Save and reboot if required.
 
 Players should share their local IP address with friends to join their session.

--- a/multiplayer.html
+++ b/multiplayer.html
@@ -7,8 +7,11 @@
 </head>
 <body>
   <h1>LAN Lobby</h1>
+  <button id="host">Host</button>
   <button id="refresh">Refresh</button>
   <ul id="sessions"></ul>
+  <script defer src="./scripts/supporting/multiplayer-sync.js"></script>
+  <script defer src="./scripts/multiplayer.js"></script>
   <script defer src="./scripts/supporting/multiplayer-lobby.js"></script>
 </body>
 </html>

--- a/scripts/supporting/multiplayer-host.js
+++ b/scripts/supporting/multiplayer-host.js
@@ -1,11 +1,30 @@
 import http from 'node:http';
 
-const sessions = [{ name: 'Test Host', host: 'localhost', port: 9000 }];
+const sessions = [];
 
 http.createServer((req, res) => {
-  if (req.url === '/sessions') {
+  if (req.url === '/sessions' && req.method === 'GET') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(sessions));
+  } else if (req.url === '/sessions' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const sess = JSON.parse(body || '{}');
+        if (sess && sess.name && sess.port) {
+          sessions.push(sess);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+        } else {
+          res.writeHead(400);
+          res.end();
+        }
+      } catch {
+        res.writeHead(400);
+        res.end();
+      }
+    });
   } else {
     res.writeHead(404);
     res.end();

--- a/scripts/supporting/multiplayer-lobby.js
+++ b/scripts/supporting/multiplayer-lobby.js
@@ -1,6 +1,8 @@
 (function () {
   const list = document.getElementById('sessions');
   const refreshBtn = document.getElementById('refresh');
+  const hostBtn = document.getElementById('host');
+  const HOST_PORT = 9000;
 
   function join(sess) {
     window.location.href = `dustland.html?host=${encodeURIComponent(sess.host)}&port=${sess.port}`;
@@ -27,6 +29,19 @@
       });
   }
 
+  async function host() {
+    const name = prompt('Session name?', 'LAN Game') || 'LAN Game';
+    hostBtn.disabled = true;
+    await globalThis.Dustland?.multiplayer?.startHost({ port: HOST_PORT });
+    fetch('http://localhost:7777/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, host: 'localhost', port: HOST_PORT })
+    }).catch(() => {});
+    window.location.href = `dustland.html?host=localhost&port=${HOST_PORT}`;
+  }
+
   refreshBtn.onclick = refresh;
+  hostBtn.onclick = host;
   refresh();
 })();


### PR DESCRIPTION
## Summary
- add Host button to multiplayer lobby and load required multiplayer scripts
- allow lobby script to start hosting and register the session
- enable lobby server to accept POST registrations and document default port

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c31c85de5083289b5fedca6c21f7a9