### PR TITLE
fix: link trainers to training dialog

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -1904,11 +1904,27 @@ const DATA = `
             {
               "label": "(Leave)",
               "to": "bye"
+            },
+            {
+              "label": "(Upgrade Skills)",
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "showTrainer",
+                  "trainer": "power"
+                }
+              ]
             }
           ]
         },
         "train": {
-          "text": "Push your limits."
+          "text": "Push your limits.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
         }
       }
     },
@@ -1930,11 +1946,27 @@ const DATA = `
             {
               "label": "(Leave)",
               "to": "bye"
+            },
+            {
+              "label": "(Upgrade Skills)",
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "showTrainer",
+                  "trainer": "endurance"
+                }
+              ]
             }
           ]
         },
         "train": {
-          "text": "Breathe deep and endure."
+          "text": "Breathe deep and endure.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
         }
       }
     },
@@ -1956,11 +1988,27 @@ const DATA = `
             {
               "label": "(Leave)",
               "to": "bye"
+            },
+            {
+              "label": "(Upgrade Skills)",
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "showTrainer",
+                  "trainer": "tricks"
+                }
+              ]
             }
           ]
         },
         "train": {
-          "text": "Learn a new trick."
+          "text": "Learn a new trick.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
         }
       }
     },

--- a/test/trainer-npcs.test.js
+++ b/test/trainer-npcs.test.js
@@ -20,12 +20,27 @@ function setupParty(){
   return context;
 }
 
+function applyEffects(tree, ctx){
+  for (const node of Object.values(tree || {})) {
+    if (Array.isArray(node.effects)) {
+      node.effects = node.effects.map(e => e.effect === 'showTrainer' ? () => ctx.TrainerUI.showTrainer(e.trainer) : e);
+    }
+    for (const choice of node.choices || []) {
+      if (Array.isArray(choice.effects)) {
+        choice.effects = choice.effects.map(e => e.effect === 'showTrainer' ? () => ctx.TrainerUI.showTrainer(e.trainer) : e);
+      }
+    }
+  }
+}
+
 function buildNpc(def){
   const calls = [];
   const context = { log: () => {}, Dustland: {}, closeDialog: () => {}, TrainerUI: { showTrainer: id => calls.push(id) } };
   vm.createContext(context);
   vm.runInContext(npcCode, context);
-  const npc = context.makeNPC(def.id, def.map || 'world', def.x || 0, def.y || 0, def.color, def.name || def.id, def.title || '', def.desc || '', def.tree, null, null, null, { trainer: def.trainer });
+  const tree = JSON.parse(JSON.stringify(def.tree));
+  applyEffects(tree, context);
+  const npc = context.makeNPC(def.id, def.map || 'world', def.x || 0, def.y || 0, def.color, def.name || def.id, def.title || '', def.desc || '', tree, null, null, null, { trainer: def.trainer });
   return { npc, calls };
 }
 


### PR DESCRIPTION
## Summary
- add explicit training choice in Dustland module trainer NPC dialogs
- update trainer NPC test to handle effect objects

## Testing
- `node scripts/supporting/placement-check.js modules/dustland.module.js`
- `node scripts/supporting/presubmit.js`
- `npm test` *(fails: slot machine works after save and load)*

------
https://chatgpt.com/codex/tasks/task_e_68c468f250f8832895a902b818b08a64