### PR TITLE
feat: allow items to grant fuel on pickup

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -507,6 +507,7 @@
           </div>
           <label>Equip<textarea id="itemEquip" rows="2"></textarea></label>
           <label>Value<input id="itemValue" type="number" min="0" /></label>
+          <label>Fuel<input id="itemFuel" type="number" min="0" /></label>
           <label>Use Type<select id="itemUseType"><option value="">(none)</option><option value="heal">Heal</option><option value="boost">Boost</option></select></label>
           <label id="itemUseAmtWrap" style="display:none">Heal Amount<input id="itemUseAmount" type="number" min="1" /></label>
           <label id="itemBoostStatWrap" style="display:none">Boost Stat<input id="itemBoostStat" /></label>

--- a/docs/design/in-progress/bunker-fast-travel.md
+++ b/docs/design/in-progress/bunker-fast-travel.md
@@ -9,6 +9,7 @@
 As of 2025-09-07, bunkers derive from building data and core travel logic with events exists. The world map overlay now shows thumbnails for each unlocked bunker and uses per-bunker save slots to preserve state across hops.
 
 As of 2025-09-08, fuel costs apply a base price plus Manhattan distance, and travel events emit `{ fromId, toId, result }` payloads for mod hooks.
+Module items can now include a `fuel` field that grants that amount on pickup, easing fuel cell placement through the Adventure Kit.
 
 ### Open questions
 - Mechanics 2 mentions distance-based fuel costs; how will the system compute distance between bunkers?

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -33,7 +33,8 @@ const DATA = `
     {
       "id": "fuel_cell",
       "name": "Fuel Cell",
-      "type": "quest"
+      "type": "quest",
+      "fuel": 50
     },
     {
       "map": "world",

--- a/modules/world-one.module.js
+++ b/modules/world-one.module.js
@@ -3,20 +3,76 @@ function seedWorldContent() {}
 const DATA = `
 {
   "seed": "world-one",
-  "start": { "map": "world", "x": 2, "y": 2 },
+  "start": {
+    "map": "world",
+    "x": 2,
+    "y": 2
+  },
   "world": [
-    [0,0,0,0,0],
-    [0,0,0,0,0],
-    [0,0,0,0,0],
-    [0,0,0,0,0],
-    [0,0,0,0,0]
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
   ],
   "items": [
-    { "id": "fuel_cell", "name": "Fuel Cell", "type": "quest" },
-    { "id": "rusty_gear", "name": "Rusty Gear", "type": "quest", "map": "world", "x": 3, "y": 2 }
+    {
+      "id": "fuel_cell",
+      "name": "Fuel Cell",
+      "type": "quest",
+      "fuel": 50
+    },
+    {
+      "id": "rusty_gear",
+      "name": "Rusty Gear",
+      "type": "quest",
+      "map": "world",
+      "x": 3,
+      "y": 2
+    }
   ],
   "buildings": [
-    { "x": 4, "y": 2, "w": 1, "h": 1, "doorX": 4, "doorY": 2, "boarded": true, "bunker": true, "bunkerId": "alpha" }
+    {
+      "x": 4,
+      "y": 2,
+      "w": 1,
+      "h": 1,
+      "doorX": 4,
+      "doorY": 2,
+      "boarded": true,
+      "bunker": true,
+      "bunkerId": "alpha"
+    }
   ],
   "npcs": [
     {
@@ -32,14 +88,31 @@ const DATA = `
         "start": {
           "text": "My rig is missing a rusty gear. Seen one?",
           "choices": [
-            { "label": "(Give gear)", "to": "turnin", "reqItem": "rusty_gear" },
-            { "label": "(Leave)", "to": "bye" }
+            {
+              "label": "(Give gear)",
+              "to": "turnin",
+              "reqItem": "rusty_gear"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
           ]
         },
         "turnin": {
           "text": "Perfect fit! Thanks.",
-          "effects": [ { "effect": "activateBunker", "id": "beta" } ],
-          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+          "effects": [
+            {
+              "effect": "activateBunker",
+              "id": "beta"
+            }
+          ],
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
         }
       }
     },
@@ -56,25 +129,62 @@ const DATA = `
         "start": {
           "text": "Power hums faintly behind the panel.",
           "choices": [
-            { "label": "(Activate)", "to": "activate" },
-            { "label": "(Fast travel)", "effects": [ { "effect": "openWorldMap", "id": "alpha" } ], "to": "bye" },
-            { "label": "(Leave)", "to": "bye" }
+            {
+              "label": "(Activate)",
+              "to": "activate"
+            },
+            {
+              "label": "(Fast travel)",
+              "effects": [
+                {
+                  "effect": "openWorldMap",
+                  "id": "alpha"
+                }
+              ],
+              "to": "bye"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
           ]
         },
         "activate": {
           "text": "Alpha bunker added to network.",
-          "effects": [ { "effect": "activateBunker", "id": "alpha" } ],
-          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+          "effects": [
+            {
+              "effect": "activateBunker",
+              "id": "alpha"
+            }
+          ],
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
         }
       }
     }
   ],
   "templates": [
-    { "id": "scrap_rat", "name": "Scrap Rat", "combat": { "HP": 3, "ATK": 1, "DEF": 0 } }
+    {
+      "id": "scrap_rat",
+      "name": "Scrap Rat",
+      "combat": {
+        "HP": 3,
+        "ATK": 1,
+        "DEF": 0
+      }
+    }
   ],
   "encounters": {
     "world": [
-      { "templateId": "scrap_rat", "loot": "fuel_cell", "maxDist": 5 }
+      {
+        "templateId": "scrap_rat",
+        "loot": "fuel_cell",
+        "maxDist": 5
+      }
     ]
   }
 }

--- a/modules/world-two.module.js
+++ b/modules/world-two.module.js
@@ -3,22 +3,104 @@ function seedWorldContent() {}
 const DATA = `
 {
   "seed": "world-two",
-  "start": { "map": "world", "x": 2, "y": 2 },
+  "start": {
+    "map": "world",
+    "x": 2,
+    "y": 2
+  },
   "world": [
-    [0,0,0,0,0,0,0],
-    [0,0,0,0,0,0,0],
-    [0,0,0,0,0,0,0],
-    [0,0,0,0,0,0,0],
-    [0,0,0,0,0,0,0],
-    [0,0,0,0,0,0,0],
-    [0,0,0,0,0,0,0]
+    [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
   ],
   "items": [
-    { "id": "fuel_cell", "name": "Fuel Cell", "type": "quest" },
-    { "id": "shiny_cog", "name": "Shiny Cog", "type": "quest", "map": "world", "x": 2, "y": 3 }
+    {
+      "id": "fuel_cell",
+      "name": "Fuel Cell",
+      "type": "quest",
+      "fuel": 50
+    },
+    {
+      "id": "shiny_cog",
+      "name": "Shiny Cog",
+      "type": "quest",
+      "map": "world",
+      "x": 2,
+      "y": 3
+    }
   ],
   "buildings": [
-    { "x": 6, "y": 3, "w": 1, "h": 1, "doorX": 6, "doorY": 3, "boarded": true, "bunker": true, "bunkerId": "beta" }
+    {
+      "x": 6,
+      "y": 3,
+      "w": 1,
+      "h": 1,
+      "doorX": 6,
+      "doorY": 3,
+      "boarded": true,
+      "bunker": true,
+      "bunkerId": "beta"
+    }
   ],
   "npcs": [
     {
@@ -34,13 +116,25 @@ const DATA = `
         "start": {
           "text": "I could use a shiny cog.",
           "choices": [
-            { "label": "(Give cog)", "to": "turnin", "reqItem": "shiny_cog" },
-            { "label": "(Leave)", "to": "bye" }
+            {
+              "label": "(Give cog)",
+              "to": "turnin",
+              "reqItem": "shiny_cog"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
           ]
         },
         "turnin": {
           "text": "Great, thanks.",
-          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
         }
       }
     },
@@ -57,25 +151,62 @@ const DATA = `
         "start": {
           "text": "Power hums faintly behind the panel.",
           "choices": [
-            { "label": "(Activate)", "to": "activate" },
-            { "label": "(Fast travel)", "effects": [ { "effect": "openWorldMap", "id": "beta" } ], "to": "bye" },
-            { "label": "(Leave)", "to": "bye" }
+            {
+              "label": "(Activate)",
+              "to": "activate"
+            },
+            {
+              "label": "(Fast travel)",
+              "effects": [
+                {
+                  "effect": "openWorldMap",
+                  "id": "beta"
+                }
+              ],
+              "to": "bye"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
           ]
         },
         "activate": {
           "text": "Beta bunker added to network.",
-          "effects": [ { "effect": "activateBunker", "id": "beta" } ],
-          "choices": [ { "label": "(Leave)", "to": "bye" } ]
+          "effects": [
+            {
+              "effect": "activateBunker",
+              "id": "beta"
+            }
+          ],
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
         }
       }
     }
   ],
   "templates": [
-    { "id": "scrap_rat", "name": "Scrap Rat", "combat": { "HP": 3, "ATK": 1, "DEF": 0 } }
+    {
+      "id": "scrap_rat",
+      "name": "Scrap Rat",
+      "combat": {
+        "HP": 3,
+        "ATK": 1,
+        "DEF": 0
+      }
+    }
   ],
   "encounters": {
     "world": [
-      { "templateId": "scrap_rat", "loot": "fuel_cell", "maxDist": 5 }
+      {
+        "templateId": "scrap_rat",
+        "loot": "fuel_cell",
+        "maxDist": 5
+      }
     ]
   }
 }

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2372,6 +2372,7 @@ function startNewItem() {
   document.getElementById('itemBoostAmount').value = 0;
   document.getElementById('itemBoostDuration').value = 0;
   document.getElementById('itemUse').value = '';
+  document.getElementById('itemFuel').value = 0;
   updateUseWrap();
   updateItemMapWrap();
   document.getElementById('addItem').textContent = 'Add Item';
@@ -2412,6 +2413,7 @@ function addItem() {
   const isEquip = ['weapon', 'armor', 'trinket'].includes(type);
   const mods = collectMods();
   const value = parseInt(document.getElementById('itemValue').value, 10) || 0;
+  const fuel = parseInt(document.getElementById('itemFuel').value, 10) || 0;
   let equip = null;
   if (isEquip) {
     try { equip = JSON.parse(document.getElementById('itemEquip').value || 'null'); } catch (e) { equip = null; }
@@ -2432,6 +2434,7 @@ function addItem() {
   const useText = document.getElementById('itemUse').value.trim();
   if (use && useText) use.text = useText;
   const item = { id, name, desc, type, tags, mods, value, use, equip };
+  if (fuel) item.fuel = fuel;
   if (narrativeId || narrativePrompt) {
     item.narrative = {};
     if (narrativeId) item.narrative.id = narrativeId;
@@ -2513,6 +2516,7 @@ function editItem(i) {
   updateModsWrap();
   loadMods(it.mods);
   document.getElementById('itemValue').value = it.value || 0;
+  document.getElementById('itemFuel').value = it.fuel || 0;
   document.getElementById('itemEquip').value = it.equip ? JSON.stringify(it.equip, null, 2) : '';
   if (it.use) {
     document.getElementById('itemUseType').value = it.use.type || '';

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -111,14 +111,15 @@ function addToInv(item) {
     throw new Error('Unknown item');
   }
   const base = cloneItem(ITEMS[it.id] || registerItem(it));
-  if (base.id === 'fuel_cell') {
-    player.fuel = (player.fuel || 0) + 50;
+  const fuel = typeof base.fuel === 'number' ? base.fuel : (base.id === 'fuel_cell' ? 50 : 0);
+  if (fuel > 0) {
+    player.fuel = (player.fuel || 0) + fuel;
     emit('item:picked', base);
-    if(base.narrative){
+    if (base.narrative) {
       emit('item:narrative', { itemId: base.id, narrative: base.narrative });
     }
     notifyInventoryChanged();
-    if (typeof log === 'function') log('Fuel +50');
+    if (typeof log === 'function') log('Fuel +' + fuel);
     return true;
   }
   if (player.inv.length >= getPartyInventoryCapacity()) {
@@ -319,6 +320,7 @@ function normalizeItem(it){
     rarity: it.rarity || 'common',
     value: val,
     scrap: typeof it.scrap === 'number' ? it.scrap : undefined,
+    fuel: typeof it.fuel === 'number' ? it.fuel : undefined,
     desc: it.desc || '',
     persona: it.persona,
     narrative: it.narrative ? { ...it.narrative } : null,

--- a/test/fuel-item.pickup.test.js
+++ b/test/fuel-item.pickup.test.js
@@ -15,7 +15,20 @@ test('fuel cell pickup adds fuel instead of inventory', () => {
     log: () => {}
   };
   vm.runInNewContext(src, context);
-  context.addToInv({ id: 'fuel_cell', name: 'Fuel Cell', type: 'quest' });
+  context.addToInv({ id: 'fuel_cell', name: 'Fuel Cell', type: 'quest', fuel: 50 });
   assert.strictEqual(context.player.fuel, 50);
+  assert.strictEqual(context.player.inv.length, 0);
+});
+
+test('custom fuel item adds specified fuel', () => {
+  const context = {
+    EventBus: { emit: () => {} },
+    party: [],
+    player: { inv: [], fuel: 0 },
+    log: () => {}
+  };
+  vm.runInNewContext(src, context);
+  context.addToInv({ id: 'barrel', name: 'Fuel Barrel', type: 'quest', fuel: 30 });
+  assert.strictEqual(context.player.fuel, 30);
   assert.strictEqual(context.player.inv.length, 0);
 });


### PR DESCRIPTION
## Summary
- allow items with a `fuel` field to grant that amount to the player on pickup
- expose item fuel amount in Adventure Kit
- mark fuel cell items in modules with 50 fuel and cover with tests

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/placement-check.js modules/world-one.module.js`
- `node scripts/supporting/placement-check.js modules/world-two.module.js`
- `node scripts/supporting/placement-check.js modules/dustland.module.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c47fd230408328bd71e0068f37f352