### PR TITLE
feat: limit module picker to five scrollable options

### DIFF
--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -200,6 +200,7 @@ function showModulePicker(){
       if (i === selectedIndex) {
         btn.className = 'btn selected';
         if (btn.focus) btn.focus();
+        btn.scrollIntoView?.({ block: 'nearest' });
       } else {
         btn.className = 'btn';
       }
@@ -216,6 +217,9 @@ function showModulePicker(){
     buttons.push(btn);
     buttonContainer.appendChild(btn);
   });
+  const btnHeight = buttons[0]?.offsetHeight || 32;
+  buttonContainer.style.maxHeight = `${(btnHeight + 8) * 5}px`;
+  buttonContainer.style.overflowY = 'auto';
   updateSelected();
 
   overlay.tabIndex = 0;

--- a/test/module-picker.test.js
+++ b/test/module-picker.test.js
@@ -128,6 +128,13 @@ test('arrow keys cycle module selection', () => {
   assert.ok(buttons[1].className.includes('selected'));
 });
 
+test('module picker limits visible options and enables scrolling', () => {
+  const overlay = bodyEl.children.find(c => c.id === 'modulePicker');
+  const container = overlay.querySelector('#moduleButtons');
+  assert.strictEqual(container.style.overflowY, 'auto');
+  assert.strictEqual(container.style.maxHeight, '200px');
+});
+
 test('broadcast story points to first fragment', () => {
   const broadcast = MODULES.find(m => m.id === 'broadcast');
   assert.ok(broadcast);


### PR DESCRIPTION
## Summary
- limit module picker to five items and enable scrolling for extras
- keep selection in view while navigating
- test module picker scroll behavior

## Testing
- `node scripts/supporting/presubmit.js dustland.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f9b4b5488328a5312e1dc0e66af0