### PR TITLE
fix: preserve ACK data when regenerating landscape

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -899,21 +899,7 @@ function generateProceduralWorld(regen) {
     for (let y = 0; y < WORLD_H; y++) {
       world.push(map.tiles[y]);
     }
-    moduleData.npcs = [];
-    moduleData.items = [];
-    moduleData.quests = [];
-    moduleData.buildings = [];
-    moduleData.interiors = [];
-    moduleData.portals = [];
-    moduleData.events = [];
-    moduleData.zones = [];
-    moduleData.encounters = [];
-    moduleData.templates = [];
     initTags();
-    buildings.length = 0;
-    portals.length = 0;
-    globalThis.interiors = {};
-    interiors = globalThis.interiors;
     renderNPCList();
     renderItemList();
     renderQuestList();


### PR DESCRIPTION
## Summary
- avoid clearing module data arrays when generating procedural landscapes in Adventure Kit
- add regression test ensuring NPCs, items, and other entities survive landscape generation

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c52ca7232c8328863846abbfc4f41a