### PR TITLE
fix: hide nano indicator when initialization fails

### DIFF
--- a/scripts/dustland-nano.js
+++ b/scripts/dustland-nano.js
@@ -38,7 +38,7 @@
     seenKeys: new Set(), // avoid re-enqueue storms
   };
 
-  const _ui = { badge:null, progress:null };
+  const _ui = { wrap:null, badge:null, progress:null };
 
   function refreshIndicator(){ 
     _updateBadge(); 
@@ -50,6 +50,7 @@
     if(!wrap) {
       return;
     }
+    _ui.wrap=wrap;
     _ui.progress=wrap.querySelector('#nanoProgress');
     _ui.badge=wrap.querySelector('#nanoBadge');
   }
@@ -57,11 +58,15 @@
   function _updateBadge(){
     _ensureUI();
     if(!_ui.badge) return;
+    if(_state.failed){
+      if(_ui.wrap) _ui.wrap.style.display='none';
+      return;
+    }
+    if(_ui.wrap) _ui.wrap.style.display='';
     const on=_state.ready && (window.NanoDialog.enabled || window.NanoPalette.enabled);
-    _ui.badge.textContent = on ? '✓' : (_state.failed ? '!' : '✗');
+    _ui.badge.textContent = on ? '✓' : '✗';
     _ui.badge.classList.toggle('on', on);
-    _ui.badge.classList.toggle('off', !on && !_state.failed);
-    _ui.badge.classList.toggle('failed', _state.failed);
+    _ui.badge.classList.toggle('off', !on);
   }
 
   function _showProgress(p){

--- a/test/nano.test.js
+++ b/test/nano.test.js
@@ -99,3 +99,16 @@ test('NanoPalette uses stamp emoji examples by default', async () => {
   await window.NanoPalette.generate();
   assert.ok(lastPrompt.includes('🏝'.repeat(3)) && lastPrompt.includes('🪨'.repeat(3)), 'prompt contains emoji examples');
 });
+
+test('hides indicator when init fails', async () => {
+  const badge = { style: {}, classList: { toggle: () => {} }, textContent: '' };
+  const progress = { style: {}, classList: { toggle: () => {} } };
+  const wrap = {
+    style: {},
+    querySelector: (sel) => sel === '#nanoProgress' ? progress : sel === '#nanoBadge' ? badge : null
+  };
+  global.document.getElementById = (id) => id === 'nanoStatus' ? wrap : null;
+  delete global.LanguageModel;
+  await window.NanoDialog.init();
+  assert.strictEqual(wrap.style.display, 'none');
+});


### PR DESCRIPTION
## Summary
- store nano status wrapper and hide it when initialization fails
- add regression test to ensure indicator is hidden when init can't start

## Testing
- `./install-deps.sh`
- `npm test` *(fails: loadModule preserves existing save data, resetAll reloads current module)*
- `node --test test/nano.test.js`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3a1f77a388328acf217e09b6f8956