### PR TITLE
fix: display lobby errors

### DIFF
--- a/scripts/supporting/multiplayer-lobby.js
+++ b/scripts/supporting/multiplayer-lobby.js
@@ -24,20 +24,30 @@
         });
         if (!data.length) list.textContent = 'No sessions found';
       })
-      .catch(() => {
-        list.textContent = 'No sessions found';
+      .catch(err => {
+        list.textContent = 'Error: ' + (err?.message || err);
       });
   }
 
   async function host() {
     const name = prompt('Session name?', 'LAN Game') || 'LAN Game';
     hostBtn.disabled = true;
-    await globalThis.Dustland?.multiplayer?.startHost({ port: HOST_PORT });
-    fetch('http://localhost:7777/sessions', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, host: 'localhost', port: HOST_PORT })
-    }).catch(() => {});
+    try {
+      await globalThis.Dustland?.multiplayer?.startHost({ port: HOST_PORT });
+    } catch (err) {
+      alert('Error: ' + (err?.message || err));
+      hostBtn.disabled = false;
+      return;
+    }
+    try {
+      await fetch('http://localhost:7777/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, host: 'localhost', port: HOST_PORT })
+      });
+    } catch (err) {
+      alert('Error: ' + (err?.message || err));
+    }
     window.location.href = `dustland.html?host=localhost&port=${HOST_PORT}`;
   }
 

--- a/test/multiplayer-lobby-errors.test.js
+++ b/test/multiplayer-lobby-errors.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+const code = await fs.readFile(new URL('../scripts/supporting/multiplayer-lobby.js', import.meta.url), 'utf8');
+
+test('refresh shows fetch error', async () => {
+  const document = makeDocument();
+  document.body.appendChild(document.getElementById('sessions'));
+  document.body.appendChild(document.getElementById('refresh'));
+  document.body.appendChild(document.getElementById('host'));
+  const context = {
+    document,
+    fetch: () => Promise.reject(new Error('boom')),
+    alert: () => {},
+    prompt: () => 'Game',
+    Dustland: { multiplayer: { startHost: async () => {} } },
+    window: { location: { href: '' } }
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  await new Promise(r => setTimeout(r));
+  assert.ok(document.getElementById('sessions').textContent.includes('boom'));
+});
+
+test('host shows start error', async () => {
+  const document = makeDocument();
+  document.body.appendChild(document.getElementById('sessions'));
+  document.body.appendChild(document.getElementById('refresh'));
+  document.body.appendChild(document.getElementById('host'));
+  const messages = [];
+  const context = {
+    document,
+    fetch: () => Promise.resolve({ json: () => [] }),
+    alert: m => messages.push(m),
+    prompt: () => 'Game',
+    Dustland: { multiplayer: { startHost: async () => { throw new Error('no ws'); } } },
+    window: { location: { href: '' } }
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  await Promise.resolve();
+  await context.document.getElementById('host').onclick();
+  assert.ok(messages[0].includes('no ws'));
+  assert.equal(document.getElementById('host').disabled, false);
+});


### PR DESCRIPTION
## Summary
- surface multiplayer lobby errors to players
- add tests for lobby error handling

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c322f06d8883288871b89cb58bc74e