### PR TITLE
feat: add engine feature showcase module

### DIFF
--- a/modules/engine-tech-demo.module.js
+++ b/modules/engine-tech-demo.module.js
@@ -1,0 +1,1197 @@
+function seedWorldContent() {}
+
+const DATA = `
+{
+  "seed": "engine-tech-demo",
+  "start": {
+    "map": "world",
+    "x": 7,
+    "y": 7
+  },
+  "items": [
+    {
+      "id": "golden_coin",
+      "name": "Golden Coin",
+      "type": "quest",
+      "value": 1
+    },
+    {
+      "id": "thanks_medal",
+      "name": "Thanks Medal",
+      "type": "trinket",
+      "slot": "trinket",
+      "mods": {
+        "LCK": 1
+      },
+      "value": 10
+    },
+    {
+      "id": "bonus_potion",
+      "name": "Healing Potion",
+      "type": "consumable",
+      "use": {
+        "type": "heal",
+        "amount": 5
+      },
+      "value": 5
+    },
+    {
+      "map": "world",
+      "x": 6,
+      "y": 7,
+      "id": "spare_potion",
+      "name": "Spare Potion",
+      "type": "consumable",
+      "use": {
+        "type": "heal",
+        "amount": 5
+      },
+      "value": 5
+    },
+    {
+      "id": "makeshift_charge",
+      "name": "Makeshift Charge",
+      "type": "quest"
+    },
+    {
+      "map": "world",
+      "x": 8,
+      "y": 7,
+      "id": "chest_key",
+      "name": "Chest Key",
+      "type": "quest",
+      "tags": [
+        "key"
+      ]
+    },
+    {
+      "id": "demo_blade",
+      "name": "Vector Blade",
+      "type": "weapon",
+      "slot": "weapon",
+      "value": 25,
+      "desc": "Balanced energy blade",
+      "mods": {
+        "ATK": 3,
+        "ADR": 15
+      },
+      "tags": [
+        "sharp",
+        "energy"
+      ]
+    },
+    {
+      "id": "demo_plating",
+      "name": "Adaptive Plating",
+      "type": "armor",
+      "slot": "body",
+      "value": 30,
+      "desc": "Reconfigurable chest armor",
+      "mods": {
+        "DEF": 3,
+        "HP": 6
+      },
+      "tags": [
+        "heavy"
+      ]
+    },
+    {
+      "id": "demo_cache",
+      "name": "Calibration Cache",
+      "type": "spoils-cache",
+      "rank": "polished",
+      "map": "world",
+      "x": 10,
+      "y": 5
+    },
+    {
+      "id": "demo_cell",
+      "name": "Fuel Cell",
+      "type": "quest",
+      "value": 0,
+      "fuel": 10,
+      "desc": "Powers the generator",
+      "map": "world",
+      "x": 11,
+      "y": 6
+    }
+  ],
+  "quests": [
+    {
+      "id": "q_fetch",
+      "title": "Fetch the Coin",
+      "desc": "Retrieve the coin from the cabin.",
+      "item": "golden_coin",
+      "reward": "thanks_medal",
+      "xp": 2
+    },
+    {
+      "id": "q_upgrade",
+      "title": "Forge an Upgrade",
+      "desc": "Use the workbench to craft an upgraded blade.",
+      "item": "demo_cell",
+      "reward": "demo_blade",
+      "xp": 4
+    }
+  ],
+  "npcs": [
+    {
+      "id": "villager",
+      "map": "world",
+      "x": 7,
+      "y": 8,
+      "color": "#cfa",
+      "name": "Worried Villager",
+      "desc": "Lost a coin in the cabin.",
+      "prompt": "Anxious villager clutching an empty coin pouch",
+      "questId": "q_fetch",
+      "tree": {
+        "start": {
+          "text": "My lucky coin is in the cabin. Can you fetch it?",
+          "choices": [
+            {
+              "label": "(Accept)",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(INT) Any advance?",
+              "to": "advance",
+              "check": {
+                "stat": "INT",
+                "dc": 5
+              }
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "advance": {
+          "text": "Sharp mind! Take this potion.",
+          "choices": [
+            {
+              "label": "(Thanks)",
+              "to": "accept",
+              "reward": "bonus_potion",
+              "q": "accept"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Please bring it soon.",
+          "choices": [
+            {
+              "label": "(I have the coin)",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "You found it! Here is your reward.",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye",
+              "reward": "thanks_medal"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "chest",
+      "map": "cabin",
+      "x": 3,
+      "y": 2,
+      "color": "#ddf",
+      "name": "Dusty Chest",
+      "desc": "Maybe it holds the coin.",
+      "prompt": "Dusty wooden chest bound by a metal lock",
+      "symbol": "?",
+      "locked": true,
+      "tree": {
+        "locked": {
+          "text": "A locked chest sits here.",
+          "choices": [
+            {
+              "label": "(Use Key)",
+              "to": "open",
+              "once": true,
+              "reqItem": "chest_key",
+              "effects": [
+                {
+                  "effect": "unlockNPC",
+                  "npcId": "chest"
+                }
+              ]
+            },
+            {
+              "label": "(Use Explosive)",
+              "to": "open",
+              "once": true,
+              "reqItem": "makeshift_charge",
+              "effects": [
+                {
+                  "effect": "unlockNPC",
+                  "npcId": "chest"
+                }
+              ]
+            },
+            {
+              "label": "(Pry with Crowbar)",
+              "to": "crowbar_open",
+              "once": true,
+              "reqItem": "crowbar",
+              "effects": [
+                {
+                  "effect": "unlockNPC",
+                  "npcId": "chest"
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "open": {
+          "text": "The chest creaks open, revealing a shiny coin.",
+          "choices": [
+            {
+              "label": "(Take Coin)",
+              "to": "empty",
+              "reward": "golden_coin",
+              "effects": [
+                {
+                  "effect": "addFlag",
+                  "flag": "chest_looted"
+                }
+              ]
+            }
+          ]
+        },
+        "crowbar_open": {
+          "text": "The crowbar pops the lid with a squeal.",
+          "choices": [
+            {
+              "label": "(Take Coin)",
+              "to": "empty",
+              "reward": "golden_coin",
+              "effects": [
+                {
+                  "effect": "addFlag",
+                  "flag": "chest_looted"
+                }
+              ]
+            }
+          ]
+        },
+        "empty": {
+          "text": "The chest is empty.",
+          "choices": [
+            {
+              "label": "(Lock Chest)",
+              "to": "locked_empty",
+              "reqItem": "chest_key",
+              "effects": [
+                {
+                  "effect": "lockNPC",
+                  "npcId": "chest"
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "locked_empty": {
+          "text": "The chest is empty and locked.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "rat",
+      "map": "cabin",
+      "x": 5,
+      "y": 2,
+      "color": "#f88",
+      "name": "Big Rat",
+      "title": "Pest",
+      "desc": "It guards the cabin.",
+      "prompt": "Large cabin rat with matted fur",
+      "tree": {
+        "start": {
+          "text": "The rat snarls.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 4,
+        "ATK": 2,
+        "DEF": 0,
+        "loot": null,
+        "auto": true
+      }
+    },
+    {
+      "id": "bandit",
+      "map": "world",
+      "x": 12,
+      "y": 8,
+      "color": "#f66",
+      "name": "Sneaky Bandit",
+      "desc": "Blocks the path.",
+      "prompt": "Sneaky bandit with a crooked dagger",
+      "tree": {
+        "start": {
+          "text": "Hand over your loot!",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 6,
+        "ATK": 3,
+        "DEF": 1,
+        "loot": null,
+        "auto": true
+      }
+    },
+    {
+      "id": "scout",
+      "map": "world",
+      "x": 9,
+      "y": 6,
+      "color": "#afa",
+      "name": "Friendly Scout",
+      "desc": "Offers to join your journey.",
+      "prompt": "Friendly scout with travel gear",
+      "tree": {
+        "start": {
+          "text": "Need a companion?",
+          "choices": [
+            {
+              "label": "(Join me)",
+              "to": "join",
+              "join": {
+                "id": "scout",
+                "name": "Scout",
+                "role": "Guide"
+              }
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "join": {
+          "text": "Let's go.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "trader",
+      "map": "world",
+      "x": 5,
+      "y": 8,
+      "color": "#caffc6",
+      "name": "Traveling Trader",
+      "desc": "Sells basic goods.",
+      "prompt": "Traveling trader carrying a pack of goods",
+      "shop": {
+        "markup": 2,
+        "refresh": 24,
+        "inv": [
+          {
+            "id": "bonus_potion"
+          }
+        ]
+      },
+      "tree": {
+        "start": {
+          "text": "Trade wares?",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "wanderer",
+      "hidden": true,
+      "map": "world",
+      "x": 4,
+      "y": 7,
+      "color": "#b8ffb6",
+      "name": "Mysterious Wanderer",
+      "desc": "Appears after you linger.",
+      "prompt": "Cloaked wanderer emerging from the dust",
+      "tree": {
+        "start": {
+          "text": "You finally noticed me.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "reveal": {
+        "flag": "visits@world@7,7",
+        "op": ">=",
+        "value": 3
+      }
+    },
+    {
+      "id": "dialog_tester",
+      "map": "world",
+      "x": 7,
+      "y": 17,
+      "color": "#fcc",
+      "name": "Dialog Tester",
+      "desc": "Demonstrates advanced dialog options.",
+      "prompt": "Curious tester with a worn notebook",
+      "tree": {
+        "start": {
+          "text": "Pick a feature to test.",
+          "choices": [
+            {
+              "label": "(Check STR)",
+              "to": "dc"
+            },
+            {
+              "label": "(Gain XP)",
+              "to": "xp"
+            },
+            {
+              "label": "(Require Coin)",
+              "to": "req_item"
+            },
+            {
+              "label": "(Need Trinket)",
+              "to": "req_slot"
+            },
+            {
+              "label": "(Move Me)",
+              "to": "move"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            },
+            {
+              "label": "(Flag Gate)",
+              "to": "flagged",
+              "if": {
+                "flag": "chest_looted"
+              }
+            }
+          ]
+        },
+        "dc": {
+          "text": "Let's see your strength.",
+          "choices": [
+            {
+              "label": "(Roll)",
+              "to": "start",
+              "check": {
+                "stat": "STR",
+                "dc": 5
+              },
+              "success": "Impressive!",
+              "failure": "Not strong enough."
+            }
+          ]
+        },
+        "xp": {
+          "text": "Testing experience award.",
+          "choices": [
+            {
+              "label": "(Earn XP)",
+              "to": "start",
+              "reward": "XP 1",
+              "success": "You feel wiser."
+            }
+          ]
+        },
+        "req_item": {
+          "text": "Do you carry the coin?",
+          "choices": [
+            {
+              "label": "(Use Coin)",
+              "to": "start",
+              "reqItem": "golden_coin",
+              "success": "Thanks for the coin.",
+              "failure": "Bring me the Golden Coin."
+            }
+          ]
+        },
+        "req_slot": {
+          "text": "Show me any trinket.",
+          "choices": [
+            {
+              "label": "(Show Trinket)",
+              "to": "start",
+              "reqSlot": "trinket",
+              "success": "Nice trinket!",
+              "failure": "You lack a trinket."
+            }
+          ]
+        },
+        "move": {
+          "text": "I can move at your request.",
+          "choices": [
+            {
+              "label": "(Step North)",
+              "to": "start",
+              "goto": {
+                "target": "npc",
+                "rel": true,
+                "y": -1
+              },
+              "success": "I moved north."
+            }
+          ]
+        },
+        "flagged": {
+          "text": "Only looters may enter this sub-dialog.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "nyx",
+      "map": "world",
+      "x": 4,
+      "y": 15,
+      "color": "#ccf",
+      "name": "Nyx",
+      "desc": "A wanderer with layered stories.",
+      "prompt": "Story-laden wanderer with a calm gaze",
+      "tree": {
+        "start": {
+          "text": "Greetings, traveler. What do you seek?",
+          "choices": [
+            {
+              "label": "Who are you?",
+              "to": "who",
+              "reward": "demo_blade",
+              "effects": null
+            },
+            {
+              "label": "Tell me a tale",
+              "to": "tale"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "who": {
+          "text": "I am Nyx. Do you seek wisdom or power?",
+          "choices": [
+            {
+              "label": "Wisdom",
+              "to": "wisdom"
+            },
+            {
+              "label": "Power",
+              "to": "power"
+            },
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "wisdom": {
+          "text": "Wisdom requires patience. Proceed?",
+          "choices": [
+            {
+              "label": "Yes",
+              "to": "lesson"
+            },
+            {
+              "label": "No",
+              "to": "start"
+            }
+          ]
+        },
+        "lesson": {
+          "text": "The dust remembers those who listen. Ask further?",
+          "choices": [
+            {
+              "label": "Tell me more",
+              "to": "secret"
+            },
+            {
+              "label": "That's enough",
+              "to": "start"
+            }
+          ]
+        },
+        "secret": {
+          "text": "You carry the weight of forgotten tales.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "power": {
+          "text": "Power corrupts. Do you still want it?",
+          "choices": [
+            {
+              "label": "Yes",
+              "to": "trial"
+            },
+            {
+              "label": "No",
+              "to": "start"
+            }
+          ]
+        },
+        "trial": {
+          "text": "Face the trial another time.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "tale": {
+          "text": "What kind of tale?",
+          "choices": [
+            {
+              "label": "Heroic",
+              "to": "heroic"
+            },
+            {
+              "label": "Tragic",
+              "to": "tragic"
+            },
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "heroic": {
+          "text": "A hero rose from dust.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "tale"
+            }
+          ]
+        },
+        "tragic": {
+          "text": "The sand swallowed cities.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "tale"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "mara",
+      "map": "world",
+      "x": 5,
+      "y": 14,
+      "color": "#fac",
+      "name": "Mara",
+      "desc": "Steely-eyed survivor.",
+      "prompt": "Steely survivor with determined eyes",
+      "tree": {
+        "start": {
+          "text": "The dust never settles, does it?",
+          "choices": [
+            {
+              "label": "Stay sharp.",
+              "to": "resolve"
+            }
+          ]
+        },
+        "resolve": {
+          "text": "Always.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "jax",
+      "map": "world",
+      "x": 8,
+      "y": 14,
+      "color": "#acf",
+      "name": "Jax",
+      "desc": "Tinker with a grin.",
+      "prompt": "Grinning tinkerer holding a spare fuse",
+      "tree": {
+        "start": {
+          "text": "Got a spare fuse?",
+          "choices": [
+            {
+              "label": "Maybe later.",
+              "to": "later"
+            }
+          ]
+        },
+        "later": {
+          "text": "I'll hold you to that.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "fabricator",
+      "map": "world",
+      "x": 6,
+      "y": 9,
+      "name": "Fabricator",
+      "desc": "Prototype workbench",
+      "prompt": "Prototype workbench humming with power",
+      "color": "#aef",
+      "symbol": "!",
+      "workbench": true,
+      "tree": {
+        "start": {
+          "text": "Slot in a fuel cell to craft upgrades.",
+          "choices": [
+            {
+              "label": "(Craft blade)",
+              "to": "craft",
+              "reqItem": "demo_cell",
+              "effects": null,
+              "reward": "demo_blade"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "craft": {
+          "text": "The blade forms instantly.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "coach",
+      "map": "world",
+      "x": 8,
+      "y": 9,
+      "name": "Combat Coach",
+      "desc": "Trainer for stat mods",
+      "prompt": "Trainer adjusting combat stances",
+      "color": "#fea",
+      "symbol": "T",
+      "trainer": "power",
+      "tree": {
+        "start": {
+          "text": "Train up?",
+          "choices": [
+            {
+              "label": "(Boost STR)",
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "modStat",
+                  "stat": "STR",
+                  "delta": 1,
+                  "duration": 1
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "train": {
+          "text": "Feel the surge!",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "relay",
+      "map": "world",
+      "x": 4,
+      "y": 9,
+      "name": "Transit Relay",
+      "desc": "Controls world map travel",
+      "prompt": "Relay console with blinking lights",
+      "color": "#aff",
+      "symbol": "#",
+      "tree": {
+        "start": {
+          "text": "Access fast-travel systems.",
+          "choices": [
+            {
+              "label": "(Sync Bunkers)",
+              "to": "sync",
+              "effects": [
+                {
+                  "effect": "activateBunker",
+                  "id": "feature_hub"
+                }
+              ]
+            },
+            {
+              "label": "(Open World Map)",
+              "to": "map",
+              "effects": [
+                {
+                  "effect": "openWorldMap",
+                  "id": "tech-demo"
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "sync": {
+          "text": "Bunker network aligned.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "map": {
+          "text": "Routes displayed.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "engineer",
+      "map": "world",
+      "x": 5,
+      "y": 9,
+      "name": "Chief Engineer",
+      "desc": "Guides module tour",
+      "prompt": "Engineer juggling diagnostic tablets",
+      "color": "#cfc",
+      "questId": "q_upgrade",
+      "tree": {
+        "start": {
+          "text": "Ready to test the engine features?",
+          "choices": [
+            {
+              "label": "(Explain goals)",
+              "to": "explain"
+            },
+            {
+              "label": "(I have the cell)",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "explain": {
+          "text": "Collect the fuel cell, craft the blade, and try every station.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "Excellent work!",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye",
+              "reward": "demo_plating"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "map": "world",
+      "x": 6,
+      "y": 6,
+      "events": [
+        {
+          "when": "enter",
+          "effect": "toast",
+          "msg": "A warm breeze soothes you."
+        },
+        {
+          "when": "enter",
+          "effect": "modStat",
+          "stat": "CHA",
+          "delta": 1,
+          "duration": 2
+        }
+      ]
+    },
+    {
+      "map": "world",
+      "x": 9,
+      "y": 9,
+      "events": [
+        {
+          "when": "enter",
+          "effect": "lightningZap"
+        }
+      ]
+    }
+  ],
+  "portals": [
+    {
+      "map": "world",
+      "x": 10,
+      "y": 9,
+      "toMap": "cabin",
+      "toX": 3,
+      "toY": 4
+    },
+    {
+      "map": "cabin",
+      "x": 3,
+      "y": 4,
+      "toMap": "world",
+      "toX": 9,
+      "toY": 9
+    }
+  ],
+  "interiors": [
+    {
+      "id": "cabin",
+      "w": 7,
+      "h": 5,
+      "grid": [
+        "🏝🏝🏝🏝🏝🏝🏝",
+        "🏝🪨🪨🪨🪨🪨🏝",
+        "🏝🪨🪨🪨🪨🪨🏝",
+        "🏝🪨🪨🪨🪨🪨🏝",
+        "🏝🏝🏝🚪🏝🏝🏝"
+      ],
+      "entryX": 3,
+      "entryY": 3
+    }
+  ],
+  "buildings": [
+    {
+      "x": 10,
+      "y": 9,
+      "interiorId": "cabin",
+      "boarded": false
+    },
+    {
+      "x": 12,
+      "y": 9,
+      "interiorId": "cabin",
+      "boarded": true
+    }
+  ],
+  "name": "Engine Feature Showcase",
+  "props": {
+    "fastTravelModules": [
+      {
+        "script": "modules/world-one.module.js",
+        "global": "WORLD_ONE_MODULE"
+      },
+      {
+        "script": "modules/world-two.module.js",
+        "global": "WORLD_TWO_MODULE"
+      }
+    ]
+  },
+  "zones": [
+    {
+      "map": "world",
+      "x": 3,
+      "y": 5,
+      "w": 4,
+      "h": 2,
+      "perStep": {
+        "hp": -1,
+        "msg": "Radiation sears your suit!"
+      },
+      "negate": "demo_plating"
+    },
+    {
+      "map": "world",
+      "x": 2,
+      "y": 9,
+      "w": 2,
+      "h": 1,
+      "useItem": {
+        "id": "demo_cell",
+        "reward": "demo_cache",
+        "once": true
+      }
+    }
+  ],
+  "templates": [
+    {
+      "id": "demo_droid",
+      "name": "Demo Droid",
+      "portraitSheet": "assets/portraits/dustland-module/scavenger_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 12,
+        "ATK": 4,
+        "DEF": 2,
+        "challenge": 5,
+        "special": {
+          "cue": "deploys a precision laser!",
+          "dmg": 3
+        },
+        "scrap": {
+          "min": 1,
+          "max": 3
+        }
+      }
+    }
+  ],
+  "encounters": {
+    "world": [
+      {
+        "templateId": "demo_droid",
+        "minDist": 1,
+        "maxDist": 4,
+        "loot": "demo_cache"
+      }
+    ]
+  },
+  "zoneEffects": [
+    {
+      "map": "world",
+      "x": 0,
+      "y": 0,
+      "w": 14,
+      "h": 14,
+      "spawns": [
+        {
+          "name": "Training Drone",
+          "HP": 6,
+          "ATK": 1,
+          "DEF": 0
+        },
+        {
+          "name": "Holo Bandit",
+          "HP": 8,
+          "ATK": 2,
+          "DEF": 1
+        }
+      ],
+      "minSteps": 2,
+      "maxSteps": 4
+    },
+    {
+      "map": "cabin",
+      "x": 0,
+      "y": 0,
+      "w": 7,
+      "h": 5,
+      "noEncounters": true
+    }
+  ]
+}
+`;
+
+function postLoad(module) {}
+
+globalThis.ENGINE_TECH_DEMO_MODULE = JSON.parse(DATA);
+globalThis.ENGINE_TECH_DEMO_MODULE.postLoad = postLoad;
+
+startGame = function () {
+  ENGINE_TECH_DEMO_MODULE.postLoad?.(ENGINE_TECH_DEMO_MODULE);
+  applyModule(ENGINE_TECH_DEMO_MODULE);
+  const s = ENGINE_TECH_DEMO_MODULE.start;
+  if (s) {
+    setPartyPos(s.x, s.y);
+    setMap(s.map, 'Engine Feature Showcase');
+  }
+};

--- a/modules/engine-tech-demo.module.json
+++ b/modules/engine-tech-demo.module.json
@@ -1,0 +1,1178 @@
+{
+  "seed": "engine-tech-demo",
+  "start": {
+    "map": "world",
+    "x": 7,
+    "y": 7
+  },
+  "items": [
+    {
+      "id": "golden_coin",
+      "name": "Golden Coin",
+      "type": "quest",
+      "value": 1
+    },
+    {
+      "id": "thanks_medal",
+      "name": "Thanks Medal",
+      "type": "trinket",
+      "slot": "trinket",
+      "mods": {
+        "LCK": 1
+      },
+      "value": 10
+    },
+    {
+      "id": "bonus_potion",
+      "name": "Healing Potion",
+      "type": "consumable",
+      "use": {
+        "type": "heal",
+        "amount": 5
+      },
+      "value": 5
+    },
+    {
+      "map": "world",
+      "x": 6,
+      "y": 7,
+      "id": "spare_potion",
+      "name": "Spare Potion",
+      "type": "consumable",
+      "use": {
+        "type": "heal",
+        "amount": 5
+      },
+      "value": 5
+    },
+    {
+      "id": "makeshift_charge",
+      "name": "Makeshift Charge",
+      "type": "quest"
+    },
+    {
+      "map": "world",
+      "x": 8,
+      "y": 7,
+      "id": "chest_key",
+      "name": "Chest Key",
+      "type": "quest",
+      "tags": [
+        "key"
+      ]
+    },
+    {
+      "id": "demo_blade",
+      "name": "Vector Blade",
+      "type": "weapon",
+      "slot": "weapon",
+      "value": 25,
+      "desc": "Balanced energy blade",
+      "mods": {
+        "ATK": 3,
+        "ADR": 15
+      },
+      "tags": [
+        "sharp",
+        "energy"
+      ]
+    },
+    {
+      "id": "demo_plating",
+      "name": "Adaptive Plating",
+      "type": "armor",
+      "slot": "body",
+      "value": 30,
+      "desc": "Reconfigurable chest armor",
+      "mods": {
+        "DEF": 3,
+        "HP": 6
+      },
+      "tags": [
+        "heavy"
+      ]
+    },
+    {
+      "id": "demo_cache",
+      "name": "Calibration Cache",
+      "type": "spoils-cache",
+      "rank": "polished",
+      "map": "world",
+      "x": 10,
+      "y": 5
+    },
+    {
+      "id": "demo_cell",
+      "name": "Fuel Cell",
+      "type": "quest",
+      "value": 0,
+      "fuel": 10,
+      "desc": "Powers the generator",
+      "map": "world",
+      "x": 11,
+      "y": 6
+    }
+  ],
+  "quests": [
+    {
+      "id": "q_fetch",
+      "title": "Fetch the Coin",
+      "desc": "Retrieve the coin from the cabin.",
+      "item": "golden_coin",
+      "reward": "thanks_medal",
+      "xp": 2
+    },
+    {
+      "id": "q_upgrade",
+      "title": "Forge an Upgrade",
+      "desc": "Use the workbench to craft an upgraded blade.",
+      "item": "demo_cell",
+      "reward": "demo_blade",
+      "xp": 4
+    }
+  ],
+  "npcs": [
+    {
+      "id": "villager",
+      "map": "world",
+      "x": 7,
+      "y": 8,
+      "color": "#cfa",
+      "name": "Worried Villager",
+      "desc": "Lost a coin in the cabin.",
+      "prompt": "Anxious villager clutching an empty coin pouch",
+      "questId": "q_fetch",
+      "tree": {
+        "start": {
+          "text": "My lucky coin is in the cabin. Can you fetch it?",
+          "choices": [
+            {
+              "label": "(Accept)",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(INT) Any advance?",
+              "to": "advance",
+              "check": {
+                "stat": "INT",
+                "dc": 5
+              }
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "advance": {
+          "text": "Sharp mind! Take this potion.",
+          "choices": [
+            {
+              "label": "(Thanks)",
+              "to": "accept",
+              "reward": "bonus_potion",
+              "q": "accept"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Please bring it soon.",
+          "choices": [
+            {
+              "label": "(I have the coin)",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "You found it! Here is your reward.",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye",
+              "reward": "thanks_medal"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "chest",
+      "map": "cabin",
+      "x": 3,
+      "y": 2,
+      "color": "#ddf",
+      "name": "Dusty Chest",
+      "desc": "Maybe it holds the coin.",
+      "prompt": "Dusty wooden chest bound by a metal lock",
+      "symbol": "?",
+      "locked": true,
+      "tree": {
+        "locked": {
+          "text": "A locked chest sits here.",
+          "choices": [
+            {
+              "label": "(Use Key)",
+              "to": "open",
+              "once": true,
+              "reqItem": "chest_key",
+              "effects": [
+                {
+                  "effect": "unlockNPC",
+                  "npcId": "chest"
+                }
+              ]
+            },
+            {
+              "label": "(Use Explosive)",
+              "to": "open",
+              "once": true,
+              "reqItem": "makeshift_charge",
+              "effects": [
+                {
+                  "effect": "unlockNPC",
+                  "npcId": "chest"
+                }
+              ]
+            },
+            {
+              "label": "(Pry with Crowbar)",
+              "to": "crowbar_open",
+              "once": true,
+              "reqItem": "crowbar",
+              "effects": [
+                {
+                  "effect": "unlockNPC",
+                  "npcId": "chest"
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "open": {
+          "text": "The chest creaks open, revealing a shiny coin.",
+          "choices": [
+            {
+              "label": "(Take Coin)",
+              "to": "empty",
+              "reward": "golden_coin",
+              "effects": [
+                {
+                  "effect": "addFlag",
+                  "flag": "chest_looted"
+                }
+              ]
+            }
+          ]
+        },
+        "crowbar_open": {
+          "text": "The crowbar pops the lid with a squeal.",
+          "choices": [
+            {
+              "label": "(Take Coin)",
+              "to": "empty",
+              "reward": "golden_coin",
+              "effects": [
+                {
+                  "effect": "addFlag",
+                  "flag": "chest_looted"
+                }
+              ]
+            }
+          ]
+        },
+        "empty": {
+          "text": "The chest is empty.",
+          "choices": [
+            {
+              "label": "(Lock Chest)",
+              "to": "locked_empty",
+              "reqItem": "chest_key",
+              "effects": [
+                {
+                  "effect": "lockNPC",
+                  "npcId": "chest"
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "locked_empty": {
+          "text": "The chest is empty and locked.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "rat",
+      "map": "cabin",
+      "x": 5,
+      "y": 2,
+      "color": "#f88",
+      "name": "Big Rat",
+      "title": "Pest",
+      "desc": "It guards the cabin.",
+      "prompt": "Large cabin rat with matted fur",
+      "tree": {
+        "start": {
+          "text": "The rat snarls.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 4,
+        "ATK": 2,
+        "DEF": 0,
+        "loot": null,
+        "auto": true
+      }
+    },
+    {
+      "id": "bandit",
+      "map": "world",
+      "x": 12,
+      "y": 8,
+      "color": "#f66",
+      "name": "Sneaky Bandit",
+      "desc": "Blocks the path.",
+      "prompt": "Sneaky bandit with a crooked dagger",
+      "tree": {
+        "start": {
+          "text": "Hand over your loot!",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 6,
+        "ATK": 3,
+        "DEF": 1,
+        "loot": null,
+        "auto": true
+      }
+    },
+    {
+      "id": "scout",
+      "map": "world",
+      "x": 9,
+      "y": 6,
+      "color": "#afa",
+      "name": "Friendly Scout",
+      "desc": "Offers to join your journey.",
+      "prompt": "Friendly scout with travel gear",
+      "tree": {
+        "start": {
+          "text": "Need a companion?",
+          "choices": [
+            {
+              "label": "(Join me)",
+              "to": "join",
+              "join": {
+                "id": "scout",
+                "name": "Scout",
+                "role": "Guide"
+              }
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "join": {
+          "text": "Let's go.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "trader",
+      "map": "world",
+      "x": 5,
+      "y": 8,
+      "color": "#caffc6",
+      "name": "Traveling Trader",
+      "desc": "Sells basic goods.",
+      "prompt": "Traveling trader carrying a pack of goods",
+      "shop": {
+        "markup": 2,
+        "refresh": 24,
+        "inv": [
+          {
+            "id": "bonus_potion"
+          }
+        ]
+      },
+      "tree": {
+        "start": {
+          "text": "Trade wares?",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "wanderer",
+      "hidden": true,
+      "map": "world",
+      "x": 4,
+      "y": 7,
+      "color": "#b8ffb6",
+      "name": "Mysterious Wanderer",
+      "desc": "Appears after you linger.",
+      "prompt": "Cloaked wanderer emerging from the dust",
+      "tree": {
+        "start": {
+          "text": "You finally noticed me.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "reveal": {
+        "flag": "visits@world@7,7",
+        "op": ">=",
+        "value": 3
+      }
+    },
+    {
+      "id": "dialog_tester",
+      "map": "world",
+      "x": 7,
+      "y": 17,
+      "color": "#fcc",
+      "name": "Dialog Tester",
+      "desc": "Demonstrates advanced dialog options.",
+      "prompt": "Curious tester with a worn notebook",
+      "tree": {
+        "start": {
+          "text": "Pick a feature to test.",
+          "choices": [
+            {
+              "label": "(Check STR)",
+              "to": "dc"
+            },
+            {
+              "label": "(Gain XP)",
+              "to": "xp"
+            },
+            {
+              "label": "(Require Coin)",
+              "to": "req_item"
+            },
+            {
+              "label": "(Need Trinket)",
+              "to": "req_slot"
+            },
+            {
+              "label": "(Move Me)",
+              "to": "move"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            },
+            {
+              "label": "(Flag Gate)",
+              "to": "flagged",
+              "if": {
+                "flag": "chest_looted"
+              }
+            }
+          ]
+        },
+        "dc": {
+          "text": "Let's see your strength.",
+          "choices": [
+            {
+              "label": "(Roll)",
+              "to": "start",
+              "check": {
+                "stat": "STR",
+                "dc": 5
+              },
+              "success": "Impressive!",
+              "failure": "Not strong enough."
+            }
+          ]
+        },
+        "xp": {
+          "text": "Testing experience award.",
+          "choices": [
+            {
+              "label": "(Earn XP)",
+              "to": "start",
+              "reward": "XP 1",
+              "success": "You feel wiser."
+            }
+          ]
+        },
+        "req_item": {
+          "text": "Do you carry the coin?",
+          "choices": [
+            {
+              "label": "(Use Coin)",
+              "to": "start",
+              "reqItem": "golden_coin",
+              "success": "Thanks for the coin.",
+              "failure": "Bring me the Golden Coin."
+            }
+          ]
+        },
+        "req_slot": {
+          "text": "Show me any trinket.",
+          "choices": [
+            {
+              "label": "(Show Trinket)",
+              "to": "start",
+              "reqSlot": "trinket",
+              "success": "Nice trinket!",
+              "failure": "You lack a trinket."
+            }
+          ]
+        },
+        "move": {
+          "text": "I can move at your request.",
+          "choices": [
+            {
+              "label": "(Step North)",
+              "to": "start",
+              "goto": {
+                "target": "npc",
+                "rel": true,
+                "y": -1
+              },
+              "success": "I moved north."
+            }
+          ]
+        },
+        "flagged": {
+          "text": "Only looters may enter this sub-dialog.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "nyx",
+      "map": "world",
+      "x": 4,
+      "y": 15,
+      "color": "#ccf",
+      "name": "Nyx",
+      "desc": "A wanderer with layered stories.",
+      "prompt": "Story-laden wanderer with a calm gaze",
+      "tree": {
+        "start": {
+          "text": "Greetings, traveler. What do you seek?",
+          "choices": [
+            {
+              "label": "Who are you?",
+              "to": "who",
+              "reward": "demo_blade",
+              "effects": null
+            },
+            {
+              "label": "Tell me a tale",
+              "to": "tale"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "who": {
+          "text": "I am Nyx. Do you seek wisdom or power?",
+          "choices": [
+            {
+              "label": "Wisdom",
+              "to": "wisdom"
+            },
+            {
+              "label": "Power",
+              "to": "power"
+            },
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "wisdom": {
+          "text": "Wisdom requires patience. Proceed?",
+          "choices": [
+            {
+              "label": "Yes",
+              "to": "lesson"
+            },
+            {
+              "label": "No",
+              "to": "start"
+            }
+          ]
+        },
+        "lesson": {
+          "text": "The dust remembers those who listen. Ask further?",
+          "choices": [
+            {
+              "label": "Tell me more",
+              "to": "secret"
+            },
+            {
+              "label": "That's enough",
+              "to": "start"
+            }
+          ]
+        },
+        "secret": {
+          "text": "You carry the weight of forgotten tales.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "power": {
+          "text": "Power corrupts. Do you still want it?",
+          "choices": [
+            {
+              "label": "Yes",
+              "to": "trial"
+            },
+            {
+              "label": "No",
+              "to": "start"
+            }
+          ]
+        },
+        "trial": {
+          "text": "Face the trial another time.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "tale": {
+          "text": "What kind of tale?",
+          "choices": [
+            {
+              "label": "Heroic",
+              "to": "heroic"
+            },
+            {
+              "label": "Tragic",
+              "to": "tragic"
+            },
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "heroic": {
+          "text": "A hero rose from dust.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "tale"
+            }
+          ]
+        },
+        "tragic": {
+          "text": "The sand swallowed cities.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "tale"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "mara",
+      "map": "world",
+      "x": 5,
+      "y": 14,
+      "color": "#fac",
+      "name": "Mara",
+      "desc": "Steely-eyed survivor.",
+      "prompt": "Steely survivor with determined eyes",
+      "tree": {
+        "start": {
+          "text": "The dust never settles, does it?",
+          "choices": [
+            {
+              "label": "Stay sharp.",
+              "to": "resolve"
+            }
+          ]
+        },
+        "resolve": {
+          "text": "Always.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "jax",
+      "map": "world",
+      "x": 8,
+      "y": 14,
+      "color": "#acf",
+      "name": "Jax",
+      "desc": "Tinker with a grin.",
+      "prompt": "Grinning tinkerer holding a spare fuse",
+      "tree": {
+        "start": {
+          "text": "Got a spare fuse?",
+          "choices": [
+            {
+              "label": "Maybe later.",
+              "to": "later"
+            }
+          ]
+        },
+        "later": {
+          "text": "I'll hold you to that.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "fabricator",
+      "map": "world",
+      "x": 6,
+      "y": 9,
+      "name": "Fabricator",
+      "desc": "Prototype workbench",
+      "prompt": "Prototype workbench humming with power",
+      "color": "#aef",
+      "symbol": "!",
+      "workbench": true,
+      "tree": {
+        "start": {
+          "text": "Slot in a fuel cell to craft upgrades.",
+          "choices": [
+            {
+              "label": "(Craft blade)",
+              "to": "craft",
+              "reqItem": "demo_cell",
+              "effects": null,
+              "reward": "demo_blade"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "craft": {
+          "text": "The blade forms instantly.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "coach",
+      "map": "world",
+      "x": 8,
+      "y": 9,
+      "name": "Combat Coach",
+      "desc": "Trainer for stat mods",
+      "prompt": "Trainer adjusting combat stances",
+      "color": "#fea",
+      "symbol": "T",
+      "trainer": "power",
+      "tree": {
+        "start": {
+          "text": "Train up?",
+          "choices": [
+            {
+              "label": "(Boost STR)",
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "modStat",
+                  "stat": "STR",
+                  "delta": 1,
+                  "duration": 1
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "train": {
+          "text": "Feel the surge!",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "relay",
+      "map": "world",
+      "x": 4,
+      "y": 9,
+      "name": "Transit Relay",
+      "desc": "Controls world map travel",
+      "prompt": "Relay console with blinking lights",
+      "color": "#aff",
+      "symbol": "#",
+      "tree": {
+        "start": {
+          "text": "Access fast-travel systems.",
+          "choices": [
+            {
+              "label": "(Sync Bunkers)",
+              "to": "sync",
+              "effects": [
+                {
+                  "effect": "activateBunker",
+                  "id": "feature_hub"
+                }
+              ]
+            },
+            {
+              "label": "(Open World Map)",
+              "to": "map",
+              "effects": [
+                {
+                  "effect": "openWorldMap",
+                  "id": "tech-demo"
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "sync": {
+          "text": "Bunker network aligned.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "map": {
+          "text": "Routes displayed.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "engineer",
+      "map": "world",
+      "x": 5,
+      "y": 9,
+      "name": "Chief Engineer",
+      "desc": "Guides module tour",
+      "prompt": "Engineer juggling diagnostic tablets",
+      "color": "#cfc",
+      "questId": "q_upgrade",
+      "tree": {
+        "start": {
+          "text": "Ready to test the engine features?",
+          "choices": [
+            {
+              "label": "(Explain goals)",
+              "to": "explain"
+            },
+            {
+              "label": "(I have the cell)",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "explain": {
+          "text": "Collect the fuel cell, craft the blade, and try every station.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "Excellent work!",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye",
+              "reward": "demo_plating"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "map": "world",
+      "x": 6,
+      "y": 6,
+      "events": [
+        {
+          "when": "enter",
+          "effect": "toast",
+          "msg": "A warm breeze soothes you."
+        },
+        {
+          "when": "enter",
+          "effect": "modStat",
+          "stat": "CHA",
+          "delta": 1,
+          "duration": 2
+        }
+      ]
+    },
+    {
+      "map": "world",
+      "x": 9,
+      "y": 9,
+      "events": [
+        {
+          "when": "enter",
+          "effect": "lightningZap"
+        }
+      ]
+    }
+  ],
+  "portals": [
+    {
+      "map": "world",
+      "x": 10,
+      "y": 9,
+      "toMap": "cabin",
+      "toX": 3,
+      "toY": 4
+    },
+    {
+      "map": "cabin",
+      "x": 3,
+      "y": 4,
+      "toMap": "world",
+      "toX": 9,
+      "toY": 9
+    }
+  ],
+  "interiors": [
+    {
+      "id": "cabin",
+      "w": 7,
+      "h": 5,
+      "grid": [
+        "🏝🏝🏝🏝🏝🏝🏝",
+        "🏝🪨🪨🪨🪨🪨🏝",
+        "🏝🪨🪨🪨🪨🪨🏝",
+        "🏝🪨🪨🪨🪨🪨🏝",
+        "🏝🏝🏝🚪🏝🏝🏝"
+      ],
+      "entryX": 3,
+      "entryY": 3
+    }
+  ],
+  "buildings": [
+    {
+      "x": 10,
+      "y": 9,
+      "interiorId": "cabin",
+      "boarded": false
+    },
+    {
+      "x": 12,
+      "y": 9,
+      "interiorId": "cabin",
+      "boarded": true
+    }
+  ],
+  "name": "Engine Feature Showcase",
+  "props": {
+    "fastTravelModules": [
+      {
+        "script": "modules/world-one.module.js",
+        "global": "WORLD_ONE_MODULE"
+      },
+      {
+        "script": "modules/world-two.module.js",
+        "global": "WORLD_TWO_MODULE"
+      }
+    ]
+  },
+  "zones": [
+    {
+      "map": "world",
+      "x": 3,
+      "y": 5,
+      "w": 4,
+      "h": 2,
+      "perStep": {
+        "hp": -1,
+        "msg": "Radiation sears your suit!"
+      },
+      "negate": "demo_plating"
+    },
+    {
+      "map": "world",
+      "x": 2,
+      "y": 9,
+      "w": 2,
+      "h": 1,
+      "useItem": {
+        "id": "demo_cell",
+        "reward": "demo_cache",
+        "once": true
+      }
+    }
+  ],
+  "templates": [
+    {
+      "id": "demo_droid",
+      "name": "Demo Droid",
+      "portraitSheet": "assets/portraits/dustland-module/scavenger_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 12,
+        "ATK": 4,
+        "DEF": 2,
+        "challenge": 5,
+        "special": {
+          "cue": "deploys a precision laser!",
+          "dmg": 3
+        },
+        "scrap": {
+          "min": 1,
+          "max": 3
+        }
+      }
+    }
+  ],
+  "encounters": {
+    "world": [
+      {
+        "templateId": "demo_droid",
+        "minDist": 1,
+        "maxDist": 4,
+        "loot": "demo_cache"
+      }
+    ]
+  },
+  "zoneEffects": [
+    {
+      "map": "world",
+      "x": 0,
+      "y": 0,
+      "w": 14,
+      "h": 14,
+      "spawns": [
+        {
+          "name": "Training Drone",
+          "HP": 6,
+          "ATK": 1,
+          "DEF": 0
+        },
+        {
+          "name": "Holo Bandit",
+          "HP": 8,
+          "ATK": 2,
+          "DEF": 1
+        }
+      ],
+      "minSteps": 2,
+      "maxSteps": 4
+    },
+    {
+      "map": "cabin",
+      "x": 0,
+      "y": 0,
+      "w": 7,
+      "h": 5,
+      "noEncounters": true
+    }
+  ]
+}

--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -11,6 +11,7 @@ const MODULES = [
   { id: 'true-dust', name: 'True Dust', file: 'modules/true-dust.module.js' },
   { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' },
   { id: 'edge', name: 'bunker-trainer-workshop', file: 'modules/edge.module.js' },
+  { id: 'engine-tech-demo', name: 'Engine Feature Showcase', file: 'modules/engine-tech-demo.module.js' },
 ];
 
 const realOpenCreator = window.openCreator;


### PR DESCRIPTION
## Summary
- add an Engine Feature Showcase module that exercises items, quests, NPCs, events, portals, interiors, buildings, zones, encounters, and templates
- embed the showcase module script and reference module props for fast travel demos
- list the new module in the module picker for easy access

## Testing
- node scripts/supporting/presubmit.js
- npm test
- node scripts/supporting/placement-check.js modules/engine-tech-demo.module.json

------
https://chatgpt.com/codex/tasks/task_e_68cac29c0bb4832894e236657e52fd65