### PR TITLE
feat: scope bunker travel networks

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -348,6 +348,13 @@
           <label for="moduleName">Module Name</label>
           <input type="text" id="moduleName" />
           </div>
+          <div style="padding:0px 13px 0px 0px;font-family: sans-serif;max-width:200px;">
+          <label for="moduleBunkerScope">Bunker Travel</label>
+          <select id="moduleBunkerScope">
+            <option value="global">Share across modules</option>
+            <option value="module">This module only</option>
+          </select>
+          </div>
           <button class="btn btn--primary" id="save" title="Download module as a JSON file">Save</button>
           <button class="btn" id="load" title="Load a module from a JSON file">Load</button>
         </div>

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -644,7 +644,9 @@ function placeHut(x,y,b={}){
     nb.bunkerId = bunkerId;
     const bunkers = (globalThis.Dustland ||= {}).bunkers || (globalThis.Dustland.bunkers = []);
     if (!bunkers.some(b => b.id === bunkerId)) {
-      const entry = { id: bunkerId, x: doorX, y: doorY, map: 'world', module: moduleName, name: moduleName, active: !boarded };
+      const ft = globalThis.Dustland?.fastTravel;
+      const network = typeof ft?.networkFor === 'function' ? ft.networkFor(moduleName) : 'global';
+      const entry = { id: bunkerId, x: doorX, y: doorY, map: 'world', module: moduleName, name: moduleName, active: !boarded, network };
       bunkers.push(entry);
     }
   }

--- a/scripts/ui/world-map.js
+++ b/scripts/ui/world-map.js
@@ -54,6 +54,8 @@
               name: moduleName || id,
               active: b.boarded !== true
             };
+            const network = ft?.networkFor?.(moduleName);
+            if(network) entry.network = network;
             ft?.upsertBunkers?.([entry]);
             const existing = result.find(r => r.id === id);
             if(existing){
@@ -93,7 +95,14 @@
       svg.style.background = '#222';
       svg.style.border = '2px solid #fff';
 
-      const dests = bunkers.filter(b => b.active && b.id !== fromId);
+      const ft = globalThis.Dustland?.fastTravel;
+      const origin = bunkers.find(b => b.id === fromId);
+      const originNet = origin?.network ?? (origin?.module ? ft?.networkFor?.(origin.module) : 'global');
+      const dests = bunkers.filter(b => {
+        if(!b.active || b.id === fromId) return false;
+        const destNet = b.network ?? (b.module ? ft?.networkFor?.(b.module) : 'global');
+        return (originNet ?? 'global') === (destNet ?? 'global');
+      });
       const pts = [];
       dests.forEach((b, i) => {
         ensureModule(b, () => {

--- a/test/world-map-fast-travel.test.js
+++ b/test/world-map-fast-travel.test.js
@@ -51,8 +51,57 @@ test('fast travel merges remote module bunkers for cost calculations', async () 
   assert.ok(globalEntry, 'remote bunker was registered globally');
   assert.strictEqual(globalEntry.x, 22);
   assert.strictEqual(globalEntry.y, 23);
+  assert.strictEqual(globalEntry.network, 'global');
 
   const cost = fastTravel.fuelCost('edge', 'alpha');
   assert.strictEqual(cost, 1 + Math.abs(5 - 22) + Math.abs(5 - 23));
   assert.ok(Number.isFinite(cost));
+});
+
+test('module-scoped bunkers remain local', async () => {
+  const context = {
+    console,
+    EventBus: { emit(){}, on(){} },
+    log(){},
+    save(){},
+    load(){},
+    player: {},
+    party: {},
+    localStorage: {
+      getItem(){ return null; },
+      setItem(){},
+      removeItem(){}
+    }
+  };
+  context.globalThis = context;
+  context.Dustland = { eventBus: context.EventBus, bunkers: [], moduleProps: { local: { bunkerTravelScope: 'module', fastTravelModules: [{ global: 'REMOTE_MODULE', module: 'remote' }] } }, loadedModules: { local: { name: 'local', seed: 1, props: { bunkerTravelScope: 'module' } } }, currentModule: 'local' };
+
+  const fastTravelSrc = readFileSync(new URL('../scripts/core/fast-travel.js', import.meta.url), 'utf8');
+  vm.runInNewContext(fastTravelSrc, context);
+
+  const fastTravel = context.Dustland.fastTravel;
+  fastTravel.upsertBunkers([{ id: 'local_a', x: 3, y: 3, map: 'world', module: 'local', active: true }]);
+  assert.strictEqual(context.Dustland.bunkers[0].network, 'module:local');
+
+  context.REMOTE_MODULE = {
+    name: 'remote',
+    buildings: [
+      { bunker: true, bunkerId: 'remote_a', x: 10, y: 10, doorX: 11, doorY: 11, boarded: false }
+    ]
+  };
+
+  const worldMapSrc = readFileSync(new URL('../scripts/ui/world-map.js', import.meta.url), 'utf8');
+  vm.runInNewContext(worldMapSrc, context);
+
+  const gather = context.Dustland.worldMap._gatherBunkers;
+  assert.ok(typeof gather === 'function');
+
+  await new Promise(resolve => gather(resolve));
+
+  const remoteEntry = context.Dustland.bunkers.find(b => b.id === 'remote_a');
+  assert.ok(remoteEntry, 'remote bunker registered');
+  assert.strictEqual(remoteEntry.network, 'global');
+
+  const cost = fastTravel.fuelCost('local_a', 'remote_a');
+  assert.strictEqual(cost, Infinity);
 });


### PR DESCRIPTION
## Summary
- allow fast travel bunkers to compute network scopes so module-only networks stay isolated
- add Adventure Kit controls to choose module or global bunker travel scope when editing modules
- extend tests to cover module-scoped bunkers and ensure remote bunkers keep global access when enabled

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cac3633afc8328acfcf0d4edef36bc