### PR TITLE
fix: expose startGame globally

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -3067,7 +3067,7 @@ function postLoad(module) {
 globalThis.DUSTLAND_MODULE = JSON.parse(DATA);
 globalThis.DUSTLAND_MODULE.postLoad = postLoad;
 
-startGame = function () {
+globalThis.startGame = function () {
   DUSTLAND_MODULE.postLoad?.(DUSTLAND_MODULE);
   const { start: s } = applyModule(DUSTLAND_MODULE) || {};
   const loc = s || { map: 'world', x: 2, y: Math.floor(WORLD_H / 2) };


### PR DESCRIPTION
## Summary
- expose Dustland module's startGame via `globalThis` so it works in strict environments

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c348753c448328b62b36141b40a702