### PR TITLE
feat: show recipe requirement counts in workbench

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -807,6 +807,13 @@ input[type="range"] {
   margin-left: 8px;
 }
 
+#workbenchOverlay .slot ul {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+  font-size: 12px;
+}
+
 .slot-list {
   display: flex;
   flex-direction: column;

--- a/scripts/workbench.js
+++ b/scripts/workbench.js
@@ -70,48 +70,55 @@
         {
           name: 'Signal Beacon',
           craft: craftSignalBeacon,
-          missing(){
-            const m = [];
-            if ((player.scrap || 0) < 5) m.push('5 scrap');
-            if ((player.fuel || 0) < 50) m.push('50 fuel');
-            return m;
-          }
+          requirements: [
+            { label: 'Scrap', key: 'scrap', amount: 5, type: 'resource' },
+            { label: 'Fuel', key: 'fuel', amount: 50, type: 'resource' }
+          ]
         },
         {
           name: 'Solar Panel Tarp',
           craft: craftSolarTarp,
-          missing(){
-            const m = [];
-            if ((player.scrap || 0) < 3) m.push('3 scrap');
-            if (!hasItem('cloth')) m.push('cloth');
-            return m;
-          }
+          requirements: [
+            { label: 'Scrap', key: 'scrap', amount: 3, type: 'resource' },
+            { label: 'Cloth', key: 'cloth', amount: 1, type: 'item' }
+          ]
         },
         {
           name: 'Bandage',
           craft: craftBandage,
-          missing(){
-            const m = [];
-            if (!hasItem('plant_fiber')) m.push('plant fiber');
-            return m;
-          }
+          requirements: [
+            { label: 'Plant Fiber', key: 'plant_fiber', amount: 1, type: 'item' }
+          ]
         }
       ];
 
       recipes.forEach(r => {
         const row = document.createElement('div');
         row.className = 'slot';
-        const miss = r.missing();
-        if (miss.length === 0){
-          row.innerHTML = `<span>${r.name}</span><button class="btn">Craft</button>`;
-          const btn = row.querySelector('button');
+        const info = document.createElement('div');
+        const title = document.createElement('span');
+        title.textContent = r.name;
+        info.appendChild(title);
+        const reqList = document.createElement('ul');
+        let craftable = true;
+        r.requirements.forEach(req => {
+          const have = req.type === 'resource' ? (player[req.key] || 0) : countItems(req.key);
+          if (have < req.amount) craftable = false;
+          const li = document.createElement('li');
+          li.textContent = `${req.label}: ${have}/${req.amount}`;
+          reqList.appendChild(li);
+        });
+        info.appendChild(reqList);
+        row.appendChild(info);
+        if (craftable){
+          const btn = document.createElement('button');
+          btn.className = 'btn';
+          btn.textContent = 'Craft';
           btn.onclick = () => { r.craft(); renderRecipes(); };
-          list.appendChild(row);
+          row.appendChild(btn);
           focusables.push(btn);
-        } else {
-          row.innerHTML = `<span>${r.name} - need ${miss.join(', ')}</span>`;
-          list.appendChild(row);
         }
+        list.appendChild(row);
       });
       focusIdx = 0;
       focusCurrent();

--- a/test/workbench.ui.test.js
+++ b/test/workbench.ui.test.js
@@ -14,7 +14,7 @@ async function loadWorkbench(dom){
   vm.runInThisContext(code);
 }
 
-test('workbench lists missing requirements for recipes you lack', async () => {
+test('workbench shows requirement counts for recipes you lack', async () => {
   const dom = new JSDOM('<div id="workbenchOverlay"><div class="workbench-window"><header><button id="closeWorkbenchBtn"></button></header><div id="workbenchRecipes"></div></div></div>');
   await loadWorkbench(dom);
   global.player = { scrap: 0, fuel: 0, inv: [] };
@@ -22,13 +22,18 @@ test('workbench lists missing requirements for recipes you lack', async () => {
   global.findItemIndex = id => player.inv.findIndex(i => i.id === id);
   global.removeFromInv = idx => player.inv.splice(idx, 1);
   global.addToInv = id => { player.inv.push({ id }); return true; };
+  global.countItems = id => player.inv.filter(i => i.id === id).length;
 
   Dustland.openWorkbench();
   const rows = dom.window.document.querySelectorAll('#workbenchRecipes .slot');
   assert.strictEqual(rows.length, 3);
-  assert.match(rows[0].textContent, /need 5 scrap, 50 fuel/i);
-  assert.match(rows[1].textContent, /need 3 scrap, cloth/i);
-  assert.match(rows[2].textContent, /need plant fiber/i);
+  assert.match(rows[0].textContent, /Scrap: 0\/5/i);
+  assert.match(rows[0].textContent, /Fuel: 0\/50/i);
+  assert.match(rows[1].textContent, /Scrap: 0\/3/i);
+  assert.match(rows[1].textContent, /Cloth: 0\/1/i);
+  assert.match(rows[2].textContent, /Plant Fiber: 0\/1/i);
+  const buttons = dom.window.document.querySelectorAll('#workbenchRecipes .slot button');
+  assert.strictEqual(buttons.length, 0);
 });
 
 test('arrow keys in workbench do not bubble to window', async () => {
@@ -39,6 +44,7 @@ test('arrow keys in workbench do not bubble to window', async () => {
   global.findItemIndex = id => player.inv.findIndex(i => i.id === id);
   global.removeFromInv = idx => player.inv.splice(idx, 1);
   global.addToInv = id => { player.inv.push({ id }); return true; };
+  global.countItems = id => player.inv.filter(i => i.id === id).length;
 
   let moved = 0;
   dom.window.addEventListener('keydown', () => { moved++; });


### PR DESCRIPTION
## Summary
- display workbench recipes as cards listing each requirement and current inventory counts
- add styling for requirement lists in the workbench UI
- test workbench UI for requirement counts and navigation

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c481f2f97883288603dcb003814bf6