### PR TITLE
fix: avoid global params redeclaration

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -178,8 +178,9 @@
     <script>
       window.addEventListener('DOMContentLoaded', () => {
         document.getElementById('title').textContent += ' v' + ENGINE_VERSION;
-        const params = new URLSearchParams(location.search);
-        const isAck = params.get('ack-player') === '1';
+        const urlParams = new URLSearchParams(location.search);
+        window.params = urlParams;
+        const isAck = urlParams.get('ack-player') === '1';
         if (isAck) {
           UI.show('moduleLoader', 'flex');
           const btns = document.getElementById('mainButtons');

--- a/dustland.html
+++ b/dustland.html
@@ -264,8 +264,9 @@
     <script defer src="./scripts/supporting/fx-debug.js"></script>
     <script defer src="./scripts/supporting/perf-debug.js"></script>
   <script>
-    const params = new URLSearchParams(location.search);
-    const isAck = params.get('ack-player') === '1';
+    const urlParams = new URLSearchParams(location.search);
+    window.params = urlParams;
+    const isAck = urlParams.get('ack-player') === '1';
     if (!isAck) window.modulePickerPending = true;
     disablePullToRefresh();
     window.addEventListener('DOMContentLoaded', () => {

--- a/scripts/ack-player.js
+++ b/scripts/ack-player.js
@@ -25,7 +25,7 @@ const urlBtn = document.getElementById('modUrlBtn');
 const fileInput = document.getElementById('modFile');
 const fileBtn = document.getElementById('modFileBtn');
 
-const params = new URLSearchParams(location.search);
+const urlParams = globalThis.params || new URLSearchParams(location.search);
 const playData = localStorage.getItem(PLAYTEST_KEY);
 if (playData) {
   try {
@@ -46,7 +46,7 @@ if (playData) {
   }
 }
 
-const autoUrl = params.get('module');
+const autoUrl = urlParams.get('module');
 if (!moduleData && autoUrl) {
   UI.setValue('modUrl', autoUrl);
   fetch(autoUrl)


### PR DESCRIPTION
## Summary
- avoid redeclaring `params` by scoping ACK player search params
- expose `window.params` from HTML pages to share URL params safely

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test` *(fails: slot machine works after save and load; passes when run individually)*


------
https://chatgpt.com/codex/tasks/task_e_68c41dccc24c8328a932cdf71da3812e