### PR TITLE
fix: restore trainer upgrade options when dialog state lacks train node

### DIFF
--- a/scripts/trainer-ui.js
+++ b/scripts/trainer-ui.js
@@ -23,9 +23,12 @@
     const data = loadTrainerData();
     const upgrades = data[id] || [];
     const npc = globalThis.currentNPC;
-    const tree = (typeof dialogState === 'object' && dialogState?.tree) || npc?.tree;
-    const trainNode = tree?.train;
+    const npcTree = npc?.tree;
+    const dsTree = typeof dialogState === 'object' ? dialogState?.tree : null;
+    const trainNode = dsTree?.train || npcTree?.train;
     if(!trainNode) return false;
+    if(dsTree && !dsTree.train) dsTree.train = trainNode;
+    if(npcTree && !npcTree.train) npcTree.train = trainNode;
     const lead = typeof leader === 'function' ? leader() : null;
     trainNode.text = `Skill Points: ${lead?.skillPoints || 0}`;
     const choices = upgrades.map(up => {
@@ -42,7 +45,6 @@
     });
     choices.push({ label: '(Back)', to: 'start' });
     trainNode.choices = choices;
-    if(npc?.tree && npc.tree !== tree) npc.tree.train = trainNode;
     return true;
   }
 

--- a/test/trainer-ui.test.js
+++ b/test/trainer-ui.test.js
@@ -41,6 +41,17 @@ test('render trainer options with stat deltas', () => {
   assert.ok(choices[0].label.includes('4→5'));
 });
 
+test('uses npc tree when dialog state lacks train node', () => {
+  const { context, npc } = setup();
+  context.dialogState = { tree: {} };
+  const m = context.makeMember('id', 'Name', 'Role');
+  context.party.push(m);
+  const ok = context.TrainerUI.showTrainer('power', 0);
+  assert.strictEqual(ok, true);
+  assert.strictEqual(npc.tree.train.choices.length, 3);
+  assert.strictEqual(context.dialogState.tree.train.choices.length, 3);
+});
+
 test('apply upgrade via effect', () => {
   const { context, npc } = setup();
   const lead = context.makeMember('lead', 'Lead', 'Role');


### PR DESCRIPTION
## Summary
- fall back to NPC dialog tree when dialog state is missing `train`
- sync train node to both trees
- test trainer UI without dialog train node

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'onclick'))*

------
https://chatgpt.com/codex/tasks/task_e_68c607505e2c8328a493ecd4b1ef70e5