### PR TITLE
fix: treat ws as optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dustland",
-  "version": "0.82.0",
+  "version": "0.142.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dustland",
-      "version": "0.82.0",
+      "version": "0.142.1",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",
@@ -14,8 +14,10 @@
         "http-server": "^14.1.1",
         "jsdom": "^26.1.0",
         "puppeteer": "^24.17.0",
-        "ws": "^8.18.3",
         "yaml-lint": "^1.7.0"
+      },
+      "optionalDependencies": {
+        "ws": "^8.18.3"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -3513,7 +3515,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "http-server": "^14.1.1",
     "jsdom": "^26.1.0",
     "puppeteer": "^24.17.0",
-    "ws": "^8.18.3",
     "yaml-lint": "^1.7.0"
+  },
+  "optionalDependencies": {
+    "ws": "^8.18.3"
   }
 }

--- a/scripts/supporting/multiplayer-sync.js
+++ b/scripts/supporting/multiplayer-sync.js
@@ -4,7 +4,18 @@
   const bus = globalThis.EventBus;
   const Multiplayer = {
     async startHost({ port = 7777 } = {}) {
-      const WSS = globalThis.WebSocketServer || (await import('ws')).WebSocketServer;
+      let WSS = globalThis.WebSocketServer;
+      if (!WSS) {
+        const isNode = typeof process !== 'undefined' && process.versions?.node;
+        if (!isNode) {
+          throw new Error('Multiplayer hosting is only supported in Node.js.');
+        }
+        try {
+          ({ WebSocketServer: WSS } = await import('ws'));
+        } catch (err) {
+          throw new Error('Missing optional dependency "ws". Run `npm install ws` to enable hosting.');
+        }
+      }
       const wss = new WSS({ port });
       let last = {};
       const broadcast = () => {


### PR DESCRIPTION
## Summary
- prevent the multiplayer host helper from importing the ws module in browser contexts
- surface clearer errors when hosting outside Node.js or when the optional ws dependency is missing
- declare ws as an optional dependency so npm installs it automatically for hosting workflows

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cadbc8f7088328a265e6d4a3940d89