### PR TITLE
fix: send vortex to world map

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -542,7 +542,7 @@ const DATA = `
               "label": "(Continue)",
               "to": "bye",
               "goto": {
-                "map": "dust_storm",
+                "map": "world",
                 "x": 10,
                 "y": 18
               }

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -217,6 +217,10 @@ function mapLabel(id){
   return interiors[id]?.label || mapLabels[id] || 'Interior';
 }
 function setMap(id,label){
+  if(typeof gridFor === 'function' && !gridFor(id)){
+    id = 'world';
+    label = label || mapLabel(id);
+  }
   state.map=id;
   party.map = id;
   state.mapEntry = null;
@@ -730,6 +734,12 @@ function load(){
     party.y = d.party[0].y ?? party.y;
   }
   party.map = state.map;
+  if(state.map === 'dust_storm'){
+    state.map = 'world';
+    party.map = 'world';
+    party.x = 10;
+    party.y = 18;
+  }
   const grid = typeof gridFor === 'function' ? gridFor(state.map) : null;
   const tile = typeof getTile === 'function' ? getTile(state.map, party.x, party.y) : null;
   if(!grid || tile === null){

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -212,6 +212,7 @@ test('uncursed gear can be removed and triggers unequip effects', () => {
   state.map = 'world';
   const mem = new Character('t1','Tester','Role');
   party.join(mem);
+  interiors.office = { grid: [[0]], w:1, h:1 };
   const helm = normalizeItem({
     id: 'helm',
     name: 'Helm',
@@ -1456,6 +1457,7 @@ test('bruise resets map to entry', async () => {
   party.map = 'whistle_room';
   party.x = 5; party.y = 5;
   state.mapEntry = { map: 'cavern', x: 2, y: 2 };
+  interiors.cavern = { grid: [[0]], w:1, h:1 };
   const m1 = new Character('p1','P1','Role');
   m1.hp = 1;
   party.join(m1);

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -151,3 +151,11 @@ test('trader patrols east-west with basic goods', () => {
   const invIds = trader.shop?.inv?.map(i => i.id);
   assert.deepStrictEqual(invIds, ['pipe_rifle', 'leather_jacket', 'water_flask']);
 });
+
+test('vortex sends player to world map', () => {
+  const data = loadModuleData();
+  const vortex = data.npcs.find(n => n.id === 'dust_storm_entrance');
+  assert.ok(vortex);
+  const goto = vortex.tree.enter.choices[0].goto;
+  assert.deepStrictEqual(goto, { map: 'world', x: 10, y: 18 });
+});

--- a/test/load-fallback.test.js
+++ b/test/load-fallback.test.js
@@ -92,3 +92,31 @@ test('load() resets invalid position to world', () => {
   assert.strictEqual(party.map, 'world');
 });
 
+test('load() relocates dust_storm saves to world', () => {
+  const world = Array.from({ length: 20 }, () => Array(20).fill(0));
+  const save = {
+    worldSeed: 1,
+    world,
+    player: {},
+    state: { map: 'dust_storm' },
+    buildings: [],
+    interiors: {},
+    itemDrops: [],
+    npcs: [],
+    quests: {},
+    party: [{ id: 'p', name: 'P', role: 'lead', lvl:1, xp:0, skillPoints:0, stats:{}, equip:{}, hp:10, map:'dust_storm', x:2, y:3, maxHp:10 }]
+  };
+  global.localStorage.getItem = () => JSON.stringify(save);
+  load();
+  assert.strictEqual(state.map, 'world');
+  assert.strictEqual(party.map, 'world');
+  assert.strictEqual(party.x, 10);
+  assert.strictEqual(party.y, 18);
+});
+
+test('setMap falls back to world when map missing', () => {
+  setMap('missing');
+  assert.strictEqual(state.map, 'world');
+  assert.strictEqual(party.map, 'world');
+});
+

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -318,7 +318,7 @@ test('merchant quest requires all treasures', () => {
   const coreFile = path.join(__dirname, '..', 'scripts', 'dustland-core.js');
   const coreSrc = fs.readFileSync(coreFile, 'utf8');
   const coreLines = coreSrc.split('\n');
-  const applySrc = coreLines.slice(373, 524).join('\n');
+  const applySrc = coreLines.slice(377, 528).join('\n');
   vm.runInNewContext(applySrc, game);
   game.applyModule(moduleData, { fullReset: false });
 


### PR DESCRIPTION
## Summary
- fix dust storm vortex to drop players on the world map instead of an undefined location
- test vortex destination to prevent regression
- relocate invalid dust_storm saves to the world map and guard against unknown map ids

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`
- `node scripts/supporting/placement-check.js modules/dustland.module.js`


------
https://chatgpt.com/codex/tasks/task_e_68c36af221248328a4721ec179ea1628