### PR TITLE
fix: reposition hall key and wand

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -367,7 +367,7 @@ const DATA = `
     },
     {
       "map": "hall",
-      "x": 14,
+      "x": 9,
       "y": 18,
       "id": "glinting_key",
       "name": "Glinting Key",
@@ -382,7 +382,7 @@ const DATA = `
     {
       "map": "hall",
       "x": 16,
-      "y": 18,
+      "y": 8,
       "id": "wand",
       "name": "Wand",
       "type": "quest",


### PR DESCRIPTION
## Summary
- move the glinting key five tiles west in the hall so it sits on the intended space
- raise the wand ten tiles north to match the updated hall layout

## Testing
- node scripts/supporting/placement-check.js modules/dustland.module.js
- node scripts/supporting/presubmit.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb05ba1abc8328938b8b3e4cc36439