### PR TITLE
fix: avoid duplicate urlParams declaration

### DIFF
--- a/scripts/ack-player.js
+++ b/scripts/ack-player.js
@@ -25,7 +25,7 @@ const urlBtn = document.getElementById('modUrlBtn');
 const fileInput = document.getElementById('modFile');
 const fileBtn = document.getElementById('modFileBtn');
 
-const urlParams = globalThis.params || new URLSearchParams(location.search);
+const params = globalThis.params || new URLSearchParams(location.search);
 const playData = localStorage.getItem(PLAYTEST_KEY);
 if (playData) {
   try {
@@ -46,7 +46,7 @@ if (playData) {
   }
 }
 
-const autoUrl = urlParams.get('module');
+const autoUrl = params.get('module');
 if (!moduleData && autoUrl) {
   UI.setValue('modUrl', autoUrl);
   fetch(autoUrl)


### PR DESCRIPTION
## Summary
- avoid redeclaring `urlParams` in ACK module player

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c478acf1b88328927944058c71c182