### PR TITLE
fix: delay wide tab layout until it fits

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -425,6 +425,15 @@ input[type="range"] {
         :root {
             --panelW: 840px;
         }
+    }
+
+    @media (min-width: 1980px) {
+        .panel {
+            width: 1280px;
+        }
+        :root {
+            --panelW: 1280px;
+        }
 
         .tabs {
             display: none;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -1142,7 +1142,7 @@ function drawEntities(ctx, list, offX, offY){
 Object.assign(window, { renderOrderSystem: { order: renderOrder, render } });
 
 // ===== HUD & Tabs =====
-const TAB_BREAKPOINT = 1600;
+const TAB_BREAKPOINT = 1980;
 let activeTab = 'inv';
 
 function updateHUD(){


### PR DESCRIPTION
## Summary
- keep the panel width bump at 1600px while leaving the tab layout intact
- add a wider 1980px breakpoint that expands the panel and shows inventory, party, and quests side by side
- sync the JavaScript tab breakpoint with the new responsive threshold

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cb60f4d5b48328898aedde93f18986