### PR TITLE
fix: show auto-combat NPCs as red on minimap

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -391,6 +391,7 @@ function getNpcColor(n) {
   if (n.shop) return '#ffee99';
   if (n.inanimate) return '#d4af37';
   if (n.questId || n.quests) return '#cc99ff';
+  if (n.combat?.auto) return '#f00';
   if ((n.combat && !n.tree) || n.attackOnSight) return '#f88';
   return '#9ef7a0';
 }

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -530,6 +530,7 @@ function getNpcColor(n){
   if(n.shop) return '#ffee99';
   if(n.inanimate) return '#d4af37';
   if(n.questId || n.quests) return '#cc99ff';
+  if(n.combat?.auto) return '#f00';
   if((n.combat && !n.tree) || n.attackOnSight) return '#f88';
   return '#9ef7a0';
 }

--- a/test/npc-color.test.js
+++ b/test/npc-color.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { createGameProxy } from './test-harness.js';
+
+const { context } = createGameProxy({});
+
+test('auto combat NPCs are red', () => {
+  const npc = { combat: { auto: true } };
+  assert.strictEqual(context.getNpcColor(npc), '#f00');
+});
+
+test('non-auto hostile NPCs are pink', () => {
+  const npc = { combat: {}, tree: null };
+  assert.strictEqual(context.getNpcColor(npc), '#f88');
+});


### PR DESCRIPTION
## Summary
- show auto-combat NPCs in red on minimap in engine and Adventure Kit
- test NPC color logic for auto and non-auto combat

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js` *(fails: Cannot set properties of null (setting 'onclick'))*


------
https://chatgpt.com/codex/tasks/task_e_68c69bdeaa6c8328a485de1133a44b56