### PR TITLE
docs: constrain design tasks to sub-1k loc work

### DIFF
--- a/docs/design/in-progress/oasis-trader.md
+++ b/docs/design/in-progress/oasis-trader.md
@@ -30,8 +30,9 @@
 - [x] Replace static shop NPC in `dustland.module.js` with a traveling trader.
 - [x] Give the trader an east-west patrol loop across the world map.
  - [x] Stock begins with scavenged gear and upgrades across three refresh waves.
-- [ ] Tune prices so early upgrades land around 60–90 scrap per key stat bump, then ease discounts for players with positive grudge standings.
-- [ ] Reserve premium gear for end-of-week refreshes but keep sticker prices within twice the best wasteland drops so progression rewards skill instead of grind.
+- [ ] Calibrate early-upgrade price bands in `data/traders/oasis.json` and `scripts/core/trader.js` so stat bumps cost 60–90 scrap (target < 200 LOC leveraging existing price helpers).
+- [ ] Teach the trader grudge meter to award stacked discounts for positive standings and surface the math in the trade UI (target < 220 LOC across logic and UI copy).
+- [ ] Define the premium gear weekly rotation tables and cap their prices at 2× top wasteland drops, plus add a regression test covering the refresh window (target < 240 LOC including data + test harness).
 
 ## Risks
 - Long refresh timers may stall players lacking supplies.

--- a/docs/design/in-progress/persona-mechanics.md
+++ b/docs/design/in-progress/persona-mechanics.md
@@ -86,13 +86,33 @@ Persona equips and other world moments should fire through the game's event bus.
 
 - [x] Prototype persona equip UI at camps (any loot cache mask should be equippable here and yield a persona).
  - [x] Hook persona stat modifiers into combat calculations.
-- [ ] Draft first mask memory quest for dustland.
+- [ ] Draft first mask memory quest for dustland (< 600 LOC across quest data, dialog, and tests).
   - [x] create an NPC mask giver (name TBD)
-  - [ ] create quest to get a persona mask (anything with the mask attribute from a loot cache)
-  - [ ] add dialog to this NPC that explains the above lore about how these aren't just disguises
+  - [ ] Use `scripts/module-tools/quests.js add` to create the fetch quest and follow-up memory beats (target < 150 LOC by extendi
+ng existing quest schema fields).
+  - [ ] Script quest triggers and rewards in `modules/dustland.module.js` using CLI helpers so the mask item flows through the jo
+urnal (target < 160 LOC).
+  - [ ] add dialog to this NPC that explains the above lore about how these aren't just disguises while updating journal entri
+es (target < 180 LOC).
+  - [ ] Add `test/persona-memory.test.js` to cover quest acceptance, completion, and persona unlock persistence (target < 100 LOC
+ by leveraging existing quest harnesses).
 - [x] Add portrait and label swap logic to the HUD.
-- [ ] Extend ACK schema and editor with reusable profile definitions.
- - [ ] Implement profile runtime service for personas, buffs, and disguises.
+- [ ] Extend ACK schema and editor with reusable profile definitions (target < 500 LOC split across schema + UI updates).
+  - [ ] Expand `scripts/module-tools/schema.js` and related prompts to expose `profiles` arrays (target < 180 LOC).
+  - [ ] Update `scripts/adventure-kit.js` to render profile pickers inside character/item inspectors (target < 220 LOC).
+  - [ ] Document the new profile JSON in `docs/guides/module-cli-tools.md` (target < 80 LOC).
+- [ ] Implement profile runtime service for personas, buffs, and disguises (target < 600 LOC across runtime + tests).
+  - [ ] Expand `scripts/core/profiles.js` to support stacked effect packs, removal hooks, and save serialization (target < 200 LOC
+).
+  - [ ] Wire the service into persona equip/unequip flows and the event bus in `scripts/camp-persona.js` and `scripts/event-bus.js
+` (target < 180 LOC).
+  - [ ] Add regression coverage in `test/profile-service.test.js` for stacking, persistence, and reload handling (target < 180 LOC
+).
 - [x] Emit `persona:equip` and `persona:unequip` events on the global bus.
 - [x] ensure load/save store the equipped persona.
-- [ ] Build editor inspector for authoring and testing effect packs into ACK.
+- [ ] Build editor inspector for authoring and testing effect packs into ACK (target < 650 LOC including UI + tests).
+  - [ ] Add a `components/wizard/effect-pack-inspector.js` panel with sortable effect lists and preview controls (target < 300 LOC
+).
+  - [ ] Teach `scripts/adventure-kit.js` to open the inspector from persona, item, and zone dialogs (target < 200 LOC).
+  - [ ] Cover the inspector with UI regression in `test/effect-pack-inspector.test.js` (target < 120 LOC using existing DOM fixtu
+res).

--- a/docs/design/in-progress/plot-draft.md
+++ b/docs/design/in-progress/plot-draft.md
@@ -176,13 +176,16 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
   - **Arc Detail:** Jax's arc is about overcoming his fear of scarcity and loss. He hoards resources and knowledge, afraid to share lest he be left with nothing. He'll learn that the caravan's strength lies in its community, not its individual stashes. He'll start by charging for every screw and bandage, but will end up building custom gear for his friends for free, his workshop becoming the heart of the caravan.
 - [x] Detail Nyx "Speaker"—a poet tuning radio static into verse; arc: chooses between broadcasting or listening.
   - **Arc Detail:** Nyx's arc is about finding her own voice. Initially, she sees herself as a mere conduit for the Ghost Signal, a passive listener. She'll discover that she has her own stories to tell, and that her poetry can be a source of hope and inspiration for the caravan. She will eventually have to choose between simply relaying the Ghost Signal's message or interpreting it and adding her own voice to it, potentially changing its meaning and impact.
-- [ ] **Implement Signature Encounters:**
+- [ ] **Implement Signature Encounters** (remaining integration < 480 LOC):
     - [x] Design and build Mara's dust storm navigation puzzle.
       - **Design:**
         - **Concept:** The player must navigate a maze-like canyon during a blinding dust storm. Visibility is near zero. The only guide is the sound of wind chimes, each with a unique pitch, that the player must follow in a specific sequence to find the safe path.
         - **Mechanics:** The player will have a new UI element that shows the direction and rough distance to the next chime. The player has to listen carefully to the pitch of the chimes to know which one to follow. Following the wrong chime will lead to dead ends, encounters with dangerous creatures, or getting lost in the storm, which drains resources.
         - **Integration:** This puzzle will be a key part of the "Broadcast Fragment 2: The Sunken City" module, where the caravan needs to cross a dangerous canyon to reach the city.
-    - [ ] Hook Mara's puzzle into the Broadcast Story sequence.
+    - [ ] Hook Mara's puzzle into the Broadcast Story sequence (target < 360 LOC across map wiring and tests).
+      - [ ] Insert the canyon puzzle map into `modules/broadcast-fragment-2.module.js` with a story flag gate and return path (target < 130 LOC).
+      - [ ] Update `modules/broadcast-fragment-2.module.js` quest steps and journal text so completion awards the compass hardware (target < 110 LOC).
+      - [ ] Add `test/mara-puzzle-story.test.js` to ensure the sequence loads, grants rewards, and reopens world travel (target < 120 LOC).
     - [x] Script Jax's timed repair sequence under combat pressure. Implemented in `jax-repair.module.js`.
     - [x] Write the dialogue and branching paths for Nyx's "conversational tuning" encounter.
       - **Concept:** Nyx needs to convince a hostile NPC to help the caravan. The NPC is emotionally volatile, and the player must choose the right dialogue options to "tune" into their emotional state and de-escalate the situation.
@@ -193,7 +196,7 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
             1.  (Empathetic) "It sounds like you've been hurt before. We're not here to take anything." -> NPC state shifts to Sad.
             2.  (Authoritative) "We need your help. Stand down." -> NPC state becomes more Angry.
             3.  (Logical) "We have resources to trade. It would be mutually beneficial." -> No change in NPC state.
-- [ ] **Doppelgänger System:**
+- [ ] **Doppelgänger System** (story integration remaining < 420 LOC):
     - [x] Create the data structure for "personas" that can be equipped by the main characters.
     - [x] Design and create the first set of alternate masks and outfits for Mara, Jax, and Nyx.
       - **Mara:**
@@ -207,41 +210,85 @@ The challenges our party faces shouldn't just be about combat. The wasteland is 
       - **Nyx:**
         - **Mask:** A porcelain mask with a single, painted tear, representing her sorrow for the lost world.
         - **Outfit:** A flowing robe made of salvaged silk, representing her artistic nature.
-        - **Alternate Persona "The Oracle":** A mask made of radio parts with glowing vacuum tubes and a practical, rugged outfit, representing her transformation into a proactive voice for the future.
-- [ ] **Implement Key Items:**
-    - [ ] Build the custom UI for the Signal Compass, including its ability to point to locations of emotional resonance.
-      - [ ] Create the "echo chamber" interior and the script that triggers a vision when the Glinting Key is used.
-    - [ ] Implement the Memory Tape's recording and playback functionality, and create an NPC who reacts to a recorded event.
-    - [ ] Wire branching quest infrastructure so every mission supports at least two outcomes with lasting effects.
-    - [ ] Persist NPC relationships and states so conversations evolve based on past decisions.
+      - **Alternate Persona "The Oracle":** A mask made of radio parts with glowing vacuum tubes and a practical, rugged outfit, representing her transformation into a proactive voice for the future.
+    - [ ] Script persona unlock set-pieces in each broadcast fragment module so the alternate masks drop at story-appropriate beats (target < 180 LOC across the three modules).
+    - [ ] Add branching dialogue in `modules/broadcast-fragment-3.module.js` reacting to which persona is equipped when confronting the Warden (target < 120 LOC).
+    - [ ] Cover the unlock flow with `test/doppelganger-story.test.js` to ensure personas persist between modules (target < 100 LOC).
+- [ ] **Implement Key Items** (target < 800 LOC across UI, modules, and tests):
+    - [ ] Build the custom UI for the Signal Compass, including its ability to point to locations of emotional resonance (target < 380 LOC).
+      - [ ] Add `components/signal-compass.js` overlay controls with pointer smoothing and audio cues (target < 180 LOC).
+      - [ ] Wire compass updates into `scripts/ui/world-map.js` and quest state watchers so hints respond to story progress (target < 120 LOC).
+      - [ ] Extend `test/signal-compass.test.js` with direction and resonance assertions (target < 60 LOC).
+      - [ ] Create the "echo chamber" interior and the script that triggers a vision when the Glinting Key is used (target < 160 LOC across module data and dialog).
+    - [ ] Implement the Memory Tape's recording and playback functionality, and create an NPC who reacts to a recorded event (target < 420 LOC).
+      - [ ] Teach `scripts/event-bus.js` and `scripts/core/quests.js` to flag notable events for capture while keeping serialization under 100 LOC (target < 160 LOC).
+      - [ ] Add a `components/memory-tape.js` playback UI and integrate it with the camp interface (target < 140 LOC).
+      - [ ] Script an NPC reaction sequence in `modules/dustland.module.js` plus cover it with `test/memory-tape-story.test.js` (target < 120 LOC).
+    - [ ] Wire branching quest infrastructure so every mission supports at least two outcomes with lasting effects (target < 520 LOC).
+      - [ ] Extend `scripts/core/quests.js` with branch nodes and fallout hooks (target < 180 LOC).
+      - [ ] Update `scripts/module-tools/schema.js` and CLI prompts to capture branch metadata (target < 160 LOC).
+      - [ ] Add `test/quest-branches.test.js` ensuring divergent outcomes persist across module loads (target < 140 LOC).
+    - [ ] Persist NPC relationships and states so conversations evolve based on past decisions (target < 460 LOC).
+      - [ ] Add relationship tracking buckets to `scripts/core/npc.js` and ensure they save/load via `scripts/game-state.js` (target < 180 LOC).
+      - [ ] Update broadcast fragment modules with relationship deltas and gating checks (target < 120 LOC).
+      - [ ] Cover conversation shifts with `test/npc-relationship-story.test.js` (target < 120 LOC).
 
 #### **Phase 3: Puzzle and World Building**
-- [ ] **Design a radio tower alignment puzzle that tunes the broadcast.**
-  - Rotating pitch, gain, and phase dials brings the broadcast into focus while Silencer patrols home in on failed attempts.
-- [ ] **Implement the radio tower alignment puzzle with full UI and integration.**
-- [ ] **Design a dust storm navigation puzzle using wind chimes along ruined billboards:** Implemented in `mara-puzzle.module.js` with chime events and a dust storm effect.
-- [ ] **Design a layered graffiti decoding puzzle to reveal a safe route before the sun bleeds out.**
-   - A collapsed overpass hides directions beneath decades of gang tags; players cycle solvent sprays to reveal each era's markings and overlay them into a route.
-   - Picking the wrong sequence bathes the wall in false sunlight and draws a quick Silencer ambush before resetting.
-- [ ] Implement the layered graffiti decoding puzzle as an interactive module and hook it into the Broadcast Story sequence.
-- [ ] Introduce roaming encounter and event scheduler so the world reacts over time.
-- [ ] Link zones and portals to narrative flags, gating routes based on prior choices.
+- [ ] **Design a radio tower alignment puzzle that tunes the broadcast** (design doc update < 180 LOC).
+  - [ ] Outline dial states, failure conditions, and audio cues in this document (< 80 LOC).
+  - [ ] Provide an ASCII or UI sketch referencing `components/dial.js` for reviewers (< 40 LOC).
+  - [ ] List integration checkpoints for module authors and QA (< 40 LOC).
+- [ ] **Implement the radio tower alignment puzzle with full UI and integration** (target < 700 LOC across module, UI, and tests).
+  - [ ] Build `modules/radio-tower.module.js` with dial puzzle rooms and Silencer patrol hooks (target < 250 LOC).
+  - [ ] Extend `components/dial.js` usage in a new `components/radio-tower-panel.js` to drive the three alignment dials (target < 220 LOC).
+  - [ ] Cover the flow with `test/radio-tower-puzzle.test.js` to assert success/fail branches (target < 160 LOC).
+- [ ] **Design a dust storm navigation puzzle using wind chimes along ruined billboards** (document refinement < 120 LOC). Implemented in `mara-puzzle.module.js` with chime events and a dust storm effect.
+  - [ ] Document audio pitch mapping, failure penalties, and reset pacing (< 60 LOC).
+  - [ ] Add an annotated map snippet showing billboard placement and safe paths (< 40 LOC).
+- [ ] **Design a layered graffiti decoding puzzle to reveal a safe route before the sun bleeds out** (design brief < 180 LOC).
+  - [ ] Describe solvent spray sequencing, clue delivery, and ambush triggers (< 80 LOC).
+  - [ ] Note accessibility considerations, including colorblind cues and audio prompts (< 60 LOC).
+- [ ] Implement the layered graffiti decoding puzzle as an interactive module and hook it into the Broadcast Story sequence (target < 540 LOC).
+  - [ ] Author `modules/graffiti-decode.module.js` with multi-layer reveal logic and quest flag outputs (target < 220 LOC).
+  - [ ] Create UI overlays in `components/graffiti-overlay.js` for spray selection and clue tracking (target < 180 LOC).
+  - [ ] Add `test/graffiti-decode-story.test.js` ensuring broadcast progression and failure recovery (target < 120 LOC).
+- [ ] Introduce roaming encounter and event scheduler so the world reacts over time (target < 480 LOC building on the reactive systems scheduler).
+  - [ ] Register roaming encounter templates and spawn rules in `data/encounters/roaming.json` (target < 120 LOC).
+  - [ ] Hook the new scheduler ticks into `modules/dustland.module.js` so patrols appear between fragments (target < 160 LOC).
+  - [ ] Cover encounter cadence with `test/roaming-encounter-scheduler.test.js` (target < 140 LOC).
+- [ ] Link zones and portals to narrative flags, gating routes based on prior choices (target < 360 LOC).
+  - [ ] Add flag checks to `scripts/core/portals.js` and `modules/broadcast-fragment-*.module.js` entries (target < 180 LOC).
+  - [ ] Add `test/portal-flags-story.test.js` verifying locked/unlocked paths (target < 120 LOC).
 - [ ] **Build Reusable Widgets:**
     - [x] Create a generic "dial" widget for puzzles like the radio tower. Implemented in `scripts/ui/dial.js`.
-    - [ ] Develop a "sound-based navigation" system that can be used for the dust storm and other similar challenges.
+    - [ ] Develop a "sound-based navigation" system that can be used for the dust storm and other similar challenges (target < 320 LOC).
+      - [ ] Implement positional audio helpers in `scripts/ui/sound-nav.js` (target < 140 LOC).
+      - [ ] Expose controls through `components/sound-nav-debug.js` for tuning and tests (target < 100 LOC).
+      - [ ] Cover guidance cues in `test/sound-navigation.test.js` (target < 80 LOC).
 - [ ] **Flesh out the World:**
-    - [ ] Design the first major hub city, where the caravan can rest, resupply, and find new quests.
-  - Map central bazaar interior and connect east and west gates to the world map.
-  - Move prototype hub content into the Dustland module and remove standalone hub files.
-  - Place trader, quest givers, and rest triggers in the hub.
-  - Integrate future features directly into Dustland instead of separate prototypes.
-    - [ ] Create a detailed world map that shows the planned route of the caravan and the locations of the first three broadcast fragments.
+    - [ ] Design the first major hub city, where the caravan can rest, resupply, and find new quests (design + implementation < 520 LOC).
+      - [ ] Map the central bazaar interior and connect east and west gates to the world map in `modules/dustland.module.js` (target < 200 LOC).
+      - [ ] Move prototype hub content into the Dustland module and remove standalone hub files via the CLI (target < 140 LOC).
+      - [ ] Place trader, quest givers, and rest triggers in the hub with supporting dialog (target < 120 LOC).
+      - [ ] Integrate future features directly into Dustland instead of separate prototypes and document the migration plan here (< 60 LOC).
+    - [ ] Create a detailed world map that shows the planned route of the caravan and the locations of the first three broadcast fragments (target < 260 LOC).
+      - [ ] Update `components/world-map.js` art layers and overlays for the route preview (target < 140 LOC).
+      - [ ] Add map legend copy and tests verifying node visibility in `test/world-map-route.test.js` (target < 100 LOC).
 
 #### **Phase 4: Testing and Integration**
-- [ ] **Playtest the Narrative Arc:** Conduct a full playthrough of the first three broadcast fragment modules to ensure the story flows logically and the mystery unfolds at a compelling pace.
-  - [ ] **Test Character Arcs:** Get feedback on the signature encounters for each character to make sure they are both fun and effective at teaching the character's core mechanics.
- - [ ] **Puzzle Usability Testing:** Have players who are unfamiliar with the puzzles test them to ensure they are challenging but not frustrating. Implement quick resets based on their feedback.
-- [ ] **Modding Tools and Documentation:** Create a tutorial for the modding community that explains how to use the broadcast fragment system to create their own stories within the Dustland universe.
+- [ ] **Playtest the Narrative Arc** (documentation pass < 120 LOC): Conduct a full playthrough of the first three broadcast fragment modules to ensure the story flows logically and the mystery unfolds at a compelling pace.
+  - [ ] Log pacing issues, gating bugs, and rewards that feel off in a shared testing doc (< 40 LOC).
+  - [ ] File or update actionable tasks in the backlog for any blockers (< 40 LOC).
+  - [ ] Summarize key findings in this design doc so narrative owners can respond (< 30 LOC).
+- [ ] **Test Character Arcs** (feedback synthesis < 90 LOC): Get feedback on the signature encounters for each character to make sure they are both fun and effective at teaching the character's core mechanics.
+  - [ ] Collect qualitative notes from at least three playtesters per encounter (< 40 LOC).
+  - [ ] Translate feedback into dialog or encounter adjustment tickets (< 30 LOC).
+- [ ] **Puzzle Usability Testing** (iteration log < 90 LOC): Have players who are unfamiliar with the puzzles test them to ensure they are challenging but not frustrating. Implement quick resets based on their feedback.
+  - [ ] Capture reset counts, failure causes, and suggested hints in a shared sheet (< 40 LOC).
+  - [ ] Queue quick follow-up fixes (UI hints, fail messaging) in existing puzzle modules (< 40 LOC).
+- [ ] **Modding Tools and Documentation** (target < 200 LOC across tutorial + samples): Create a tutorial for the modding community that explains how to use the broadcast fragment system to create their own stories within the Dustland universe.
+  - [ ] Draft `docs/guides/broadcast-fragments.md` covering data schema, sequencing, and verification steps (< 120 LOC).
+  - [ ] Attach a sample fragment JSON and annotated screenshots for reference (< 60 LOC).
 
 ### Verification Instructions
 

--- a/docs/design/in-progress/reactive-systems.md
+++ b/docs/design/in-progress/reactive-systems.md
@@ -33,6 +33,11 @@
 - [x] Implement item narrative tagging in engine and Adventure Kit.
  - [x] Extend quest definitions to support branching and persistence.
  - [x] Add NPC memory storage and retrieval utilities.
-- [ ] Build event scheduler for world and NPC timelines.
+- [ ] Stand up the event scheduler core loop in `scripts/core/event-scheduler.js` (target < 250 LOC; reuse existing timer utilit
+ies).
+- [ ] Load world and NPC timeline definitions from module JSON via `scripts/module-loader.js` (target < 180 LOC; extend existing
+ schema objects rather than inventing new parsers).
+- [ ] Emit schedule-driven events and add regression tests covering world + NPC triggers in `test/event-scheduler.test.js` (targ
+et < 200 LOC combining implementation and tests).
 - [x] Allow zones and portals to register and check narrative flags.
 


### PR DESCRIPTION
## Summary
- spell out the remaining event-scheduler milestones in the reactive systems design so each chunk stays well under 1k LOC
- replace the Oasis Trader economy TODOs with concrete pricing, grudge, and premium rotation tasks scoped for small patches
- expand persona mechanics and plot draft action items with detailed subtasks and new test hooks so open work is broken into sub-1k LOC deliverables

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68c9caed8bac8328a550fc334f632f34