### PR TITLE
feat: default NPC colors and player icon

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -398,7 +398,8 @@
           <label>Name<input id="npcName" placeholder="NPC name" /></label>
           <label>Title<input id="npcTitle" placeholder="NPC title" /></label>
           <label>Description<textarea id="npcDesc" rows="2"></textarea></label>
-          <label>Color<input id="npcColor" type="color" value="#9ef7a0" /></label>
+          <label><input type="checkbox" id="npcColorOverride"> Override Color</label>
+          <label id="npcColorWrap" style="display:none">Color<input id="npcColor" type="color" value="#9ef7a0" /></label>
           <label>Symbol<input id="npcSymbol" maxlength="1" value="!" /></label>
           <label>Map<select id="npcMap"></select></label>
           <div class="xy">
@@ -417,6 +418,7 @@
           <label><input type="checkbox" id="npcPortraitLock" checked> Lock Portrait</label>
           <label><input type="checkbox" id="npcHidden"> Hidden NPC</label>
           <label><input type="checkbox" id="npcLocked"> Locked NPC</label>
+          <label><input type="checkbox" id="npcInanimate"> Inanimate</label>
           <div id="revealOpts" style="display:none">
             <label>Flag Type<select id="npcFlagType"><option value="visits">Visited Tile</option><option value="party">Party Flag</option></select></label>
             <div id="revealVisit">

--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -139,6 +139,7 @@
               const n = NPCS.find(n => n.id === eff.npcId);
               if (n) {
                 n.color = eff.color;
+                n.overrideColor = true;
                 if (typeof render === 'function') render();
               }
             }

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -498,8 +498,13 @@ function render(gameState=state, dt){
     else if(layer==='entitiesBelow'){ drawEntities(ctx, below, offX, offY); }
     else if(layer==='player'){
       const px=(pos.x-camX+offX)*TS, py=(pos.y-camY+offY)*TS;
-      ctx.fillStyle='#d9ffbe'; ctx.fillRect(px,py,TS,TS);
-      ctx.fillStyle='#000'; ctx.fillText('@',px+4,py+12);
+      const cx = px + TS/2, cy = py + TS/2;
+      ctx.fillStyle='#f0f';
+      ctx.beginPath(); ctx.arc(cx, cy, TS/2 - 2, 0, Math.PI*2); ctx.fill();
+      ctx.strokeStyle='#f0f';
+      ctx.lineWidth=2;
+      ctx.beginPath(); ctx.arc(cx, cy, TS/2 + 2, 0, Math.PI*2); ctx.stroke();
+      ctx.fillStyle='#fff'; ctx.fillText('@',px+4,py+12);
     }
     else if(layer==='entitiesAbove'){ drawEntities(ctx, above, offX, offY); }
   }
@@ -519,13 +524,30 @@ function render(gameState=state, dt){
   ctx.strokeRect(0.5,0.5,vW*TS-1,vH*TS-1);
 }
 
+function getNpcColor(n){
+  if(n.overrideColor && n.color) return n.color;
+  if(n.trainer) return '#ffcc99';
+  if(n.shop) return '#ffee99';
+  if(n.inanimate) return '#d4af37';
+  if(n.questId || n.quests) return '#cc99ff';
+  if((n.combat && !n.tree) || n.attackOnSight) return '#f88';
+  return '#9ef7a0';
+}
+
+function getNpcSymbol(n){
+  if(n.symbol) return n.symbol;
+  if(n.inanimate) return '?';
+  if(n.questId || n.quests) return '★';
+  return '!';
+}
+
 function drawEntities(ctx, list, offX, offY){
   const { w:vW, h:vH } = getViewSize();
   for(const n of list){
     if(n.x>=camX&&n.y>=camY&&n.x<camX+vW&&n.y<camY+vH){
       const vx=(n.x-camX+offX)*TS, vy=(n.y-camY+offY)*TS;
-      ctx.fillStyle=n.color; ctx.fillRect(vx,vy,TS,TS);
-      ctx.fillStyle='#000'; ctx.fillText(n.symbol || '!',vx+5,vy+12);
+      ctx.fillStyle=getNpcColor(n); ctx.fillRect(vx,vy,TS,TS);
+      ctx.fillStyle='#000'; ctx.fillText(getNpcSymbol(n),vx+5,vy+12);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add default NPC colors and symbols with optional override in editor and engine
- render player as magenta circle with @ overlay
- allow npcColor effect to mark colors as overrides

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js` *(fails: TypeError: Cannot set properties of null (setting 'onclick'))*

------
https://chatgpt.com/codex/tasks/task_e_68c6985014d08328b13ad75ccc9c95c7