### PR TITLE
fix: guard module picker unload hook

### DIFF
--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -127,7 +127,7 @@ function loadModule(moduleInfo){
     };
     if (loadBtn) UI.show('loadBtn');
     globalThis.modulePickerPending = false;
-    warnOnUnload();
+    if (typeof warnOnUnload === 'function') warnOnUnload();
     openCreator();
   };
   document.body.appendChild(script);


### PR DESCRIPTION
## Summary
- avoid ReferenceError when warnOnUnload is missing

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a110ab308328bb78b2c2bd944af3