### PR TITLE
fix: block mobile refresh and warn on leave

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -38,6 +38,7 @@ input[type="range"] {
         margin: 0;
         background: radial-gradient(circle at top, #141614 0%, var(--bg) 70%);
         color: var(--ink);
+        overscroll-behavior-y: none;
         font: 14px/1.5 'Pixelify Sans', sans-serif;
     }
 

--- a/dustland.html
+++ b/dustland.html
@@ -263,6 +263,8 @@
     <script defer src="./scripts/supporting/fx-debug.js"></script>
     <script defer src="./scripts/supporting/perf-debug.js"></script>
   <script>
+    disablePullToRefresh();
+    warnOnUnload();
     window.addEventListener('DOMContentLoaded', () => {
       document.getElementById('title').textContent += ' v' + ENGINE_VERSION;
       const params = new URLSearchParams(location.search);
@@ -282,6 +284,22 @@
       modeScript.src = isAck ? './scripts/ack-player.js' : './scripts/module-picker.js';
       document.body.appendChild(modeScript);
     });
+    function disablePullToRefresh() {
+      let startY = 0;
+      document.addEventListener('touchstart', e => {
+        startY = e.touches[0].clientY;
+      }, {passive: true});
+      document.addEventListener('touchmove', e => {
+        const y = e.touches[0].clientY;
+        if (window.scrollY === 0 && y > startY) e.preventDefault();
+      }, {passive: false});
+    }
+    function warnOnUnload() {
+      window.addEventListener('beforeunload', e => {
+        e.preventDefault();
+        e.returnValue = '';
+      });
+    }
   </script>
   <!-- Persona overlay -->
   <div class="overlay" id="personaOverlay" role="dialog" aria-modal="true" tabindex="-1">


### PR DESCRIPTION
## Summary
- prevent mobile pull-to-refresh to avoid accidental reloads
- confirm navigation away to protect game progress

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3435cc95c8328b7ba423ff41f6a6e