### PR TITLE
Add fuel-checked bunker fast travel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-09-14
+- Bunker door now opens fast-travel map with fuel cost confirmation.
+
 ## 2025-09-13
 - Added button to clear saved game data.
 

--- a/scripts/core/fast-travel.js
+++ b/scripts/core/fast-travel.js
@@ -64,7 +64,7 @@
 
   globalThis.Dustland = globalThis.Dustland || {};
   globalThis.Dustland.fastTravel = { fuelCost, travel, activateBunker , saveSlot, loadSlot};
-  globalThis.openWorldMap = globalThis.openWorldMap || function(){
-    if(typeof log==='function') log('World map opened.');
+  globalThis.openWorldMap = globalThis.openWorldMap || function(id){
+    globalThis.Dustland?.worldMap?.open?.(id);
   };
 })();

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -532,7 +532,7 @@ function interactAt(x, y) {
         if(b.boarded){ log('The doorway is boarded up from the outside.'); bus.emit('sfx','denied'); return true; }
         if(b.bunker){
           Dustland.fastTravel?.activateBunker?.(b.bunkerId);
-          if(typeof openWorldMap==='function') openWorldMap();
+          if(typeof openWorldMap==='function') openWorldMap(b.bunkerId);
           bus.emit('sfx','confirm');
           return true;
         }

--- a/scripts/ui/world-map.js
+++ b/scripts/ui/world-map.js
@@ -38,7 +38,14 @@
         thumb.style.margin = '4px';
         thumb.style.cursor = 'pointer';
         thumb.title = info.name || b.id;
-        thumb.onclick = () => travel(fromId, b.id);
+        thumb.onclick = () => {
+          const ft = globalThis.Dustland?.fastTravel;
+          const cost = ft?.fuelCost?.(fromId, b.id) || 0;
+          const fuel = globalThis.player?.fuel || 0;
+          const name = info.name || b.id;
+          if(fuel < cost){ alert(`Need ${cost} fuel to travel.`); return; }
+          if(confirm(`Travel to ${name} for ${cost} fuel?`)) travel(fromId, b.id);
+        };
         list.appendChild(thumb);
       });
     });
@@ -76,7 +83,7 @@
   function renderThumb(moduleData, info){
     const canvas = document.createElement('canvas');
     const world = moduleData?.world;
-    const scale = 4;
+    const scale = 1;
     if(Array.isArray(world) && world[0]){
       canvas.width = world[0].length * scale;
       canvas.height = world.length * scale;

--- a/test/bunker-fast-travel.test.js
+++ b/test/bunker-fast-travel.test.js
@@ -24,8 +24,8 @@ test('entering bunker opens world map and activates fast travel', async () => {
   const state = { map:'world' };
   global.party = party;
   global.state = state;
-  let opened = false;
-  global.openWorldMap = () => { opened = true; };
+  let opened = null;
+  global.openWorldMap = id => { opened = id; };
   const handlers = {};
   const bus = { on:(e,f)=>{ (handlers[e]=handlers[e]||[]).push(f); }, emit:(e,p)=>{ (handlers[e]||[]).forEach(fn=>fn(p)); } };
   global.EventBus = bus;
@@ -57,7 +57,7 @@ test('entering bunker opens world map and activates fast travel', async () => {
 
   interactAt(0,0);
 
-  assert.strictEqual(opened, true);
+  assert.strictEqual(opened, 'bunker_0_0');
   assert.strictEqual(activated, 'bunker_0_0');
   assert.strictEqual(state.map, 'world');
 });


### PR DESCRIPTION
## Summary
- trigger world map fast travel UI when entering bunker doors
- display 1px-per-tile thumbnails with fuel cost confirmation
- test bunker interaction and document fast travel update

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'onclick'))*

------
https://chatgpt.com/codex/tasks/task_e_68c47f8a88288328b33217d6c75f8a56