### PR TITLE
fix: reduce random encounter loot drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-09-12
+- Reduced random encounter enemy loot drops in Dustland by 25%.
+
 ## 2025-09-11
 - Equipment now toasts stat changes when equipped.
 

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2640,31 +2640,37 @@ const DATA = `
       {
         "templateId": "vine_creature",
         "loot": "plant_fiber",
+        "lootChance": 0.75,
         "maxDist": 20
       },
       {
         "templateId": "rotwalker",
         "loot": "water_flask",
+        "lootChance": 0.75,
         "maxDist": 24
       },
       {
         "templateId": "scavenger",
         "loot": "raider_knife",
+        "lootChance": 0.75,
         "maxDist": 36
       },
       {
         "templateId": "sand_titan",
         "loot": "artifact_blade",
+        "lootChance": 0.75,
         "minDist": 30
       },
       {
         "templateId": "dune_reaper",
         "loot": "artifact_blade",
+        "lootChance": 0.75,
         "minDist": 40
       },
       {
         "templateId": "sand_colossus",
         "loot": "artifact_blade",
+        "lootChance": 0.75,
         "minDist": 44
       }
     ]

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -595,7 +595,8 @@ function doAttack(dmg, type = 'basic'){
         stats.count += 1;
         if (turnsTaken <= 1) stats.quick += 1;
       }
-      if (target.loot) addToInv?.(target.loot);
+      // lootChance defaults to 1 (100%) if unspecified
+      if (target.loot && Math.random() < (target.lootChance ?? 1)) addToInv?.(target.loot);
 
       // Bandits sometimes drop scrap
       if (/bandit/i.test(target.id) && Math.random() < 0.5){
@@ -801,7 +802,8 @@ function enemyAttack(){
       stats.count += 1;
       if (turnsTaken <= 1) stats.quick += 1;
     }
-    if (enemy.loot) addToInv?.(enemy.loot);
+    // lootChance defaults to 1 (100%) if unspecified
+    if (enemy.loot && Math.random() < (enemy.lootChance ?? 1)) addToInv?.(enemy.loot);
     if (/bandit/i.test(enemy.id) && Math.random() < 0.5){
       player.scrap = (player.scrap || 0) + 1;
       updateHUD?.();

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1385,6 +1385,36 @@ test('bandits can drop scrap on defeat', async () => {
   assert.strictEqual(player.scrap, 1);
 });
 
+test('lootChance prevents drops on high rolls', async () => {
+  NPCS.length = 0;
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  party.join(m1);
+  const origRand = Math.random;
+  Math.random = () => 0.8;
+  const resultPromise = openCombat([{ name:'E', hp:1, loot:{ id:'l', name:'L' }, lootChance:0.75 }]);
+  handleCombatKey({ key:'Enter' });
+  await resultPromise;
+  Math.random = origRand;
+  assert.strictEqual(player.inv.length, 0);
+});
+
+test('lootChance allows drops on low rolls', async () => {
+  NPCS.length = 0;
+  party.length = 0;
+  player.inv.length = 0;
+  const m1 = new Character('p1','P1','Role');
+  party.join(m1);
+  const origRand = Math.random;
+  Math.random = () => 0.5;
+  const resultPromise = openCombat([{ name:'E', hp:1, loot:{ id:'l', name:'L' }, lootChance:0.75 }]);
+  handleCombatKey({ key:'Enter' });
+  await resultPromise;
+  Math.random = origRand;
+  assert.ok(player.inv.some(it => it.id === 'l'));
+});
+
 test('fallen party members are revived after combat', async () => {
   NPCS.length = 0;
   party.length = 0;


### PR DESCRIPTION
## Summary
- add optional `lootChance` for enemy drops and use it in combat
- lower Dustland random encounter drop rates to 75%
- cover lootChance behavior with tests

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c346d366d48328a69845de02ef1392