### PR TITLE
feat: add workbench checkbox for NPCs

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -459,6 +459,7 @@
             <label>Markup<input id="shopMarkup" type="number" min="1" value="2" /></label>
             <label>Refresh<input id="shopRefresh" type="number" min="0" value="0" /></label>
           </div>
+          <label><input type="checkbox" id="npcWorkbench"> Workbench NPC</label>
           <div id="treeWrap">
             <label>Dialog Tree</label>
             <button class="btn" type="button" id="editDialog">Edit Dialog</button>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2022,6 +2022,7 @@ function startNewNPC() {
   document.getElementById('npcSpecialDelay').value = '';
   document.getElementById('npcCombat').checked = false;
   document.getElementById('npcShop').checked = false;
+  document.getElementById('npcWorkbench').checked = false;
   document.getElementById('shopMarkup').value = 2;
   document.getElementById('shopRefresh').value = 0;
   updateNPCOptSections();
@@ -2067,6 +2068,7 @@ function collectNPCFromForm() {
   const turnin = document.getElementById('npcTurnin').value.trim();
   const combat = document.getElementById('npcCombat').checked;
   const shop = document.getElementById('npcShop').checked;
+  const workbench = document.getElementById('npcWorkbench').checked;
   const shopMarkup = parseInt(document.getElementById('shopMarkup').value, 10) || 2;
   const shopRefresh = parseInt(document.getElementById('shopRefresh').value, 10) || 0;
   const hidden = document.getElementById('npcHidden').checked;
@@ -2135,6 +2137,7 @@ function collectNPCFromForm() {
     }
   }
   if (shop) npc.shop = { markup: shopMarkup, refresh: shopRefresh, inv: [] };
+  if (workbench) npc.workbench = true;
   if (hidden && flag) npc.hidden = true, npc.reveal = { flag, op, value: val };
   if (npcPortraitPath) npc.portraitSheet = npcPortraitPath;
   else if (npcPortraitIndex > 0) npc.portraitSheet = npcPortraits[npcPortraitIndex];
@@ -2251,6 +2254,7 @@ function editNPC(i) {
   document.getElementById('npcSpecialDelay').value = n.combat?.special?.delay ?? '';
   document.getElementById('npcCombat').checked = !!n.combat;
   document.getElementById('npcShop').checked = !!n.shop;
+  document.getElementById('npcWorkbench').checked = !!n.workbench;
   document.getElementById('shopMarkup').value = n.shop ? n.shop.markup || 2 : 2;
   document.getElementById('shopRefresh').value = n.shop ? n.shop.refresh || 0 : 0;
   updateNPCOptSections();

--- a/test/npc-patrol.test.js
+++ b/test/npc-patrol.test.js
@@ -158,6 +158,68 @@ test('collectNPCFromForm reads loot chance', async () => {
   assert.strictEqual(npc.combat.lootChance, 0.25);
 });
 
+test('collectNPCFromForm reads workbench checkbox', async () => {
+  const document = makeDocument();
+  // required fields with minimal values
+  mkInput(document, 'npcId', 'n');
+  mkInput(document, 'npcName', 'Name');
+  mkInput(document, 'npcTitle', '');
+  mkTextarea(document, 'npcDesc', '');
+  mkInput(document, 'npcColor', '#fff');
+  mkInput(document, 'npcSymbol', '!');
+  mkInput(document, 'npcMap', 'world');
+  mkInput(document, 'npcX', '0');
+  mkInput(document, 'npcY', '0');
+  mkTextarea(document, 'npcDialog', 'hi');
+  mkSelect(document, 'npcQuests', []);
+  mkTextarea(document, 'npcAccept', '');
+  mkTextarea(document, 'npcTurnin', '');
+  mkCheckbox(document, 'npcCombat', false);
+  mkCheckbox(document, 'npcShop', false);
+  mkCheckbox(document, 'npcWorkbench', false);
+  mkInput(document, 'shopMarkup', '2');
+  mkCheckbox(document, 'npcHidden', false);
+  mkCheckbox(document, 'npcLocked', false);
+  mkCheckbox(document, 'npcPortraitLock', true);
+  mkInput(document, 'npcOp', '>=');
+  mkInput(document, 'npcVal', '1');
+  mkTextarea(document, 'npcTree', '');
+  mkInput(document, 'npcHP', '5');
+  mkInput(document, 'npcATK', '0');
+  mkInput(document, 'npcDEF', '0');
+  mkInput(document, 'npcLoot', '');
+  mkCheckbox(document, 'npcBoss', false);
+  mkInput(document, 'npcSpecialCue', '');
+  mkInput(document, 'npcSpecialDmg', '');
+  mkInput(document, 'npcSpecialDelay', '');
+  mkCheckbox(document, 'npcPatrol', false);
+
+  const context = {
+    document,
+    npcPortraitPath: '',
+    npcPortraitIndex: 0,
+    npcPortraits: [],
+    updateTreeData() {},
+    applyCombatTree() {},
+    removeCombatTree() {},
+    loadTreeEditor() {},
+    getRevealFlag() { return ''; },
+    gatherLoopFields() { return []; }
+  };
+  vm.createContext(context);
+  const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+  const start = code.indexOf('function collectNPCFromForm');
+  const end = code.indexOf('// Add a new NPC', start);
+  vm.runInContext(code.slice(start, end), context);
+
+  const npc1 = context.collectNPCFromForm();
+  assert.ok(!('workbench' in npc1));
+
+  document.getElementById('npcWorkbench').checked = true;
+  const npc2 = context.collectNPCFromForm();
+  assert.strictEqual(npc2.workbench, true);
+});
+
 test('collectEncounter reads loot chance', async () => {
   const document = makeDocument();
   mkInput(document, 'encMap', 'world');


### PR DESCRIPTION
## Summary
- add Workbench NPC checkbox to Adventure Kit form
- persist workbench flag when editing NPCs
- test that workbench checkbox is read in NPC form

## Testing
- `./install-deps.sh`
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c489d5fa988328b59fa232c85b3b3b