### PR TITLE
fix: prevent spacebar from scrolling page during gameplay

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -1983,7 +1983,13 @@ function runTests(){
       case 'ArrowDown': case 's': case 'S': move(0,1); break;
       case 'ArrowLeft': case 'a': case 'A': move(-1,0); break;
       case 'ArrowRight': case 'd': case 'D': move(1,0); break;
-      case 'e': case 'E': case ' ': interact(); break;
+      case ' ': case 'Spacebar':
+        e.preventDefault();
+        interact();
+        break;
+      case 'e': case 'E':
+        interact();
+        break;
       case 't': case 'T': case 'g': case 'G': takeNearestItem(); break;
       case 'o': case 'O': toggleAudio(); break;
       case 'c': case 'C': toggleMobileControls(); break;


### PR DESCRIPTION
## Summary
- prevent the spacebar from triggering the browser page scroll while interacting in the game
- handle both modern and legacy spacebar key values before invoking the interaction logic

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cb5765a3808328840887f1887125be