### PR TITLE
feat: add persona camp overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-09-09
+- Added overlay UI for equipping personas at camp.
+
 ## 2025-09-08
 - Added bunker flag for buildings, enabling fast travel via world map.
 

--- a/dustland.css
+++ b/dustland.css
@@ -733,6 +733,28 @@ input[type="range"] {
   margin-left: 8px;
 }
 
+#personaOverlay .persona-window {
+  width: 260px;
+  background: #0f120f;
+  border: 1px solid #2b3b2b;
+  border-radius: 8px;
+  box-shadow: 0 0 20px #000;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+#personaOverlay .persona-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#personaOverlay .persona-list .btn {
+  width: 100%;
+}
+
 .slot-list {
   display: flex;
   flex-direction: column;

--- a/dustland.html
+++ b/dustland.html
@@ -283,6 +283,14 @@
       document.body.appendChild(modeScript);
     });
   </script>
+  <!-- Persona overlay -->
+  <div class="overlay" id="personaOverlay" role="dialog" aria-modal="true" tabindex="-1">
+    <div class="persona-window">
+      <h2>Equip Persona</h2>
+      <div id="personaList" class="persona-list"></div>
+      <button id="closePersonaBtn" class="btn">Close</button>
+    </div>
+  </div>
   <!-- Shop overlay -->
   <div class="overlay" id="shopOverlay" role="dialog" aria-modal="true" tabindex="-1">
     <div class="shop-window">

--- a/scripts/camp-persona.js
+++ b/scripts/camp-persona.js
@@ -3,7 +3,13 @@
   const gs = globalThis.Dustland?.gameState;
   if (!bus || !gs?.applyPersona) return;
   const btn = document.getElementById('campBtn');
+  const overlay = document.getElementById('personaOverlay');
+  const list = document.getElementById('personaList');
+  const closeBtn = document.getElementById('closePersonaBtn');
   if (btn) btn.addEventListener('click', () => bus.emit('camp:open'));
+  if (closeBtn && overlay) {
+    closeBtn.addEventListener('click', () => overlay.classList.remove('shown'));
+  }
   bus.on('camp:open', () => {
     const pos = globalThis.party;
     const map = globalThis.state?.map || 'world';
@@ -28,10 +34,20 @@
     globalThis.log?.('You rest until healed.');
     const state = gs.getState?.() || {};
     const member = state.party && state.party[0];
-    if (!member) return;
+    if (!member || !overlay || !list) return;
     const ids = Object.keys(state.personas || {});
     if (!ids.length) return;
-    const choice = prompt(`Equip persona for ${member.name}`, ids.join(','));
-    if (choice && state.personas[choice]) gs.applyPersona(member.id, choice);
+    list.innerHTML = '';
+    ids.forEach(id => {
+      const b = document.createElement('button');
+      b.className = 'btn';
+      b.textContent = id;
+      b.addEventListener('click', () => {
+        overlay.classList.remove('shown');
+        gs.applyPersona(member.id, id);
+      }, { once: true });
+      list.appendChild(b);
+    });
+    overlay.classList.add('shown');
   });
 })();

--- a/test/camp.test.js
+++ b/test/camp.test.js
@@ -3,16 +3,20 @@ import { test } from 'node:test';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
 import { EventEmitter } from 'node:events';
+import { JSDOM } from 'jsdom';
 
-test('camp:open heals party and refills hydration', async () => {
+test('camp:open heals party and shows persona menu', async () => {
+  const dom = new JSDOM('<!doctype html><body><button id="campBtn"></button><div class="overlay" id="personaOverlay"><div class="persona-window"><div id="personaList" class="persona-list"></div><button id="closePersonaBtn" class="btn"></button></div></div></body>', { pretendToBeVisual: true });
+  const { document } = dom.window;
   const bus = new EventEmitter();
   let healed = false;
   let msg = '';
+  let applied = '';
   const healAll = () => { healed = true; };
   const log = m => { msg = m; };
   const gs = {
     getState: () => ({ party: [{ id: 'p1', name: 'Hero' }], personas: { a: {} } }),
-    applyPersona: () => {}
+    applyPersona: (pid, id) => { applied = id; }
   };
   const party = [{ id: 'p1', name: 'Hero', hydration: 0 }];
   party.x = 0; party.y = 0;
@@ -20,10 +24,9 @@ test('camp:open heals party and refills hydration', async () => {
   const sandbox = {
     EventBus: bus,
     Dustland: { gameState: gs, zoneEffects: [] },
-    document: { getElementById: () => null },
+    document,
     healAll,
     log,
-    prompt: () => null,
     party,
     state,
     updateHUD: () => {}
@@ -35,9 +38,18 @@ test('camp:open heals party and refills hydration', async () => {
   assert.ok(healed);
   assert.equal(party[0].hydration, 2);
   assert.equal(msg, 'You rest until healed.');
+  const overlay = document.getElementById('personaOverlay');
+  assert.ok(overlay.classList.contains('shown'));
+  const btn = document.querySelector('#personaList .btn');
+  assert.ok(btn);
+  btn.click();
+  assert.equal(applied, 'a');
+  assert.ok(!overlay.classList.contains('shown'));
 });
 
 test('camp:open blocked in dry or damaging zones', async () => {
+  const dom = new JSDOM('<!doctype html><body><div class="overlay" id="personaOverlay"><div class="persona-window"><div id="personaList" class="persona-list"></div><button id="closePersonaBtn" class="btn"></button></div></div></body>', { pretendToBeVisual: true });
+  const { document } = dom.window;
   const bus = new EventEmitter();
   let healed = false;
   let msg = '';
@@ -53,10 +65,9 @@ test('camp:open blocked in dry or damaging zones', async () => {
   const sandbox = {
     EventBus: bus,
     Dustland: { gameState: gs, zoneEffects: [] },
-    document: { getElementById: () => null },
+    document,
     healAll,
     log,
-    prompt: () => null,
     party,
     state,
     updateHUD: () => {}
@@ -71,6 +82,7 @@ test('camp:open blocked in dry or damaging zones', async () => {
   assert.ok(!healed);
   assert.equal(party[0].hydration, 1);
   assert.equal(msg, "You can't camp here.");
+  assert.ok(!document.getElementById('personaOverlay').classList.contains('shown'));
 
   zones[0] = { map: 'world', x: 0, y: 0, w: 1, h: 1, perStep: { hp: -1 } };
   healed = false; msg = '';


### PR DESCRIPTION
## Summary
- replace camp persona prompt with overlay UI and buttons
- style persona overlay to match existing controls
- add tests for persona menu interactions

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`
- `./install-deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c299665ae08328a42d606564569fc5