### PR TITLE
feat: inject trainer options dynamically

### DIFF
--- a/docs/design/completed/rpg-progression.md
+++ b/docs/design/completed/rpg-progression.md
@@ -68,7 +68,7 @@ Here’s the roadmap. We’ll build the core systems first, get the player-facin
 - [x] **Trainer UI Implementation:** Build the data-driven "Upgrade Skills" overlay showing upgrade costs and before/after stat changes.
 
 #### **Phase 3: Content Implementation (The World)**
- - [x] **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer's `tree` object should include the **Upgrade Skills** dialog option and their unique list of available upgrades.
+ - [x] **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer should specify a `trainer` type so the dialog system can inject the **Upgrade Skills** option and pull their unique list of upgrades.
   - [x] **Enemy Presets:** Define enemy stat allocations per level in `scripts/core/presets.js`. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
 - [x] **Zone Population:** Populate the "Scrap Wastes" (Levels 1-5) with 5-7 on-level enemies and one or two higher-level "challenge" enemies off the main path. Ensure the zone layout naturally funnels players back toward a trainer NPC.
 - [x] **Boss Mechanics:** Implement the first boss with a telegraphed special move. This involves creating a visual cue (e.g., a "charging up" animation or effect) and a corresponding high-damage attack that triggers after a short delay.

--- a/docs/design/completed/trainer-ui-mockup.md
+++ b/docs/design/completed/trainer-ui-mockup.md
@@ -22,7 +22,7 @@ Selecting a row highlights it and fills the preview. The point total updates in 
 
 ### Data Driven
 
-Each trainer owns a `tree` object that lists possible upgrades. The UI reads this object and renders rows automatically:
+Each trainer specifies a `trainer` type that maps to a list of upgrades. The UI reads from that list and renders rows automatically:
 
 ```
 const trainerTrees = {

--- a/docs/guides/qa-checks.md
+++ b/docs/guides/qa-checks.md
@@ -108,8 +108,8 @@ Validation tasks should remain unchecked unless the process yields at least one 
   - Check: confirm implementation matches description.
 - **rpg-progression.md** — **Trainer UI Implementation:** Build the data-driven "Upgrade Skills" overlay showing upgrade costs and before/after stat changes.
   - Check: confirm implementation matches description.
-- **rpg-progression.md** — **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer's `tree` object should include the **Upgrade Skills** dialog option and their unique list of available upgrades.
-  - Check: confirm implementation matches description.
+ - **rpg-progression.md** — **Trainer NPCs:** Create at least three specialized trainer NPCs (e.g., Power, Endurance, Tricks) and place them in the world. Each trainer should define a `trainer` type so the dialog system injects the **Upgrade Skills** option and loads their unique upgrade list.
+   - Check: confirm implementation matches description.
 - **rpg-progression.md** — **Enemy Presets:** Define enemy stat allocations per level in `scripts/core/presets.js`. For example, a "Scrapper" preset might allocate points into `STR` and `AGI`, while a "Bulwark" preset focuses on `DEF`.
   - Check: confirm implementation matches description.
 - **rpg-progression.md** — **Zone Population:** Populate the "Scrap Wastes" (Levels 1-5) with 5-7 on-level enemies and one or two higher-level "challenge" enemies off the main path. Ensure the zone layout naturally funnels players back toward a trainer NPC.

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -1893,20 +1893,11 @@ const DATA = `
       "title": "Power Trainer",
       "desc": "A former arena champ teaching raw strength.",
       "portraitSheet": "assets/portraits/dustland-module/brakk_4.png",
+      "trainer": "power",
       "tree": {
         "start": {
           "text": "Brakk cracks his knuckles.",
           "choices": [
-            {
-              "label": "(Upgrade Skills)",
-              "to": "train",
-              "effects": [
-                {
-                  "effect": "showTrainer",
-                  "trainer": "power"
-                }
-              ]
-            },
             {
               "label": "(Leave)",
               "to": "bye"
@@ -1914,13 +1905,7 @@ const DATA = `
           ]
         },
         "train": {
-          "text": "Push your limits.",
-          "choices": [
-            {
-              "label": "(Back)",
-              "to": "start"
-            }
-          ]
+          "text": "Push your limits."
         }
       }
     },
@@ -1934,20 +1919,11 @@ const DATA = `
       "title": "Endurance Trainer",
       "desc": "A grizzled scavenger preaching survival.",
       "portraitSheet": "assets/portraits/dustland-module/rusty_4.png",
+      "trainer": "endurance",
       "tree": {
         "start": {
           "text": "Rusty studies your stance.",
           "choices": [
-            {
-              "label": "(Upgrade Skills)",
-              "to": "train",
-              "effects": [
-                {
-                  "effect": "showTrainer",
-                  "trainer": "endurance"
-                }
-              ]
-            },
             {
               "label": "(Leave)",
               "to": "bye"
@@ -1955,13 +1931,7 @@ const DATA = `
           ]
         },
         "train": {
-          "text": "Breathe deep and endure.",
-          "choices": [
-            {
-              "label": "(Back)",
-              "to": "start"
-            }
-          ]
+          "text": "Breathe deep and endure."
         }
       }
     },
@@ -1975,20 +1945,11 @@ const DATA = `
       "title": "Tricks Trainer",
       "desc": "A nimble tinkerer teaching odd moves.",
       "portraitSheet": "assets/portraits/dustland-module/mira_4.png",
+      "trainer": "tricks",
       "tree": {
         "start": {
           "text": "Mira twirls a coin.",
           "choices": [
-            {
-              "label": "(Upgrade Skills)",
-              "to": "train",
-              "effects": [
-                {
-                  "effect": "showTrainer",
-                  "trainer": "tricks"
-                }
-              ]
-            },
             {
               "label": "(Leave)",
               "to": "bye"
@@ -1996,13 +1957,7 @@ const DATA = `
           ]
         },
         "train": {
-          "text": "Learn a new trick.",
-          "choices": [
-            {
-              "label": "(Back)",
-              "to": "start"
-            }
-          ]
+          "text": "Learn a new trick."
         }
       }
     },

--- a/scripts/core/npc.js
+++ b/scripts/core/npc.js
@@ -3,8 +3,8 @@ var Dustland = globalThis.Dustland;
 const NPC_COLOR = '#9ef7a0';
 const OBJECT_COLOR = '#225a20';
 class NPC {
-  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,quests=null,questDialogs=null,processNode=null,processChoice=null,combat=null,shop=false,workbench=false,portraitSheet=null,portraitLock=true,symbol='!',door=false,locked=false,prompt=null,unlockTime=null,questIdx=0}) {
-    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,quests,questDialogs,combat,shop,workbench,portraitSheet,portraitLock,symbol,door,locked,prompt,unlockTime,questIdx});
+  constructor({id,map,x,y,color,name,title,desc,tree,quest=null,quests=null,questDialogs=null,processNode=null,processChoice=null,combat=null,shop=false,workbench=false,portraitSheet=null,portraitLock=true,symbol='!',door=false,locked=false,prompt=null,unlockTime=null,questIdx=0,trainer=null}) {
+    Object.assign(this, {id,map,x,y,color,name,title,desc,tree,quest,quests,questDialogs,combat,shop,workbench,portraitSheet,portraitLock,symbol,door,locked,prompt,unlockTime,questIdx,trainer});
     if (Array.isArray(this.quests) && !this.quest) {
       this.quest = this.quests[this.questIdx] || null;
     }
@@ -97,6 +97,20 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
     }
     tree.sell = tree.sell || {text: 'What are you selling?', choices: []};
   }
+  if (opts?.trainer) {
+    tree = tree || {};
+    tree.start = tree.start || {text: '', choices: []};
+    tree.start.choices = tree.start.choices || [];
+    if (!tree.start.choices.some(c => c.to === 'train')) {
+      tree.start.choices.unshift({
+        label: '(Upgrade Skills)',
+        to: 'train',
+        effects: [{ effect: 'showTrainer', trainer: opts.trainer }]
+      });
+    }
+    tree.train = tree.train || { text: '', choices: [{ label: '(Back)', to: 'start' }] };
+    if (!tree.train.choices?.length) tree.train.choices = [{ label: '(Back)', to: 'start' }];
+  }
   const q = quest || (opts?.quests ? opts.quests[0] : null);
   color = color || (opts?.symbol && opts.symbol !== '!' ? OBJECT_COLOR : NPC_COLOR);
   return new NPC({id,map,x,y,color,name,title,desc,tree,quest:q,processNode,processChoice, ...(opts || {})});
@@ -145,6 +159,8 @@ function createNpcFactory(defs) {
       if (n.symbol) opts.symbol = n.symbol;
       if (n.door) opts.door = n.door;
       if (typeof n.locked === 'boolean') opts.locked = n.locked;
+      if (n.trainer) opts.trainer = n.trainer;
+      else if (n.id && n.id.startsWith('trainer_')) opts.trainer = n.id.split('_')[1];
       if (Array.isArray(n.quests)) {
         opts.quests = n.quests.map(q => typeof q === 'string' ? (globalThis.quests?.[q] || null) : q).filter(Boolean);
       }

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -660,7 +660,8 @@ function save(){
     loop:n.loop,
     portraitSheet:n.portraitSheet,
     portraitLock:n.portraitLock,
-    symbol:n.symbol
+    symbol:n.symbol,
+    trainer:n.trainer
   }));
   const questData = {};
   Object.keys(quests).forEach(k=>{
@@ -706,7 +707,13 @@ function load(){
     const qd=d.quests[id];
     const q=new Quest(id,qd.title,qd.desc); q.status=qd.status; q.pinned=qd.pinned||false; quests[id]=q;
   });
-
+  const moduleNpcs = globalThis.moduleData?.npcs || [];
+  (d.npcs || []).forEach(n => {
+    if (!n.trainer) {
+      const m = moduleNpcs.find(m => m.id === n.id || m.name === n.name);
+      if (m && m.trainer) n.trainer = m.trainer;
+    }
+  });
   const npcFactory = createNpcFactory(d.npcs || []);
   if (typeof NPCS !== 'undefined') NPCS.length = 0;
   (d.npcs||[]).forEach(n=>{

--- a/test/load-trainer-legacy.test.js
+++ b/test/load-trainer-legacy.test.js
@@ -1,0 +1,97 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function stubEl(){
+  const el = {
+    style:{},
+    classList:{ add(){}, remove(){}, toggle(){}, contains(){ return false; } },
+    textContent:'',
+    onclick:null,
+    children:[],
+    dataset:{},
+    appendChild(child){ this.children.push(child); child.parentElement=this; },
+    prepend(child){ this.children.unshift(child); child.parentElement=this; },
+    querySelector: () => stubEl(),
+    querySelectorAll: () => [],
+    getContext: () => ({
+      clearRect(){}, drawImage(){}, fillRect(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){},
+      save(){}, restore(){}, translate(){}, font:'', fillText(){}, globalAlpha:1
+    }),
+    addEventListener(){},
+    remove(){},
+    parentElement:{ appendChild(){}, querySelectorAll(){ return []; } }
+  };
+  return el;
+}
+
+global.requestAnimationFrame = () => {};
+Object.assign(global, {
+  window: global,
+  innerWidth: 800,
+  innerHeight: 600,
+  addEventListener(){},
+  localStorage: { getItem: () => null, setItem(){}, removeItem(){} },
+  location: { href: '' }
+});
+
+global.document = {
+  body: stubEl(),
+  head: stubEl(),
+  createElement: () => stubEl(),
+  getElementById: () => stubEl(),
+  querySelector: () => stubEl()
+};
+
+global.log = () => {};
+global.toast = () => {};
+global.renderInv = () => {};
+global.renderParty = () => {};
+global.renderQuests = () => {};
+global.updateHUD = () => {};
+global.centerCamera = () => {};
+
+const files = [
+  '../scripts/event-bus.js',
+  '../scripts/core/actions.js',
+  '../scripts/core/effects.js',
+  '../scripts/core/spoils-cache.js',
+  '../scripts/core/abilities.js',
+  '../scripts/core/party.js',
+  '../scripts/core/inventory.js',
+  '../scripts/core/movement.js',
+  '../scripts/core/dialog.js',
+  '../scripts/core/combat.js',
+  '../scripts/core/quests.js',
+  '../scripts/core/npc.js',
+  '../scripts/game-state.js',
+  '../scripts/dustland-core.js'
+];
+for (const f of files) {
+  const code = await fs.readFile(new URL(f, import.meta.url), 'utf8');
+  vm.runInThisContext(code, { filename: f });
+}
+
+test('load() infers trainer type for legacy saves', () => {
+  global.moduleData = {
+    npcs: [{ id: 'trainer_power', name: 'Brakk', trainer: 'power' }]
+  };
+  const save = {
+    worldSeed: 1,
+    world: [[0]],
+    player: {},
+    state: { map: 'world' },
+    buildings: [],
+    interiors: {},
+    itemDrops: [],
+    npcs: [{ id: 'trainer_power', name: 'Brakk', map: 'world', x: 0, y: 0, tree: { start: { text: '', choices: [{ label: '(Leave)', to: 'bye' }] } } }],
+    quests: {},
+    party: []
+  };
+  global.localStorage.getItem = () => JSON.stringify(save);
+  load();
+  assert.strictEqual(NPCS[0].trainer, 'power');
+  const labels = NPCS[0].tree.start.choices.map(c => c.label);
+  assert.ok(labels.includes('(Upgrade Skills)'));
+});


### PR DESCRIPTION
## Summary
- build trainer dialog branches at runtime when an NPC defines a `trainer` type
- persist trainer flag through save data and update module NPC definitions
- document and test dynamic trainer injection
- infer trainer type on load for legacy saves missing the flag

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/placement-check.js modules/dustland.module.js`
- `node scripts/supporting/balance-tester-agent.js` *(fails: Cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a26bb540832895cb266c74d45e44