### PR TITLE
feat: add npc memory and trader grudge ui

### DIFF
--- a/docs/design/in-progress/oasis-trader.md
+++ b/docs/design/in-progress/oasis-trader.md
@@ -21,7 +21,7 @@
 ## Implementation Sketch
 - [x] Extend `scripts/core/trader.js` with `inventory` arrays and `grudge` fields.
 - [x] Store refresh schedules in the module json and make editable by ACK.
-- [ ] Update `scripts/ui/trade.js` to display timers and grudge indicators.
+ - [x] Update `scripts/ui/trade.js` to display timers and grudge indicators.
 - [x] Emit `trader:refresh` events for mods to hook into.
 
 > **Clown:** Keep the JSON flat so mods can drop in new traders without rewriting logic.

--- a/docs/design/in-progress/persona-mechanics.md
+++ b/docs/design/in-progress/persona-mechanics.md
@@ -85,7 +85,7 @@ Persona equips and other world moments should fire through the game's event bus.
 ## Tasks
 
 - [ ] Prototype persona equip UI at camps (any loot cache mask should be equippable here and yield a persona).
-- [ ] Hook persona stat modifiers into combat calculations.
+ - [x] Hook persona stat modifiers into combat calculations.
 - [ ] Draft first mask memory quest for dustland.
   - [ ] create an NPC mask giver (name TBD)
   - [ ] create quest to get a persona mask (anything with the mask attribute from a loot cache)

--- a/docs/design/in-progress/plot-draft.md
+++ b/docs/design/in-progress/plot-draft.md
@@ -105,7 +105,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
   - The caravan catches the ghost of a broadcast near the Salt Flats and tracks its fading pulses by night.
   - Ruined rail towns and dead malls scatter false echoes, but the crew rigs antennas and readings to keep the trail alive.
   - A final shiver of sound draws them to a collapsed observatory where the signal sinks beneath the horizon, promising deeper secrets.
-- [ ] **Define the Ghost Signal:** Write 3-bullet lore (as above) explaining the origin and nature of the signal. Is it benevolent, malevolent, or something in between?
+- [x] **Define the Ghost Signal:** Write 3-bullet lore (as above) explaining the origin and nature of the signal. Is it benevolent, malevolent, or something in between?
   - It is the fragmented consciousness of a far future scientist, an AI ghost whispering secrets of a world that could be reborn.
   - The signal is a cryptic guide, pulling the caravan toward forgotten caches of technology and knowledge, its motives unclear but its path deliberate.
   - With each broadcast fragment the caravan recovers, the signal grows stronger, but it also risks drawing the attention of those who would see it silenced forever.

--- a/docs/design/in-progress/reactive-systems.md
+++ b/docs/design/in-progress/reactive-systems.md
@@ -32,7 +32,7 @@
 ### Action Items
 - [x] Implement item narrative tagging in engine and Adventure Kit.
 - [ ] Extend quest definitions to support branching and persistence.
-- [ ] Add NPC memory storage and retrieval utilities.
+ - [x] Add NPC memory storage and retrieval utilities.
 - [ ] Build event scheduler for world and NPC timelines.
 - [ ] Allow zones and portals to register and check narrative flags.
 

--- a/dustland.html
+++ b/dustland.html
@@ -297,6 +297,8 @@
       <header>
         <div id="shopName"></div>
         <div id="shopScrap"></div>
+        <div id="shopTimer"></div>
+        <div id="shopGrudge"></div>
         <button id="closeShopBtn" class="btn">Close</button>
       </header>
       <div class="shop-panels">

--- a/scripts/core/npc.js
+++ b/scripts/core/npc.js
@@ -58,6 +58,14 @@ class NPC {
       this.processChoice = (c) => { capChoice(c); };
     }
   }
+
+  remember(key, value){
+    Dustland.gameState?.rememberNPC?.(this.id, key, value);
+  }
+
+  recall(key){
+    return Dustland.gameState?.recallNPC?.(this.id, key);
+  }
 }
 
 function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNode, processChoice, opts) {

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -983,6 +983,7 @@ function openShop(npc) {
   }
   function renderShop() {
     renderScrap();
+    globalThis.Dustland?.updateTradeUI?.(npc);
     shopBuy.innerHTML = '';
     shopSell.innerHTML = '';
 

--- a/scripts/game-state.js
+++ b/scripts/game-state.js
@@ -1,6 +1,6 @@
 (function(){
   globalThis.Dustland = globalThis.Dustland || {};
-  const state = { party: [], world: {}, inventory: [], flags: {}, clock: 0, quests: [], difficulty: 'normal', personas: {}, effectPacks: {} };
+  const state = { party: [], world: {}, inventory: [], flags: {}, clock: 0, quests: [], difficulty: 'normal', personas: {}, effectPacks: {}, npcMemory: {} };
   function getState(){ return state; }
   function updateState(fn){
     if (typeof fn === 'function') fn(state);
@@ -23,6 +23,22 @@
   function loadEffectPacks(packs){
     if(packs) Object.entries(packs).forEach(([evt, list]) => addEffectPack(evt, list));
   }
+  function rememberNPC(id, key, value){
+    if(!id || !key) return;
+    const m = state.npcMemory[id] || (state.npcMemory[id] = {});
+    m[key] = value;
+  }
+  function recallNPC(id, key){
+    return state.npcMemory[id] ? state.npcMemory[id][key] : undefined;
+  }
+  function forgetNPC(id, key){
+    if(!id) return;
+    if(key){
+      if(state.npcMemory[id]) delete state.npcMemory[id][key];
+    }else{
+      delete state.npcMemory[id];
+    }
+  }
   function applyPersona(memberId, personaId){
     const persona = state.personas[personaId];
     if (!persona) return;
@@ -41,5 +57,5 @@
     if (typeof renderParty === 'function') renderParty();
     if (typeof updateHUD === 'function') updateHUD();
   }
-  Dustland.gameState = { getState, updateState, getDifficulty, setDifficulty, setPersona, getPersona, applyPersona, addEffectPack, loadEffectPacks };
+  Dustland.gameState = { getState, updateState, getDifficulty, setDifficulty, setPersona, getPersona, applyPersona, addEffectPack, loadEffectPacks, rememberNPC, recallNPC, forgetNPC };
 })();

--- a/scripts/ui/trade.js
+++ b/scripts/ui/trade.js
@@ -1,0 +1,17 @@
+(function(){
+  const timerEl = typeof document !== 'undefined' ? document.getElementById('shopTimer') : null;
+  const grudgeEl = typeof document !== 'undefined' ? document.getElementById('shopGrudge') : null;
+  function updateTradeUI(trader){
+    if(timerEl){
+      const hrs = trader?.refresh || 0;
+      timerEl.textContent = hrs > 0 ? `Refresh in ${hrs}h` : '';
+    }
+    if(grudgeEl){
+      const g = trader?.grudge || 0;
+      grudgeEl.textContent = g > 0 ? `Grudge: ${g}` : '';
+      grudgeEl.style.color = g >= 3 ? '#c33' : '';
+    }
+  }
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.updateTradeUI = updateTradeUI;
+})();

--- a/test/npc-memory.test.js
+++ b/test/npc-memory.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
+const npcCode = await fs.readFile(new URL('../scripts/core/npc.js', import.meta.url), 'utf8');
+
+test('npc memory stores values', () => {
+  const context = {
+    Dustland: { actions: {} },
+    player: { inv: [], scrap: 0 },
+    CURRENCY: 's',
+    renderInv: () => {},
+    updateHUD: () => {},
+    textEl: {},
+    dialogState: {},
+    renderDialog: () => {},
+    closeDialog: () => {},
+    defaultQuestProcessor: () => {},
+    queueNanoDialogForNPCs: () => {}
+  };
+  vm.createContext(context);
+  vm.runInContext(gs, context);
+  vm.runInContext(npcCode, context);
+  const npc = new context.NPC({ id: 'n1', map: 'w', x: 0, y: 0, color: '#fff', name: 'Bob', title: '', desc: '', tree: { start: { text: '', choices: [] } } });
+  npc.remember('favor', 2);
+  assert.strictEqual(context.Dustland.gameState.recallNPC('n1', 'favor'), 2);
+  npc.remember('favor', 3);
+  assert.strictEqual(npc.recall('favor'), 3);
+  context.Dustland.gameState.forgetNPC('n1', 'favor');
+  assert.strictEqual(npc.recall('favor'), undefined);
+});

--- a/test/persona-combat.test.js
+++ b/test/persona-combat.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { createGameProxy } from './test-harness.js';
+
+test('persona STR mod increases attack damage', async () => {
+  const { context } = createGameProxy([]);
+  context.updateHUD = () => {};
+  context.renderParty = () => {};
+  context.log = () => {};
+  const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
+  vm.runInContext(gs, context);
+  const partyJs = await fs.readFile(new URL('../scripts/core/party.js', import.meta.url), 'utf8');
+  vm.runInContext(partyJs, context);
+  const combatJs = await fs.readFile(new URL('../scripts/core/combat.js', import.meta.url), 'utf8');
+  vm.runInContext(combatJs, context);
+
+  const hero = context.makeMember('h', 'Hero', '', {});
+  context.joinParty(hero);
+  context.Dustland.gameState.updateState(s => { s.party = context.party; });
+  hero.applyEquipmentStats();
+
+  const enemy = { name: 'Dummy', hp: 10, maxHp: 10, ATK: 1, _bonus: {}, stats: {} };
+
+  context.__testAttack(hero, enemy, 1);
+  const baseHp = enemy.hp;
+
+  enemy.hp = 10;
+  context.Dustland.gameState.setPersona('p1', { mods: { STR: 2 } });
+  context.Dustland.gameState.applyPersona('h', 'p1');
+  context.__testAttack(hero, enemy, 1);
+  const boostedHp = enemy.hp;
+
+  assert.ok(boostedHp < baseHp);
+});

--- a/test/trade.ui.test.js
+++ b/test/trade.ui.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+test('trade UI shows timer and grudge', async () => {
+  const dom = new JSDOM('<div id="shopTimer"></div><div id="shopGrudge"></div>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  const code = await fs.readFile(new URL('../scripts/ui/trade.js', import.meta.url), 'utf8');
+  vm.runInThisContext(code);
+  Dustland.updateTradeUI({ refresh: 5, grudge: 2 });
+  assert.strictEqual(document.getElementById('shopTimer').textContent, 'Refresh in 5h');
+  assert.strictEqual(document.getElementById('shopGrudge').textContent, 'Grudge: 2');
+});


### PR DESCRIPTION
## Summary
- add persistent NPC memory utilities
- show trader refresh timers and grudges in shop UI
- document ghost signal lore and mark persona combat hooks complete

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68c33e4c42e0832892ea362ec8ad3bbb