### PR TITLE
feat: brighten better equipment indicator

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -336,8 +336,8 @@ input[type="range"] {
     }
 
     .slot.better {
-        border-color: #5b7b5b;
-        background: #121712;
+        border-color: #00ff00;
+        background: #003300;
     }
 
     .slot.clickable {


### PR DESCRIPTION
## Summary
- make inventory upgrade highlight use a brighter green for visibility

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3438a8b7c832892467f1e1d0727ae