### PR TITLE
fix: add scrap drops to edge enemies

### DIFF
--- a/modules/edge.module.js
+++ b/modules/edge.module.js
@@ -114,7 +114,11 @@ const DATA = `
       "combat": {
         "HP": 5,
         "ATK": 1,
-        "DEF": 0
+        "DEF": 0,
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
       }
     }
   ],


### PR DESCRIPTION
## Summary
- add a scrap drop range to the Fuel Ghoul template in the edge module so defeated enemies yield 3-5 scrap

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/balance-tester-agent.js

------
https://chatgpt.com/codex/tasks/task_e_68cac7b35b448328b43fd87a91ca4eca