### PR TITLE
feat: add scrap drop settings for npc templates

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -700,6 +700,10 @@
           <label>Special Dmg<input id="templateSpecialDmg" type="number" min="1" /></label>
           <label>Loot<select id="templateLoot"></select></label>
           <label>Loot %<input id="templateLootChance" type="number" min="0" max="100" value="100" /></label>
+          <label>Drop Scrap<input id="templateDropScrap" type="checkbox" /></label>
+          <label class="templateScrapField" style="display:none">Scrap %<input id="templateScrapChance" type="number" min="0" max="100" value="100" /></label>
+          <label class="templateScrapField" style="display:none">Min Scrap<input id="templateScrapMin" type="number" min="0" value="1" /></label>
+          <label class="templateScrapField" style="display:none">Max Scrap<input id="templateScrapMax" type="number" min="0" value="1" /></label>
           <label>Requires<input id="templateRequires" /></label>
         <button class="btn" id="addTemplate">Add Template</button>
         <button class="btn" id="delTemplate" style="display:none">Delete Template</button>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2700,6 +2700,12 @@ function deleteEncounter(){
 function showTemplateEditor(show){
   document.getElementById('templateEditor').style.display = show ? 'block' : 'none';
 }
+function toggleTemplateScrapFields(){
+  const show = document.getElementById('templateDropScrap').checked;
+  document.querySelectorAll('.templateScrapField').forEach(el => {
+    el.style.display = show ? 'inline-block' : 'none';
+  });
+}
 function startNewTemplate(){
   editTemplateIdx = -1;
   document.getElementById('templateId').value = nextId('template', moduleData.templates);
@@ -2715,9 +2721,14 @@ function startNewTemplate(){
   document.getElementById('templateSpecialDmg').value = '';
   populateItemDropdown(document.getElementById('templateLoot'), '');
   document.getElementById('templateLootChance').value = 100;
+  document.getElementById('templateDropScrap').checked = false;
+  document.getElementById('templateScrapChance').value = 100;
+  document.getElementById('templateScrapMin').value = 1;
+  document.getElementById('templateScrapMax').value = 1;
   document.getElementById('templateRequires').value = '';
   document.getElementById('addTemplate').textContent = 'Add Template';
   document.getElementById('delTemplate').style.display = 'none';
+  toggleTemplateScrapFields();
   showTemplateEditor(true);
 }
 function collectTemplate(){
@@ -2734,12 +2745,22 @@ function collectTemplate(){
   const specialDmg = parseInt(document.getElementById('templateSpecialDmg').value,10) || 0;
   const loot = document.getElementById('templateLoot').value.trim();
   const lootChancePct = parseFloat(document.getElementById('templateLootChance').value);
+  const dropScrap = document.getElementById('templateDropScrap').checked;
+  const scrapChancePct = parseFloat(document.getElementById('templateScrapChance').value);
+  const scrapMin = parseInt(document.getElementById('templateScrapMin').value,10) || 0;
+  const scrapMax = parseInt(document.getElementById('templateScrapMax').value,10) || scrapMin;
   const requires = document.getElementById('templateRequires').value.trim();
   const combat = { HP, ATK, DEF };
   if (challenge) combat.challenge = challenge;
   if (loot) combat.loot = loot;
   if (!isNaN(lootChancePct) && lootChancePct >= 0 && lootChancePct < 100) {
     combat.lootChance = lootChancePct / 100;
+  }
+  if (dropScrap) {
+    combat.scrap = { min: scrapMin, max: scrapMax };
+    if (!isNaN(scrapChancePct) && scrapChancePct >= 0 && scrapChancePct < 100) {
+      combat.scrap.chance = scrapChancePct / 100;
+    }
   }
   if (requires) combat.requires = requires;
   if (specialCue || specialDmg) {
@@ -2775,9 +2796,15 @@ function editTemplate(i){
   document.getElementById('templateSpecialDmg').value = t.combat?.special?.dmg || '';
   populateItemDropdown(document.getElementById('templateLoot'), t.combat?.loot || '');
   document.getElementById('templateLootChance').value = t.combat?.lootChance != null ? Math.round(t.combat.lootChance * 100) : 100;
+  const scrap = t.combat?.scrap;
+  document.getElementById('templateDropScrap').checked = !!scrap;
+  document.getElementById('templateScrapChance').value = scrap?.chance != null ? Math.round(scrap.chance * 100) : 100;
+  document.getElementById('templateScrapMin').value = scrap?.min ?? 1;
+  document.getElementById('templateScrapMax').value = scrap?.max ?? 1;
   document.getElementById('templateRequires').value = t.combat?.requires || '';
   document.getElementById('addTemplate').textContent = 'Update Template';
   document.getElementById('delTemplate').style.display = 'block';
+  toggleTemplateScrapFields();
   showTemplateEditor(true);
 }
 function renderTemplateList(){
@@ -3832,6 +3859,7 @@ document.getElementById('closeEncounter').onclick = () => showEncounterEditor(fa
 document.getElementById('newTemplate').onclick = startNewTemplate;
 document.getElementById('addTemplate').onclick = addTemplate;
 document.getElementById('delTemplate').onclick = deleteTemplate;
+document.getElementById('templateDropScrap').onchange = toggleTemplateScrapFields;
 document.getElementById('npcPrevP').onclick = () => {
   npcPortraitIndex = (npcPortraitIndex + npcPortraits.length - 1) % npcPortraits.length;
   npcPortraitPath = '';

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -629,8 +629,17 @@ function doAttack(dmg, type = 'basic'){
       // lootChance defaults to 1 (100%) if unspecified
       if (target.loot && Math.random() < (target.lootChance ?? 1)) addToInv?.(target.loot);
 
-      // Bandits sometimes drop scrap
-      if (/bandit/i.test(target.id) && Math.random() < 0.5){
+      if (typeof target.scrap === 'object' && Math.random() < (target.scrap.chance ?? 1)) {
+        const min = target.scrap.min ?? 1;
+        const max = target.scrap.max ?? min;
+        const amt = Math.floor(Math.random() * (max - min + 1)) + min;
+        if (amt > 0) {
+          player.scrap = (player.scrap || 0) + amt;
+          updateHUD?.();
+          const who = target.name || target.id || 'foe';
+          log?.(`You find ${amt} scrap on the ${who}.`);
+        }
+      } else if (/bandit/i.test(target.id) && Math.random() < 0.5){
         player.scrap = (player.scrap || 0) + 1;
         updateHUD?.();
         log?.('You find 1 scrap on the bandit.');

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1401,6 +1401,22 @@ test('bandits can drop scrap on defeat', async () => {
   assert.strictEqual(player.scrap, 1);
 });
 
+test('npc scrap config drops scrap', async () => {
+  NPCS.length = 0;
+  party.length = 0;
+  player.inv.length = 0;
+  player.scrap = 0;
+  const m1 = new Character('p1','P1','Role');
+  party.join(m1);
+  const origRand = Math.random;
+  Math.random = () => 0;
+  const resultPromise = openCombat([{ id:'rat', name:'Rat', hp:1, scrap:{ min:2, max:4 } }]);
+  handleCombatKey({ key:'Enter' });
+  await resultPromise;
+  Math.random = origRand;
+  assert.strictEqual(player.scrap, 2);
+});
+
 test('lootChance prevents drops on high rolls', async () => {
   NPCS.length = 0;
   party.length = 0;


### PR DESCRIPTION
## Summary
- add scrap drop controls to ACK NPC templates
- support configurable scrap drops during combat
- test NPC scrap drop configuration

## Testing
- `node scripts/supporting/presubmit.js adventure-kit.html`
- `node scripts/supporting/balance-tester-agent.js` *(fails: TypeError: Cannot set properties of null (setting 'onclick'))*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c52645fc4883288517a6d1a34573fd