### PR TITLE
fix: restore trainer portal and preserve trainer effects

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -1993,7 +1993,13 @@ const DATA = `
             },
             {
               "label": "(Upgrade Skills)",
-              "to": "train"
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "showTrainer",
+                  "trainer": "power"
+                }
+              ]
             }
           ]
         },
@@ -2030,7 +2036,13 @@ const DATA = `
             },
             {
               "label": "(Upgrade Skills)",
-              "to": "train"
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "showTrainer",
+                  "trainer": "endurance"
+                }
+              ]
             }
           ]
         },
@@ -13839,12 +13851,12 @@ const DATA = `
       ]
     },
     {
-      "x": 116,
-      "y": 1,
+      "x": 117,
+      "y": 0,
       "w": 3,
       "h": 3,
-      "doorX": 117,
-      "doorY": 3,
+      "doorX": 118,
+      "doorY": 2,
       "interiorId": "portal_hut",
       "boarded": false,
       "grid": [


### PR DESCRIPTION
## Summary
- add missing showTrainer effects to Dustland trainer NPC choices and restore the portal hut coordinates
- teach the Adventure Kit dialog editor to preserve unknown choice effects (like showTrainer) without breaking other effect editing
- ensure collectNPCFromForm always injects trainer effects while tolerating trainer toggles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2cd70b888328b50882a10393ab65