### PR TITLE
fix: stop roads from meandering over water

### DIFF
--- a/scripts/procedural-map.js
+++ b/scripts/procedural-map.js
@@ -224,20 +224,20 @@ function carveRoads(tiles, centers, edges, field, seed = 1) {
       const py = y0;
       x0 = opts[0].nx;
       y0 = opts[0].ny;
-      if (px !== x0 && py !== y0) {
+      if (px !== x0 && py !== y0 && tiles[py][x0] !== TILE.WATER) {
         tiles[py][x0] = TILE.ROAD;
       }
       if (rand() < 0.3) {
         const jx = Math.max(0, Math.min(w - 1, x0 + (rand() < 0.5 ? -1 : 1)));
         const jy = Math.max(0, Math.min(h - 1, y0 + (rand() < 0.5 ? -1 : 1)));
-        tiles[jy][jx] = TILE.ROAD;
+        if (tiles[jy][jx] !== TILE.WATER) tiles[jy][jx] = TILE.ROAD;
       }
     }
     tiles[y0][x0] = TILE.ROAD;
     if (rand() < 0.3) {
       const jx = Math.max(0, Math.min(w - 1, x0 + (rand() < 0.5 ? -1 : 1)));
       const jy = Math.max(0, Math.min(h - 1, y0 + (rand() < 0.5 ? -1 : 1)));
-      tiles[jy][jx] = TILE.ROAD;
+      if (tiles[jy][jx] !== TILE.WATER) tiles[jy][jx] = TILE.ROAD;
     }
   }
   return tiles;

--- a/test/procedural-map.test.js
+++ b/test/procedural-map.test.js
@@ -134,6 +134,20 @@ test('carveRoads favors contour paths', () => {
   assert.notEqual(roaded[1][0], 4);
 });
 
+test('carveRoads skips jitter over water', () => {
+  globalThis.TILE = { SAND: 0, ROAD: 4, WATER: 2 };
+  const tiles = [
+    [0, 0, 0],
+    [2, 2, 2],
+    [0, 0, 0]
+  ];
+  const field = Array.from({ length: 3 }, () => Array(3).fill(0));
+  const centers = [{ x: 0, y: 0 }, { x: 2, y: 0 }];
+  const edges = [[0, 1]];
+  const roaded = globalThis.carveRoads(tiles, centers, edges, field, 1);
+  assert.deepEqual(roaded[1], [2, 2, 2]);
+});
+
 test('scatterRuins respects spacing and terrain', () => {
   globalThis.TILE = { SAND: 0, WATER: 2, ROAD: 4, RUIN: 6 };
   const size = 10;


### PR DESCRIPTION
## Summary
- block road jitter from painting water tiles
- add regression test for water-adjacent roads

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c52d960af48328a76f8d454986151f