### PR TITLE
fix: allow repeated security guard check

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -219,8 +219,7 @@ const OFFICE_IMPL = (() => {
               check: { stat: 'CHA', dc: DC.TALK },
               success: 'He sighs and hands over a spare card.',
               failure: 'Rules are rules.',
-              reward: 'access_card',
-              once: true
+              reward: 'access_card'
             },
             { label: '(Leave)', to: 'bye' }
           ]

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -65,6 +65,17 @@ test('office module uses object visuals for elevator and vending machine', () =>
   );
 });
 
+test('security guard persuasion can be retried', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.join(__dirname, '..', 'modules', 'office.module.js');
+  const src = readNormalized(file);
+  const guardRegex = /\{\s*id: 'security',[\s\S]*?\r?\n\s*\},\r?\n\s*\{\s*id: 'worker1'/;
+  const match = src.match(guardRegex);
+  assert(match);
+  const objSrc = match[0].replace(/,\r?\n\s*\{\s*id: 'worker1'[\s\S]*/, '');
+  assert.doesNotMatch(objSrc, /once:\s*true/);
+});
+
 test('startGame grants 10 scrap', () => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const file = path.join(__dirname, '..', 'modules', 'office.module.js');


### PR DESCRIPTION
## Summary
- Allow persuasion check with office security guard to be retried
- Test that security guard dialog no longer uses a one-time check

## Testing
- `node scripts/supporting/placement-check.js modules/office.module.js`
- `node scripts/supporting/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c47709ee448328a855630d530ac86f