### PR TITLE
fix: sync trainer options with dialog

### DIFF
--- a/scripts/trainer-ui.js
+++ b/scripts/trainer-ui.js
@@ -45,6 +45,7 @@
     });
     choices.push({ label: '(Back)', to: 'start' });
     trainNode.choices = choices;
+    trainNode.next = choices;
     return true;
   }
 

--- a/test/trainer-ui.test.js
+++ b/test/trainer-ui.test.js
@@ -50,6 +50,7 @@ test('uses npc tree when dialog state lacks train node', () => {
   assert.strictEqual(ok, true);
   assert.strictEqual(npc.tree.train.choices.length, 3);
   assert.strictEqual(context.dialogState.tree.train.choices.length, 3);
+  assert.strictEqual(context.dialogState.tree.train.next.length, 3);
 });
 
 test('apply upgrade via effect', () => {


### PR DESCRIPTION
## Summary
- keep trainer dialog choices in sync with normalized dialog tree
- verify trainer UI populates `next` options

## Testing
- `node scripts/supporting/presubmit.js`
- `npm test`
- `node scripts/supporting/balance-tester-agent.js` *(fails: TypeError: Cannot set properties of null (setting 'onclick'))*

------
https://chatgpt.com/codex/tasks/task_e_68c6a16fc1d483289dae5343e88b55cb