### PR TITLE
fix: clarify template challenge scale

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -695,7 +695,7 @@
           <label>HP<input id="templateHP" type="number" min="1" value="5" /></label>
           <label>ATK<input id="templateATK" type="number" min="1" value="1" /></label>
           <label>DEF<input id="templateDEF" type="number" min="0" value="0" /></label>
-          <label>Challenge<input id="templateChallenge" type="number" min="0" /></label>
+          <label>Challenge (1-10)<span class="help" title="Higher values improve loot cache drops">(?)</span><input id="templateChallenge" type="number" min="1" max="10" /></label>
           <label>Special Cue<input id="templateSpecialCue" /></label>
           <label>Special Dmg<input id="templateSpecialDmg" type="number" min="1" /></label>
           <label>Loot<select id="templateLoot"></select></label>

--- a/docs/guides/module-cli-tools.md
+++ b/docs/guides/module-cli-tools.md
@@ -152,6 +152,8 @@ complete module object looks like this:
 }
 ```
 
+- `challenge` is a 1–10 rating that boosts loot cache drop odds and tier.
+
 ### Item
 
 ```json
@@ -319,8 +321,9 @@ Common examples:
     "HP": 0,
     "ATK": 0,
     "DEF": 0,
-    "challenge": 0,
+    "challenge": 1,
     "special": { "cue": "text", "dmg": 0 }
   }
 }
 ```
+- `challenge` is a 1–10 rating that boosts loot cache drop odds and tier.

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -2740,7 +2740,7 @@ function collectTemplate(){
   const HP = parseInt(document.getElementById('templateHP').value,10) || 1;
   const ATK = parseInt(document.getElementById('templateATK').value,10) || 1;
   const DEF = parseInt(document.getElementById('templateDEF').value,10) || 0;
-  const challenge = parseInt(document.getElementById('templateChallenge').value,10) || 0;
+  const challenge = parseInt(document.getElementById('templateChallenge').value,10);
   const specialCue = document.getElementById('templateSpecialCue').value.trim();
   const specialDmg = parseInt(document.getElementById('templateSpecialDmg').value,10) || 0;
   const loot = document.getElementById('templateLoot').value.trim();
@@ -2751,7 +2751,7 @@ function collectTemplate(){
   const scrapMax = parseInt(document.getElementById('templateScrapMax').value,10) || scrapMin;
   const requires = document.getElementById('templateRequires').value.trim();
   const combat = { HP, ATK, DEF };
-  if (challenge) combat.challenge = challenge;
+  if (challenge > 0) combat.challenge = Math.min(10, challenge); // higher values improve loot caches
   if (loot) combat.loot = loot;
   if (!isNaN(lootChancePct) && lootChancePct >= 0 && lootChancePct < 100) {
     combat.lootChance = lootChancePct / 100;

--- a/test/npc-patrol.test.js
+++ b/test/npc-patrol.test.js
@@ -262,5 +262,32 @@ test('collectTemplate reads loot chance', async () => {
   vm.runInContext(code.slice(start, end), context);
   const t = context.collectTemplate();
   assert.strictEqual(t.combat.lootChance, 0.1);
+  assert.ok(!('challenge' in t.combat));
+});
+
+test('collectTemplate clamps challenge to 1-10', async () => {
+  const document = makeDocument();
+  mkInput(document, 'templateId', 't');
+  mkInput(document, 'templateName', 'T');
+  mkTextarea(document, 'templateDesc', '');
+  mkInput(document, 'templateColor', '#fff');
+  mkInput(document, 'templatePortrait', '');
+  mkInput(document, 'templateHP', '5');
+  mkInput(document, 'templateATK', '1');
+  mkInput(document, 'templateDEF', '0');
+  mkInput(document, 'templateChallenge', '42');
+  mkInput(document, 'templateSpecialCue', '');
+  mkInput(document, 'templateSpecialDmg', '0');
+  mkInput(document, 'templateLoot', '');
+  mkInput(document, 'templateLootChance', '100');
+  mkInput(document, 'templateRequires', '');
+  const context = { document };
+  vm.createContext(context);
+  const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+  const start = code.indexOf('function collectTemplate');
+  const end = code.indexOf('function addTemplate', start);
+  vm.runInContext(code.slice(start, end), context);
+  const t = context.collectTemplate();
+  assert.strictEqual(t.combat.challenge, 10);
 });
 


### PR DESCRIPTION
## Summary
- constrain template challenge input to a 1–10 scale and note its loot cache effect
- clamp collected challenge values to range and document scale in module CLI guide
- add tests covering challenge omission and clamping

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c52a11e8648328826de645bad725b8