### PR TITLE
fix: use seeded rng for slot machine

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2926,7 +2926,7 @@ function pullSlots(cost, payouts) {
   const luck = (lead?.stats?.LCK || 0) + (lead?._bonus?.LCK || 0);
   const eff = Math.max(0, luck - 7);
   let idx = Math.floor(rng() * payouts.length);
-  if (eff > 0 && Math.random() < eff * 0.05) {
+  if (eff > 0 && rng() < eff * 0.05) {
     idx = Math.min(idx + 1, payouts.length - 1);
     log('Lucky spin!');
   }

--- a/test/slot-machine-luck.test.js
+++ b/test/slot-machine-luck.test.js
@@ -15,6 +15,7 @@ test('leader luck above 7 boosts slot machine payout', async () => {
   globalThis.log = (m) => logMessages.push(m);
   globalThis.updateHUD = () => {};
   globalThis.addToInv = () => {};
+  const origRng = globalThis.rng;
   globalThis.rng = () => 0;
   globalThis.applyModule = () => ({ start: {} });
   vm.runInThisContext(code, { filename: 'dustland.module.js' });
@@ -22,8 +23,6 @@ test('leader luck above 7 boosts slot machine payout', async () => {
   const slotNpc = globalThis.DUSTLAND_MODULE.npcs.find(n => n.id === 'slots');
   globalThis.party = [{ stats: { LCK: 7 }, _bonus: { LCK: 0 }, name: 'Hero' }];
   globalThis.leader = () => party[0];
-  const origRandom = Math.random;
-  Math.random = () => 0;
 
   const play = slotNpc.tree.start.choices[0].effects[0];
   play();
@@ -36,5 +35,5 @@ test('leader luck above 7 boosts slot machine payout', async () => {
   assert.equal(player.scrap, 5);
   assert.ok(logMessages.some(m => m.includes('Lucky spin')));
 
-  Math.random = origRandom;
+  globalThis.rng = origRng;
 });


### PR DESCRIPTION
## Summary
- ensure slot machine luck check uses seeded RNG
- adjust slot machine luck test for deterministic RNG

## Testing
- `node scripts/supporting/placement-check.js modules/dustland.module.js`
- `node scripts/supporting/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3794b48b88328bf2efb0596b8e8a7