### PR TITLE
fix: handle fast travel bunker registration

### DIFF
--- a/scripts/core/fast-travel.js
+++ b/scripts/core/fast-travel.js
@@ -1,6 +1,7 @@
 (function(){
-  const bus = (globalThis.Dustland && globalThis.Dustland.eventBus) || globalThis.EventBus;
-  const bunkers = globalThis.Dustland?.bunkers || [];
+  const dl = globalThis.Dustland = globalThis.Dustland || {};
+  const bus = dl.eventBus || globalThis.EventBus;
+  const bunkers = dl.bunkers || (dl.bunkers = []);
   const BASE_COST = 1;
   const FUEL_PER_TILE = 1;
   const saveKey = id => `dustland_slot_${id}`;
@@ -38,6 +39,20 @@
     return true;
   }
 
+  function upsertBunkers(list){
+    if(!Array.isArray(list) || !list.length) return bunkers;
+    list.forEach(entry => {
+      if(!entry || !entry.id) return;
+      const existing = bunkers.find(b => b.id === entry.id);
+      if(existing){
+        Object.assign(existing, entry);
+      } else {
+        bunkers.push({ ...entry });
+      }
+    });
+    return bunkers;
+  }
+
   function saveSlot(id){
     if(!id || typeof save !== 'function' || !globalThis.localStorage) return;
     save();
@@ -63,7 +78,7 @@
   }
 
   globalThis.Dustland = globalThis.Dustland || {};
-  globalThis.Dustland.fastTravel = { fuelCost, travel, activateBunker , saveSlot, loadSlot};
+  globalThis.Dustland.fastTravel = { fuelCost, travel, activateBunker , saveSlot, loadSlot, upsertBunkers };
   globalThis.openWorldMap = globalThis.openWorldMap || function(id){
     globalThis.Dustland?.worldMap?.open?.(id);
   };

--- a/test/world-map-fast-travel.test.js
+++ b/test/world-map-fast-travel.test.js
@@ -1,0 +1,58 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+test('fast travel merges remote module bunkers for cost calculations', async () => {
+  const context = {
+    console,
+    EventBus: { emit(){}, on(){} },
+    log(){},
+    save(){},
+    load(){},
+    player: {},
+    party: {},
+    localStorage: {
+      getItem(){ return null; },
+      setItem(){},
+      removeItem(){}
+    }
+  };
+  context.globalThis = context;
+  context.Dustland = { eventBus: context.EventBus, bunkers: [] };
+
+  const fastTravelSrc = readFileSync(new URL('../scripts/core/fast-travel.js', import.meta.url), 'utf8');
+  vm.runInNewContext(fastTravelSrc, context);
+
+  const fastTravel = context.Dustland.fastTravel;
+  fastTravel.upsertBunkers([{ id: 'edge', x: 5, y: 5, map: 'world', module: 'edge', active: true }]);
+  assert.strictEqual(fastTravel.fuelCost('edge', 'alpha'), Infinity);
+
+  context.Dustland.currentModule = 'edge';
+  context.Dustland.moduleProps = { edge: { fastTravelModules: [{ global: 'WORLD_ONE_MODULE' }] } };
+  context.Dustland.loadedModules = {};
+  context.WORLD_ONE_MODULE = {
+    name: 'world-one',
+    buildings: [
+      { bunker: true, bunkerId: 'alpha', x: 20, y: 21, doorX: 22, doorY: 23, boarded: false }
+    ]
+  };
+
+  const worldMapSrc = readFileSync(new URL('../scripts/ui/world-map.js', import.meta.url), 'utf8');
+  vm.runInNewContext(worldMapSrc, context);
+
+  const gather = context.Dustland.worldMap._gatherBunkers;
+  assert.ok(typeof gather === 'function');
+
+  const bunkers = await new Promise(resolve => gather(resolve));
+  assert.ok(bunkers.some(b => b.id === 'alpha'));
+
+  const globalEntry = context.Dustland.bunkers.find(b => b.id === 'alpha');
+  assert.ok(globalEntry, 'remote bunker was registered globally');
+  assert.strictEqual(globalEntry.x, 22);
+  assert.strictEqual(globalEntry.y, 23);
+
+  const cost = fastTravel.fuelCost('edge', 'alpha');
+  assert.strictEqual(cost, 1 + Math.abs(5 - 22) + Math.abs(5 - 23));
+  assert.ok(Number.isFinite(cost));
+});


### PR DESCRIPTION
## Summary
- ensure the fast travel module owns the bunker list and exposes an upsert helper for callers
- register remote-module bunkers when gathering world map destinations and surface fuel issues through in-game messaging
- add a regression test that exercises cross-module bunker discovery and fuel cost calculation

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68c9b833876c8328b3000f769cc6c0b2