### PR TITLE
feat: add mask memory quest to true dust

### DIFF
--- a/docs/design/in-progress/persona-mechanics.md
+++ b/docs/design/in-progress/persona-mechanics.md
@@ -86,10 +86,10 @@ Persona equips and other world moments should fire through the game's event bus.
 
 - [x] Prototype persona equip UI at camps (any loot cache mask should be equippable here and yield a persona).
  - [x] Hook persona stat modifiers into combat calculations.
-- [ ] Draft first mask memory quest for dustland.
+- [x] Draft first mask memory quest for dustland.
   - [x] create an NPC mask giver (name TBD)
-  - [ ] create quest to get a persona mask (anything with the mask attribute from a loot cache)
-  - [ ] add dialog to this NPC that explains the above lore about how these aren't just disguises
+  - [x] create quest to get a persona mask (anything with the mask attribute from a loot cache)
+  - [x] add dialog to this NPC that explains the above lore about how these aren't just disguises
 - [x] Add portrait and label swap logic to the HUD.
 - [ ] Extend ACK schema and editor with reusable profile definitions.
  - [ ] Implement profile runtime service for personas, buffs, and disguises.

--- a/modules/true-dust.module.js
+++ b/modules/true-dust.module.js
@@ -286,14 +286,48 @@ const DATA = `
       "y": 5,
       "name": "Mask Hermit",
       "title": "Mask Giver",
-      "desc": "A cloaked figure offers a mask.",
+      "desc": "A cloaked hermit claims masks carry borrowed lives.",
       "tree": {
         "start": {
-          "text": "A cloaked figure offers a mask.",
+          "text": "The hermit traces glyphs across a blank mask, murmuring that personas are borrowed lives.",
           "choices": [
             {
-              "label": "(Take mask)",
-              "to": "give"
+              "label": "(Ask about the masks)",
+              "to": "lore"
+            },
+            {
+              "label": "(Accept the mask's memory)",
+              "to": "accept",
+              "q": "accept",
+              "if": {
+                "flag": "mask_memory_stage",
+                "op": "<",
+                "value": 1
+              },
+              "setFlag": {
+                "flag": "mask_memory_stage",
+                "op": "set",
+                "value": 1
+              }
+            },
+            {
+              "label": "(Offer recovered mask)",
+              "to": "do_turnin",
+              "q": "turnin",
+              "if": {
+                "flag": "mask_memory_stage",
+                "op": "=",
+                "value": 1
+              }
+            },
+            {
+              "label": "(Reflect on the persona)",
+              "to": "after",
+              "if": {
+                "flag": "mask_memory_stage",
+                "op": ">=",
+                "value": 2
+              }
             },
             {
               "label": "(Leave)",
@@ -301,17 +335,50 @@ const DATA = `
             }
           ]
         },
-        "give": {
-          "text": "The mask hums with strange energy.",
+        "give": null,
+        "lore": {
+          "text": "These aren't disguises, the hermit whispers. Slip one on and the past rides your pulse until you let go.",
           "choices": [
             {
-              "label": "(Thanks)",
-              "to": "bye",
-              "reward": "mara_mask"
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Bring me any mask you dredge up from the caches around Stonegate. The persona bound to it will wake when we share the ritual.",
+          "choices": [
+            {
+              "label": "(I'll return)",
+              "to": "bye"
+            }
+          ]
+        },
+        "do_turnin": {
+          "text": "He turns the scavenged mask in his hands, listening for the echo trapped inside.",
+          "choices": [
+            {
+              "label": "(Channel the memory)",
+              "to": "after",
+              "setFlag": {
+                "flag": "mask_memory_stage",
+                "op": "set",
+                "value": 2
+              }
+            }
+          ]
+        },
+        "after": {
+          "text": "The hermit presses the awakened mask into your hands and urges you to rest at camp so it can choose whose face to wear.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
             }
           ]
         }
-      }
+      },
+      "questId": "mask_memory"
     }
   ],
   "items": [
@@ -405,6 +472,16 @@ const DATA = `
       "id": "bandit_purge",
       "title": "Bandit Purge",
       "desc": "Help Mayor Ganton clear the road to Lakeside."
+    },
+    {
+      "id": "mask_memory",
+      "title": "Echoes in the Mask",
+      "desc": "Recover a mask from buried caches for the Mask Hermit.",
+      "itemTag": "mask",
+      "count": 1,
+      "reward": "mara_mask",
+      "xp": 4,
+      "autoStart": false
     }
   ],
   "portals": [
@@ -700,7 +777,10 @@ function postLoad(module) {
   if (bandit && bandit.combat) {
     bandit.combat.effects = [() => setFlag('bandits_cleared', 1)];
   }
-  module.quests?.forEach(q => addQuest(q.id, q.title, q.desc, q));
+  module.quests?.forEach(q => {
+    if (q && q.autoStart === false) return;
+    addQuest(q.id, q.title, q.desc, q);
+  });
 }
 
 globalThis.TRUE_DUST = JSON.parse(DATA);

--- a/test/true-dust.mask-quest.test.js
+++ b/test/true-dust.mask-quest.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const src = await fs.readFile(new URL('../modules/true-dust.module.js', import.meta.url), 'utf8');
+
+test('mask quest requires mask tag and manual start', async () => {
+  const added = [];
+  const context = {
+    setInterval: () => 0,
+    clearInterval: () => {},
+    setFlag: () => {},
+    addQuest: (...args) => { added.push(args); },
+    party: [],
+    dialogState: {},
+    console
+  };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(src, context);
+  const mod = context.TRUE_DUST;
+  mod.postLoad(mod);
+
+  const quest = mod.quests.find(q => q.id === 'mask_memory');
+  assert.ok(quest, 'mask quest is registered');
+  assert.strictEqual(quest.itemTag, 'mask');
+  assert.strictEqual(quest.count, 1);
+  assert.strictEqual(quest.reward, 'mara_mask');
+  assert.strictEqual(quest.autoStart, false);
+
+  assert.ok(added.some(([id]) => id === 'bandit_purge'));
+  assert.ok(!added.some(([id]) => id === 'mask_memory'));
+
+  const npc = mod.npcs.find(n => n.id === 'mask_giver');
+  assert.ok(npc, 'mask giver exists');
+  assert.strictEqual(npc.questId, 'mask_memory');
+  const accept = npc.tree.start.choices.find(c => c.q === 'accept');
+  assert.ok(accept, 'accept choice wired');
+  assert.strictEqual(accept.if.flag, 'mask_memory_stage');
+  assert.strictEqual(accept.setFlag?.value, 1);
+  const turnin = npc.tree.start.choices.find(c => c.q === 'turnin');
+  assert.ok(turnin, 'turn-in choice wired');
+  assert.strictEqual(turnin.if.value, 1);
+});


### PR DESCRIPTION
## Summary
- add a mask memory quest to the True Dust module with new quest data and NPC dialog
- gate auto quest activation so manual quests can opt out and log design doc progress
- cover the new behavior with a node-based unit test for quest wiring

## Testing
- node scripts/supporting/placement-check.js modules/true-dust.module.js
- node scripts/supporting/presubmit.js
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c9c9f79cec8328bb574afab309d923