### PR TITLE
feat: expand silencer encounter

### DIFF
--- a/docs/design/in-progress/plot-draft.md
+++ b/docs/design/in-progress/plot-draft.md
@@ -93,7 +93,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
 #### **Phase 0: Writing Pass**
 - [ ] Draft a scene-by-scene outline with placeholder dialog for the caravan's opening leg.
 - [ ] Flesh out Mara, Jax, and Nyx arcs with at least two key conversations each.
-- [ ] Sketch early Silencer encounters with sample rival dialogue.
+- [x] Sketch early Silencer encounters with sample rival dialogue.
 
 ### Opening Leg Outline
 1. **Campfire Departure** – *Mara:* "Dawn's thin. Pack up."
@@ -113,7 +113,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
   - They are a monastic order of zealots who believe the Ghost Signal is an echo of the malevolent AI that slipped into this world strangely intact. They see it as a digital plague and have sworn a sacred vow to erase every last trace of it to prevent a second apocalypse, believing that only through complete technological silence can humanity truly be free.
   - Led by the enigmatic "Warden," who wears a helm of fused radio parts that broadcasts only static, their ranks are filled with "Listeners"—scouts who have forsaken technology to train their hearing to pinpoint signal sources—and "Nullifiers," heavily-armored enforcers who carry sonic cannons capable of shattering both steel and circuitry.
   - The Silencers hunt with relentless, calculated precision. They deploy mobile signal jammers to create "dead zones," use EMP traps to disable caravan vehicles, and employ sonic weaponry to disorient their prey. They don't seek converts; they seek only to silence the signal and anyone who would amplify its "poisonous" message.
-  - Draft the first encounter at a derelict relay where players choose to sneak past, negotiate, or clash with a Silencer patrol.
+  - [x] Draft the first encounter at a derelict relay where players choose to taunt, sneak past, negotiate, or clash with a Silencer patrol.
 
 > **Wing:** Early rival tension sets the pace—make their gear look repurposed and their tactics ruthless.
 

--- a/modules/silencer-encounter.module.js
+++ b/modules/silencer-encounter.module.js
@@ -1,8 +1,13 @@
 function seedWorldContent() {}
-const DATA = `{
+const DATA = `
+{
   "seed": "silencer-encounter",
   "name": "silencer-encounter",
-  "start": { "map": "arena", "x": 2, "y": 2 },
+  "start": {
+    "map": "arena",
+    "x": 2,
+    "y": 2
+  },
   "items": [],
   "quests": [],
   "npcs": [
@@ -16,15 +21,85 @@ const DATA = `{
       "prompt": "Hooded drifter with goggles and a muffled scarf",
       "tree": {
         "start": {
-          "text": "The Silencer narrows his eyes. You're after the signal too.",
+          "text": "A Silencer scout scans the relay. How do you approach?",
           "choices": [
-            { "label": "It's mine.", "to": "taunt" },
-            { "label": "Back away.", "to": "bye" }
+            {
+              "label": "Sneak past",
+              "to": "sneak"
+            },
+            {
+              "label": "Negotiate",
+              "to": "talk"
+            },
+            {
+              "label": "Clash",
+              "to": "fight"
+            },
+            {
+              "label": "Taunt",
+              "to": "taunt"
+            }
           ]
         },
         "taunt": {
-          "text": "We'll see who reaches it first, he replies.",
-          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+          "text": "You bark a challenge. The scout's visor tilts, amused.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye",
+              "effects": [
+                {
+                  "effect": "toast",
+                  "msg": "The scout bides his time."
+                }
+              ]
+            }
+          ]
+        },
+        "sneak": {
+          "text": "You slip past while his visor fogs.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye",
+              "effects": [
+                {
+                  "effect": "toast",
+                  "msg": "You avoid the scout."
+                }
+              ]
+            }
+          ]
+        },
+        "talk": {
+          "text": "State your business, he grates. You keep it brief and he lets you pass.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye",
+              "effects": [
+                {
+                  "effect": "toast",
+                  "msg": "The scout steps aside."
+                }
+              ]
+            }
+          ]
+        },
+        "fight": {
+          "text": "You reach for your weapon but the scout backs off, marking you.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye",
+              "effects": [
+                {
+                  "effect": "toast",
+                  "msg": "Conflict avoided—for now."
+                }
+              ]
+            }
+          ]
         }
       }
     }
@@ -48,7 +123,8 @@ const DATA = `{
   "events": [],
   "portals": [],
   "buildings": []
-}`;
+}
+`;
 
 function postLoad(module) {}
 


### PR DESCRIPTION
## Summary
- restore taunt option and branch for the Silencer scout encounter
- mention taunt choice in plot draft

## Testing
- `node scripts/supporting/placement-check.js modules/silencer-encounter.module.js`
- `node scripts/supporting/presubmit.js`
- `npm test`
- `node scripts/supporting/balance-tester-agent.js` (fails: TypeError: Cannot set properties of null (setting 'onclick'))

------
https://chatgpt.com/codex/tasks/task_e_68c3d87b80e48328a17b22889495dc5a