### PR TITLE
docs: define scheduler data schema

### DIFF
--- a/data/modules/schema.js
+++ b/data/modules/schema.js
@@ -213,6 +213,25 @@ globalThis.ACK_MODULE_SCHEMA = {
         "additionalProperties": true
       }
     },
+    "schedules": {
+      "type": "object",
+      "properties": {
+        "world": { "$ref": "#/definitions/scheduleList" },
+        "npcs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "npcId": { "type": "string" },
+              "timeline": { "$ref": "#/definitions/scheduleList" }
+            },
+            "required": ["npcId", "timeline"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "zones": {
       "type": "array",
       "items": {
@@ -290,6 +309,151 @@ globalThis.ACK_MODULE_SCHEMA = {
     "dialogTree": {
       "type": "object",
       "additionalProperties": { "$ref": "#/definitions/dialogNode" }
+    },
+    "scheduleList": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/scheduleEntry" }
+    },
+    "scheduleEntry": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string" },
+        "event": { "type": "string" },
+        "payload": { "type": "object" },
+        "trigger": { "$ref": "#/definitions/scheduleTrigger" },
+        "repeat": { "$ref": "#/definitions/repeatRule" },
+        "prerequisites": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/schedulePrerequisite" }
+        },
+        "notes": { "type": "string" }
+      },
+      "required": ["event", "trigger"],
+      "additionalProperties": false
+    },
+    "scheduleTrigger": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "immediate" }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "time" },
+            "hour": { "type": "integer", "minimum": 0, "maximum": 23 },
+            "minute": { "type": "integer", "minimum": 0, "maximum": 59 },
+            "day": { "type": ["integer", "string"] }
+          },
+          "required": ["type", "hour"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "delay" },
+            "hours": { "type": "integer", "minimum": 0 },
+            "minutes": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["type"],
+          "anyOf": [
+            { "required": ["hours"] },
+            { "required": ["minutes"] }
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "afterEvent" },
+            "eventId": { "type": "string" },
+            "offsetHours": { "type": "integer", "minimum": 0 },
+            "offsetMinutes": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["type", "eventId"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "repeatRule": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["none", "interval", "daily", "weekly"]
+        },
+        "intervalHours": { "type": "integer", "minimum": 0 },
+        "intervalMinutes": { "type": "integer", "minimum": 0 },
+        "maxRuns": { "type": "integer", "minimum": 1 },
+        "days": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "skipIfActive": { "type": "boolean" }
+      },
+      "required": ["type"],
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "interval" } } },
+          "then": {
+            "anyOf": [
+              { "required": ["intervalHours"] },
+              { "required": ["intervalMinutes"] }
+            ]
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "weekly" } } },
+          "then": { "required": ["days"] }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "schedulePrerequisite": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "flag" },
+            "flag": { "type": "string" },
+            "value": { "type": ["boolean", "string", "number"] }
+          },
+          "required": ["type", "flag"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "questState" },
+            "questId": { "type": "string" },
+            "state": { "type": "string" }
+          },
+          "required": ["type", "questId", "state"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "eventComplete" },
+            "eventId": { "type": "string" }
+          },
+          "required": ["type", "eventId"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "script" },
+            "handler": { "type": "string" }
+          },
+          "required": ["type", "handler"],
+          "additionalProperties": false
+        }
+      ]
     },
     "dialogNode": {
       "type": "object",

--- a/docs/design/in-progress/reactive-systems.md
+++ b/docs/design/in-progress/reactive-systems.md
@@ -34,7 +34,7 @@
  - [x] Extend quest definitions to support branching and persistence.
  - [x] Add NPC memory storage and retrieval utilities.
 - [ ] Build event scheduler for world and NPC timelines.
-  - [ ] Specify scheduler data structures (timeline entries, repeat rules, prerequisites) and document them for Adventure Kit authors.
+  - [x] Specify scheduler data structures (timeline entries, repeat rules, prerequisites) and document them for Adventure Kit authors. (See `data/modules/schema.js` and `docs/guides/event-scheduler.md`.)
   - [ ] Implement a tick-driven scheduler service that queues world/NPC events, persists progress to saves, and survives map transitions.
   - [ ] Add editor tooling to visualize upcoming events and allow designers to fast-forward or cancel entries during testing.
   - [ ] Write automated tests covering chained events, missed ticks after load, and NPC reactions triggered by the scheduler.

--- a/docs/guides/event-scheduler.md
+++ b/docs/guides/event-scheduler.md
@@ -1,0 +1,97 @@
+# Event Scheduler Data Reference
+
+The event scheduler lets modules describe timed world and NPC behavior without hand-coding timers. This guide documents the data structures Adventure Kit authors can now use inside their module JSON to stage upcoming events.
+
+## Where schedule data lives
+
+Add a new optional `schedules` block to your module definition. It contains two collections:
+
+- `world`: timeline entries that fire regardless of specific NPCs.
+- `npcs`: an array of `{ npcId, timeline }` objects. Each timeline drives events for a specific NPC id in the module.
+
+```json
+{
+  "schedules": {
+    "world": [
+      { "event": "stonegate:dawn-toast", "trigger": { "type": "time", "hour": 6 }, "repeat": { "type": "daily" } }
+    ],
+    "npcs": [
+      {
+        "npcId": "rygar",
+        "timeline": [
+          {
+            "id": "rygar-morning-patrol",
+            "label": "Rygar patrol leaves Stonegate",
+            "event": "npc:rygar:patrol",
+            "trigger": { "type": "time", "hour": 7, "minute": 30 },
+            "repeat": { "type": "daily", "skipIfActive": true },
+            "prerequisites": [
+              { "type": "flag", "flag": "stonegate.unlocked" }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The scheduler service (to be implemented in a later task) will read these entries, emit the configured events, and persist progress across saves.
+
+## Timeline entries
+
+Each entry in a timeline follows the schema defined in `data/modules/schema.js`:
+
+- `id` *(optional)* – Unique identifier so other entries can reference this one in `afterEvent` triggers or prerequisites.
+- `label` *(optional)* – Short human-friendly description that editor tooling can surface.
+- `event` *(required)* – Event key that the scheduler will emit on the global event bus.
+- `payload` *(optional)* – Object passed as the payload when the event fires.
+- `trigger` *(required)* – Defines when the event should occur. See [Trigger types](#trigger-types).
+- `repeat` *(optional)* – Controls how often the event repeats. See [Repeat rules](#repeat-rules).
+- `prerequisites` *(optional)* – Array of conditions that must be met before the entry can queue. See [Prerequisites](#prerequisites).
+- `notes` *(optional)* – Free-form text for designers.
+
+## Trigger types
+
+The `trigger` field supports four shapes:
+
+| Type | Description |
+| --- | --- |
+| `immediate` | Fires as soon as prerequisites are satisfied. Useful for one-shot follow-ups chained off other entries. |
+| `time` | Fires at a specific in-world hour/minute, optionally scoped to a named or numbered day. Provide `hour` (0–23) and optional `minute` and `day`. |
+| `delay` | Waits for the specified `hours` and/or `minutes` once the entry becomes eligible. |
+| `afterEvent` | Runs after another scheduled entry completes. Provide `eventId` referencing the other entry's `id`, plus optional `offsetHours`/`offsetMinutes`. |
+
+## Repeat rules
+
+Repeat blocks share a simple structure:
+
+- `type` *(required)* – One of `none`, `interval`, `daily`, or `weekly`.
+- `intervalHours` / `intervalMinutes` *(interval only)* – How long to wait between runs. At least one must be present.
+- `days` *(weekly only)* – Array of day identifiers (e.g., `"monday"`, `"day3"`) that the event should run on.
+- `maxRuns` *(optional)* – Caps how many times the entry repeats before retiring.
+- `skipIfActive` *(optional)* – When `true`, the scheduler will not queue a new instance while an earlier run is still executing.
+
+Omit the `repeat` block entirely for one-shot events. Use `type: "none"` to make the intent explicit while still allowing `maxRuns` or `skipIfActive` to apply.
+
+## Prerequisites
+
+Prerequisites gate timeline entries until certain conditions are met. The schema supports four primitives:
+
+| Type | Fields | Purpose |
+| --- | --- | --- |
+| `flag` | `flag`, optional `value` | Requires a world or module flag to match the expected value (defaults to truthy). |
+| `questState` | `questId`, `state` | Ensures a quest has reached a particular state before scheduling. |
+| `eventComplete` | `eventId` | Waits for another scheduled entry (identified by `id`) to finish at least once. |
+| `script` | `handler` | Calls a custom handler function exported on the module to perform advanced checks. |
+
+Combine multiple prerequisite objects to model AND logic. The scheduler will only enqueue the entry when every listed prerequisite is satisfied.
+
+## Authoring tips
+
+- Give every major entry an `id` and `label` so editor tooling and debug logs stay readable.
+- Use `event` namespaces (e.g., `npc:rygar:patrol`) to avoid collisions with base game hooks.
+- Pair `afterEvent` triggers with `repeat` rules to build multi-step chains that loop over time.
+- Keep payloads compact—stick to serialisable primitives so the eventual scheduler can persist state cleanly.
+
+With these structures in place, upcoming work on the scheduler service and editor visualisation can focus on runtime logic while Adventure Kit authors start sketching their timelines today.


### PR DESCRIPTION
## Summary
- extend the module JSON schema with optional `schedules` data structures for world and NPC timelines
- document scheduler timelines, triggers, repeat rules, and prerequisites for Adventure Kit authors
- mark the reactive systems design task for documenting scheduler data as complete

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cacf913630832896c7ab73895506a3