### PR TITLE
fix: reduce rotwalker and vine creature loot chance

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2640,13 +2640,13 @@ const DATA = `
       {
         "templateId": "vine_creature",
         "loot": "plant_fiber",
-        "lootChance": 0.75,
+        "lootChance": 0.25,
         "maxDist": 20
       },
       {
         "templateId": "rotwalker",
         "loot": "water_flask",
-        "lootChance": 0.75,
+        "lootChance": 0.25,
         "maxDist": 24
       },
       {

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -130,6 +130,17 @@ test('vine creature drops plant fiber', () => {
   const encounter = data.encounters.world.find(e => e.templateId === 'vine_creature');
   assert.ok(encounter);
   assert.strictEqual(encounter.loot, 'plant_fiber');
+  assert.strictEqual(encounter.lootChance, 0.25);
+});
+
+test('rotwalker drops water flask', () => {
+  const data = loadModuleData();
+  const template = data.templates.find(t => t.id === 'rotwalker');
+  assert.ok(template);
+  const encounter = data.encounters.world.find(e => e.templateId === 'rotwalker');
+  assert.ok(encounter);
+  assert.strictEqual(encounter.loot, 'water_flask');
+  assert.strictEqual(encounter.lootChance, 0.25);
 });
 
 test('northeast hut has portal to hall', () => {


### PR DESCRIPTION
## Summary
- lower rotwalker and vine creature loot drop chance to 25%
- cover rotwalker and vine creature encounter loot chances with tests

## Testing
- `node scripts/supporting/presubmit.js`
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/balance-tester-agent.js`

------
https://chatgpt.com/codex/tasks/task_e_68c348f563b88328ad99f52b1781c06e