### PR TITLE
feat: add dial widget for puzzles

### DIFF
--- a/docs/design/in-progress/plot-draft.md
+++ b/docs/design/in-progress/plot-draft.md
@@ -148,7 +148,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
 - [ ] Introduce roaming encounter and event scheduler so the world reacts over time.
 - [ ] Link zones and portals to narrative flags, gating routes based on prior choices.
 - [ ] **Build Reusable Widgets:**
-    - [ ] Create a generic "dial" widget for puzzles like the radio tower.
+    - [x] Create a generic "dial" widget for puzzles like the radio tower. Implemented in `scripts/ui/dial.js`.
     - [ ] Develop a "sound-based navigation" system that can be used for the dust storm and other similar challenges.
 - [ ] **Flesh out the World:**
     - [ ] Design the first major hub city, where the caravan can rest, resupply, and find new quests.

--- a/scripts/ui/dial.js
+++ b/scripts/ui/dial.js
@@ -1,0 +1,44 @@
+(function(){
+  function createDial(opts){
+    opts = opts || {};
+    const dial = document.createElement('div');
+    dial.style.position = 'relative';
+    dial.style.width = '40px';
+    dial.style.height = '40px';
+    dial.style.border = '2px solid #999';
+    dial.style.borderRadius = '50%';
+    const knob = document.createElement('div');
+    knob.style.position = 'absolute';
+    knob.style.left = '50%';
+    knob.style.top = '50%';
+    knob.style.width = '6px';
+    knob.style.height = '20px';
+    knob.style.background = '#c33';
+    knob.style.transformOrigin = '50% 100%';
+    dial.appendChild(knob);
+    const min = opts.min ?? 0;
+    const max = opts.max ?? 100;
+    let value = opts.value ?? min;
+    function set(val){
+      value = Math.max(min, Math.min(max, val));
+      const ratio = (value - min) / (max - min);
+      const angle = ratio * 270 - 135;
+      knob.style.transform = 'translate(-50%, -100%) rotate(' + angle + 'deg)';
+      if(opts.onChange) opts.onChange(value);
+    }
+    dial.addEventListener('click', e => {
+      const rect = dial.getBoundingClientRect();
+      const x = e.clientX - rect.left - rect.width / 2;
+      const y = e.clientY - rect.top - rect.height / 2;
+      let angle = Math.atan2(y, x) * 180 / Math.PI;
+      angle += 180;
+      const val = min + (angle / 360) * (max - min);
+      set(val);
+    });
+    set(value);
+    return { el: dial, set };
+  }
+  globalThis.Dustland = globalThis.Dustland || {};
+  globalThis.Dustland.ui = globalThis.Dustland.ui || {};
+  globalThis.Dustland.ui.createDial = createDial;
+})();


### PR DESCRIPTION
## Summary
- create generic dial widget for puzzle interfaces
- mark dial widget task as complete in plot design doc

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3cc3187fc8328b9d222587efa2216