### PR TITLE
feat: add workbench overlay

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -761,6 +761,35 @@ input[type="range"] {
   width: 100%;
 }
 
+#workbenchOverlay .workbench-window {
+  width: 300px;
+  background: #0f120f;
+  border: 1px solid #2b3b2b;
+  border-radius: 8px;
+  box-shadow: 0 0 20px #000;
+  max-height: min(480px, 92vh);
+  display: flex;
+  flex-direction: column;
+}
+
+#workbenchOverlay .workbench-window header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  border-bottom: 1px solid #2b3b2b;
+}
+
+#workbenchOverlay .slot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#workbenchOverlay .slot button {
+  margin-left: 8px;
+}
+
 .slot-list {
   display: flex;
   flex-direction: column;

--- a/dustland.html
+++ b/dustland.html
@@ -309,6 +309,16 @@
       <button id="closePersonaBtn" class="btn">Close</button>
     </div>
   </div>
+  <!-- Workbench overlay -->
+  <div class="overlay" id="workbenchOverlay" role="dialog" aria-modal="true" tabindex="-1">
+    <div class="workbench-window">
+      <header>
+        <div>Workbench</div>
+        <button id="closeWorkbenchBtn" class="btn">Close</button>
+      </header>
+      <div id="workbenchRecipes" class="slot-list"></div>
+    </div>
+  </div>
   <!-- Shop overlay -->
   <div class="overlay" id="shopOverlay" role="dialog" aria-modal="true" tabindex="-1">
     <div class="shop-window">

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2129,35 +2129,7 @@ const DATA = `
       "title": "Crafter",
       "desc": "Tools litter the surface.",
       "prompt": "Cluttered workbench stacked with tools",
-      "tree": {
-        "start": {
-          "text": "The workbench awaits projects.",
-          "choices": [
-            {
-              "label": "(Craft signal beacon)",
-              "to": "craft"
-            },
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
-          ]
-        },
-        "craft": {
-          "text": "You piece together a beacon.",
-          "effects": [
-            {
-              "effect": "craftSignalBeacon"
-            }
-          ],
-          "choices": [
-            {
-              "label": "(Back)",
-              "to": "start"
-            }
-          ]
-        }
-      }
+      "workbench": true
     },
     {
       "id": "scrap_behemoth",

--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -81,6 +81,9 @@
           case 'log':
             if (typeof log === 'function') log(eff.msg || '');
             break;
+          case 'openWorkbench':
+            globalThis.Dustland?.openWorkbench?.();
+            break;
           case 'addFlag': {
             const p = ctx.party || globalThis.party;
             if (p) {

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -473,7 +473,11 @@ function interactAt(x, y) {
   const info = queryTile(x, y);
   if (info.entities.length) {
     const npc = info.entities[0];
-    openDialog(npc);
+    if (npc.workbench) {
+      Dustland.openWorkbench?.();
+    } else {
+      openDialog(npc);
+    }
     bus.emit('sfx', 'confirm');
     return true;
   }

--- a/scripts/core/npc.js
+++ b/scripts/core/npc.js
@@ -3,8 +3,8 @@ var Dustland = globalThis.Dustland;
 const NPC_COLOR = '#9ef7a0';
 const OBJECT_COLOR = '#225a20';
 class NPC {
-  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,quests=null,questDialogs=null,processNode=null,processChoice=null,combat=null,shop=false,portraitSheet=null,portraitLock=true,symbol='!',door=false,locked=false,prompt=null,unlockTime=null,questIdx=0}) {
-    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,quests,questDialogs,combat,shop,portraitSheet,portraitLock,symbol,door,locked,prompt,unlockTime,questIdx});
+  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,quests=null,questDialogs=null,processNode=null,processChoice=null,combat=null,shop=false,workbench=false,portraitSheet=null,portraitLock=true,symbol='!',door=false,locked=false,prompt=null,unlockTime=null,questIdx=0}) {
+    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,quests,questDialogs,combat,shop,workbench,portraitSheet,portraitLock,symbol,door,locked,prompt,unlockTime,questIdx});
     if (Array.isArray(this.quests) && !this.quest) {
       this.quest = this.quests[this.questIdx] || null;
     }
@@ -29,6 +29,10 @@ class NPC {
       } else if (this.shop && node === 'buy') {
         closeDialog();
         Dustland.openShop?.(this);
+        return;
+      } else if (this.workbench && node === 'start') {
+        closeDialog();
+        Dustland.openWorkbench?.();
         return;
       }
     };
@@ -126,6 +130,7 @@ function createNpcFactory(defs) {
       const opts = {};
       if (n.combat) opts.combat = n.combat;
       if (n.shop) opts.shop = n.shop;
+      if (n.workbench) opts.workbench = true;
       if (n.portraitSheet) opts.portraitSheet = n.portraitSheet;
       if (n.portraitLock === false) opts.portraitLock = false;
       if (n.prompt) opts.prompt = n.prompt;

--- a/scripts/workbench.js
+++ b/scripts/workbench.js
@@ -50,5 +50,100 @@
     log('Crafted a bandage.');
   }
 
+  function openWorkbench(){
+    const overlay = document.getElementById('workbenchOverlay');
+    const list = document.getElementById('workbenchRecipes');
+    const closeBtn = document.getElementById('closeWorkbenchBtn');
+    if (!overlay || !list || !closeBtn) return;
+
+    let focusables = [];
+    let focusIdx = 0;
+
+    function focusCurrent(){
+      if (focusables.length) focusables[focusIdx].focus();
+    }
+
+    function renderRecipes(){
+      list.innerHTML = '';
+      focusables = [];
+      const recipes = [
+        {
+          name: 'Signal Beacon',
+          craft: craftSignalBeacon,
+          missing(){
+            const m = [];
+            if ((player.scrap || 0) < 5) m.push('5 scrap');
+            if ((player.fuel || 0) < 50) m.push('50 fuel');
+            return m;
+          }
+        },
+        {
+          name: 'Solar Panel Tarp',
+          craft: craftSolarTarp,
+          missing(){
+            const m = [];
+            if ((player.scrap || 0) < 3) m.push('3 scrap');
+            if (!hasItem('cloth')) m.push('cloth');
+            return m;
+          }
+        },
+        {
+          name: 'Bandage',
+          craft: craftBandage,
+          missing(){
+            const m = [];
+            if (!hasItem('plant_fiber')) m.push('plant fiber');
+            return m;
+          }
+        }
+      ];
+
+      recipes.forEach(r => {
+        const row = document.createElement('div');
+        row.className = 'slot';
+        const miss = r.missing();
+        if (miss.length === 0){
+          row.innerHTML = `<span>${r.name}</span><button class="btn">Craft</button>`;
+          const btn = row.querySelector('button');
+          btn.onclick = () => { r.craft(); renderRecipes(); };
+          list.appendChild(row);
+          focusables.push(btn);
+        } else {
+          row.innerHTML = `<span>${r.name} - need ${miss.join(', ')}</span>`;
+          list.appendChild(row);
+        }
+      });
+      focusIdx = 0;
+      focusCurrent();
+    }
+
+    function close(){
+      overlay.classList.remove('shown');
+      overlay.removeEventListener('keydown', handleKey);
+    }
+
+    function handleKey(e){
+      e.stopPropagation();
+      if (e.key === 'Escape') { close(); return; }
+      if (e.key === 'ArrowDown') {
+        focusIdx = (focusIdx + 1) % focusables.length;
+        focusCurrent();
+        e.preventDefault();
+      } else if (e.key === 'ArrowUp') {
+        focusIdx = (focusIdx - 1 + focusables.length) % focusables.length;
+        focusCurrent();
+        e.preventDefault();
+      }
+    }
+
+    closeBtn.onclick = close;
+    overlay.classList.add('shown');
+    overlay.tabIndex = -1;
+    overlay.addEventListener('keydown', handleKey);
+    renderRecipes();
+    overlay.focus();
+  }
+
   Dustland.workbench = { craftSignalBeacon, craftSolarTarp, craftBandage };
+  Dustland.openWorkbench = openWorkbench;
 })();

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -85,8 +85,7 @@ test('workshop building includes workbench NPC', () => {
   const npc = data.npcs.find(n => n.id === 'workbench');
   assert.ok(npc);
   assert.strictEqual(npc.map, 'workshop');
-  const hasCraft = npc.tree?.start?.choices?.some(c => c.label.includes('Craft signal beacon'));
-  assert.ok(hasCraft);
+  assert.ok(npc.workbench);
 });
 
 test('workshop no longer stores power cells', () => {

--- a/test/workbench.ui.test.js
+++ b/test/workbench.ui.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import { JSDOM } from 'jsdom';
+import vm from 'node:vm';
+
+async function loadWorkbench(dom){
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.requestAnimationFrame = () => {};
+  global.EventBus = { emit: () => {} };
+  global.log = () => {};
+  const code = await fs.readFile(new URL('../scripts/workbench.js', import.meta.url), 'utf8');
+  vm.runInThisContext(code);
+}
+
+test('workbench lists missing requirements for recipes you lack', async () => {
+  const dom = new JSDOM('<div id="workbenchOverlay"><div class="workbench-window"><header><button id="closeWorkbenchBtn"></button></header><div id="workbenchRecipes"></div></div></div>');
+  await loadWorkbench(dom);
+  global.player = { scrap: 0, fuel: 0, inv: [] };
+  global.hasItem = id => player.inv.some(i => i.id === id);
+  global.findItemIndex = id => player.inv.findIndex(i => i.id === id);
+  global.removeFromInv = idx => player.inv.splice(idx, 1);
+  global.addToInv = id => { player.inv.push({ id }); return true; };
+
+  Dustland.openWorkbench();
+  const rows = dom.window.document.querySelectorAll('#workbenchRecipes .slot');
+  assert.strictEqual(rows.length, 3);
+  assert.match(rows[0].textContent, /need 5 scrap, 50 fuel/i);
+  assert.match(rows[1].textContent, /need 3 scrap, cloth/i);
+  assert.match(rows[2].textContent, /need plant fiber/i);
+});
+
+test('arrow keys in workbench do not bubble to window', async () => {
+  const dom = new JSDOM('<div id="workbenchOverlay"><div class="workbench-window"><header><button id="closeWorkbenchBtn"></button></header><div id="workbenchRecipes"></div></div></div>');
+  await loadWorkbench(dom);
+  global.player = { scrap: 5, fuel: 50, inv: [ { id: 'cloth' }, { id: 'plant_fiber' } ] };
+  global.hasItem = id => player.inv.some(i => i.id === id);
+  global.findItemIndex = id => player.inv.findIndex(i => i.id === id);
+  global.removeFromInv = idx => player.inv.splice(idx, 1);
+  global.addToInv = id => { player.inv.push({ id }); return true; };
+
+  let moved = 0;
+  dom.window.addEventListener('keydown', () => { moved++; });
+  Dustland.openWorkbench();
+  const overlay = dom.window.document.getElementById('workbenchOverlay');
+  const evt = new dom.window.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+  overlay.dispatchEvent(evt);
+  assert.strictEqual(moved, 0);
+  const buttons = dom.window.document.querySelectorAll('#workbenchRecipes .slot button');
+  assert.strictEqual(buttons.length, 3);
+});


### PR DESCRIPTION
## Summary
- add dedicated workbench overlay with recipe list
- support workbench NPCs and movement
- cover workbench UI with tests

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3534727488328bd842a1fbe643871