### PR TITLE
fix: resolve placement check script path

### DIFF
--- a/test/placement-check.test.js
+++ b/test/placement-check.test.js
@@ -4,8 +4,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const script = path.join(repoRoot, 'scripts', 'supporting', 'placement-check.js');
 
 function run(file) {


### PR DESCRIPTION
## Summary
- make `placement-check.test.js` compute the script path using `fileURLToPath` for Windows compatibility

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test test/placement-check.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c46d69c46883289025ed349ec59ca3