### PR TITLE
feat: add hydration meter and module picker entries

### DIFF
--- a/docs/design/in-progress/hydration-system.md
+++ b/docs/design/in-progress/hydration-system.md
@@ -26,7 +26,7 @@
 ## Implementation Sketch
 - [x] Add `hydration` property to party members in `scripts/core/status.js`.
  - [x] Broadcast `hydration:tick` from the world loop; listeners reduce the meter only in zones marked dry.
-- [ ] Update the HUD with a compact droplet meter next to HP when not full (games that don't trigger this effect shouldn't have to worry about this as the meter should hide)
+- [x] Update the HUD with a compact droplet meter next to HP when not full (games that don't trigger this effect shouldn't have to worry about this as the meter should hide)
 - [x] Seed a starter canteen in character creation via `data/items/starter.js`.
 
 > **Gizmo:** Keep values in `data/balance/hydration.json` so modders can adjust without touching code.

--- a/docs/design/in-progress/multiplayer.md
+++ b/docs/design/in-progress/multiplayer.md
@@ -19,4 +19,4 @@ LAN-based peer-to-peer sessions let a host share their world. A small lobby list
 - [x] Prototype world-state sync over WebSockets.
 - [x] Build a lobby screen to list and join LAN sessions.
 - [x] Draft player-facing firewall and port-forwarding guide.
-- [ ] create button in UI for multiplayer mode accessible from a glyph button under the pencil (adventure kit) in module select
+- [x] create button in UI for multiplayer mode accessible from a glyph button under the pencil (adventure kit) in module select

--- a/docs/design/in-progress/true-dust.md
+++ b/docs/design/in-progress/true-dust.md
@@ -37,7 +37,7 @@ The Dustland opens its eyes with a whisper of grit and memory. "True Dust" drops
 - [x] Design Lakeside dockhand scene: give pendant fragment when Rygar present; deliver warning note when absent.
 - [x] Log quest updates for Rygar's Echo, Static Whisper, and Bandit Purge.
 - [x] Test Stonegate safety, radio range, bandit balance, and Lakeside branching outcomes.
-- [ ] wire up true dust to module select
+- [x] wire up true dust to module select
 
 ## Verification Instructions
 

--- a/dustland.css
+++ b/dustland.css
@@ -130,6 +130,11 @@ input[type="range"] {
         font-weight: 700
     }
 
+    .hud .hydration {
+        margin-left: 4px;
+        font-size: 12px;
+    }
+
     .hudbar {
         position: relative;
         width: 100%;

--- a/dustland.html
+++ b/dustland.html
@@ -25,7 +25,7 @@
         <div class="hud">
           <div id="weatherBanner" class="weather-banner" hidden></div>
           <div class="badge">
-            <div class="label">HP <span id="hp">10</span></div>
+            <div class="label">HP <span id="hp">10</span><span id="hydrationMeter" class="hydration" hidden></span></div>
             <div class="hudbar" id="hpBar" role="progressbar" aria-label="Health" aria-valuemin="0" aria-valuemax="10" aria-valuenow="10">
               <div class="ghost" id="hpGhost"></div>
               <div class="fill" id="hpFill"></div>

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -11,6 +11,7 @@ const scrEl = document.getElementById('scrap');
 const hpBar = document.getElementById('hpBar');
 const hpFill = document.getElementById('hpFill');
 const hpGhost = document.getElementById('hpGhost');
+const hydEl = document.getElementById('hydrationMeter');
 const adrBar = document.getElementById('adrBar');
 const adrFill = document.getElementById('adrFill');
 const statusIcons = document.getElementById('statusIcons');
@@ -602,6 +603,17 @@ function updateHUD(){
           statusIcons.appendChild(s);
         }
       }
+    }
+  }
+  if(hydEl){
+    const h = player.hydration;
+    const maxHyd = 2;
+    if(typeof h === 'number' && h < maxHyd){
+      hydEl.textContent = '💧'.repeat(h);
+      hydEl.hidden = false;
+    }else{
+      hydEl.textContent = '';
+      hydEl.hidden = true;
     }
   }
   updateHUD._lastHpVal = player.hp;

--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -8,6 +8,7 @@ const MODULES = [
   { id: 'pit', name: 'PIT.BAS', file: 'modules/pit-bas.module.js' },
   { id: 'other', name: 'OTHER.BAS', file: 'modules/other-bas.module.js' },
   { id: 'two-worlds', name: 'Two Worlds', file: 'modules/two-worlds.module.js' },
+  { id: 'true-dust', name: 'True Dust', file: 'modules/true-dust.module.js' },
   { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' }
 ];
 

--- a/test/hydration-hud.test.js
+++ b/test/hydration-hud.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+import { basicDom } from './dom-fixture.js';
+
+const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
+const code = full.split('// ===== Boot =====')[0];
+
+class AudioCtx {
+  createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
+  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
+  get destination(){ return {}; }
+  get currentTime(){ return 0; }
+}
+
+const AudioStub = class { constructor(){ this.addEventListener = () => {}; } cloneNode(){ return new AudioStub(); } };
+
+function setup(html){
+  const dom = new JSDOM(html);
+  dom.window.AudioContext = AudioCtx;
+  dom.window.webkitAudioContext = AudioCtx;
+  const dummyCtx = new Proxy({}, { get: () => () => {}, set: () => true });
+  dom.window.HTMLCanvasElement.prototype.getContext = () => dummyCtx;
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    requestAnimationFrame: fn => fn(),
+    EventBus: { on: () => {}, emit: () => {} },
+    fxConfig: {},
+    player: { hp: 10, hydration: 2, scrap: 0 },
+    leader: () => ({ maxHp: 10 }),
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    Audio: AudioStub,
+    NanoDialog: { enabled: true }
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  return context;
+}
+
+test('hydration meter shows droplets when not full', () => {
+  const html = `<body><canvas id="game"></canvas>${basicDom}<span id="hydrationMeter" hidden></span><div id="hpBar" class="hudbar"><div id="hpGhost"></div><div id="hpFill"></div></div><div id="adrBar" class="hudbar adr"><div id="adrFill"></div></div><div id="statusIcons"></div></body>`;
+  const ctx = setup(html);
+  ctx.player.hydration = 1;
+  ctx.updateHUD();
+  const hyd = ctx.document.getElementById('hydrationMeter');
+  assert.equal(hyd.textContent, '💧');
+  assert.ok(!hyd.hidden);
+  ctx.player.hydration = 2;
+  ctx.updateHUD();
+  assert.ok(hyd.hidden);
+});

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -95,6 +95,14 @@ test('adventure kit glyph navigates to editor', () => {
   assert.strictEqual(global.location.href, 'adventure-kit.html');
 });
 
+test('multiplayer glyph navigates to multiplayer', () => {
+  const overlay = bodyEl.children.find(c => c.id === 'modulePicker');
+  const glyph = overlay.children.find(c => c.id === 'mpGlyph');
+  assert.ok(glyph);
+  glyph.onclick();
+  assert.strictEqual(global.location.href, 'multiplayer.html');
+});
+
 test('particles respawn at edges after aging', () => {
   const canvas = stubEl();
   const dust = startDust(canvas);
@@ -136,6 +144,12 @@ test('two-worlds module points to entry script', () => {
   const tw = MODULES.find(m => m.id === 'two-worlds');
   assert.ok(tw);
   assert.strictEqual(tw.file, 'modules/two-worlds.module.js');
+});
+
+test('true-dust module points to entry script', () => {
+  const td = MODULES.find(m => m.id === 'true-dust');
+  assert.ok(td);
+  assert.strictEqual(td.file, 'modules/true-dust.module.js');
 });
 
 test('enter key loads selected module', () => {


### PR DESCRIPTION
## Summary
- show a hydration droplet meter next to the HP badge
- wire the True Dust module into the module picker and document its completion
- test multiplayer glyph navigation and hydration HUD behavior

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c323496470832887f8cafe9b00ac78