### PR TITLE
feat: show hp bar with adrenaline circle in combat

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -617,7 +617,25 @@ input[type="range"] {
 #combatOverlay .enemy-row { align-items:flex-start; }
 #combatOverlay .party-row { align-items:flex-end; }
 #combatOverlay .member { position:relative; display:flex; flex-direction:column; align-items:center; }
-#combatOverlay .enemy .hudbar, #combatOverlay .member .hudbar { width:48px; margin-top:2px; }
+#combatOverlay .enemy .hudwrap, #combatOverlay .member .hudwrap {
+  width:48px;
+  margin-top:2px;
+  display:flex;
+  align-items:center;
+}
+
+#combatOverlay .hudwrap .hudbar {
+  width:34px;
+}
+
+#combatOverlay .adr-circle {
+  width:10px;
+  height:10px;
+  border-radius:50%;
+  margin-left:4px;
+  background:#273027;
+  border:1px solid #1c261c;
+}
 #combatOverlay .label { margin-top:4px; text-align:center; }
 #combatOverlay .enemy.active .portrait, #combatOverlay .member.active .portrait { border-color:#5c8a5c; }
 #combatOverlay .turn { text-align:center; margin-bottom:4px; }

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -130,15 +130,21 @@ function renderCombat(){
     setPortraitDiv(p, e);
     wrap.appendChild(p);
 
-    const hp  = document.createElement('div'); hp.className  = 'hudbar'; hp.style.width = '48px';
+    const bars = document.createElement('div');
+    bars.className = 'hudwrap';
+    bars.style.width = '48px';
+
+    const hp  = document.createElement('div'); hp.className  = 'hudbar'; hp.style.width = '34px';
     const hpf = document.createElement('div'); hpf.className = 'fill';
     hpf.style.width = Math.max(0, Math.min(100, (e.hp / (e.maxHp || 1)) * 100)) + '%';
-    hp.appendChild(hpf); wrap.appendChild(hp);
+    hp.appendChild(hpf); bars.appendChild(hp);
 
-    const adr  = document.createElement('div'); adr.className  = 'hudbar adr'; adr.style.width = '48px';
-    const adrf = document.createElement('div'); adrf.className = 'fill';
-    adrf.style.width = Math.max(0, Math.min(100, (e.adr / (e.maxAdr || 1)) * 100)) + '%';
-    adr.appendChild(adrf); wrap.appendChild(adr);
+    const adr  = document.createElement('div'); adr.className  = 'adr-circle';
+    const adrDeg = Math.max(0, Math.min(360, (e.adr / (e.maxAdr || 1)) * 360));
+    adr.style.background = `conic-gradient(#d98b8b 0deg ${adrDeg}deg, #273027 ${adrDeg}deg 360deg)`;
+    bars.appendChild(adr);
+
+    wrap.appendChild(bars);
 
     const lab = document.createElement('div'); lab.className = 'label'; lab.textContent = e.name || '';
     wrap.appendChild(lab);
@@ -156,15 +162,21 @@ function renderCombat(){
     setPortraitDiv(p, m);
     wrap.appendChild(p);
 
-    const hp  = document.createElement('div'); hp.className  = 'hudbar'; hp.style.width = '48px';
+    const bars = document.createElement('div');
+    bars.className = 'hudwrap';
+    bars.style.width = '48px';
+
+    const hp  = document.createElement('div'); hp.className  = 'hudbar'; hp.style.width = '34px';
     const hpf = document.createElement('div'); hpf.className = 'fill';
     hpf.style.width = Math.max(0, Math.min(100, (m.hp / (m.maxHp || 1)) * 100)) + '%';
-    hp.appendChild(hpf); wrap.appendChild(hp);
+    hp.appendChild(hpf); bars.appendChild(hp);
 
-    const adr  = document.createElement('div'); adr.className  = 'hudbar adr'; adr.style.width = '48px';
-    const adrf = document.createElement('div'); adrf.className = 'fill';
-    adrf.style.width = Math.max(0, Math.min(100, (m.adr / (m.maxAdr || 1)) * 100)) + '%';
-    adr.appendChild(adrf); wrap.appendChild(adr);
+    const adr  = document.createElement('div'); adr.className  = 'adr-circle';
+    const adrDeg = Math.max(0, Math.min(360, (m.adr / (m.maxAdr || 1)) * 360));
+    adr.style.background = `conic-gradient(#d98b8b 0deg ${adrDeg}deg, #273027 ${adrDeg}deg 360deg)`;
+    bars.appendChild(adr);
+
+    wrap.appendChild(bars);
 
     const lab = document.createElement('div'); lab.className = 'label'; lab.textContent = m.name || '';
     wrap.appendChild(lab);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1508,8 +1508,8 @@ test('combat hp bars update after damage', async () => {
   ]);
 
   handleCombatKey({ key:'Enter' });
-  const enemyHp = combatEnemies.children[0].children[1].children[0].style.width;
-  const memberHp = combatParty.children[0].children[1].children[0].style.width;
+  const enemyHp = combatEnemies.children[0].children[1].children[0].children[0].style.width;
+  const memberHp = combatParty.children[0].children[1].children[0].children[0].style.width;
   assert.strictEqual(enemyHp, '50%');
   assert.strictEqual(memberHp, '50%');
 
@@ -1531,7 +1531,7 @@ test('enemy hp bar defaults maxHp to hp', async () => {
   ]);
 
   handleCombatKey({ key:'Enter' });
-  const enemyHp = combatEnemies.children[0].children[1].children[0].style.width;
+  const enemyHp = combatEnemies.children[0].children[1].children[0].children[0].style.width;
   assert.strictEqual(enemyHp, '50%');
 
   handleCombatKey({ key:'Enter' });


### PR DESCRIPTION
## Summary
- replace combat adrenaline bars with hp bars and pie-chart style adrenaline indicators
- style combat bars for new layout
- update hp bar tests for new structure

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c411fc0bb0832893ee2899dc6ff3ab