### PR TITLE
fix: display trainer options on first talk

### DIFF
--- a/scripts/trainer-ui.js
+++ b/scripts/trainer-ui.js
@@ -23,7 +23,8 @@
     const data = loadTrainerData();
     const upgrades = data[id] || [];
     const npc = globalThis.currentNPC;
-    const trainNode = npc?.tree?.train;
+    const tree = (typeof dialogState === 'object' && dialogState?.tree) || npc?.tree;
+    const trainNode = tree?.train;
     if(!trainNode) return false;
     const member = globalThis.party?.[memberIndex];
     const lead = typeof leader === 'function' ? leader() : null;
@@ -42,6 +43,7 @@
     });
     choices.push({ label: '(Back)', to: 'start' });
     trainNode.choices = choices;
+    if(npc?.tree && npc.tree !== tree) npc.tree.train = trainNode;
     return true;
   }
 


### PR DESCRIPTION
## Summary
- update TrainerUI to modify dialog state tree so training choices render immediately

## Testing
- `./install-deps.sh`
- `node scripts/supporting/presubmit.js`
- `npm test`
- `node scripts/supporting/balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'onclick'))*

------
https://chatgpt.com/codex/tasks/task_e_68c5259b6fd883288688f465c6a0ffa6