### PR TITLE
fix: normalize mira party color

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -916,7 +916,7 @@ const DATA = `
       "map": "world",
       "x": 16,
       "y": 55,
-      "color": "#fF0000",
+      "color": "#ff0000",
       "name": "Mira",
       "title": "Blade Dancer",
       "desc": "A lithe fighter ready to strike back.",


### PR DESCRIPTION
## Summary
- update party_mira's color hex to lowercase red so overrideColor renders correctly

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68cb5aaab6748328a0132ca3f7ef3b7d