### PR TITLE
feat: expand world two map with bunker

### DIFF
--- a/modules/world-two.module.js
+++ b/modules/world-two.module.js
@@ -5,18 +5,20 @@ const DATA = `
   "seed": "world-two",
   "start": { "map": "world", "x": 2, "y": 2 },
   "world": [
-    [0,0,0,0,0],
-    [0,0,0,0,0],
-    [0,0,0,0,0],
-    [0,0,0,0,0],
-    [0,0,0,0,0]
+    [0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0]
   ],
   "items": [
     { "id": "fuel_cell", "name": "Fuel Cell", "type": "quest" },
     { "id": "shiny_cog", "name": "Shiny Cog", "type": "quest", "map": "world", "x": 2, "y": 3 }
   ],
   "buildings": [
-    { "x": 4, "y": 2, "w": 1, "h": 1, "doorX": 4, "doorY": 2, "boarded": true, "bunker": true, "bunkerId": "beta" }
+    { "x": 6, "y": 3, "w": 1, "h": 1, "doorX": 6, "doorY": 3, "boarded": true, "bunker": true, "bunkerId": "beta" }
   ],
   "npcs": [
     {
@@ -45,8 +47,8 @@ const DATA = `
     {
       "id": "bunker_beta",
       "map": "world",
-      "x": 4,
-      "y": 2,
+      "x": 6,
+      "y": 3,
       "color": "#aaa",
       "name": "Bunker Beta",
       "desc": "A flickering terminal awaits activation.",

--- a/scripts/ui/world-map.js
+++ b/scripts/ui/world-map.js
@@ -2,7 +2,7 @@
   const bunkers = globalThis.Dustland?.bunkers || [];
   const moduleMap = {
     alpha: { script: 'modules/world-one.module.js', global: 'WORLD_ONE_MODULE', name: 'World One', map: 'world', x: 4, y: 2 },
-    beta: { script: 'modules/world-two.module.js', global: 'WORLD_TWO_MODULE', name: 'World Two', map: 'world', x: 4, y: 2 }
+    beta: { script: 'modules/world-two.module.js', global: 'WORLD_TWO_MODULE', name: 'World Two', map: 'world', x: 6, y: 3 }
   };
 
   function ensureModule(id, cb){


### PR DESCRIPTION
## Summary
- enlarge World Two overworld to 7x7 grid
- add a bunker building and NPC positioned at (6,3)
- update world map module to match new bunker coordinates

## Testing
- `node scripts/supporting/placement-check.js modules/world-two.module.js`
- `node scripts/supporting/presubmit.js`
- `npm test` *(fails: persona STR mod increases attack damage)*

------
https://chatgpt.com/codex/tasks/task_e_68c3bc25d8d88328a230959e44ffbb05