### PR TITLE
feat: add trainer overlay using leader skill points

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -492,7 +492,8 @@ input[type="range"] {
         body.mobile-on #start,
         body.mobile-on #creator,
         body.mobile-on #moduleLoader,
-        body.mobile-on #shopOverlay {
+        body.mobile-on #shopOverlay,
+        body.mobile-on #trainerOverlay {
             bottom: var(--ctrlH);
             height: calc(100% - var(--ctrlH));
         }

--- a/dustland.html
+++ b/dustland.html
@@ -341,5 +341,16 @@
       </div>
     </div>
   </div>
+
+  <div class="overlay" id="trainerOverlay" role="dialog" aria-modal="true" tabindex="-1">
+    <div class="dialog">
+      <header>
+        <div id="trainerLeader"></div>
+        <div id="trainerPoints"></div>
+        <button id="closeTrainerBtn" class="btn">Close</button>
+      </header>
+      <div class="choices" id="trainerChoices"></div>
+    </div>
+  </div>
 </body>
 </html>

--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -282,11 +282,13 @@ function respec(memberIndex=selectedMember){
 function trainStat(stat, memberIndex = selectedMember){
   const m = party[memberIndex];
   if(!m) return false;
-  if(m.skillPoints <= 0){
+  const lead = leader();
+  if(!lead || lead.skillPoints <= 0 || m.skillPoints <= 0){
     log('No skill points to spend.');
     return false;
   }
-  m.skillPoints -= 1;
+  lead.skillPoints -= 1;
+  if(m !== lead) m.skillPoints -= 1;
   if(stat === 'HP'){
     m.maxHp += 5;
     m.hp = m.maxHp;

--- a/test/skill-badge.test.js
+++ b/test/skill-badge.test.js
@@ -13,6 +13,7 @@ function setup(){
   ids.forEach(id=>document.body.appendChild(document.getElementById(id)));
   document.body.appendChild(document.querySelector('.tabs'));
   vm.runInContext(partyCode, context);
+  context.updateHUD = () => {};
   return { context, document };
 }
 
@@ -47,4 +48,16 @@ test('badge updates without duplication on re-render', () => {
   const badges = document.querySelectorAll('.spbadge');
   assert.strictEqual(badges.length, 1);
   assert.strictEqual(String(badges[0].textContent), '3');
+});
+
+test('badge removed after training', () => {
+  const { context, document } = setup();
+  const m = context.makeMember('id','Name','Role');
+  m.skillPoints = 1;
+  context.party.push(m);
+  context.renderParty();
+  assert.ok(document.querySelector('.spbadge'));
+  context.trainStat('STR', 0);
+  const badgeAfter = document.querySelector('.spbadge');
+  assert.strictEqual(badgeAfter, null);
 });

--- a/test/trainer-flow.playtest.test.js
+++ b/test/trainer-flow.playtest.test.js
@@ -9,7 +9,7 @@ const partyCode = await fs.readFile(new URL('../scripts/core/party.js', import.m
 const dataCode = await fs.readFile(new URL('../data/skills/trainer-upgrades.js', import.meta.url), 'utf8');
 
 function setup(){
-  const dom = new JSDOM('<!doctype html><body></body>', { url: 'https://example.com' });
+  const dom = new JSDOM('<!doctype html><body><div id="trainerOverlay"><div id="trainerLeader"></div><div id="trainerPoints"></div><button id="closeTrainerBtn"></button><div id="trainerChoices"></div></div></body>', { url: 'https://example.com' });
   const context = {
     ...dom.window,
     log: () => {},
@@ -28,11 +28,13 @@ function setup(){
 test('trainer upgrade flow stays under fifteen seconds', async () => {
   const { context, dom } = setup();
   const m = context.makeMember('id', 'Name', 'Role');
+  const lead = context.makeMember('lead', 'Lead', 'Role');
+  lead.skillPoints = 1;
   m.skillPoints = 1;
-  context.party.push(m);
+  context.party.push(lead); context.party.push(m);
   const start = Date.now();
-  await context.TrainerUI.showTrainer('power', 0);
-  const btn = dom.window.document.querySelector('#trainer_ui button');
+  await context.TrainerUI.showTrainer('power', 1);
+  const btn = dom.window.document.querySelector('#trainerChoices .choice');
   btn.click();
   const end = Date.now();
   assert.ok(end - start < 15000);


### PR DESCRIPTION
## Summary
- show skill training in dedicated overlay with dialog-style buttons
- training spends party leader skill points and updates member badges
- add tests for badge removal and trainer overlay flow

## Testing
- `node scripts/supporting/presubmit.js dustland.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c379336d4c832886feeb87ba0d871d