### PR TITLE
feat: pulse player indicator

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -498,8 +498,13 @@ function render(gameState=state, dt){
     else if(layer==='entitiesBelow'){ drawEntities(ctx, below, offX, offY); }
     else if(layer==='player'){
       const px=(pos.x-camX+offX)*TS, py=(pos.y-camY+offY)*TS;
-      ctx.fillStyle='#d9ffbe'; ctx.fillRect(px,py,TS,TS);
-      ctx.fillStyle='#000'; ctx.fillText('@',px+4,py+12);
+      const cx=px+TS/2, cy=py+TS/2;
+      const pulse=1+0.1*Math.sin(Date.now()/200);
+      const size=TS*pulse;
+      ctx.fillStyle='#d9ffbe';
+      ctx.fillRect(cx-size/2,cy-size/2,size,size);
+      ctx.fillStyle='#000';
+      ctx.fillText('@',cx-4,cy+4);
     }
     else if(layer==='entitiesAbove'){ drawEntities(ctx, above, offX, offY); }
   }


### PR DESCRIPTION
## Summary
- softly pulse player indicator by scaling its tile each frame

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c609adec54832897d71d0ecd7345c6