### PR TITLE
fix: exit code for placement check

### DIFF
--- a/scripts/supporting/placement-check.js
+++ b/scripts/supporting/placement-check.js
@@ -47,4 +47,4 @@ function check(kind, obj) {
 (data.items || []).forEach(i => check('item', i));
 (data.npcs || []).forEach(n => check('npc', n));
 
-if (errors) process.exit(1);
+process.exit(errors ? 1 : 0);


### PR DESCRIPTION
## Summary
- ensure placement-check script exits with status 0 when there are no placement errors

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4207fe20883289bcadaeb46ae0a49