### PR TITLE
fix: gate adrenaline blur behind low health

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -1263,10 +1263,17 @@ function pulseAdrenaline(t){
     disp.style.removeProperty('--fxBloom');
     return;
   }
+  const maxHp = lead.maxHp ?? lead.hp ?? 0;
+  const cappedMaxHp = maxHp > 0 ? maxHp : 1;
+  const hpVal = typeof lead.hp === 'number' ? Math.max(0, Math.min(cappedMaxHp, lead.hp)) : cappedMaxHp;
+  const hpRatio = hpVal / cappedMaxHp;
+  const lowHealthFactor = Math.max(0, 1 - Math.min(1, hpRatio / 0.5));
   const pulse = (Math.sin(t / 200) + 1) / 2;
   const intensity = ratio * pulse;
-  const blur = intensity * 4;
-  disp.style.setProperty('--fxBloom', `brightness(${1 + intensity}) blur(${blur}px)`);
+  const blur = intensity * 4 * lowHealthFactor;
+  const bloom = [`brightness(${1 + intensity})`];
+  if(blur > 0.1) bloom.push(`blur(${blur}px)`);
+  disp.style.setProperty('--fxBloom', bloom.join(' '));
 }
 
 function showTab(which){

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -112,3 +112,17 @@ test('adrenaline bloom pulses with adr ratio', async () => {
   const bloom2 = ctx.document.getElementById('game').style.getPropertyValue('--fxBloom');
   assert.equal(bloom2, '');
 });
+
+test('adrenaline blur only activates at low health', async () => {
+  const ctx = setup(HUD_HTML);
+  ctx.fxConfig.adrenalineTint = true;
+  ctx.leader = () => ({ maxHp: 10, hp: 10, adr: 50, maxAdr: 100 });
+  ctx.pulseAdrenaline(0);
+  const healthyBloom = ctx.document.getElementById('game').style.getPropertyValue('--fxBloom');
+  assert.ok(/brightness/.test(healthyBloom));
+  assert.ok(!/blur\(/.test(healthyBloom));
+  ctx.leader = () => ({ maxHp: 10, hp: 3, adr: 50, maxAdr: 100 });
+  ctx.pulseAdrenaline(0);
+  const lowHpBloom = ctx.document.getElementById('game').style.getPropertyValue('--fxBloom');
+  assert.ok(/blur\(/.test(lowHpBloom));
+});


### PR DESCRIPTION
## Summary
- scale the HUD adrenaline bloom blur by the leader's health so high-health states stay sharp
- only append the blur filter when its intensity is meaningful
- add a HUD test that confirms the blur activates once health drops

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cb6bcaf2c083289b6e7304eccb44f8