### PR TITLE
fix: gate footstep bump behind fx toggle

### DIFF
--- a/dustland.html
+++ b/dustland.html
@@ -112,6 +112,10 @@
           <input type="checkbox" id="fxColorBleed" />
         </div>
         <div class="field">
+          <label for="fxFootstepBump">Footstep Camera Bump</label>
+          <input type="checkbox" id="fxFootstepBump" />
+        </div>
+        <div class="field">
           <label for="fxGrayscale">Grayscale</label>
           <input type="checkbox" id="fxGrayscale" />
         </div>

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -695,6 +695,8 @@ function playWindChime(x, y) {
 }
 
 function footstepBump(){
+  const fx = globalThis.fxConfig;
+  if(!fx || !fx.footstepBump) return;
   const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
   bumpX = (Math.random()-0.5) * FOOTSTEP_BUMP_RANGE;
   bumpY = (Math.random()-0.5) * FOOTSTEP_BUMP_RANGE;

--- a/scripts/fx-config.js
+++ b/scripts/fx-config.js
@@ -10,6 +10,7 @@
     scanlines: false, // overlay horizontal scanlines
     crtShear: false, // slight screen skew effect
     colorBleed: false, // simple chromatic aberration
+    footstepBump: false, // camera shake when walking
     grayscale: false, // render world in grayscale
     adrenalineTint: true // green saturation scales with adrenaline
   };

--- a/scripts/supporting/fx-debug.js
+++ b/scripts/supporting/fx-debug.js
@@ -11,6 +11,7 @@
   const scanlines = document.getElementById('fxScanlines');
   const shear = document.getElementById('fxCrtShear');
   const colorBleed = document.getElementById('fxColorBleed');
+  const footstepBump = document.getElementById('fxFootstepBump');
   const grayscale = document.getElementById('fxGrayscale');
   const adrTint = document.getElementById('fxAdrTint');
   const canvas = document.getElementById('game');
@@ -60,6 +61,7 @@
     if(scanlines) scanlines.checked = !!globalThis.fxConfig.scanlines;
     if(shear) shear.checked = !!globalThis.fxConfig.crtShear;
     if(colorBleed) colorBleed.checked = !!globalThis.fxConfig.colorBleed;
+    if(footstepBump) footstepBump.checked = !!globalThis.fxConfig.footstepBump;
     if(grayscale) grayscale.checked = !!globalThis.fxConfig.grayscale;
     if(adrTint) adrTint.checked = globalThis.fxConfig.adrenalineTint !== false;
     applyFx();
@@ -89,6 +91,7 @@
   scanlines?.addEventListener('change', e => { globalThis.fxConfig.scanlines = e.target.checked; applyFx(); });
   shear?.addEventListener('change', e => { globalThis.fxConfig.crtShear = e.target.checked; applyFx(); });
   colorBleed?.addEventListener('change', e => { globalThis.fxConfig.colorBleed = e.target.checked; applyFx(); });
+  footstepBump?.addEventListener('change', e => { globalThis.fxConfig.footstepBump = e.target.checked; });
   grayscale?.addEventListener('change', e => { globalThis.fxConfig.grayscale = e.target.checked; globalThis.updateHUD?.(); });
   adrTint?.addEventListener('change', e => { globalThis.fxConfig.adrenalineTint = e.target.checked; globalThis.updateHUD?.(); });
 

--- a/test/fx-debug.test.js
+++ b/test/fx-debug.test.js
@@ -26,6 +26,26 @@ test('damage flash checkbox updates fxConfig', async () => {
   assert.equal(window.fxConfig.damageFlash, true);
 });
 
+test('footstep bump checkbox updates fxConfig', async () => {
+  const document = makeDocument();
+  const window = { document };
+  window.fxConfig = { footstepBump: false };
+  const sandbox = { window, document, fxConfig: window.fxConfig };
+  sandbox.globalThis = sandbox;
+  sandbox.setTimeout = setTimeout;
+  sandbox.clearTimeout = clearTimeout;
+  document.getElementById('fxPanel').appendChild(document.getElementById('fxFootstepBump'));
+  const code = await fs.readFile(new URL('../scripts/supporting/fx-debug.js', import.meta.url), 'utf8');
+  vm.runInNewContext(code, sandbox);
+  const cb = document.getElementById('fxFootstepBump');
+  cb.checked = true;
+  cb.dispatchEvent({ type:'change' });
+  assert.equal(window.fxConfig.footstepBump, true);
+  cb.checked = false;
+  cb.dispatchEvent({ type:'change' });
+  assert.equal(window.fxConfig.footstepBump, false);
+});
+
 test('fx checkboxes apply classes and update config', async () => {
   const document = makeDocument();
   const window = { document };


### PR DESCRIPTION
## Summary
- add a Footstep Camera Bump toggle to the FX debug panel
- disable the footstep bump effect unless the toggle is enabled via fxConfig
- cover the new toggle wiring with unit tests

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cb1287624c8328aef61721adbf25aa