### PR TITLE
fix: convert world map rows before rendering

### DIFF
--- a/scripts/ui/world-map.js
+++ b/scripts/ui/world-map.js
@@ -115,9 +115,18 @@
 
   function renderThumb(moduleData, info){
     const canvas = document.createElement('canvas');
-    const world = moduleData?.world;
+    let world = moduleData?.world;
     const scale = 1;
     if(Array.isArray(world) && world[0]){
+      if(typeof world[0] === 'string'){
+        const gfe = globalThis.gridFromEmoji;
+        if(typeof gfe === 'function'){
+          world = gfe(world);
+          moduleData.world = world;
+        }else{
+          world = [];
+        }
+      }
       canvas.width = world[0].length * scale;
       canvas.height = world.length * scale;
       const ctx = canvas.getContext('2d');

--- a/test/world-map.preview.test.js
+++ b/test/world-map.preview.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+test('renderThumb converts string rows to grid', async () => {
+  const document = makeDocument();
+  const context = { document, window: { document }, Dustland: {} };
+  context.gridFromEmoji = rows => rows.map(r => Array.from(r).map(() => 1));
+  vm.createContext(context);
+  let code = await fs.readFile(new URL('../scripts/ui/world-map.js', import.meta.url), 'utf8');
+  code = code.replace('function renderThumb', 'globalThis.renderThumb = function renderThumb');
+  vm.runInContext(code, context);
+  const data = { world: ['aa', 'bb'] };
+  const canvas = context.renderThumb(data);
+  assert.strictEqual(canvas.width, 2);
+  assert.strictEqual(canvas.height, 2);
+  assert.ok(Array.isArray(data.world[0]));
+});


### PR DESCRIPTION
## Summary
- convert world map preview rows using `gridFromEmoji`
- add tests for preview rendering with string rows

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c527aa76bc8328a6858c381d69d835