### PR TITLE
fix: show camp interface without masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-09-15
+- Camp interface now appears even when no masks are available.
+
 ## 2025-09-14
 - Bunker door now opens fast-travel map with fuel cost confirmation.
 

--- a/scripts/camp-persona.js
+++ b/scripts/camp-persona.js
@@ -37,18 +37,24 @@
     const member = state.party && state.party[0];
     if (!member || !overlay || !list) return;
     const ids = Object.keys(state.personas || {});
-    if (!ids.length) return;
     list.innerHTML = '';
-    ids.forEach(id => {
-      const b = document.createElement('button');
-      b.className = 'btn';
-      b.textContent = id;
-      b.addEventListener('click', () => {
-        overlay.classList.remove('shown');
-        gs.applyPersona(member.id, id);
-      }, { once: true });
-      list.appendChild(b);
-    });
+    if (!ids.length) {
+      const msg = document.createElement('div');
+      msg.className = 'muted';
+      msg.textContent = 'No masks available';
+      list.appendChild(msg);
+    } else {
+      ids.forEach(id => {
+        const b = document.createElement('button');
+        b.className = 'btn';
+        b.textContent = id;
+        b.addEventListener('click', () => {
+          overlay.classList.remove('shown');
+          gs.applyPersona(member.id, id);
+        }, { once: true });
+        list.appendChild(b);
+      });
+    }
     overlay.classList.add('shown');
   });
 })();

--- a/test/camp.test.js
+++ b/test/camp.test.js
@@ -47,6 +47,41 @@ test('camp:open heals party and shows persona menu', async () => {
   assert.ok(!overlay.classList.contains('shown'));
 });
 
+test('camp:open shows message when no personas', async () => {
+  const dom = new JSDOM('<!doctype html><body><div class="overlay" id="personaOverlay"><div class="persona-window"><div id="personaList" class="persona-list"></div><button id="closePersonaBtn" class="btn"></button></div></div></body>', { pretendToBeVisual: true });
+  const { document } = dom.window;
+  const bus = new EventEmitter();
+  let healed = false;
+  const healAll = () => { healed = true; };
+  const gs = {
+    getState: () => ({ party: [{ id: 'p1', name: 'Hero' }], personas: {} }),
+    applyPersona: () => {}
+  };
+  const party = [{ id: 'p1', name: 'Hero', hydration: 0 }];
+  party.x = 0; party.y = 0;
+  const state = { map: 'world' };
+  const sandbox = {
+    EventBus: bus,
+    Dustland: { gameState: gs, zoneEffects: [] },
+    document,
+    healAll,
+    log: () => {},
+    party,
+    state,
+    updateHUD: () => {}
+  };
+  sandbox.globalThis = sandbox;
+  const code = await fs.readFile(new URL('../scripts/camp-persona.js', import.meta.url), 'utf8');
+  vm.runInNewContext(code, sandbox);
+  bus.emit('camp:open');
+  assert.ok(healed);
+  const overlay = document.getElementById('personaOverlay');
+  assert.ok(overlay.classList.contains('shown'));
+  const btn = document.querySelector('#personaList .btn');
+  assert.ok(!btn);
+  assert.match(document.getElementById('personaList').textContent, /No masks/);
+});
+
 test('camp:open blocked in dry or damaging zones', async () => {
   const dom = new JSDOM('<!doctype html><body><div class="overlay" id="personaOverlay"><div class="persona-window"><div id="personaList" class="persona-list"></div><button id="closePersonaBtn" class="btn"></button></div></div></body>', { pretendToBeVisual: true });
   const { document } = dom.window;


### PR DESCRIPTION
## Summary
- ensure camp overlay always displays, showing a message when no masks are available
- test camp flow with and without personas
- document camp overlay behavior

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4a22df470832884f06c113727001b