### PR TITLE
fix: ensure stat mods raise attack minimum

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -516,8 +516,11 @@ function doAttack(dmg, type = 'basic'){
   const statBonus = Math.max(0, statVal - 4);
   const atkBonus  = attacker._bonus?.ATK || 0;
   const base      = dmg + atkBonus + statBonus;
-  const minBase   = Math.max(1, base - 3);
-  let dealt       = Math.floor(Math.random() * (base - minBase + 1)) + minBase;
+  let minBase = base > 3
+    ? Math.max(1, base - 3)
+    : Math.max(1, base - 3 + statBonus);
+  minBase     = Math.min(base, minBase);
+  let dealt   = Math.floor(Math.random() * (base - minBase + 1)) + minBase;
 
   const adrPct = Math.max(0, Math.min(1, (attacker.adr ?? 0) / (attacker.maxAdr || 100)));
   const mult  = 1 + adrPct * (attacker.adrDmgMod || 1);


### PR DESCRIPTION
## Summary
- boost minimum attack damage when stat bonuses exceed base power

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js` *(fails: TypeError: Cannot set properties of null (setting 'onclick'))*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4123cda58832880aad496ad80eae4