### PR TITLE
feat: add clear save button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-09-13
+- Added button to clear saved game data.
+
 ## 2025-09-12
 - Reduced random encounter enemy loot drops in Dustland by 25%.
 

--- a/README.nfo
+++ b/README.nfo
@@ -65,7 +65,7 @@ _______________________________________________________________________________
 [ SAVE DATA ]
   - Saved to localStorage under key: dustland_crt
   - “Reset” clears party/inventory and returns you to Creator.
-  - To fully wipe: clear the site’s localStorage from your browser.
+  - “Clear Save” removes the saved game from localStorage.
 
 [ PROJECT LAYOUT ]
   - dustland.html

--- a/dustland.html
+++ b/dustland.html
@@ -53,6 +53,7 @@
         <div style="margin-top:8px" id="mainButtons">
           <button class="btn" id="saveBtn">Save</button>
           <button class="btn" id="loadBtn">Load</button>
+          <button class="btn" id="clearBtn">Clear Save</button>
           <button class="btn" id="resetBtn">Reset</button>
           <button class="btn" id="settingsBtn">Settings</button>
           <button class="btn" id="fxBtn">FX</button>

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -738,6 +738,12 @@ function load(){
   if (typeof toast === 'function') toast('Game loaded.');
 }
 
+function clearSave(){
+  localStorage.removeItem('dustland_crt');
+  log('Save cleared.');
+  if (typeof toast === 'function') toast('Save cleared.');
+}
+
 const startEl = document.getElementById('start');
 const startContinue = document.getElementById('startContinue');
 const startNew = document.getElementById('startNew');

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -1099,6 +1099,9 @@ function runTests(){
 if (document.getElementById('saveBtn')) {
   document.getElementById('saveBtn').onclick=()=>save();
   document.getElementById('loadBtn').onclick=()=>{ load(); };
+  document.getElementById('clearBtn').onclick=()=>{
+    if (confirm('Delete saved game?')) clearSave();
+  };
   document.getElementById('resetBtn').onclick=()=>{
     if (confirm('Reset game and return to character creation?')) resetAll();
   };

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1749,6 +1749,21 @@ test('save/load preserves persona assignments', () => {
   assert.strictEqual(party[0].persona, 'mask');
 });
 
+test('clearSave removes stored game data', () => {
+  const store = { dustland_crt: '{}' };
+  const orig = global.localStorage;
+  let removed = false;
+  global.localStorage = {
+    setItem(k, v){ store[k] = v; },
+    getItem(k){ return store[k]; },
+    removeItem(k){ removed = true; delete store[k]; }
+  };
+  clearSave();
+  assert.ok(removed);
+  assert.strictEqual(store.dustland_crt, undefined);
+  global.localStorage = orig;
+});
+
 test('combat overlay sits behind the log panel', async () => {
   const css = await fs.readFile(new URL('../dustland.css', import.meta.url), 'utf8');
   assert.match(css, /\.panel\s*{[\s\S]*z-index:\s*15/);


### PR DESCRIPTION
## Summary
- add a UI control to delete saved progress
- implement clearSave helper and hook up to new button
- document save clearing

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c358562380832895e1694b03f8e05d