### PR TITLE
fix: prevent module picker syntax errors

### DIFF
--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -9,7 +9,7 @@ const MODULES = [
   { id: 'other', name: 'OTHER.BAS', file: 'modules/other-bas.module.js' },
   { id: 'two-worlds', name: 'Two Worlds', file: 'modules/two-worlds.module.js' },
   { id: 'true-dust', name: 'True Dust', file: 'modules/true-dust.module.js' },
-  { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' }
+  { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' },
   { id: 'edge', name: 'bunker-trainer-workshop', file: 'modules/edge.module.js' },
 ];
 

--- a/scripts/supporting/json-to-module.js
+++ b/scripts/supporting/json-to-module.js
@@ -48,6 +48,10 @@ const endIdx = lines.findIndex((l, i) => i > startIdx && l.trim() === '];');
 const entry = `  { id: '${base}', name: '${data.name || base}', file: 'modules/${base}.module.js' },`;
 const exists = lines.slice(startIdx, endIdx).some(l => l.includes(`file: 'modules/${base}.module.js'`));
 if (!exists) {
+  const lastIdx = endIdx - 1;
+  if (!lines[lastIdx].trim().endsWith(',')) {
+    lines[lastIdx] += ',';
+  }
   lines.splice(endIdx, 0, entry);
   fs.writeFileSync(pickerPath, lines.join('\n'));
   console.log(`Updated ${pickerPath}`);

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -159,7 +159,9 @@ test('true-dust module points to entry script', () => {
 });
 
 test('enter key loads selected module', () => {
-  loadModule(MODULES[MODULES.length - 1]);
+  const golden = MODULES.find(m => m.id === 'golden');
+  assert.ok(golden);
+  loadModule(golden);
   assert.ok(global.location.href.includes('golden.module.json'));
 });
 


### PR DESCRIPTION
## Summary
- add missing comma in module-picker and keep new edge module entry
- ensure json-to-module inserts trailing commas when appending modules
- adjust module-picker test to load golden module by id

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c48ec17204832890f24c9b676ab07a