### PR TITLE
feat: widen ruin hub spacing

### DIFF
--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -243,7 +243,7 @@ function carveRoads(tiles, centers, edges, field, seed = 1) {
   return tiles;
 }
 
-function scatterRuins(tiles, seed = 1, radius = 6) {
+function scatterRuins(tiles, seed = 1, radius = 12) {
   const rand = mulberry32(typeof seed === 'string' ? hashString(seed) : seed);
   const h = tiles.length;
   const w = tiles[0].length;
@@ -286,7 +286,7 @@ function scatterRuins(tiles, seed = 1, radius = 6) {
       }
     }
   }
-  return { tiles, ruins };
+  return { tiles, ruins, hubs };
 }
 
 function findRegionCenters(tiles) {
@@ -370,6 +370,7 @@ function generateProceduralMap(seed, width, height, scale = 4, falloff = 0, feat
     const res = scatterRuins(tiles, seed);
     tiles = res.tiles;
     feat.ruins = res.ruins;
+    feat.ruinHubs = res.hubs;
   }
   return { tiles, regions: centers, roads: edges, features: feat };
 }

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -165,6 +165,21 @@ test('scatterRuins respects spacing and terrain', () => {
   assert.ok(clustered);
 });
 
+test('scatterRuins spreads hubs apart', () => {
+  globalThis.TILE = { SAND: 0, WATER: 2, ROAD: 4, RUIN: 6 };
+  const grid = Array.from({ length: 32 }, () => Array(32).fill(0));
+  const res = globalThis.scatterRuins(grid, 7);
+  const hubs = res.hubs;
+  for (let i = 0; i < hubs.length; i++) {
+    for (let j = i + 1; j < hubs.length; j++) {
+      const dx = hubs[i].x - hubs[j].x;
+      const dy = hubs[i].y - hubs[j].y;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      assert.ok(d >= 12);
+    }
+  }
+});
+
 test('generateProceduralMap returns grid of requested size', () => {
   globalThis.TILE = { SAND: 0, WATER: 2, BRUSH: 3, ROCK: 5, ROAD: 4, RUIN: 6 };
   const map = globalThis.generateProceduralMap(1, 10, 8);


### PR DESCRIPTION
## Summary
- Increase default ruin hub radius to space clusters further apart
- Return ruin hub coordinates and store them during map generation
- Verify hub spacing with a new test

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c52d0bee38832897db9c7a9585a32d