### PR TITLE
fix: load default trainer upgrades

### DIFF
--- a/scripts/trainer-ui.js
+++ b/scripts/trainer-ui.js
@@ -1,6 +1,22 @@
 (function(){
   function loadTrainerData(){
-    return globalThis.TRAINER_UPGRADES || {};
+    if(!globalThis.TRAINER_UPGRADES){
+      globalThis.TRAINER_UPGRADES = {
+        power: [
+          { id: 'str', label: 'STR +1', cost: 1, type: 'stat', stat: 'STR', delta: 1 },
+          { id: 'agi', label: 'AGI +1', cost: 1, type: 'stat', stat: 'AGI', delta: 1 }
+        ],
+        endurance: [
+          { id: 'hp', label: 'Max HP +5', cost: 1, type: 'stat', stat: 'HP', delta: 5 },
+          { id: 'def', label: 'DEF +1', cost: 1, type: 'stat', stat: 'DEF', delta: 1 }
+        ],
+        tricks: [
+          { id: 'per', label: 'PER +1', cost: 1, type: 'stat', stat: 'PER', delta: 1 },
+          { id: 'lck', label: 'LCK +1', cost: 1, type: 'stat', stat: 'LCK', delta: 1 }
+        ]
+      };
+    }
+    return globalThis.TRAINER_UPGRADES;
   }
 
   function showTrainer(id, memberIndex = 0){


### PR DESCRIPTION
## Summary
- provide built-in trainer upgrade data so "Upgrade Skills" menus populate even if external data is missing

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c39f60c18c8328b935bc8a71eb93a0