### PR TITLE
fix: preserve save when selecting module

### DIFF
--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -123,7 +123,6 @@ function loadModule(moduleInfo){
       realResetAll();
       loadModule(moduleInfo);
     };
-    localStorage.removeItem('dustland_crt');
     openCreator();
   };
   document.body.appendChild(script);

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -156,3 +156,18 @@ test('enter key loads selected module', () => {
   loadModule(MODULES[MODULES.length - 1]);
   assert.ok(global.location.href.includes('golden.module.json'));
 });
+
+test('loadModule preserves existing save data', () => {
+  const ls = {
+    data: { 'dustland_crt': 'foo' },
+    getItem(key){ return this.data[key] || null; },
+    setItem(key, val){ this.data[key] = val; },
+    removeItem(key){ delete this.data[key]; }
+  };
+  global.localStorage = ls;
+  loadModule(MODULES[0]);
+  const scriptEl = bodyEl.children.find(c => c.id === 'activeModuleScript');
+  assert.ok(scriptEl);
+  scriptEl.onload();
+  assert.strictEqual(ls.getItem('dustland_crt'), 'foo');
+});


### PR DESCRIPTION
## Summary
- stop module picker from wiping localStorage save data
- add regression test to ensure saved games persist after selecting a module

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c356e245f0832884503a00ef7aa6a1