### PR TITLE
fix: delay load option until module picked

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -264,12 +264,13 @@
     <script defer src="./scripts/supporting/fx-debug.js"></script>
     <script defer src="./scripts/supporting/perf-debug.js"></script>
   <script>
+    const params = new URLSearchParams(location.search);
+    const isAck = params.get('ack-player') === '1';
+    if (!isAck) window.modulePickerPending = true;
     disablePullToRefresh();
     warnOnUnload();
     window.addEventListener('DOMContentLoaded', () => {
       document.getElementById('title').textContent += ' v' + ENGINE_VERSION;
-      const params = new URLSearchParams(location.search);
-      const isAck = params.get('ack-player') === '1';
       if (isAck) {
         UI.show('moduleLoader', 'flex');
         const btns = document.getElementById('mainButtons');

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -1242,7 +1242,7 @@ requestAnimationFrame(draw);
   const isAck = params.get('ack-player') === '1';
   if (location.hash.includes('test')) {
     runTests();
-  } else if (!isAck) {
+  } else if (!isAck && !globalThis.modulePickerPending) {
     const saveStr = globalThis.localStorage?.getItem('dustland_crt');
     if (saveStr) {
       showStart();

--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -18,6 +18,8 @@ const realResetAll = window.resetAll;
 window.openCreator = () => {};
 window.showStart = () => {};
 window.resetAll = () => {};
+const loadBtn = document.getElementById('loadBtn');
+if (loadBtn) UI.hide('loadBtn');
 
 function startDust(canvas, getScale = () => 1){
   const ctx = canvas.getContext('2d');
@@ -123,6 +125,8 @@ function loadModule(moduleInfo){
       realResetAll();
       loadModule(moduleInfo);
     };
+    if (loadBtn) UI.show('loadBtn');
+    globalThis.modulePickerPending = false;
     openCreator();
   };
   document.body.appendChild(script);

--- a/test/module-picker.playtest.test.js
+++ b/test/module-picker.playtest.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { basicDom } from './dom-fixture.js';
+
+test('engine waits for module picker before boot', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const html = `<!DOCTYPE html><body>${basicDom}<canvas id="game"></canvas></body>`;
+  const dom = new JSDOM(html, { url: 'http://localhost/dustland.html' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.location = window.location;
+  window.requestAnimationFrame = () => {};
+  global.requestAnimationFrame = window.requestAnimationFrame;
+  window.NanoDialog = { init: () => {} };
+  global.NanoDialog = window.NanoDialog;
+  window.AudioContext = function() {};
+  window.webkitAudioContext = window.AudioContext;
+  window.Audio = function(){ return { cloneNode: () => ({ play: () => {} }) }; };
+  global.Audio = window.Audio;
+  global.EventBus = { on: () => {}, emit: () => {} };
+  global.TS = 16;
+  global.camX = 0;
+  global.camY = 0;
+  global.interactAt = () => {};
+  window.HTMLCanvasElement.prototype.getContext = () => ({
+    drawImage: () => {},
+    clearRect: () => {},
+    getImageData: () => ({ data: [] }),
+    putImageData: () => {}
+  });
+  const store = { dustland_crt: '{}' };
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: k => store[k],
+      setItem: (k,v) => { store[k] = String(v); },
+      removeItem: k => { delete store[k]; }
+    }
+  });
+  global.localStorage = window.localStorage;
+  let startShown = false;
+  let creatorOpened = false;
+  global.showStart = () => { startShown = true; };
+  global.openCreator = () => { creatorOpened = true; };
+  global.bootMap = () => {};
+  global.draw = () => {};
+  global.runTests = () => {};
+  global.modulePickerPending = true;
+  const enginePath = path.join(__dirname, '..', 'scripts', 'dustland-engine.js');
+  window.eval(fs.readFileSync(enginePath, 'utf8'));
+  assert.ok(!startShown && !creatorOpened, 'engine should not boot when module picker pending');
+});

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -57,7 +57,13 @@ Object.assign(global, {
   location: { href: '' }
 });
 
-global.UI = { remove: () => {} };
+const hidden = [];
+const shown = [];
+global.UI = {
+  remove: () => {},
+  hide: id => hidden.push(id),
+  show: id => shown.push(id)
+};
 
 const bodyEl = stubEl();
 const headEl = stubEl();
@@ -66,7 +72,7 @@ global.document = {
   body: bodyEl,
   head: headEl,
   createElement: () => stubEl(),
-  getElementById: () => null
+  getElementById: id => id === 'loadBtn' ? stubEl() : null
 };
 
 
@@ -170,4 +176,9 @@ test('loadModule preserves existing save data', () => {
   assert.ok(scriptEl);
   scriptEl.onload();
   assert.strictEqual(ls.getItem('dustland_crt'), 'foo');
+  assert.ok(shown.includes('loadBtn'));
+});
+
+test('load button hidden until module loads', () => {
+  assert.ok(hidden.includes('loadBtn'));
 });


### PR DESCRIPTION
## Summary
- avoid showing start menu before module selection by flagging pending picker
- hide save-load controls until a module finishes loading
- cover module picker boot path with tests

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c395d9179883288c7065dc504ab938