### PR TITLE
feat: add combat grenades

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -205,6 +205,37 @@ const DATA = `
       }
     },
     {
+      "id": "frag_grenade",
+      "name": "Frag Grenade",
+      "type": "consumable",
+      "use": {
+        "type": "grenade",
+        "amount": 6,
+        "text": "You pull the pin and lob the grenade!"
+      },
+      "scrap": 300,
+      "value": 300,
+      "tags": [
+        "grenade"
+      ]
+    },
+    {
+      "id": "incendiary_grenade",
+      "name": "Incendiary Grenade",
+      "type": "consumable",
+      "use": {
+        "type": "grenade",
+        "amount": 5,
+        "text": "Flames burst across the battlefield."
+      },
+      "scrap": 300,
+      "value": 300,
+      "tags": [
+        "grenade",
+        "fire"
+      ]
+    },
+    {
       "map": "world",
       "x": 18,
       "y": 43,
@@ -1625,6 +1656,12 @@ const DATA = `
           },
           {
             "id": "water_flask"
+          },
+          {
+            "id": "frag_grenade"
+          },
+          {
+            "id": "incendiary_grenade"
           }
         ]
       },

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -167,7 +167,7 @@ test('trader patrols east-west with basic goods', () => {
     { x: 110, y: 44 }
   ]);
   const invIds = trader.shop?.inv?.map(i => i.id);
-  assert.deepStrictEqual(invIds, ['pipe_rifle', 'leather_jacket', 'water_flask']);
+  assert.deepStrictEqual(invIds, ['pipe_rifle', 'leather_jacket', 'water_flask', 'frag_grenade', 'incendiary_grenade']);
 });
 
 test('vortex sends player to world map', () => {

--- a/test/grenade-item.test.js
+++ b/test/grenade-item.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM(`
+  <div id="combatOverlay"></div>
+  <div id="combatEnemies"></div>
+  <div id="combatParty"></div>
+  <div id="combatCmd"></div>
+  <div id="turnIndicator"></div>
+`);
+
+global.window = dom.window;
+global.document = dom.window.document;
+global.EventBus = { emit() {} };
+global.log = () => {};
+global.toast = () => {};
+global.updateHUD = () => {};
+
+global.player = { hp: 10, inv: [], scrap: 0 };
+
+await import('../scripts/core/party.js');
+await import('../scripts/core/combat.js');
+await import('../scripts/core/inventory.js');
+
+test('grenade consumable damages every enemy', async () => {
+  player.inv.length = 0;
+  player.scrap = 0;
+  party.length = 0;
+  const thrower = makeMember('hero', 'Hero', 'Scout');
+  thrower.stats.STR = 6;
+  party.push(thrower);
+  selectedMember = 0;
+
+  addToInv({
+    id: 'test_grenade',
+    name: 'Test Grenade',
+    type: 'consumable',
+    use: { type: 'grenade', amount: 5 },
+    scrap: 300,
+    value: 300
+  });
+
+  const enemies = [
+    { name: 'Ghoul', hp: 8, maxHp: 8, DEF: 1 },
+    { name: 'Bandit', hp: 7, maxHp: 7, DEF: 0 }
+  ];
+
+  const ready = openCombat(enemies);
+  const used = useItem(0);
+  assert.strictEqual(used, true);
+  const stateEnemies = __combatState.enemies;
+  assert.strictEqual(stateEnemies[0].hp, 4);
+  assert.strictEqual(stateEnemies[1].hp, 2);
+  assert.strictEqual(player.inv.length, 0);
+
+  closeCombat('flee');
+  await ready;
+});
+
+test('grenade that overkills clears the encounter', async () => {
+  player.inv.length = 0;
+  party.length = 0;
+  const thrower = makeMember('hero2', 'Heroine', 'Scout');
+  party.push(thrower);
+  selectedMember = 0;
+
+  addToInv({
+    id: 'wipe_grenade',
+    name: 'Wipe Grenade',
+    type: 'consumable',
+    use: { type: 'grenade', amount: 12 },
+    scrap: 300,
+    value: 300
+  });
+
+  const enemies = [
+    { name: 'A', hp: 4, maxHp: 4, DEF: 0 },
+    { name: 'B', hp: 3, maxHp: 3, DEF: 0 }
+  ];
+
+  const ready = openCombat(enemies);
+  const used = useItem(0);
+  assert.strictEqual(used, true);
+  assert.strictEqual(__combatState.enemies.length, 0);
+  assert.strictEqual(document.getElementById('combatOverlay').classList.contains('shown'), false);
+
+  await ready;
+});

--- a/test/trader-price-scan.test.js
+++ b/test/trader-price-scan.test.js
@@ -19,7 +19,7 @@ test('collectPricingData summarizes dustland traders and scrap', () => {
   const trader = moduleReport.vendors.find(v => v.name === 'Cass the Trader');
   assert.ok(trader);
   const ids = trader.items.map(it => it.id);
-  assert.deepStrictEqual(ids, ['pipe_rifle', 'leather_jacket', 'water_flask']);
+  assert.deepStrictEqual(ids, ['pipe_rifle', 'leather_jacket', 'water_flask', 'frag_grenade', 'incendiary_grenade']);
   const pipeRifle = trader.items.find(it => it.id === 'pipe_rifle');
   assert.ok(pipeRifle);
   assert.strictEqual(pipeRifle.price, 0);


### PR DESCRIPTION
## Summary
- add frag and incendiary grenades to the Dustland module and stock them at Cass's shop
- wire grenade consumables into combat with an AoE damage helper and updated inventory handling
- add coverage for grenade combat flow and refresh existing trader expectations

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js
- node scripts/supporting/balance-tester-agent.js

------
https://chatgpt.com/codex/tasks/task_e_68cac2c4366c8328b0d5c67a681d48c4