### PR TITLE
fix: allow scrolling in mobile panel

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -291,6 +291,7 @@
       }, {passive: true});
       document.addEventListener('touchmove', e => {
         const y = e.touches[0].clientY;
+        if (e.target.closest('.panel .content')) return;
         if (window.scrollY === 0 && y > startY) e.preventDefault();
       }, {passive: false});
     }


### PR DESCRIPTION
## Summary
- permit touch scroll gestures inside party, inventory, and quest panels

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c352d8018883288f28f31d9f058fd2