### PR TITLE
feat: add module summary utility

### DIFF
--- a/scripts/supporting/module-summary.js
+++ b/scripts/supporting/module-summary.js
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+function loadModule(path) {
+  const text = fs.readFileSync(path, 'utf8');
+  const match = text.match(/const DATA = `([\s\S]*?)`;/);
+  if (!match) {
+    throw new Error('No DATA string found');
+  }
+  return JSON.parse(match[1]);
+}
+
+function summarize(mod) {
+  const lines = [];
+  lines.push(`seed: ${mod.seed}`);
+  if (mod.start) {
+    lines.push(`start: ${mod.start.map} (${mod.start.x},${mod.start.y})`);
+  }
+  if (Array.isArray(mod.items)) {
+    lines.push(`items: ${mod.items.length}`);
+    const names = mod.items.map(i => i.name || i.id);
+    if (names.length) {
+      lines.push(`  ${names.join(', ')}`);
+    }
+  }
+  if (Array.isArray(mod.quests)) {
+    lines.push(`quests: ${mod.quests.length}`);
+    const titles = mod.quests.map(q => q.title || q.id);
+    if (titles.length) {
+      lines.push(`  ${titles.join(', ')}`);
+    }
+  }
+  if (Array.isArray(mod.npcs)) {
+    lines.push(`npcs: ${mod.npcs.length}`);
+    mod.npcs.forEach(n => {
+      const nodes = n.tree ? Object.keys(n.tree).length : 0;
+      lines.push(`  ${n.name || n.id} (${nodes})`);
+    });
+  }
+  if (Array.isArray(mod.events)) {
+    lines.push(`events: ${mod.events.length}`);
+  }
+  if (Array.isArray(mod.zones)) {
+    lines.push(`zones: ${mod.zones.length}`);
+  }
+  if (Array.isArray(mod.buildings)) {
+    lines.push(`buildings: ${mod.buildings.length}`);
+  }
+  if (Array.isArray(mod.portals)) {
+    lines.push(`portals: ${mod.portals.length}`);
+  }
+  if (Array.isArray(mod.interiors)) {
+    lines.push(`interiors: ${mod.interiors.length}`);
+  }
+  return lines.join('\n');
+}
+
+export { loadModule, summarize };
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  const modPath = process.argv[2];
+  if (!modPath) {
+    console.error('Usage: node module-summary.js <module-file>');
+    process.exit(1);
+  }
+  const mod = loadModule(modPath);
+  console.log(summarize(mod));
+}

--- a/test/module-summary.test.js
+++ b/test/module-summary.test.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { summarize } from '../scripts/supporting/module-summary.js';
+
+const mod = {
+  seed: 'demo',
+  items: [
+    { id: 'a', name: 'Alpha' },
+    { id: 'b' }
+  ],
+  quests: [
+    { id: 'q1', title: 'Quest One' }
+  ],
+  npcs: [
+    { name: 'Guide', tree: { start: {}, end: {} } }
+  ]
+};
+
+const lines = summarize(mod).split('\n');
+assert(lines.includes('items: 2'));
+assert(lines.includes('  Alpha, b'));
+assert(lines.includes('quests: 1'));
+assert(lines.includes('  Quest One'));
+assert(lines.includes('npcs: 1'));
+assert(lines.includes('  Guide (2)'));
+


### PR DESCRIPTION
## Summary
- add module summary script to count core elements in a module file
- list item and quest names and show each NPC's dialog node count
- cover summary logic with basic unit test

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c31dc3b3f083288a874fbb0aea6e9f