### PR TITLE
test: verify workbench crafting adds inventory item

### DIFF
--- a/test/workbench.ui.test.js
+++ b/test/workbench.ui.test.js
@@ -10,8 +10,30 @@ async function loadWorkbench(dom){
   global.requestAnimationFrame = () => {};
   global.EventBus = { emit: () => {} };
   global.log = () => {};
-  const code = await fs.readFile(new URL('../scripts/workbench.js', import.meta.url), 'utf8');
-  vm.runInThisContext(code);
+  global.closeDialog = () => {};
+  const wbCode = await fs.readFile(new URL('../scripts/workbench.js', import.meta.url), 'utf8');
+  vm.runInThisContext(wbCode);
+  if (typeof NPC === 'undefined') {
+    const npcCode = await fs.readFile(new URL('../scripts/core/npc.js', import.meta.url), 'utf8');
+    vm.runInThisContext(npcCode);
+  }
+  global.openDialog = (npc, node='start') => npc.processNode(node);
+}
+
+function useWorkbench(){
+  const npc = new NPC({
+    id: 'bench',
+    map: 'world',
+    x: 0,
+    y: 0,
+    color: '#fff',
+    name: 'Workbench',
+    title: '',
+    desc: '',
+    tree: { start: { text: '', choices: [{ label: '(Leave)', to: 'bye' }] } },
+    workbench: true
+  });
+  openDialog(npc);
 }
 
 test('workbench shows requirement counts for recipes you lack', async () => {
@@ -24,7 +46,7 @@ test('workbench shows requirement counts for recipes you lack', async () => {
   global.addToInv = id => { player.inv.push({ id }); return true; };
   global.countItems = id => player.inv.filter(i => i.id === id).length;
 
-  Dustland.openWorkbench();
+  useWorkbench();
   const rows = dom.window.document.querySelectorAll('#workbenchRecipes .slot');
   assert.strictEqual(rows.length, 3);
   assert.match(rows[0].textContent, /Scrap: 0\/5/i);
@@ -48,11 +70,31 @@ test('arrow keys in workbench do not bubble to window', async () => {
 
   let moved = 0;
   dom.window.addEventListener('keydown', () => { moved++; });
-  Dustland.openWorkbench();
+  useWorkbench();
   const overlay = dom.window.document.getElementById('workbenchOverlay');
   const evt = new dom.window.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
   overlay.dispatchEvent(evt);
   assert.strictEqual(moved, 0);
   const buttons = dom.window.document.querySelectorAll('#workbenchRecipes .slot button');
   assert.strictEqual(buttons.length, 3);
+});
+
+test('clicking craft adds item to inventory', async () => {
+  const dom = new JSDOM('<div id="workbenchOverlay"><div class="workbench-window"><header><button id="closeWorkbenchBtn"></button></header><div id="workbenchRecipes"></div></div></div>');
+  await loadWorkbench(dom);
+  global.player = { scrap: 5, fuel: 50, inv: [ { id: 'cloth' }, { id: 'plant_fiber' } ] };
+  global.hasItem = id => player.inv.some(i => i.id === id);
+  global.findItemIndex = id => player.inv.findIndex(i => i.id === id);
+  global.removeFromInv = idx => player.inv.splice(idx, 1);
+  global.addToInv = id => { player.inv.push({ id }); return true; };
+  global.countItems = id => player.inv.filter(i => i.id === id).length;
+
+  useWorkbench();
+  let buttons = dom.window.document.querySelectorAll('#workbenchRecipes .slot button');
+  assert.strictEqual(buttons.length, 3);
+  buttons[2].click();
+  assert.ok(player.inv.some(i => i.id === 'bandage'));
+  assert.ok(!player.inv.some(i => i.id === 'plant_fiber'));
+  buttons = dom.window.document.querySelectorAll('#workbenchRecipes .slot button');
+  assert.strictEqual(buttons.length, 2);
 });


### PR DESCRIPTION
## Summary
- add UI integration test for crafting at workbench to ensure items enter inventory and resources are consumed
- open workbench via NPC dialog instead of direct call

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c49a032e2883288b263c429e25caf8