### PR TITLE
feat: tag items for story hooks

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -453,6 +453,7 @@
           <label><input type="checkbox" id="npcShop"> Shop NPC</label>
           <div id="shopOpts" style="display:none">
             <label>Markup<input id="shopMarkup" type="number" min="1" value="2" /></label>
+            <label>Refresh<input id="shopRefresh" type="number" min="0" value="0" /></label>
           </div>
           <div id="treeWrap">
             <label>Dialog Tree</label>
@@ -486,6 +487,8 @@
           <label>Description<textarea id="itemDesc" rows="2"></textarea></label>
           <label>Tags<input id="itemTags" list="tagOptions" /></label>
           <datalist id="tagOptions"></datalist>
+          <label>Narrative ID<input id="itemNarrativeId" /></label>
+          <label>Narrative Prompt<input id="itemNarrativePrompt" /></label>
           <label><input id="itemOnMap" type="checkbox"/> On Map</label>
           <label id="itemMapWrap">Map<select id="itemMap"></select></label>
           <div class="xy" id="itemXY">

--- a/docs/design/in-progress/oasis-trader.md
+++ b/docs/design/in-progress/oasis-trader.md
@@ -20,7 +20,7 @@
 
 ## Implementation Sketch
 - [x] Extend `scripts/core/trader.js` with `inventory` arrays and `grudge` fields.
-- [ ] Store refresh schedules in the module json and make editable by ACK.
+- [x] Store refresh schedules in the module json and make editable by ACK.
 - [ ] Update `scripts/ui/trade.js` to display timers and grudge indicators.
 - [x] Emit `trader:refresh` events for mods to hook into.
 

--- a/docs/design/in-progress/persona-mechanics.md
+++ b/docs/design/in-progress/persona-mechanics.md
@@ -94,5 +94,5 @@ Persona equips and other world moments should fire through the game's event bus.
 - [ ] Extend ACK schema and editor with reusable profile definitions.
  - [ ] Implement profile runtime service for personas, buffs, and disguises.
 - [ ] Emit `persona:equip` and `persona:unequip` events on the global bus.
-- [ ] ensure load/save store the equipped persona.
+- [x] ensure load/save store the equipped persona.
 - [ ] Build editor inspector for authoring and testing effect packs into ACK.

--- a/docs/design/in-progress/plot-draft.md
+++ b/docs/design/in-progress/plot-draft.md
@@ -127,7 +127,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
     - [ ] Script Jax's timed repair sequence under combat pressure. Implemented in `jax-repair.module.js`.
     - [ ] Write the dialogue and branching paths for Nyx's "conversational tuning" encounter.
 - [ ] **Doppelgänger System:**
-    - [ ] Create the data structure for "personas" that can be equipped by the main characters.
+    - [x] Create the data structure for "personas" that can be equipped by the main characters.
     - [ ] Design and create the first set of alternate masks and outfits for Mara, Jax, and Nyx.
 - [ ] **Implement Key Items:**
     - [ ] Build the custom UI for the Signal Compass, including its ability to point to locations of emotional resonance.

--- a/docs/design/in-progress/reactive-systems.md
+++ b/docs/design/in-progress/reactive-systems.md
@@ -30,7 +30,7 @@
 - Interiors declare entry/exit events so transitions carry emotional beats.
 
 ### Action Items
-- [ ] Implement item narrative tagging in engine and Adventure Kit.
+- [x] Implement item narrative tagging in engine and Adventure Kit.
 - [ ] Extend quest definitions to support branching and persistence.
 - [ ] Add NPC memory storage and retrieval utilities.
 - [ ] Build event scheduler for world and NPC timelines.

--- a/modules/golden.module.json
+++ b/modules/golden.module.json
@@ -296,6 +296,7 @@
       "prompt": "Traveling trader carrying a pack of goods",
       "shop": {
         "markup": 2,
+        "refresh": 24,
         "inv": [
           {
             "id": "bonus_potion"

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1975,6 +1975,7 @@ function startNewNPC() {
   document.getElementById('npcCombat').checked = false;
   document.getElementById('npcShop').checked = false;
   document.getElementById('shopMarkup').value = 2;
+  document.getElementById('shopRefresh').value = 0;
   updateNPCOptSections();
   document.getElementById('addNPC').style.display = 'block';
   document.getElementById('cancelNPC').style.display = 'none';
@@ -2019,6 +2020,7 @@ function collectNPCFromForm() {
   const combat = document.getElementById('npcCombat').checked;
   const shop = document.getElementById('npcShop').checked;
   const shopMarkup = parseInt(document.getElementById('shopMarkup').value, 10) || 2;
+  const shopRefresh = parseInt(document.getElementById('shopRefresh').value, 10) || 0;
   const hidden = document.getElementById('npcHidden').checked;
   const locked = document.getElementById('npcLocked').checked;
   const portraitLock = document.getElementById('npcPortraitLock').checked;
@@ -2080,7 +2082,7 @@ function collectNPCFromForm() {
       if (!isNaN(delay)) npc.combat.special.delay = delay;
     }
   }
-  if (shop) npc.shop = { markup: shopMarkup, inv: [] };
+  if (shop) npc.shop = { markup: shopMarkup, refresh: shopRefresh, inv: [] };
   if (hidden && flag) npc.hidden = true, npc.reveal = { flag, op, value: val };
   if (npcPortraitPath) npc.portraitSheet = npcPortraitPath;
   else if (npcPortraitIndex > 0) npc.portraitSheet = npcPortraits[npcPortraitIndex];
@@ -2197,6 +2199,7 @@ function editNPC(i) {
   document.getElementById('npcCombat').checked = !!n.combat;
   document.getElementById('npcShop').checked = !!n.shop;
   document.getElementById('shopMarkup').value = n.shop ? n.shop.markup || 2 : 2;
+  document.getElementById('shopRefresh').value = n.shop ? n.shop.refresh || 0 : 0;
   updateNPCOptSections();
   document.getElementById('addNPC').style.display = 'none';
   document.getElementById('cancelNPC').style.display = 'none';
@@ -2300,6 +2303,8 @@ function startNewItem() {
   document.getElementById('itemType').value = '';
   document.getElementById('itemDesc').value = '';
   document.getElementById('itemTags').value = '';
+  document.getElementById('itemNarrativeId').value = '';
+  document.getElementById('itemNarrativePrompt').value = '';
   document.getElementById('itemMap').value = '';
   document.getElementById('itemX').value = 0;
   document.getElementById('itemY').value = 0;
@@ -2345,6 +2350,8 @@ function addItem() {
   const tags = document.getElementById('itemTags').value.split(',').map(t=>t.trim()).filter(Boolean);
   collectKnownTags(tags);
   updateTagOptions();
+  const narrativeId = document.getElementById('itemNarrativeId').value.trim();
+  const narrativePrompt = document.getElementById('itemNarrativePrompt').value.trim();
   const onMap = document.getElementById('itemOnMap').checked;
   const map = onMap ? document.getElementById('itemMap').value.trim() : '';
   const x = parseInt(document.getElementById('itemX').value, 10) || 0;
@@ -2372,6 +2379,11 @@ function addItem() {
   const useText = document.getElementById('itemUse').value.trim();
   if (use && useText) use.text = useText;
   const item = { id, name, desc, type, tags, mods, value, use, equip };
+  if (narrativeId || narrativePrompt) {
+    item.narrative = {};
+    if (narrativeId) item.narrative.id = narrativeId;
+    if (narrativePrompt) item.narrative.prompt = narrativePrompt;
+  }
   if (onMap && map) {
     item.map = map;
     item.x = x;
@@ -2388,6 +2400,8 @@ function addItem() {
   document.getElementById('cancelItem').style.display = 'none';
   document.getElementById('delItem').style.display = 'none';
   loadMods({});
+  document.getElementById('itemNarrativeId').value = '';
+  document.getElementById('itemNarrativePrompt').value = '';
   renderItemList();
   selectedObj = null;
   drawWorld();
@@ -2436,6 +2450,8 @@ function editItem(i) {
   collectKnownTags(it.tags || []);
   updateTagOptions();
   document.getElementById('itemTags').value = (it.tags || []).join(',');
+  document.getElementById('itemNarrativeId').value = it.narrative ? it.narrative.id || '' : '';
+  document.getElementById('itemNarrativePrompt').value = it.narrative ? it.narrative.prompt || '' : '';
   document.getElementById('itemMap').value = it.map || '';
   document.getElementById('itemX').value = it.x || 0;
   document.getElementById('itemY').value = it.y || 0;
@@ -2513,6 +2529,8 @@ function closeItemEditor() {
   document.getElementById('cancelItem').style.display = 'none';
   document.getElementById('delItem').style.display = 'none';
   loadMods({});
+  document.getElementById('itemNarrativeId').value = '';
+  document.getElementById('itemNarrativePrompt').value = '';
   renderItemList();
   selectedObj = null;
   showItemEditor(false);

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -10,6 +10,7 @@
  * @property {string} [desc]
  * @property {number} [rarity]
  * @property {number} [value]
+ * @property {{id:string, prompt?:string}} [narrative]
  */
 
 /**
@@ -35,7 +36,8 @@ function cloneItem(it){
     mods: { ...it.mods },
     tags: Array.isArray(it.tags) ? [...it.tags] : [],
     use: it.use ? JSON.parse(JSON.stringify(it.use)) : null,
-    equip: it.equip ? JSON.parse(JSON.stringify(it.equip)) : null
+    equip: it.equip ? JSON.parse(JSON.stringify(it.equip)) : null,
+    narrative: it.narrative ? { ...it.narrative } : null
   };
 }
 /**
@@ -112,6 +114,9 @@ function addToInv(item) {
   if (base.id === 'fuel_cell') {
     player.fuel = (player.fuel || 0) + 50;
     emit('item:picked', base);
+    if(base.narrative){
+      emit('item:narrative', { itemId: base.id, narrative: base.narrative });
+    }
     notifyInventoryChanged();
     if (typeof log === 'function') log('Fuel +50');
     return true;
@@ -121,6 +126,9 @@ function addToInv(item) {
   }
   player.inv.push(base);
   emit('item:picked', base);
+  if(base.narrative){
+    emit('item:narrative', { itemId: base.id, narrative: base.narrative });
+  }
   notifyInventoryChanged();
   return true;
 }
@@ -305,6 +313,7 @@ function normalizeItem(it){
     scrap: typeof it.scrap === 'number' ? it.scrap : undefined,
     desc: it.desc || '',
     persona: it.persona,
+    narrative: it.narrative ? { ...it.narrative } : null,
   };
 }
 

--- a/scripts/core/trader.js
+++ b/scripts/core/trader.js
@@ -5,6 +5,7 @@ class Trader {
     this.id = id;
     this.inventory = Array.isArray(opts.inventory) ? [...opts.inventory] : [];
     this.grudge = opts.grudge || 0;
+    this.refresh = typeof opts.refresh === 'number' ? opts.refresh : 0;
   }
 
   addItem(item){

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -664,7 +664,21 @@ function save(){
     questData[k]={title:q.title,desc:q.desc,status:q.status,pinned:!!q.pinned};
   });
   const partyData = Array.from(party, p => ({
-    id:p.id,name:p.name,role:p.role,lvl:p.lvl,xp:p.xp,skillPoints:p.skillPoints,stats:p.stats,equip:p.equip,hp:p.hp,map:p.map,x:p.x,y:p.y,maxHp:p.maxHp,portraitSheet:p.portraitSheet
+    id:p.id,
+    name:p.name,
+    role:p.role,
+    lvl:p.lvl,
+    xp:p.xp,
+    skillPoints:p.skillPoints,
+    stats:p.stats,
+    equip:p.equip,
+    hp:p.hp,
+    map:p.map,
+    x:p.x,
+    y:p.y,
+    maxHp:p.maxHp,
+    portraitSheet:p.portraitSheet,
+    persona:p.persona
   }));
   const data={worldSeed, world, player, state, buildings, interiors, itemDrops, npcs:npcData, quests:questData, party:partyData};
   localStorage.setItem('dustland_crt', JSON.stringify(data));
@@ -709,8 +723,14 @@ function load(){
     const mem=new Character(m.id,m.name,m.role);
     Object.assign(mem,m);
     mem.skillPoints = m.skillPoints || 0;
-    mem.applyEquipmentStats();
     party.push(mem);
+  });
+  Dustland.gameState.updateState(s=>{ s.party = party; });
+  party.forEach(mem => {
+    mem.applyEquipmentStats();
+    if(mem.persona) {
+      Dustland.gameState.applyPersona(mem.id, mem.persona);
+    }
   });
   setMap(state.map);
   refreshUI();

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -112,6 +112,7 @@ const files = [
   '../scripts/core/combat.js',
   '../scripts/core/quests.js',
   '../scripts/core/npc.js',
+  '../scripts/game-state.js',
   '../scripts/dustland-core.js'
 ];
 for (const f of files) {
@@ -1690,6 +1691,27 @@ test('save/load preserves NPC loops', () => {
   load();
   global.localStorage = orig;
   assert.deepStrictEqual(NPCS[0].loop, [{x:0,y:0},{x:2,y:0}]);
+});
+
+test('save/load preserves persona assignments', () => {
+  party.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  party.join(m1);
+  Dustland.gameState.setPersona('mask', { id:'mask', label:'Mask' });
+  Dustland.gameState.applyPersona('p1','mask');
+  const store = {};
+  const orig = global.localStorage;
+  global.localStorage = {
+    setItem(k,v){ store[k]=v; },
+    getItem(k){ return store[k]; },
+    removeItem(k){ delete store[k]; }
+  };
+  save();
+  party[0].persona = undefined;
+  Dustland.gameState.updateState(s=>{ s.party = party; });
+  load();
+  global.localStorage = orig;
+  assert.strictEqual(party[0].persona, 'mask');
 });
 
 test('combat overlay sits behind the log panel', async () => {

--- a/test/item-narrative.test.js
+++ b/test/item-narrative.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+// ensure narrative tags emit events on pickup
+
+test('narrative tag emits item:narrative', async () => {
+  const events = [];
+  const bus = { emit(evt, payload){ events.push({ evt, payload }); } };
+  const context = { console, EventBus: bus, player:{ inv:[] }, party:[{}], log:()=>{}, toast:()=>{} };
+  vm.createContext(context);
+  const inv = await fs.readFile(new URL('../scripts/core/inventory.js', import.meta.url), 'utf8');
+  vm.runInContext(inv, context);
+  context.registerItem({ id:'n1', name:'Narrative', type:'misc', narrative:{ id:'story1', prompt:'?' } });
+  context.addToInv('n1');
+  const evt = events.find(e => e.evt === 'item:narrative');
+  assert.ok(evt);
+  assert.strictEqual(evt.payload.itemId, 'n1');
+  assert.strictEqual(
+    JSON.stringify(evt.payload.narrative),
+    JSON.stringify({ id:'story1', prompt:'?' })
+  );
+});


### PR DESCRIPTION
## Summary
- persist party personas in saves
- allow items to carry narrative tags and emit events
- support trader refresh schedules editable in Adventure Kit

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c33140e8ec8328a74e6356438ff6f9