### PR TITLE
feat: promote trainer effect to core engine

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2976,8 +2976,6 @@ function handleCustomEffects(list) {
   return (list ?? []).map(e => {
     if (!e || typeof e !== 'object') return e;
     switch (e.effect) {
-      case 'showTrainer':
-        return () => TrainerUI?.showTrainer?.(e.trainer);
       case 'pullSlots':
         return () => pullSlots(e.cost, e.payouts);
       case 'buyMemoryWorm':

--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -84,6 +84,9 @@
           case 'openWorkbench':
             globalThis.Dustland?.openWorkbench?.();
             break;
+          case 'showTrainer':
+            if (eff.trainer) TrainerUI?.showTrainer?.(eff.trainer);
+            break;
           case 'addFlag': {
             const p = ctx.party || globalThis.party;
             if (p) {

--- a/scripts/core/npc.js
+++ b/scripts/core/npc.js
@@ -105,7 +105,7 @@ function makeNPC(id, map, x, y, color, name, title, desc, tree, quest, processNo
       tree.start.choices.unshift({
         label: '(Upgrade Skills)',
         to: 'train',
-        effects: [() => TrainerUI?.showTrainer?.(opts.trainer)]
+        effects: [{ effect: 'showTrainer', trainer: opts.trainer }]
       });
     }
     tree.train = tree.train ?? { text: '', choices: [{ label: '(Back)', to: 'start' }] };


### PR DESCRIPTION
## Summary
- support `showTrainer` effect in core engine
- emit `showTrainer` effect from trainer NPCs
- drop trainer-specific effect shim from dustland module
- update trainer NPC tests to use engine effects

## Testing
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/placement-check.js modules/dustland.module.js`
- `node scripts/supporting/balance-tester-agent.js` *(fails: Cannot set properties of null)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c699f7d22c8328899504d5603555ce