### PR TITLE
fix: rerun module postLoad when loading saves

### DIFF
--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -766,6 +766,7 @@ function load(){
     }
   });
   setMap(state.map);
+  globalThis.moduleData?.postLoad?.(globalThis.moduleData);
   refreshUI();
   log('Game loaded.');
   if (typeof toast === 'function') toast('Game loaded.');

--- a/test/load-postload.test.js
+++ b/test/load-postload.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+function stubEl(){
+  const el = {
+    style:{},
+    classList:{ add(){}, remove(){}, toggle(){}, contains(){ return false; } },
+    textContent:'',
+    onclick:null,
+    children:[],
+    dataset:{},
+    appendChild(child){ this.children.push(child); child.parentElement=this; },
+    prepend(child){ this.children.unshift(child); child.parentElement=this; },
+    querySelector: () => stubEl(),
+    querySelectorAll: () => [],
+    getContext: () => ({
+      clearRect(){}, drawImage(){}, fillRect(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){},
+      save(){}, restore(){}, translate(){}, font:'', fillText(){}, globalAlpha:1
+    }),
+    addEventListener(){},
+    remove(){},
+    parentElement:{ appendChild(){}, querySelectorAll(){ return []; } }
+  };
+  return el;
+}
+
+global.requestAnimationFrame = () => {};
+Object.assign(global, {
+  window: global,
+  innerWidth: 800,
+  innerHeight: 600,
+  addEventListener(){},
+  localStorage: { getItem: () => null, setItem(){}, removeItem(){} },
+  location: { href: '' }
+});
+
+global.document = {
+  body: stubEl(),
+  head: stubEl(),
+  createElement: () => stubEl(),
+  getElementById: () => stubEl(),
+  querySelector: () => stubEl()
+};
+
+global.log = () => {};
+global.toast = () => {};
+global.renderInv = () => {};
+global.renderParty = () => {};
+global.renderQuests = () => {};
+global.updateHUD = () => {};
+global.centerCamera = () => {};
+
+const files = [
+  '../scripts/event-bus.js',
+  '../scripts/core/actions.js',
+  '../scripts/core/effects.js',
+  '../scripts/core/spoils-cache.js',
+  '../scripts/core/abilities.js',
+  '../scripts/core/party.js',
+  '../scripts/core/inventory.js',
+  '../scripts/core/movement.js',
+  '../scripts/core/dialog.js',
+  '../scripts/core/combat.js',
+  '../scripts/core/quests.js',
+  '../scripts/core/npc.js',
+  '../scripts/game-state.js',
+  '../scripts/dustland-core.js'
+];
+for (const f of files) {
+  const code = await fs.readFile(new URL(f, import.meta.url), 'utf8');
+  vm.runInThisContext(code, { filename: f });
+}
+
+test('load() runs module postLoad hook', () => {
+  let called = 0;
+  global.moduleData = { npcs: [], postLoad: () => { called++; } };
+  const save = {
+    worldSeed: 1,
+    world: [[0]],
+    player: {},
+    state: { map: 'world' },
+    buildings: [],
+    interiors: {},
+    itemDrops: [],
+    npcs: [],
+    quests: {},
+    party: [{ id: 'p', name: 'P', role: 'lead', lvl:1, xp:0, skillPoints:0, stats:{}, equip:{}, hp:10, map:'world', x:0, y:0, maxHp:10 }]
+  };
+  global.localStorage.getItem = () => JSON.stringify(save);
+  load();
+  assert.strictEqual(called, 1);
+});


### PR DESCRIPTION
## Summary
- rerun module postLoad after loading saved games so custom dialog effects work
- add regression test ensuring load() calls module postLoad hook

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3bd59ced8832884c8e5086aead9c2