### PR TITLE
feat: toast on item pickup

### DIFF
--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -990,6 +990,7 @@ on('inventory:changed', () => {
 
 on('item:picked', (it) => {
   log?.(`Picked up ${it.name}`);
+  toast?.(`Picked up ${it.name}`);
 });
 
 on('mentor:bark', (evt) => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -178,12 +178,17 @@ test('createRNG produces deterministic sequences', () => {
     party.length = 0;
     party.join(new Character('t', 'T', 't'));
     const oldLog = global.log;
+    const oldToast = global.toast;
     const logs = [];
+    const toasts = [];
     global.log = (msg) => logs.push(msg);
+    global.toast = (msg) => toasts.push(msg);
     registerItem({ id: 'stone', name: 'Stone' });
     addToInv('stone');
     assert.deepStrictEqual(logs, ['Picked up Stone']);
+    assert.deepStrictEqual(toasts, ['Picked up Stone']);
     global.log = oldLog;
+    global.toast = oldToast;
   });
 
 test('cursed items reveal on unequip attempt and stay equipped', () => {


### PR DESCRIPTION
## Summary
- toast a message when picking up items
- test that item pickup also triggers a toast

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3440e59588328afd960f6b4400f43