### PR TITLE
fix: support inventory stacking

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -1328,7 +1328,7 @@ input[type="range"] {
     opacity:0;
   }
 }
-.cache-count { margin-left:4px; font-weight:700; }
+.cache-count, .stack-count { margin-left:4px; font-weight:700; }
 .jitter { animation:jitter .3s infinite; }
 @keyframes jitter {
   0%{ transform:translate(0,0); }

--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -163,7 +163,8 @@
               for (let i = player.inv.length - 1; i >= 0; i--) {
                 const it = player.inv[i];
                 if (it.tags && it.tags.map(t => t.toLowerCase()).includes(eff.tag.toLowerCase())) {
-                  removeFromInv(i);
+                  const qty = Math.max(1, Number.isFinite(it?.count) ? it.count : 1);
+                  removeFromInv(i, qty);
                 }
               }
             }

--- a/scripts/core/spoils-cache.js
+++ b/scripts/core/spoils-cache.js
@@ -80,8 +80,12 @@ const SpoilsCache = {
     if(!player?.inv) return null;
     const idx = player.inv.findIndex(c => c.type === 'spoils-cache' && c.rank === rank);
     if(idx === -1) return null;
-    player.inv.splice(idx,1);
-    notifyInventoryChanged?.();
+    if (typeof removeFromInv === 'function') {
+      removeFromInv(idx);
+    } else {
+      player.inv.splice(idx,1);
+      notifyInventoryChanged?.();
+    }
     const item = globalThis.ItemGen?.generate?.(rank, rng);
     if(item){
       if(typeof addToInv === 'function'){

--- a/scripts/core/trader.js
+++ b/scripts/core/trader.js
@@ -1,19 +1,45 @@
 const bus = (globalThis.Dustland && globalThis.Dustland.eventBus) || globalThis.EventBus;
+const SHOP_STACK_LIMIT = 256;
 
 class Trader {
   constructor(id, opts = {}){
     this.id = id;
     this.waves = Array.isArray(opts.waves) ? opts.waves.map(w => [...w]) : null;
     this.waveIndex = 0;
-    this.inventory = Array.isArray(opts.inventory) ? [...opts.inventory]
-      : (this.waves ? [...this.waves[0]] : []);
+    this.inventory = [];
+    const seed = Array.isArray(opts.inventory) ? opts.inventory : (this.waves ? this.waves[0] : []);
+    if (Array.isArray(seed)) {
+      seed.forEach(entry => this.addItem(entry));
+    }
     this.grudge = opts.grudge || 0;
     this.markup = opts.markup || 1;
     this.refreshHours = typeof opts.refresh === 'number' ? opts.refresh : 0;
   }
 
   addItem(item){
-    this.inventory.push(item);
+    if (!item) return;
+    const entry = typeof item === 'string' ? { id: item } : { ...item };
+    const id = entry.id;
+    if (!id) return;
+    const max = Number.isFinite(entry.maxStack) ? entry.maxStack : SHOP_STACK_LIMIT;
+    let remaining = Math.max(1, Number.isFinite(entry.count) ? entry.count : 1);
+    for (const invItem of this.inventory){
+      if (!invItem || invItem.id !== id) continue;
+      const limit = Math.min(SHOP_STACK_LIMIT, Number.isFinite(invItem.maxStack) ? invItem.maxStack : max);
+      const current = Math.max(1, Number.isFinite(invItem.count) ? invItem.count : 1);
+      const space = limit - current;
+      if (space <= 0) continue;
+      const add = Math.min(space, remaining);
+      invItem.count = current + add;
+      remaining -= add;
+      if (!remaining) break;
+    }
+    while (remaining > 0){
+      const add = Math.min(SHOP_STACK_LIMIT, Number.isFinite(entry.maxStack) ? entry.maxStack : SHOP_STACK_LIMIT, remaining);
+      const next = { ...entry, count: add };
+      this.inventory.push(next);
+      remaining -= add;
+    }
   }
 
   clearGrudge(){
@@ -37,7 +63,9 @@ class Trader {
     this.grudge = 0;
     if (this.waves && this.waveIndex < this.waves.length - 1) {
       this.waveIndex++;
-      this.inventory = [...this.waves[this.waveIndex]];
+      this.inventory = [];
+      const nextWave = this.waves[this.waveIndex] || [];
+      nextWave.forEach(entry => this.addItem(entry));
     }
     bus?.emit('trader:refresh', { trader: this });
   }

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -909,6 +909,7 @@ function renderInv(){
     inv.appendChild(ctrl);
     if(player.inv.length===0){ inv.appendChild(Object.assign(document.createElement('div'),{className:'slot muted',textContent:'(empty)'})); return; }
     player.inv.forEach((it,i)=>{
+      const qty = Math.max(1, Number.isFinite(it?.count) ? it.count : 1);
       const row=document.createElement('div');
       row.className='slot';
       const cb=document.createElement('input');
@@ -916,7 +917,7 @@ function renderInv(){
       cb.onchange=()=>{ if(cb.checked) dropSet.add(i); else dropSet.delete(i); };
       row.appendChild(cb);
       const span=document.createElement('span');
-      span.textContent=it.name;
+      span.textContent=qty>1?`${it.name} x${qty}`:it.name;
       row.appendChild(span);
       inv.appendChild(row);
     });
@@ -937,8 +938,11 @@ function renderInv(){
   const caches = {};
   const others = [];
   player.inv.forEach(it => {
+    const qty = Math.max(1, Number.isFinite(it?.count) ? it.count : 1);
     if(it.type === 'spoils-cache'){
-      (caches[it.rank] ||= []).push(it);
+      const bucket = caches[it.rank] || (caches[it.rank] = { items: [], total: 0 });
+      bucket.items.push(it);
+      bucket.total += qty;
     } else {
       others.push(it);
     }
@@ -956,7 +960,9 @@ function renderInv(){
       }
     }
   }
-  Object.entries(caches).forEach(([rank, items]) => {
+  Object.entries(caches).forEach(([rank, info]) => {
+    const items = info.items;
+    const total = info.total || items.length;
     const row=document.createElement('div');
     row.className='slot cache-slot';
     const icon = SpoilsCache.renderIcon(rank, () => {
@@ -970,11 +976,11 @@ function renderInv(){
       wrap.appendChild(icon);
       const count=document.createElement('span');
       count.className='cache-count';
-      count.textContent='x'+items.length;
+      count.textContent='x'+total;
       wrap.appendChild(count);
       row.appendChild(wrap);
     }
-    if(items.length>1){
+    if(total>1){
       const btn=document.createElement('button');
       btn.className='btn jitter';
       btn.textContent='Open All';
@@ -984,6 +990,7 @@ function renderInv(){
     inv.appendChild(row);
   });
   others.forEach(it => {
+    const qty = Math.max(1, Number.isFinite(it?.count) ? it.count : 1);
     const row=document.createElement('div');
     row.className='slot';
     row.style.display='flex';
@@ -1023,6 +1030,12 @@ function renderInv(){
       btnWrap.appendChild(useBtn);
     }
     row.appendChild(labelSpan);
+    if(qty>1){
+      const countSpan=document.createElement('span');
+      countSpan.className='stack-count';
+      countSpan.textContent='x'+qty;
+      row.appendChild(countSpan);
+    }
     row.appendChild(btnWrap);
     const mods = Object.entries(it.mods || {})
       .map(([k, v]) => `${k} ${v >= 0 ? '+' : ''}${v}`)
@@ -1187,16 +1200,23 @@ function openShop(npc) {
     shopInv.forEach((it, idx) => {
       const item = getItem(it.id);
       if (!item) return;
+      const qty = Math.max(1, Number.isFinite(it?.count) ? it.count : 1);
       const row = document.createElement('div');
       row.className = 'slot';
       const price = Math.ceil(item.value * markup);
-      row.innerHTML = `<span>${item.name} - ${price} ${CURRENCY}</span><button class="btn">Buy</button>`;
+      const name = qty > 1 ? `${item.name} x${qty}` : item.name;
+      row.innerHTML = `<span>${name} - ${price} ${CURRENCY}</span><button class="btn">Buy</button>`;
       row.querySelector('button').onclick = () => {
         if (player.scrap >= price) {
           if (addToInv(item)) {
             player.scrap -= price;
             if (!npc.vending) {
-              npc.shop.inv.splice(idx, 1);
+              const current = Math.max(1, Number.isFinite(it?.count) ? it.count : 1);
+              if (current > 1) {
+                it.count = current - 1;
+              } else {
+                npc.shop.inv.splice(idx, 1);
+              }
             }
             npc.shop.grudge = 0;
             renderShop();
@@ -1218,10 +1238,18 @@ function openShop(npc) {
       const row = document.createElement('div');
       row.className = 'slot';
       const price = typeof item.scrap === 'number' ? item.scrap : Math.floor(item.value / markup);
-      row.innerHTML = `<span>${item.name} - ${price} ${CURRENCY}</span><button class="btn">Sell</button>`;
+      const qty = Math.max(1, Number.isFinite(item?.count) ? item.count : 1);
+      const name = qty > 1 ? `${item.name} x${qty}` : item.name;
+      row.innerHTML = `<span>${name} - ${price} ${CURRENCY}</span><button class="btn">Sell</button>`;
       row.querySelector('button').onclick = () => {
         player.scrap += price;
-        npc.shop.inv.push({ id: item.id });
+        const existing = npc.shop.inv.find(entry => entry?.id === item.id && Math.max(1, Number.isFinite(entry.count) ? entry.count : 1) < 256);
+        if (existing) {
+          const current = Math.max(1, Number.isFinite(existing.count) ? existing.count : 1);
+          existing.count = Math.min(256, current + 1);
+        } else {
+          npc.shop.inv.push({ id: item.id, count: 1 });
+        }
         removeFromInv(idx);
         renderShop();
         updateHUD();

--- a/test/office.module.test.js
+++ b/test/office.module.test.js
@@ -162,7 +162,16 @@ test('vending machine buys access card for scrap', () => {
   global.toast = () => {};
   global.CURRENCY = 's';
   global.player = { scrap: 0, inv: [accessCard] };
-  global.removeFromInv = (idx) => { player.inv.splice(idx, 1); };
+  global.removeFromInv = (idx, qty = 1) => {
+    const item = player.inv[idx];
+    if (!item) return;
+    const count = Number.isFinite(item?.count) ? item.count : 1;
+    if (count > qty) {
+      item.count = count - qty;
+    } else {
+      player.inv.splice(idx, 1);
+    }
+  };
   global.updateHUD = () => {};
   global.addToInv = () => true;
   global.getItem = () => accessCard;

--- a/test/true-dust.mask-quest-flow.test.js
+++ b/test/true-dust.mask-quest-flow.test.js
@@ -38,12 +38,23 @@ test('mask memory quest updates journal and checkpoints', async () => {
     party: [{}, {}],
     player: { inv: [], scrap: 0 },
     addToInv: item => { context.player.inv.push(item); return true; },
-    removeFromInv: idx => { if (idx > -1) context.player.inv.splice(idx, 1); },
+    removeFromInv: (idx, qty = 1) => {
+      if (idx < 0) return;
+      const item = context.player.inv[idx];
+      if (!item) return;
+      const count = Number.isFinite(item?.count) ? item.count : 1;
+      if (count > qty) {
+        item.count = count - qty;
+      } else {
+        context.player.inv.splice(idx, 1);
+      }
+    },
     countItems: tag => {
       const needle = typeof tag === 'string' ? tag.toLowerCase() : '';
       return context.player.inv.reduce((sum, it) => {
         const tags = Array.isArray(it?.tags) ? it.tags.map(t => t.toLowerCase()) : [];
-        return sum + (it.id === tag || tags.includes(needle) ? 1 : 0);
+        const qty = Math.max(1, Number.isFinite(it?.count) ? it.count : 1);
+        return sum + (it.id === tag || tags.includes(needle) ? qty : 0);
       }, 0);
     },
     findItemIndex: tag => {

--- a/test/workbench-crafting.test.js
+++ b/test/workbench-crafting.test.js
@@ -30,7 +30,16 @@ test('craftSolarTarp uses cloth and scrap', () => {
     addToInv: id => { context.player.inv.push({ id }); return true; },
     hasItem: id => context.player.inv.some(i => i.id === id),
     findItemIndex: id => context.player.inv.findIndex(i => i.id === id),
-    removeFromInv: idx => context.player.inv.splice(idx, 1),
+    removeFromInv: (idx, qty = 1) => {
+      const item = context.player.inv[idx];
+      if (!item) return;
+      const count = Number.isFinite(item?.count) ? item.count : 1;
+      if (count > qty) {
+        item.count = count - qty;
+      } else {
+        context.player.inv.splice(idx, 1);
+      }
+    },
     log: () => {}
   };
   vm.runInNewContext(src, context);
@@ -48,7 +57,16 @@ test('craftBandage consumes plant fiber', () => {
     addToInv: id => { context.player.inv.push({ id }); return true; },
     hasItem: id => context.player.inv.some(i => i.id === id),
     findItemIndex: id => context.player.inv.findIndex(i => i.id === id),
-    removeFromInv: idx => context.player.inv.splice(idx, 1),
+    removeFromInv: (idx, qty = 1) => {
+      const item = context.player.inv[idx];
+      if (!item) return;
+      const count = Number.isFinite(item?.count) ? item.count : 1;
+      if (count > qty) {
+        item.count = count - qty;
+      } else {
+        context.player.inv.splice(idx, 1);
+      }
+    },
     log: () => {}
   };
   vm.runInNewContext(src, context);

--- a/test/workbench.ui.test.js
+++ b/test/workbench.ui.test.js
@@ -20,9 +20,18 @@ test('workbench shows requirement counts for recipes you lack', async () => {
   global.player = { scrap: 0, fuel: 0, inv: [] };
   global.hasItem = id => player.inv.some(i => i.id === id);
   global.findItemIndex = id => player.inv.findIndex(i => i.id === id);
-  global.removeFromInv = idx => player.inv.splice(idx, 1);
+  global.removeFromInv = (idx, qty = 1) => {
+    const item = player.inv[idx];
+    if (!item) return;
+    const count = Number.isFinite(item?.count) ? item.count : 1;
+    if (count > qty) {
+      item.count = count - qty;
+    } else {
+      player.inv.splice(idx, 1);
+    }
+  };
   global.addToInv = id => { player.inv.push({ id }); return true; };
-  global.countItems = id => player.inv.filter(i => i.id === id).length;
+  global.countItems = id => player.inv.reduce((sum, it) => sum + (it.id === id ? Math.max(1, Number.isFinite(it?.count) ? it.count : 1) : 0), 0);
 
   Dustland.openWorkbench();
   const rows = dom.window.document.querySelectorAll('#workbenchRecipes .slot');
@@ -42,9 +51,18 @@ test('arrow keys in workbench do not bubble to window', async () => {
   global.player = { scrap: 5, fuel: 50, inv: [ { id: 'cloth' }, { id: 'plant_fiber' } ] };
   global.hasItem = id => player.inv.some(i => i.id === id);
   global.findItemIndex = id => player.inv.findIndex(i => i.id === id);
-  global.removeFromInv = idx => player.inv.splice(idx, 1);
+  global.removeFromInv = (idx, qty = 1) => {
+    const item = player.inv[idx];
+    if (!item) return;
+    const count = Number.isFinite(item?.count) ? item.count : 1;
+    if (count > qty) {
+      item.count = count - qty;
+    } else {
+      player.inv.splice(idx, 1);
+    }
+  };
   global.addToInv = id => { player.inv.push({ id }); return true; };
-  global.countItems = id => player.inv.filter(i => i.id === id).length;
+  global.countItems = id => player.inv.reduce((sum, it) => sum + (it.id === id ? Math.max(1, Number.isFinite(it?.count) ? it.count : 1) : 0), 0);
 
   let moved = 0;
   dom.window.addEventListener('keydown', () => { moved++; });


### PR DESCRIPTION
## Summary
- add stack-aware inventory operations including drop, pickup, and count updates
- surface stack counts in the UI and ensure NPC shops/traders aggregate quantities
- update supporting code and tests to work with stackable items

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cac9e7724883288b950950bf50a8ea