### PR TITLE
fix: shim trainer roles for legacy saves

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2939,6 +2939,17 @@ function handleCustomEffects(list) {
 }
 
 function postLoad(module) {
+  // Shim trainer assignments for compatibility with older saves.
+  const trainers = [
+    { id: 'trainer_power', name: 'Brakk', trainer: 'power' },
+    { id: 'trainer_endurance', name: 'Rusty', trainer: 'endurance' },
+    { id: 'trainer_tricks', name: 'Mira', trainer: 'tricks' }
+  ];
+  for (const t of trainers) {
+    const npc = module.npcs?.find(n => n.id === t.id || n.name === t.name);
+    if (npc) npc.trainer = t.trainer;
+  }
+
   const exit = module.npcs?.find(n => n.id === 'exitdoor');
   if (exit) {
     exit.processNode = function (node) {


### PR DESCRIPTION
## Summary
- always assign trainer roles to Brakk, Rusty, and Mira during Dustland module postLoad to ensure old saves gain trainer functionality

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/placement-check.js modules/dustland.module.js`
- `node scripts/supporting/balance-tester-agent.js` *(fails: TypeError: Cannot set properties of null (setting 'onclick'))*
- `npm test` *(fails: persona STR mod increases attack damage)*

------
https://chatgpt.com/codex/tasks/task_e_68c4167a16788328b41f84aa8eb98a1c