### PR TITLE
fix: enable workbench, trainer, and bunkers in game

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -248,11 +248,11 @@
     <script defer src="./scripts/core/npc.js"></script>
     <script defer src="./scripts/game-state.js"></script>
     <script defer src="./scripts/core/personas.js"></script>
+    <script defer src="./scripts/dustland-core.js"></script>
     <script defer src="./scripts/workbench.js"></script>
     <script defer src="./components/dial.js"></script>
     <script defer src="./data/skills/trainer-upgrades.js"></script>
     <script defer src="./scripts/trainer-ui.js"></script>
-    <script defer src="./scripts/dustland-core.js"></script>
     <script defer src="./scripts/core/fast-travel.js"></script>
     <script defer src="./scripts/ui/world-map.js"></script>
     <script defer src="./scripts/core/event-flags.js"></script>


### PR DESCRIPTION
## Summary
- remove unintended workbench overlay and gameplay scripts from Adventure Kit
- load workbench, trainer, fast-travel, and world map scripts after core in game

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/placement-check.js modules/edge.module.js`


------
https://chatgpt.com/codex/tasks/task_e_68c499d4e4cc83289f5c0a869bd36799