### PR TITLE
feat: add flaggable zones and trader grudge

### DIFF
--- a/docs/design/in-progress/oasis-trader.md
+++ b/docs/design/in-progress/oasis-trader.md
@@ -27,8 +27,8 @@
 > **Clown:** Keep the JSON flat so mods can drop in new traders without rewriting logic.
 
 ## Dustland Integration
-- [ ] Replace static shop NPC in `dustland.module.js` with a traveling trader.
-- [ ] Give the trader an east-west patrol loop across the world map.
+- [x] Replace static shop NPC in `dustland.module.js` with a traveling trader.
+- [x] Give the trader an east-west patrol loop across the world map.
 - [ ] Stock begins with scavenged gear and upgrades across three refresh waves.
 - [ ] Raise prices roughly 300 scrap per stat point above crowbar and flak jacket drops.
 - [ ] Final wave sells top-tier gear well above 500 scrap.

--- a/docs/design/in-progress/persona-mechanics.md
+++ b/docs/design/in-progress/persona-mechanics.md
@@ -84,15 +84,15 @@ Persona equips and other world moments should fire through the game's event bus.
 
 ## Tasks
 
-- [ ] Prototype persona equip UI at camps (any loot cache mask should be equippable here and yield a persona).
+- [x] Prototype persona equip UI at camps (any loot cache mask should be equippable here and yield a persona).
  - [x] Hook persona stat modifiers into combat calculations.
 - [ ] Draft first mask memory quest for dustland.
   - [ ] create an NPC mask giver (name TBD)
   - [ ] create quest to get a persona mask (anything with the mask attribute from a loot cache)
   - [ ] add dialog to this NPC that explains the above lore about how these aren't just disguises
-- [ ] Add portrait and label swap logic to the HUD.
+- [x] Add portrait and label swap logic to the HUD.
 - [ ] Extend ACK schema and editor with reusable profile definitions.
  - [ ] Implement profile runtime service for personas, buffs, and disguises.
-- [ ] Emit `persona:equip` and `persona:unequip` events on the global bus.
+- [x] Emit `persona:equip` and `persona:unequip` events on the global bus.
 - [x] ensure load/save store the equipped persona.
 - [ ] Build editor inspector for authoring and testing effect packs into ACK.

--- a/docs/design/in-progress/reactive-systems.md
+++ b/docs/design/in-progress/reactive-systems.md
@@ -34,5 +34,5 @@
 - [ ] Extend quest definitions to support branching and persistence.
  - [x] Add NPC memory storage and retrieval utilities.
 - [ ] Build event scheduler for world and NPC timelines.
-- [ ] Allow zones and portals to register and check narrative flags.
+- [x] Allow zones and portals to register and check narrative flags.
 

--- a/scripts/camp-persona.js
+++ b/scripts/camp-persona.js
@@ -16,6 +16,7 @@
     const zones = globalThis.Dustland?.zoneEffects || [];
     if (pos) {
       for (const z of zones) {
+        if(z.if && !globalThis.checkFlagCondition?.(z.if)) continue;
         if ((z.map || 'world') !== map) continue;
         if (pos.x < z.x || pos.y < z.y || pos.x >= z.x + (z.w || 0) || pos.y >= z.y + (z.h || 0)) continue;
         if (z.dry || (z.perStep?.hp < 0) || (z.step?.hp < 0)) {

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -27,6 +27,7 @@ function zoneAttrs(map,x,y){
   let maxSteps = null;
   const zones = globalThis.Dustland?.zoneEffects || [];
   for(const z of zones){
+    if(z.if && !globalThis.checkFlagCondition?.(z.if)) continue;
     if((z.map||'world')!==map) continue;
     if(x<z.x || y<z.y || x>=z.x+(z.w||0) || y>=z.y+(z.h||0)) continue;
     if(z.noEncounters) noEncounters = true;
@@ -209,6 +210,7 @@ function applyZones(map,x,y){
   const zones = globalThis.Dustland?.zoneEffects || [];
   let weatherZone = null;
   for(const z of zones){
+    if(z.if && !globalThis.checkFlagCondition?.(z.if)) continue;
     if((z.map||'world')!==map) continue;
     if(x<z.x || y<z.y || x>=z.x+(z.w||0) || y>=z.y+(z.h||0)) continue;
     if(z.require && !hasItemOrEquipped(z.require)) continue;
@@ -256,6 +258,7 @@ function updateZoneMsgs(map,x,y){
   const zones = globalThis.Dustland?.zoneEffects || [];
   const current = [];
   for(const z of zones){
+    if(z.if && !globalThis.checkFlagCondition?.(z.if)) continue;
     if((z.map||'world')!==map) continue;
     if(x<z.x || y<z.y || x>=z.x+(z.w||0) || y>=z.y+(z.h||0)) continue;
     const step = z.perStep || z.step;
@@ -506,6 +509,11 @@ function interactAt(x, y) {
   if(x===party.x && y===party.y){
     const p=portals.find(p=> p.map===state.map && p.x===x && p.y===y);
     if(p){
+      if(p.if && !globalThis.checkFlagCondition?.(p.if)){
+        log(p.blockedMsg || 'It\'s locked.');
+        bus.emit('sfx','denied');
+        return true;
+      }
       const target=p.toMap;
       const I=interiors[target];
       const px = (typeof p.toX==='number') ? p.toX : (I?I.entryX:0);

--- a/scripts/core/status.js
+++ b/scripts/core/status.js
@@ -12,6 +12,7 @@
     const y = party.y;
     let dry = false;
     for(const z of zones){
+      if(z.if && !globalThis.checkFlagCondition?.(z.if)) continue;
       if((z.map||'world')!==map) continue;
       if(x<z.x || y<z.y || x>=z.x+(z.w||0) || y>=z.y+(z.h||0)) continue;
       if(z.dry){ dry = true; break; }

--- a/scripts/core/trader.js
+++ b/scripts/core/trader.js
@@ -5,7 +5,8 @@ class Trader {
     this.id = id;
     this.inventory = Array.isArray(opts.inventory) ? [...opts.inventory] : [];
     this.grudge = opts.grudge || 0;
-    this.refresh = typeof opts.refresh === 'number' ? opts.refresh : 0;
+    this.markup = opts.markup || 1;
+    this.refreshHours = typeof opts.refresh === 'number' ? opts.refresh : 0;
   }
 
   addItem(item){
@@ -16,7 +17,21 @@ class Trader {
     this.grudge = 0;
   }
 
+  recordCancel(){
+    this.grudge++;
+  }
+
+  price(value){
+    const m = this.markup * (this.grudge >= 3 ? 1.1 : 1);
+    return Math.ceil(value * m);
+  }
+
+  recordPurchase(){
+    this.grudge = 0;
+  }
+
   refresh(){
+    this.grudge = 0;
     bus?.emit('trader:refresh', { trader: this });
   }
 }

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -260,6 +260,7 @@ function registerZoneEffects(list){
     const id = z.useItem?.id;
     if(id && globalThis.EventBus?.on){
       globalThis.EventBus.on(`used:${id}`, () => {
+        if(z.if && !globalThis.checkFlagCondition?.(z.if)) return;
         const map = z.map || 'world';
         if(party.map !== map) return;
         const { x, y } = party;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -983,12 +983,13 @@ function openShop(npc) {
   }
   function renderShop() {
     renderScrap();
-    globalThis.Dustland?.updateTradeUI?.(npc);
+    globalThis.Dustland?.updateTradeUI?.(npc.shop);
     shopBuy.innerHTML = '';
     shopSell.innerHTML = '';
 
     const shopInv = npc.shop.inv || [];
-    const markup = npc.vending ? 1 : npc.shop.markup || 2;
+    const baseMarkup = npc.vending ? 1 : npc.shop.markup || 2;
+    const markup = baseMarkup * (npc.shop.grudge >= 3 ? 1.1 : 1);
 
     shopInv.forEach((it, idx) => {
       const item = getItem(it.id);
@@ -1004,6 +1005,7 @@ function openShop(npc) {
             if (!npc.vending) {
               npc.shop.inv.splice(idx, 1);
             }
+            npc.shop.grudge = 0;
             renderShop();
             updateHUD();
             madePurchase = true;
@@ -1041,6 +1043,8 @@ function openShop(npc) {
     shopOverlay.classList.remove('shown');
     shopOverlay.removeEventListener('keydown', handleKey);
     if (!madePurchase && npc) {
+      npc.shop.grudge = (npc.shop.grudge || 0) + 1;
+      globalThis.Dustland?.updateTradeUI?.(npc.shop);
       npc.cancelCount = (npc.cancelCount || 0) + 1;
       if (npc.cancelCount >= 2) {
         npc.tree.start.text = 'Buy or move on.';
@@ -1048,7 +1052,9 @@ function openShop(npc) {
       }
     } else if (npc) {
       npc.cancelCount = 0;
+      npc.shop.grudge = 0;
       npc.tree.start.text = 'Got goods to sell? I pay in scrap.';
+      globalThis.Dustland?.updateTradeUI?.(npc.shop);
     }
   }
   function handleKey(e) {

--- a/scripts/game-state.js
+++ b/scripts/game-state.js
@@ -45,7 +45,8 @@
     const member = state.party.find(m => m.id === memberId);
     if (!member) return;
     const prev = member.persona;
-    if (prev && prev !== personaId) {
+    if (prev === personaId) return; // no change
+    if (prev) {
       globalThis.Dustland?.profiles?.remove?.(member, prev);
       globalThis.EventBus?.emit('persona:unequip', { memberId, personaId: prev });
     }

--- a/test/persona-events.test.js
+++ b/test/persona-events.test.js
@@ -16,6 +16,7 @@ test('applyPersona emits equip and unequip', async () => {
   gsApi.setPersona('mask2', {});
   gsApi.applyPersona('mara', 'mask1');
   gsApi.applyPersona('mara', 'mask2');
+  gsApi.applyPersona('mara', 'mask2');
   const plain = JSON.parse(JSON.stringify(events.filter(e => e.evt !== 'state:changed')));
   assert.deepStrictEqual(plain, [
     { evt: 'persona:equip', payload: { memberId: 'mara', personaId: 'mask1' } },

--- a/test/pit-bas.module.test.js
+++ b/test/pit-bas.module.test.js
@@ -317,8 +317,7 @@ test('merchant quest requires all treasures', () => {
   vm.runInNewContext(questsSrc, game);
   const coreFile = path.join(__dirname, '..', 'scripts', 'dustland-core.js');
   const coreSrc = fs.readFileSync(coreFile, 'utf8');
-  const coreLines = coreSrc.split('\n');
-  const applySrc = coreLines.slice(377, 528).join('\n');
+  const applySrc = coreSrc.match(/function applyModule[\s\S]*?return moduleData;\n}/)[0];
   vm.runInNewContext(applySrc, game);
   game.applyModule(moduleData, { fullReset: false });
 

--- a/test/trader-grudge.test.js
+++ b/test/trader-grudge.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const code = await fs.readFile(new URL('../scripts/core/trader.js', import.meta.url), 'utf8');
+const context = { EventBus: { emit: () => {} } };
+vm.createContext(context);
+vm.runInContext(code, context);
+const Trader = context.Dustland.Trader;
+
+test('grudge raises prices after cancellations', () => {
+  const t = new Trader('t1', { markup: 1 });
+  assert.strictEqual(t.price(10), 10);
+  t.recordCancel();
+  t.recordCancel();
+  t.recordCancel();
+  assert.strictEqual(t.grudge, 3);
+  assert.strictEqual(t.price(10), 11);
+  t.refresh();
+  assert.strictEqual(t.grudge, 0);
+  assert.strictEqual(t.price(10), 10);
+});


### PR DESCRIPTION
## Summary
- allow zones and portals to require narrative flags
- tweak trader prices based on grudge and prevent persona re-equip noise

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3bc4122e48328ac9751f856e6e99b