### PR TITLE
feat: link personas to mask loot

### DIFF
--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -304,6 +304,7 @@ function normalizeItem(it){
     value: val,
     scrap: typeof it.scrap === 'number' ? it.scrap : undefined,
     desc: it.desc || '',
+    persona: it.persona,
   };
 }
 

--- a/scripts/core/item-generator.js
+++ b/scripts/core/item-generator.js
@@ -68,6 +68,12 @@ const ItemGen = {
     };
     item.scrap = this.scrapValues[rank] ?? this.calcScrap(item);
     item.tags = [noun.toLowerCase()];
+    if(noun.toLowerCase() === 'mask'){
+      const plist = Object.keys(globalThis.Dustland?.personaTemplates || {});
+      if(plist.length){
+        item.persona = this.pick(plist, rng);
+      }
+    }
     return item;
   }
 };

--- a/scripts/core/personas.js
+++ b/scripts/core/personas.js
@@ -1,11 +1,19 @@
 (function(){
   if(!globalThis.Dustland) globalThis.Dustland = {};
-  const setPersona = globalThis.Dustland.gameState?.setPersona;
-  if(typeof setPersona !== 'function') return;
-  const personas = [
-    { id: 'mara.masked', label: 'Masked Mara', portrait: 'assets/portraits/hidden_hermit_4.png', mods: { AGI: 1 } },
-    { id: 'jax.patchwork', label: 'Patchwork Jax', portrait: 'assets/portraits/iron_brute_4.png', mods: { STR: 1 } },
-    { id: 'nyx.veiled', label: 'Veiled Nyx', portrait: 'assets/portraits/nora_4.png', mods: { INT: 1 } }
-  ];
-  personas.forEach(p => setPersona(p.id, p));
+  const gs = globalThis.Dustland.gameState;
+  const bus = globalThis.EventBus;
+  if(!gs?.setPersona || !bus?.on) return;
+  const templates = {
+    'mara.masked': { id: 'mara.masked', label: 'Masked Mara', portrait: 'assets/portraits/hidden_hermit_4.png', mods: { AGI: 1 } },
+    'jax.patchwork': { id: 'jax.patchwork', label: 'Patchwork Jax', portrait: 'assets/portraits/iron_brute_4.png', mods: { STR: 1 } },
+    'nyx.veiled': { id: 'nyx.veiled', label: 'Veiled Nyx', portrait: 'assets/portraits/nora_4.png', mods: { INT: 1 } }
+  };
+  globalThis.Dustland.personaTemplates = templates;
+  bus.on('item:picked', it => {
+    const tags = Array.isArray(it?.tags) ? it.tags.map(t => t.toLowerCase()) : [];
+    if(!tags.includes('mask')) return;
+    const pid = it.persona;
+    const p = templates[pid];
+    if(pid && p) gs.setPersona(pid, p);
+  });
 })();

--- a/test/persona-hud.test.js
+++ b/test/persona-hud.test.js
@@ -13,6 +13,7 @@ test('renderParty reflects persona portrait and label', async () => {
   vm.runInContext(gs, context);
   const ps = await fs.readFile(new URL('../scripts/core/personas.js', import.meta.url), 'utf8');
   vm.runInContext(ps, context);
+  context.EventBus.emit('item:picked', { tags:['mask'], persona:'mara.masked' });
   context.Dustland.gameState.updateState(s => { s.party = party; });
   context.Dustland.gameState.applyPersona('mara', 'mara.masked');
   context.renderParty();

--- a/test/persona-mask-drop.test.js
+++ b/test/persona-mask-drop.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const genCode = await fs.readFile(new URL('../scripts/core/item-generator.js', import.meta.url), 'utf8');
+const cacheCode = await fs.readFile(new URL('../scripts/core/spoils-cache.js', import.meta.url), 'utf8');
+const invCode = await fs.readFile(new URL('../scripts/core/inventory.js', import.meta.url), 'utf8');
+const gsCode = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
+const personasCode = await fs.readFile(new URL('../scripts/core/personas.js', import.meta.url), 'utf8');
+
+const listeners = {};
+const bus = { on(evt,fn){ (listeners[evt]=listeners[evt]||[]).push(fn); }, emit(evt,p){ (listeners[evt]||[]).forEach(fn=>fn(p)); } };
+global.EventBus = bus;
+global.party = [{}];
+vm.runInThisContext(genCode, { filename: 'core/item-generator.js' });
+vm.runInThisContext(cacheCode, { filename: 'core/spoils-cache.js' });
+vm.runInThisContext(invCode, { filename: 'core/inventory.js' });
+vm.runInThisContext(gsCode, { filename: 'game-state.js' });
+vm.runInThisContext(personasCode, { filename: 'core/personas.js' });
+
+test('mask cache drop registers persona', () => {
+  global.player = { inv: [SpoilsCache.create('sealed')] };
+  global.notifyInventoryChanged = () => {};
+  const origPick = ItemGen.pick;
+  ItemGen.pick = (list, rng) => list.includes('Mask') ? 'MASK' : origPick(list, rng);
+  const item = SpoilsCache.open('sealed');
+  ItemGen.pick = origPick;
+  const pid = item.persona;
+  assert.ok(pid);
+  assert.ok(global.Dustland.gameState.getPersona(pid));
+  delete global.player;
+});

--- a/test/persona-mods.test.js
+++ b/test/persona-mods.test.js
@@ -8,7 +8,9 @@ import { JSDOM } from 'jsdom';
 
 test('persona mods apply combat bonuses', async () => {
   const dom = new JSDOM('<body></body>');
-  const context = { window: dom.window, document: dom.window.document, console };
+  const listeners = {};
+  const bus = { on(evt,fn){ (listeners[evt]=listeners[evt]||[]).push(fn); }, emit(evt,p){ (listeners[evt]||[]).forEach(fn=>fn(p)); } };
+  const context = { window: dom.window, document: dom.window.document, console, EventBus: bus };
   vm.createContext(context);
   context.log = () => {};
   context.renderParty = () => {};
@@ -19,6 +21,7 @@ test('persona mods apply combat bonuses', async () => {
   vm.runInContext(partyJs, context);
   const personasJs = await fs.readFile(new URL('../scripts/core/personas.js', import.meta.url), 'utf8');
   vm.runInContext(personasJs, context);
+  bus.emit('item:picked', { tags:['mask'], persona:'mara.masked' });
   const { makeMember, joinParty } = context;
   const m = makeMember('mara', 'Mara', 'scout');
   joinParty(m);

--- a/test/personas-apply.test.js
+++ b/test/personas-apply.test.js
@@ -6,13 +6,16 @@ import { JSDOM } from 'jsdom';
 
 test('applyPersona assigns persona to party member', async () => {
   const dom = new JSDOM('<body></body>');
-  const context = { window: dom.window, document: dom.window.document, console };
+  const listeners = {};
+  const bus = { on(evt,fn){ (listeners[evt]=listeners[evt]||[]).push(fn); }, emit(evt,p){ (listeners[evt]||[]).forEach(fn=>fn(p)); } };
+  const context = { window: dom.window, document: dom.window.document, console, EventBus: bus };
   vm.createContext(context);
   const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
   vm.runInContext(gs, context);
   context.Dustland.gameState.updateState(s => { s.party = [{ id: 'mara', name: 'Mara' }]; });
   const ps = await fs.readFile(new URL('../scripts/core/personas.js', import.meta.url), 'utf8');
   vm.runInContext(ps, context);
+  bus.emit('item:picked', { tags:['mask'], persona:'mara.masked' });
   const applyPersona = context.Dustland.gameState.applyPersona;
   applyPersona('mara', 'mara.masked');
   const st = context.Dustland.gameState.getState();

--- a/test/personas.test.js
+++ b/test/personas.test.js
@@ -6,12 +6,17 @@ import { JSDOM } from 'jsdom';
 
 test('personas register alternate masks', async () => {
   const dom = new JSDOM('<body></body>');
-  const context = { window: dom.window, document: dom.window.document, console };
+  const listeners = {};
+  const bus = { on(evt,fn){ (listeners[evt]=listeners[evt]||[]).push(fn); }, emit(evt,p){ (listeners[evt]||[]).forEach(fn=>fn(p)); } };
+  const context = { window: dom.window, document: dom.window.document, console, EventBus: bus };
   vm.createContext(context);
   const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
   vm.runInContext(gs, context);
   const ps = await fs.readFile(new URL('../scripts/core/personas.js', import.meta.url), 'utf8');
   vm.runInContext(ps, context);
+  bus.emit('item:picked', { tags:['mask'], persona:'mara.masked' });
+  bus.emit('item:picked', { tags:['Mask'], persona:'jax.patchwork' });
+  bus.emit('item:picked', { tags:['MASK'], persona:'nyx.veiled' });
   const gp = context.Dustland.gameState.getPersona;
   assert.ok(gp('mara.masked'));
   assert.ok(gp('jax.patchwork'));


### PR DESCRIPTION
## Summary
- tie persona templates to mask items and register on pickup
- generate masks with persona IDs
- preserve persona IDs in inventory and test mask-driven persona unlock
- normalize mask tag and noun case handling for equality checks

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3218f202883288aec9fa9f0c8fd79