### PR TITLE
fix: align npc icon colors in dustland

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -927,7 +927,7 @@ const DATA = `
       "map": "world",
       "x": 15,
       "y": 21,
-      "color": "#f66",
+      "color": "#ff0000",
       "name": "Nora",
       "title": "Storm Caller",
       "desc": "Crackling energy dances across her gauntlet.",
@@ -955,7 +955,8 @@ const DATA = `
         },
         "auto": true
       },
-      "symbol": "!"
+      "symbol": "!",
+      "overrideColor": true
     },
     {
       "id": "party_tess",
@@ -1689,7 +1690,7 @@ const DATA = `
       "map": "world",
       "x": 32,
       "y": 48,
-      "color": "#f66",
+      "color": "#ff0000",
       "name": "Scavenger Rat",
       "title": "Vermin",
       "desc": "A giant rat rooting through scraps.",
@@ -1712,7 +1713,8 @@ const DATA = `
         "loot": "water_flask",
         "auto": true
       },
-      "symbol": "!"
+      "symbol": "!",
+      "overrideColor": true
     },
     {
       "id": "rust_bandit",


### PR DESCRIPTION
## Summary
- set party_nora's map icon color override to pure red so it matches other hostiles
- apply the same explicit red override to scavenger_rat for consistent presentation

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68c9bf338bd48328b8bc3be68e820c56