### PR TITLE
feat: make loot drop rates configurable

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -448,6 +448,7 @@
             <label>ATK<input id="npcATK" type="number" min="0" value="0" /></label>
             <label>DEF<input id="npcDEF" type="number" min="0" value="0" /></label>
             <label>Loot<input id="npcLoot" /></label>
+            <label>Loot %<input id="npcLootChance" type="number" min="0" max="100" value="100" /></label>
             <label><input type="checkbox" id="npcBoss" /> Boss</label>
             <label>Special Cue<input id="npcSpecialCue" /></label>
             <label>Special DMG<input id="npcSpecialDmg" type="number" min="0" /></label>
@@ -668,6 +669,7 @@
           <label>Min Dist<input id="encMinDist" type="number" min="0" /></label>
           <label>Max Dist<input id="encMaxDist" type="number" min="0" /></label>
           <label>Loot<select id="encLoot"></select></label>
+          <label>Loot %<input id="encLootChance" type="number" min="0" max="100" value="100" /></label>
           <button class="btn" id="addEncounter">Add Enemy</button>
           <button class="btn" type="button" id="cancelEncounter" style="display:none">Cancel</button>
           <button class="btn" id="delEncounter" style="display:none">Delete Enemy</button>
@@ -691,6 +693,7 @@
           <label>Special Cue<input id="templateSpecialCue" /></label>
           <label>Special Dmg<input id="templateSpecialDmg" type="number" min="1" /></label>
           <label>Loot<select id="templateLoot"></select></label>
+          <label>Loot %<input id="templateLootChance" type="number" min="0" max="100" value="100" /></label>
           <label>Requires<input id="templateRequires" /></label>
         <button class="btn" id="addTemplate">Add Template</button>
         <button class="btn" id="delTemplate" style="display:none">Delete Template</button>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2015,6 +2015,7 @@ function startNewNPC() {
   document.getElementById('npcATK').value = 0;
   document.getElementById('npcDEF').value = 0;
   document.getElementById('npcLoot').value = '';
+  document.getElementById('npcLootChance').value = 100;
   document.getElementById('npcBoss').checked = false;
   document.getElementById('npcSpecialCue').value = '';
   document.getElementById('npcSpecialDmg').value = '';
@@ -2115,12 +2116,16 @@ function collectNPCFromForm() {
     const ATK = parseInt(document.getElementById('npcATK').value, 10) || 0;
     const DEF = parseInt(document.getElementById('npcDEF').value, 10) || 0;
     const loot = document.getElementById('npcLoot').value.trim();
+    const lootChancePct = parseFloat(document.getElementById('npcLootChance').value);
     const boss = document.getElementById('npcBoss').checked;
     const cue = document.getElementById('npcSpecialCue').value.trim();
     const dmg = parseInt(document.getElementById('npcSpecialDmg').value, 10);
     const delay = parseInt(document.getElementById('npcSpecialDelay').value, 10);
     npc.combat = { HP, ATK, DEF };
     if (loot) npc.combat.loot = loot;
+    if (!isNaN(lootChancePct) && lootChancePct >= 0 && lootChancePct < 100) {
+      npc.combat.lootChance = lootChancePct / 100;
+    }
     if (boss) npc.combat.boss = true;
     if (cue || !isNaN(dmg) || !isNaN(delay)) {
       npc.combat.special = {};
@@ -2239,6 +2244,7 @@ function editNPC(i) {
   document.getElementById('npcATK').value = n.combat?.ATK ?? 0;
   document.getElementById('npcDEF').value = n.combat?.DEF ?? 0;
   document.getElementById('npcLoot').value = n.combat?.loot || '';
+  document.getElementById('npcLootChance').value = n.combat?.lootChance != null ? Math.round(n.combat.lootChance * 100) : 100;
   document.getElementById('npcBoss').checked = !!n.combat?.boss;
   document.getElementById('npcSpecialCue').value = n.combat?.special?.cue || '';
   document.getElementById('npcSpecialDmg').value = n.combat?.special?.dmg ?? '';
@@ -2597,6 +2603,7 @@ function startNewEncounter(){
   const tmplSel = document.getElementById('encTemplate');
   populateTemplateDropdown(tmplSel, '');
   populateItemDropdown(document.getElementById('encLoot'), '');
+  document.getElementById('encLootChance').value = 100;
   document.getElementById('addEncounter').textContent = 'Add Enemy';
   document.getElementById('delEncounter').style.display = 'none';
   showEncounterEditor(true);
@@ -2608,7 +2615,11 @@ function collectEncounter(){
   const minDist = parseInt(document.getElementById('encMinDist').value,10) || 0;
   const maxDist = parseInt(document.getElementById('encMaxDist').value,10) || 0;
   const loot = document.getElementById('encLoot').value.trim();
+  const lootChancePct = parseFloat(document.getElementById('encLootChance').value);
   const entry = { map, templateId, loot, minDist, maxDist };
+  if (!isNaN(lootChancePct) && lootChancePct >= 0 && lootChancePct < 100) {
+    entry.lootChance = lootChancePct / 100;
+  }
   return entry;
 }
 function addEncounter(){
@@ -2629,6 +2640,7 @@ function editEncounter(i){
   document.getElementById('encMinDist').value = e.minDist || '';
   document.getElementById('encMaxDist').value = e.maxDist || '';
   populateItemDropdown(document.getElementById('encLoot'), e.loot || '');
+  document.getElementById('encLootChance').value = e.lootChance != null ? Math.round(e.lootChance * 100) : 100;
   document.getElementById('addEncounter').textContent = 'Update Enemy';
   document.getElementById('delEncounter').style.display = 'block';
   showEncounterEditor(true);
@@ -2672,6 +2684,7 @@ function startNewTemplate(){
   document.getElementById('templateSpecialCue').value = '';
   document.getElementById('templateSpecialDmg').value = '';
   populateItemDropdown(document.getElementById('templateLoot'), '');
+  document.getElementById('templateLootChance').value = 100;
   document.getElementById('templateRequires').value = '';
   document.getElementById('addTemplate').textContent = 'Add Template';
   document.getElementById('delTemplate').style.display = 'none';
@@ -2690,10 +2703,14 @@ function collectTemplate(){
   const specialCue = document.getElementById('templateSpecialCue').value.trim();
   const specialDmg = parseInt(document.getElementById('templateSpecialDmg').value,10) || 0;
   const loot = document.getElementById('templateLoot').value.trim();
+  const lootChancePct = parseFloat(document.getElementById('templateLootChance').value);
   const requires = document.getElementById('templateRequires').value.trim();
   const combat = { HP, ATK, DEF };
   if (challenge) combat.challenge = challenge;
   if (loot) combat.loot = loot;
+  if (!isNaN(lootChancePct) && lootChancePct >= 0 && lootChancePct < 100) {
+    combat.lootChance = lootChancePct / 100;
+  }
   if (requires) combat.requires = requires;
   if (specialCue || specialDmg) {
     combat.special = {};
@@ -2727,6 +2744,7 @@ function editTemplate(i){
   document.getElementById('templateSpecialCue').value = t.combat?.special?.cue || '';
   document.getElementById('templateSpecialDmg').value = t.combat?.special?.dmg || '';
   populateItemDropdown(document.getElementById('templateLoot'), t.combat?.loot || '');
+  document.getElementById('templateLootChance').value = t.combat?.lootChance != null ? Math.round(t.combat.lootChance * 100) : 100;
   document.getElementById('templateRequires').value = t.combat?.requires || '';
   document.getElementById('addTemplate').textContent = 'Update Template';
   document.getElementById('delTemplate').style.display = 'block';

--- a/test/npc-patrol.test.js
+++ b/test/npc-patrol.test.js
@@ -5,16 +5,14 @@ import vm from 'node:vm';
 import { makeDocument } from './test-harness.js';
 
 function mkInput(document, id, value = '') {
-  const el = document.createElement('input');
-  el.id = id;
+  const el = document.getElementById(id);
   el.value = value;
   document.body.appendChild(el);
   return el;
 }
 
 function mkSelect(document, id, values = []) {
-  const el = document.createElement('select');
-  el.id = id;
+  const el = document.getElementById(id);
   el.multiple = true;
   values.forEach(v => {
     const opt = document.createElement('option');
@@ -27,17 +25,15 @@ function mkSelect(document, id, values = []) {
 }
 
 function mkCheckbox(document, id, checked = false) {
-  const el = document.createElement('input');
+  const el = document.getElementById(id);
   el.type = 'checkbox';
-  el.id = id;
   el.checked = checked;
   document.body.appendChild(el);
   return el;
 }
 
 function mkTextarea(document, id, value = '') {
-  const el = document.createElement('textarea');
-  el.id = id;
+  const el = document.getElementById(id);
   el.value = value;
   document.body.appendChild(el);
   return el;
@@ -102,5 +98,107 @@ test('collectNPCFromForm uses patrol checkbox for loops', async () => {
   document.getElementById('npcPatrol').checked = true;
   const npc2 = context.collectNPCFromForm();
   assert.deepStrictEqual(npc2.loop, [{ x: 0, y: 0 }, { x: 1, y: 0 }]);
+});
+
+test('collectNPCFromForm reads loot chance', async () => {
+  const document = makeDocument();
+  // required fields with minimal values
+  mkInput(document, 'npcId', 'n');
+  mkInput(document, 'npcName', 'Name');
+  mkInput(document, 'npcTitle', '');
+  mkTextarea(document, 'npcDesc', '');
+  mkInput(document, 'npcColor', '#fff');
+  mkInput(document, 'npcSymbol', '!');
+  mkInput(document, 'npcMap', 'world');
+  mkInput(document, 'npcX', '0');
+  mkInput(document, 'npcY', '0');
+  mkTextarea(document, 'npcDialog', 'hi');
+  mkSelect(document, 'npcQuests', []);
+  mkTextarea(document, 'npcAccept', '');
+  mkTextarea(document, 'npcTurnin', '');
+  mkCheckbox(document, 'npcCombat', true);
+  mkCheckbox(document, 'npcShop', false);
+  mkInput(document, 'shopMarkup', '2');
+  mkCheckbox(document, 'npcHidden', false);
+  mkCheckbox(document, 'npcLocked', false);
+  mkCheckbox(document, 'npcPortraitLock', true);
+  mkInput(document, 'npcOp', '>=');
+  mkInput(document, 'npcVal', '1');
+  mkTextarea(document, 'npcTree', '');
+  mkInput(document, 'npcHP', '5');
+  mkInput(document, 'npcATK', '0');
+  mkInput(document, 'npcDEF', '0');
+  mkInput(document, 'npcLoot', 'rat_tail');
+  mkInput(document, 'npcLootChance', '25');
+  mkCheckbox(document, 'npcBoss', false);
+  mkInput(document, 'npcSpecialCue', '');
+  mkInput(document, 'npcSpecialDmg', '');
+  mkInput(document, 'npcSpecialDelay', '');
+  mkCheckbox(document, 'npcPatrol', false);
+
+  const context = {
+    document,
+    npcPortraitPath: '',
+    npcPortraitIndex: 0,
+    npcPortraits: [],
+    updateTreeData() {},
+    applyCombatTree() {},
+    removeCombatTree() {},
+    loadTreeEditor() {},
+    getRevealFlag() { return ''; },
+    gatherLoopFields() { return []; }
+  };
+  vm.createContext(context);
+  const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+  const start = code.indexOf('function collectNPCFromForm');
+  const end = code.indexOf('// Add a new NPC', start);
+  vm.runInContext(code.slice(start, end), context);
+
+  const npc = context.collectNPCFromForm();
+  assert.strictEqual(npc.combat.lootChance, 0.25);
+});
+
+test('collectEncounter reads loot chance', async () => {
+  const document = makeDocument();
+  mkInput(document, 'encMap', 'world');
+  mkInput(document, 'encTemplate', 't');
+  mkInput(document, 'encMinDist', '0');
+  mkInput(document, 'encMaxDist', '0');
+  mkInput(document, 'encLoot', 'rat_tail');
+  mkInput(document, 'encLootChance', '30');
+  const context = { document };
+  vm.createContext(context);
+  const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+  const start = code.indexOf('function collectEncounter');
+  const end = code.indexOf('function addEncounter', start);
+  vm.runInContext(code.slice(start, end), context);
+  const e = context.collectEncounter();
+  assert.strictEqual(e.lootChance, 0.3);
+});
+
+test('collectTemplate reads loot chance', async () => {
+  const document = makeDocument();
+  mkInput(document, 'templateId', 't');
+  mkInput(document, 'templateName', 'T');
+  mkTextarea(document, 'templateDesc', '');
+  mkInput(document, 'templateColor', '#fff');
+  mkInput(document, 'templatePortrait', '');
+  mkInput(document, 'templateHP', '5');
+  mkInput(document, 'templateATK', '1');
+  mkInput(document, 'templateDEF', '0');
+  mkInput(document, 'templateChallenge', '0');
+  mkInput(document, 'templateSpecialCue', '');
+  mkInput(document, 'templateSpecialDmg', '0');
+  mkInput(document, 'templateLoot', 'rat_tail');
+  mkInput(document, 'templateLootChance', '10');
+  mkInput(document, 'templateRequires', '');
+  const context = { document };
+  vm.createContext(context);
+  const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+  const start = code.indexOf('function collectTemplate');
+  const end = code.indexOf('function addTemplate', start);
+  vm.runInContext(code.slice(start, end), context);
+  const t = context.collectTemplate();
+  assert.strictEqual(t.combat.lootChance, 0.1);
 });
 


### PR DESCRIPTION
## Summary
- allow loot drop rates to be configured for NPCs, random encounters, and templates
- test loot drop chance parsing in Adventure Kit forms

## Testing
- `npm run lint`
- `node --test --test-concurrency=1`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c41a6946bc832898e3a9bff8c62df2