### PR TITLE
fix: honor mira color override

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -941,7 +941,8 @@ const DATA = `
         },
         "auto": true
       },
-      "symbol": "!"
+      "symbol": "!",
+      "overrideColor": true
     },
     {
       "id": "party_nora",


### PR DESCRIPTION
## Summary
- enable Mira's Dustland module entry to override the default NPC color so her configured red swatch renders in-game

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68cb4fc80a748328a6eae389195aa527