### PR TITLE
fix: scaffold module json via node script

### DIFF
--- a/data/modules/cli-demo.json
+++ b/data/modules/cli-demo.json
@@ -1,0 +1,164 @@
+{
+  "seed": "cli-demo-seed",
+  "name": "CLI Demo Adventure",
+  "start": {
+    "map": "world",
+    "x": 6,
+    "y": 5
+  },
+  "items": [
+    {
+      "id": "starter_kit",
+      "name": "Starter Kit",
+      "type": "quest",
+      "map": "world",
+      "x": 5,
+      "y": 5
+    },
+    {
+      "id": "camp_rations",
+      "name": "Camp Rations",
+      "type": "food",
+      "map": "world",
+      "x": 7,
+      "y": 5
+    }
+  ],
+  "quests": [
+    {
+      "id": "trail_briefing",
+      "title": "Trail Briefing",
+      "desc": "Talk to Rowan and inspect the humming stones.",
+      "reward": "starter_kit",
+      "xp": 2
+    },
+    {
+      "id": "coded_stone",
+      "title": "Decode the Stone",
+      "desc": "Use the cipher wheel Rowan gave you to decode the humming stone.",
+      "reward": "camp_rations",
+      "xp": 4
+    }
+  ],
+  "npcs": [
+    {
+      "id": "guide_rowan",
+      "map": "world",
+      "x": 6,
+      "y": 5,
+      "name": "Guide Rowan",
+      "color": "#44ccff",
+      "prompt": "A seasoned scout checking their compass",
+      "tree": {
+        "start": {
+          "text": "Welcome to the CLI-built adventure.",
+          "choices": [
+            {
+              "label": "Any tips?",
+              "to": "tip"
+            },
+            {
+              "label": "Let's head out.",
+              "to": "bye"
+            },
+            {
+              "label": "Do you have any other work?",
+              "to": "quest_offer"
+            }
+          ]
+        },
+        "tip": {
+          "text": "Stay alert and keep your supplies ready.",
+          "choices": [
+            {
+              "label": "Thanks.",
+              "to": "bye"
+            }
+          ]
+        },
+        "bye": {
+          "text": "I'll meet you at the lookout.",
+          "choices": [
+            {
+              "label": "Leave",
+              "to": "end"
+            }
+          ]
+        },
+        "quest_offer": {
+          "text": "I found a coded stone near the ridge. Want to decipher it?",
+          "choices": [
+            {
+              "label": "I'll take the challenge.",
+              "to": "accept_coded",
+              "q": "accept"
+            },
+            {
+              "label": "Not right now.",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept_coded": {
+          "text": "Take this cipher wheel and meet me when you're done.",
+          "choices": [
+            {
+              "label": "I'll get started.",
+              "to": "bye",
+              "reward": "camp_rations"
+            }
+          ]
+        }
+      },
+      "questId": "coded_stone"
+    }
+  ],
+  "events": [
+    {
+      "map": "world",
+      "x": 7,
+      "y": 5,
+      "events": [
+        {
+          "when": "enter",
+          "effect": "toast",
+          "msg": "The air hums with old power."
+        },
+        {
+          "when": "enter",
+          "effect": "modStat",
+          "stat": "PER",
+          "delta": 1,
+          "duration": 3
+        }
+      ]
+    }
+  ],
+  "portals": [],
+  "interiors": [
+    {
+      "id": "trail_hut",
+      "w": 3,
+      "h": 3,
+      "entryX": 1,
+      "entryY": 1,
+      "grid": [
+        "🏝🚪🏝",
+        "🪨🪨🪨",
+        "🏝🏝🏝"
+      ]
+    }
+  ],
+  "buildings": [
+    {
+      "x": 8,
+      "y": 5,
+      "interiorId": "trail_hut",
+      "name": "Trail Hut",
+      "boarded": false
+    }
+  ],
+  "zones": [],
+  "templates": [],
+  "module": "modules/cli-demo.module.js"
+}

--- a/modules/cli-demo.module.js
+++ b/modules/cli-demo.module.js
@@ -1,0 +1,182 @@
+function seedWorldContent() {}
+
+const DATA = `
+{
+  "seed": "cli-demo-seed",
+  "name": "CLI Demo Adventure",
+  "start": {
+    "map": "world",
+    "x": 6,
+    "y": 5
+  },
+  "items": [
+    {
+      "id": "starter_kit",
+      "name": "Starter Kit",
+      "type": "quest",
+      "map": "world",
+      "x": 5,
+      "y": 5
+    },
+    {
+      "id": "camp_rations",
+      "name": "Camp Rations",
+      "type": "food",
+      "map": "world",
+      "x": 7,
+      "y": 5
+    }
+  ],
+  "quests": [
+    {
+      "id": "trail_briefing",
+      "title": "Trail Briefing",
+      "desc": "Talk to Rowan and inspect the humming stones.",
+      "reward": "starter_kit",
+      "xp": 2
+    },
+    {
+      "id": "coded_stone",
+      "title": "Decode the Stone",
+      "desc": "Use the cipher wheel Rowan gave you to decode the humming stone.",
+      "reward": "camp_rations",
+      "xp": 4
+    }
+  ],
+  "npcs": [
+    {
+      "id": "guide_rowan",
+      "map": "world",
+      "x": 6,
+      "y": 5,
+      "name": "Guide Rowan",
+      "color": "#44ccff",
+      "prompt": "A seasoned scout checking their compass",
+      "tree": {
+        "start": {
+          "text": "Welcome to the CLI-built adventure.",
+          "choices": [
+            {
+              "label": "Any tips?",
+              "to": "tip"
+            },
+            {
+              "label": "Let's head out.",
+              "to": "bye"
+            },
+            {
+              "label": "Do you have any other work?",
+              "to": "quest_offer"
+            }
+          ]
+        },
+        "tip": {
+          "text": "Stay alert and keep your supplies ready.",
+          "choices": [
+            {
+              "label": "Thanks.",
+              "to": "bye"
+            }
+          ]
+        },
+        "bye": {
+          "text": "I'll meet you at the lookout.",
+          "choices": [
+            {
+              "label": "Leave",
+              "to": "end"
+            }
+          ]
+        },
+        "quest_offer": {
+          "text": "I found a coded stone near the ridge. Want to decipher it?",
+          "choices": [
+            {
+              "label": "I'll take the challenge.",
+              "to": "accept_coded",
+              "q": "accept"
+            },
+            {
+              "label": "Not right now.",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept_coded": {
+          "text": "Take this cipher wheel and meet me when you're done.",
+          "choices": [
+            {
+              "label": "I'll get started.",
+              "to": "bye",
+              "reward": "camp_rations"
+            }
+          ]
+        }
+      },
+      "questId": "coded_stone"
+    }
+  ],
+  "events": [
+    {
+      "map": "world",
+      "x": 7,
+      "y": 5,
+      "events": [
+        {
+          "when": "enter",
+          "effect": "toast",
+          "msg": "The air hums with old power."
+        },
+        {
+          "when": "enter",
+          "effect": "modStat",
+          "stat": "PER",
+          "delta": 1,
+          "duration": 3
+        }
+      ]
+    }
+  ],
+  "portals": [],
+  "interiors": [
+    {
+      "id": "trail_hut",
+      "w": 3,
+      "h": 3,
+      "entryX": 1,
+      "entryY": 1,
+      "grid": [
+        "🏝🚪🏝",
+        "🪨🪨🪨",
+        "🏝🏝🏝"
+      ]
+    }
+  ],
+  "buildings": [
+    {
+      "x": 8,
+      "y": 5,
+      "interiorId": "trail_hut",
+      "name": "Trail Hut",
+      "boarded": false
+    }
+  ],
+  "zones": [],
+  "templates": []
+}
+`;
+
+function postLoad(module) {}
+
+globalThis.CLI_DEMO_MODULE = JSON.parse(DATA);
+globalThis.CLI_DEMO_MODULE.postLoad = postLoad;
+
+startGame = function () {
+  CLI_DEMO_MODULE.postLoad?.(CLI_DEMO_MODULE);
+  applyModule(CLI_DEMO_MODULE);
+  const s = CLI_DEMO_MODULE.start;
+  if (s) {
+    setPartyPos(s.x, s.y);
+    setMap(s.map, 'CLI Demo Adventure');
+  }
+};

--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -12,6 +12,7 @@ const MODULES = [
   { id: 'golden', name: 'Golden Sample', file: 'modules/golden.module.json' },
   { id: 'edge', name: 'bunker-trainer-workshop', file: 'modules/edge.module.js' },
   { id: 'engine-tech-demo', name: 'Engine Feature Showcase', file: 'modules/engine-tech-demo.module.js' },
+  { id: 'cli-demo', name: 'CLI Demo Adventure', file: 'modules/cli-demo.module.js' },
 ];
 
 const realOpenCreator = window.openCreator;

--- a/scripts/module-tools/create-cli-adventure.sh
+++ b/scripts/module-tools/create-cli-adventure.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT_DIR"
+
+MODULE_NAME=${1:-cli-demo}
+JSON_PATH="data/modules/${MODULE_NAME}.json"
+JS_PATH="modules/${MODULE_NAME}.module.js"
+
+rm -f "$JSON_PATH" "$JS_PATH"
+
+node scripts/module-tools/init-module-json.js "$JSON_PATH" \
+  seed="${MODULE_NAME}-seed" \
+  name="CLI Demo Adventure" \
+  map=world \
+  x=6 \
+  y=5
+
+node scripts/module-tools/append.js "$JSON_PATH" items id=starter_kit name="Starter Kit" type=quest map=world x=5 y=5
+node scripts/module-tools/append.js "$JSON_PATH" items id=camp_rations name="Camp Rations" type=food map=world x=7 y=5
+
+node scripts/module-tools/add-npc.js "$JSON_PATH" \
+  id=guide_rowan \
+  map=world \
+  x=6 \
+  y=5 \
+  name="Guide Rowan" \
+  color=#44ccff \
+  prompt="A seasoned scout checking their compass" \
+  "tree.start.text=Welcome to the CLI-built adventure." \
+  "tree.start.choices.0.label=Any tips?" \
+  "tree.start.choices.0.to=tip" \
+  "tree.start.choices.1.label=Let's head out." \
+  "tree.start.choices.1.to=bye" \
+  "tree.tip.text=Stay alert and keep your supplies ready." \
+  "tree.tip.choices.0.label=Thanks." \
+  "tree.tip.choices.0.to=bye" \
+  "tree.bye.text=I'll meet you at the lookout." \
+  "tree.bye.choices.0.label=Leave" \
+  "tree.bye.choices.0.to=end"
+
+node scripts/module-tools/append.js "$JSON_PATH" interiors \
+  id=trail_hut \
+  w=3 \
+  h=3 \
+  entryX=1 \
+  entryY=1 \
+  "grid.0=🏝🚪🏝" \
+  "grid.1=🪨🪨🪨" \
+  "grid.2=🏝🏝🏝"
+
+node scripts/module-tools/add-building.js "$JSON_PATH" \
+  x=8 \
+  y=5 \
+  interiorId=trail_hut \
+  name="Trail Hut" \
+  boarded=false
+
+node scripts/module-tools/append.js "$JSON_PATH" events \
+  map=world \
+  x=7 \
+  y=5 \
+  "events.0.when=enter" \
+  "events.0.effect=toast" \
+  "events.0.msg=The air hums with old power." \
+  "events.1.when=enter" \
+  "events.1.effect=modStat" \
+  "events.1.stat=PER" \
+  "events.1.delta=1" \
+  "events.1.duration=3"
+
+node scripts/module-tools/append.js "$JSON_PATH" quests \
+  id=trail_briefing \
+  title="Trail Briefing" \
+  desc="Talk to Rowan and inspect the humming stones." \
+  reward=starter_kit \
+  xp=2
+
+node scripts/supporting/json-to-module.js "$JSON_PATH"
+
+echo "Adventure module created: $JSON_PATH -> $JS_PATH"

--- a/scripts/module-tools/extend-cli-adventure.sh
+++ b/scripts/module-tools/extend-cli-adventure.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT_DIR"
+
+MODULE_NAME=${1:-cli-demo}
+JSON_PATH="data/modules/${MODULE_NAME}.json"
+JS_PATH="modules/${MODULE_NAME}.module.js"
+
+if [[ ! -f "$JS_PATH" ]]; then
+  echo "Module file $JS_PATH not found. Run create-cli-adventure.sh first." >&2
+  exit 1
+fi
+
+node scripts/supporting/module-json.js export "$JS_PATH"
+
+if [[ ! -f "$JSON_PATH" ]]; then
+  echo "Export failed; JSON file $JSON_PATH not found." >&2
+  exit 1
+fi
+
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan questId coded_stone
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.start.choices.2.label" "Do you have any other work?"
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.start.choices.2.to" quest_offer
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.quest_offer.text" "I found a coded stone near the ridge. Want to decipher it?"
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.quest_offer.choices.0.label" "I'll take the challenge."
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.quest_offer.choices.0.to" accept_coded
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.quest_offer.choices.0.q" accept
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.quest_offer.choices.1.label" "Not right now."
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.quest_offer.choices.1.to" bye
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.accept_coded.text" "Take this cipher wheel and meet me when you're done."
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.accept_coded.choices.0.label" "I'll get started."
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.accept_coded.choices.0.to" bye
+node scripts/module-tools/edit-npc.js "$JSON_PATH" guide_rowan "tree.accept_coded.choices.0.reward" camp_rations
+
+node scripts/module-tools/append.js "$JSON_PATH" quests \
+  id=coded_stone \
+  title="Decode the Stone" \
+  desc="Use the cipher wheel Rowan gave you to decode the humming stone." \
+  reward=camp_rations \
+  xp=4
+
+node scripts/supporting/module-json.js import "$JS_PATH"
+
+echo "Adventure module extended and re-imported from $JSON_PATH into $JS_PATH"

--- a/scripts/module-tools/init-module-json.js
+++ b/scripts/module-tools/init-module-json.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseValue } from './utils.js';
+
+const [file, ...args] = process.argv.slice(2);
+if (!file) {
+  console.error('Usage: node scripts/module-tools/init-module-json.js <moduleFile> [seed=...] [name=...] [map=...] [x=...] [y=...]');
+  process.exit(1);
+}
+
+const defaults = createDefaults(file);
+for (const arg of args) {
+  const eq = arg.indexOf('=');
+  if (eq === -1) {
+    console.error(`Invalid argument: ${arg}`);
+    process.exit(1);
+  }
+  const key = arg.slice(0, eq);
+  const value = parseValue(arg.slice(eq + 1));
+  if (key in defaults) {
+    defaults[key] = value;
+  } else {
+    console.error(`Unknown option: ${key}`);
+    process.exit(1);
+  }
+}
+
+const start = {
+  map: defaults.map,
+  x: Number.isFinite(defaults.x) ? defaults.x : Number(defaults.x) || 0,
+  y: Number.isFinite(defaults.y) ? defaults.y : Number(defaults.y) || 0
+};
+
+const moduleData = {
+  seed: defaults.seed,
+  name: defaults.name,
+  start,
+  items: [],
+  quests: [],
+  npcs: [],
+  events: [],
+  portals: [],
+  interiors: [],
+  buildings: [],
+  zones: [],
+  templates: []
+};
+
+fs.mkdirSync(path.dirname(file), { recursive: true });
+fs.writeFileSync(file, JSON.stringify(moduleData, null, 2) + '\n');
+
+function createDefaults(filePath) {
+  const basename = path.basename(filePath, path.extname(filePath));
+  const displayName = basename
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+  return {
+    seed: `${basename}-seed`,
+    name: displayName || 'New Adventure',
+    map: 'world',
+    x: 0,
+    y: 0
+  };
+}


### PR DESCRIPTION
## Summary
- add init-module-json.js to create module skeleton JSON from CLI arguments
- update create-cli-adventure.sh to use the node initializer instead of an inline heredoc

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/cli-demo.module.js

------
https://chatgpt.com/codex/tasks/task_e_68cad15bbde883289271c476b4b7db29