### PR TITLE
fix: stack combat bars and amber party xp

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -168,22 +168,6 @@ input[type="range"] {
         background: #f55
     }
 
-    .hudbar.adrwrap {
-      padding-right: 10px;
-      overflow: visible;
-      box-sizing: border-box;
-    }
-
-    .hudbar .adrpie {
-      position: absolute;
-      top: -2px;
-      right: -2px;
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-      border: 1px solid #273027;
-      background: conic-gradient(#d98b8b var(--adr-angle,0deg), #273027 var(--adr-angle,0deg));
-    }
 
     .status-row {
         display: flex;
@@ -395,7 +379,7 @@ input[type="range"] {
 }
 .xpbar .fill {
   height: 100%;
-  background: #8bd98d;
+  background: #d9b98b;
   transition: width .2s;
 }
 .xpbar:hover {

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -170,7 +170,7 @@ function renderCombat(){
     setPortraitDiv(p, m);
     wrap.appendChild(p);
 
-    const hp  = document.createElement('div'); hp.className  = 'hudbar adrwrap'; hp.style.width = '48px';
+    const hp  = document.createElement('div'); hp.className  = 'hudbar'; hp.style.width = '48px';
     if (typeof hp.setAttribute === 'function') {
       hp.setAttribute('role','progressbar');
       hp.setAttribute('aria-label','Health');
@@ -180,19 +180,19 @@ function renderCombat(){
     }
     const hpf = document.createElement('div'); hpf.className = 'fill';
     hpf.style.width = Math.max(0, Math.min(100, (m.hp / (m.maxHp || 1)) * 100)) + '%';
-    hp.appendChild(hpf);
-    const pie = document.createElement('div'); pie.className = 'adrpie';
-    if (typeof pie.setAttribute === 'function') {
-      pie.setAttribute('role','progressbar');
-      pie.setAttribute('aria-label','Adrenaline');
-      pie.setAttribute('aria-valuemin','0');
-      pie.setAttribute('aria-valuemax', m.maxAdr || 1);
-      pie.setAttribute('aria-valuenow', m.adr || 0);
+    hp.appendChild(hpf); wrap.appendChild(hp);
+
+    const adr  = document.createElement('div'); adr.className  = 'hudbar adr'; adr.style.width = '48px';
+    if (typeof adr.setAttribute === 'function') {
+      adr.setAttribute('role','progressbar');
+      adr.setAttribute('aria-label','Adrenaline');
+      adr.setAttribute('aria-valuemin','0');
+      adr.setAttribute('aria-valuemax', m.maxAdr || 1);
+      adr.setAttribute('aria-valuenow', m.adr || 0);
     }
-    const adrPct = Math.max(0, Math.min(100, ((m.adr || 0) / (m.maxAdr || 1)) * 100));
-    pie.style.setProperty('--adr-angle', (adrPct * 3.6) + 'deg');
-    hp.appendChild(pie);
-    wrap.appendChild(hp);
+    const adrf = document.createElement('div'); adrf.className = 'fill';
+    adrf.style.width = Math.max(0, Math.min(100, ((m.adr || 0) / (m.maxAdr || 1)) * 100)) + '%';
+    adr.appendChild(adrf); wrap.appendChild(adr);
 
     const lab = document.createElement('div'); lab.className = 'label'; lab.textContent = m.name || '';
     wrap.appendChild(lab);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1534,7 +1534,7 @@ test('combat hp bars update after damage', async () => {
   assert.strictEqual(res.result, 'loot');
 });
 
-test('party adrenaline pie reflects adr percent', async () => {
+test('party adrenaline bar reflects adr percent', async () => {
   party.length = 0;
   player.inv.length = 0;
   const m1 = new Character('p1','P1','Role');
@@ -1548,13 +1548,14 @@ test('party adrenaline pie reflects adr percent', async () => {
     { name:'E1', hp:1, maxHp:1 }
   ]);
 
-  const pie = combatParty.children[0].children[1].children[1];
-  assert.strictEqual(pie.style.getPropertyValue('--adr-angle'), '180deg');
-  if (typeof pie.getAttribute === 'function') {
-    assert.strictEqual(pie.getAttribute('role'), 'progressbar');
-    assert.strictEqual(pie.getAttribute('aria-valuenow'), '50');
-    assert.strictEqual(pie.getAttribute('aria-valuemax'), '100');
-    assert.strictEqual(pie.getAttribute('aria-valuemin'), '0');
+  const adr = combatParty.children[0].children[2];
+  const fill = adr.children[0];
+  assert.strictEqual(fill.style.width, '50%');
+  if (typeof adr.getAttribute === 'function') {
+    assert.strictEqual(adr.getAttribute('role'), 'progressbar');
+    assert.strictEqual(adr.getAttribute('aria-valuenow'), '50');
+    assert.strictEqual(adr.getAttribute('aria-valuemax'), '100');
+    assert.strictEqual(adr.getAttribute('aria-valuemin'), '0');
   }
 
   handleCombatKey({ key:'Enter' });


### PR DESCRIPTION
## Summary
- show separate health and adrenaline bars under combat portraits
- use amber fill for party XP bar

## Testing
- `npm test` *(fails: apply upgrade via effect — expected 5 got 4)*
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c535404220832897f0c0a77ca48803