### PR TITLE
fix: drop unload warning from module picker

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -268,7 +268,6 @@
     const isAck = params.get('ack-player') === '1';
     if (!isAck) window.modulePickerPending = true;
     disablePullToRefresh();
-    warnOnUnload();
     window.addEventListener('DOMContentLoaded', () => {
       document.getElementById('title').textContent += ' v' + ENGINE_VERSION;
       if (isAck) {

--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -127,6 +127,7 @@ function loadModule(moduleInfo){
     };
     if (loadBtn) UI.show('loadBtn');
     globalThis.modulePickerPending = false;
+    warnOnUnload();
     openCreator();
   };
   document.body.appendChild(script);


### PR DESCRIPTION
## Summary
- remove automatic unload confirmation when opening dustland
- re-enable confirmation once a module has been loaded

## Testing
- `npm test` (passed)
- `node scripts/supporting/presubmit.js`

------
https://chatgpt.com/codex/tasks/task_e_68c39df97f088328baf0cce40c0fdff5