### PR TITLE
fix: render trainer upgrades within dialog

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -492,8 +492,7 @@ input[type="range"] {
         body.mobile-on #start,
         body.mobile-on #creator,
         body.mobile-on #moduleLoader,
-        body.mobile-on #shopOverlay,
-        body.mobile-on #trainerOverlay {
+        body.mobile-on #shopOverlay {
             bottom: var(--ctrlH);
             height: calc(100% - var(--ctrlH));
         }

--- a/dustland.html
+++ b/dustland.html
@@ -341,16 +341,5 @@
       </div>
     </div>
   </div>
-
-  <div class="overlay" id="trainerOverlay" role="dialog" aria-modal="true" tabindex="-1">
-    <div class="dialog">
-      <header>
-        <div id="trainerLeader"></div>
-        <div id="trainerPoints"></div>
-        <button id="closeTrainerBtn" class="btn">Close</button>
-      </header>
-      <div class="choices" id="trainerChoices"></div>
-    </div>
-  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show trainer upgrade options inside the dialog window
- drop unused trainer overlay markup and styles
- test trainer upgrade rendering and flow

## Testing
- `npm run lint`
- `node --test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c39734463c83289267b8f1effc6a43