### PR TITLE
fix: reset invalid start positions on load

### DIFF
--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -725,6 +725,22 @@ function load(){
     mem.skillPoints = m.skillPoints || 0;
     party.push(mem);
   });
+  if(d.party && d.party[0]){
+    party.x = d.party[0].x ?? party.x;
+    party.y = d.party[0].y ?? party.y;
+  }
+  party.map = state.map;
+  const grid = typeof gridFor === 'function' ? gridFor(state.map) : null;
+  const tile = typeof getTile === 'function' ? getTile(state.map, party.x, party.y) : null;
+  if(!grid || tile === null){
+    state.map = 'world';
+    party.map = 'world';
+    const wx = world?.[0]?.length ? Math.floor(world[0].length/2) : 0;
+    const wy = world?.length ? Math.floor(world.length/2) : 0;
+    setPartyPos(wx, wy);
+  } else {
+    setPartyPos(party.x, party.y);
+  }
   Dustland.gameState.updateState(s=>{ s.party = party; });
   party.forEach(mem => {
     mem.applyEquipmentStats();

--- a/test/load-fallback.test.js
+++ b/test/load-fallback.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function stubEl(){
+  const el = {
+    style:{},
+    classList:{ add(){}, remove(){}, toggle(){}, contains(){ return false; } },
+    textContent:'',
+    onclick:null,
+    children:[],
+    dataset:{},
+    appendChild(child){ this.children.push(child); child.parentElement=this; },
+    prepend(child){ this.children.unshift(child); child.parentElement=this; },
+    querySelector: () => stubEl(),
+    querySelectorAll: () => [],
+    getContext: () => ({
+      clearRect(){}, drawImage(){}, fillRect(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){},
+      save(){}, restore(){}, translate(){}, font:'', fillText(){}, globalAlpha:1
+    }),
+    addEventListener(){},
+    remove(){},
+    parentElement:{ appendChild(){}, querySelectorAll(){ return []; } }
+  };
+  return el;
+}
+
+global.requestAnimationFrame = () => {};
+Object.assign(global, {
+  window: global,
+  innerWidth: 800,
+  innerHeight: 600,
+  addEventListener(){},
+  localStorage: { getItem: () => null, setItem(){}, removeItem(){} },
+  location: { href: '' }
+});
+
+global.document = {
+  body: stubEl(),
+  head: stubEl(),
+  createElement: () => stubEl(),
+  getElementById: () => stubEl(),
+  querySelector: () => stubEl()
+};
+
+global.log = () => {};
+global.toast = () => {};
+global.renderInv = () => {};
+global.renderParty = () => {};
+global.renderQuests = () => {};
+global.updateHUD = () => {};
+global.centerCamera = () => {};
+
+const files = [
+  '../scripts/event-bus.js',
+  '../scripts/core/actions.js',
+  '../scripts/core/effects.js',
+  '../scripts/core/spoils-cache.js',
+  '../scripts/core/abilities.js',
+  '../scripts/core/party.js',
+  '../scripts/core/inventory.js',
+  '../scripts/core/movement.js',
+  '../scripts/core/dialog.js',
+  '../scripts/core/combat.js',
+  '../scripts/core/quests.js',
+  '../scripts/core/npc.js',
+  '../scripts/game-state.js',
+  '../scripts/dustland-core.js'
+];
+for (const f of files) {
+  const code = await fs.readFile(new URL(f, import.meta.url), 'utf8');
+  vm.runInThisContext(code, { filename: f });
+}
+
+test('load() resets invalid position to world', () => {
+  const save = {
+    worldSeed: 1,
+    world: [[0]],
+    player: {},
+    state: { map: 'void' },
+    buildings: [],
+    interiors: {},
+    itemDrops: [],
+    npcs: [],
+    quests: {},
+    party: [{ id: 'p', name: 'P', role: 'lead', lvl:1, xp:0, skillPoints:0, stats:{}, equip:{}, hp:10, map:'void', x:5, y:5, maxHp:10 }]
+  };
+  global.localStorage.getItem = () => JSON.stringify(save);
+  load();
+  assert.strictEqual(state.map, 'world');
+  assert.strictEqual(party.map, 'world');
+});
+


### PR DESCRIPTION
## Summary
- reset player to world map when loading from invalid map or tile
- add regression test for invalid position fallback

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c368bc6e0c8328bc73a97898f2cda7