### PR TITLE
feat: add adjustable font scale setting

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -74,6 +74,11 @@
         <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
         <button class="btn" id="tileCharToggle">ASCII Tiles: On</button>
         <div class="field">
+          <label for="fontScale">Font Scale</label>
+          <input type="range" id="fontScale" min="1" max="1.75" step="0.05" value="1" />
+          <div class="small" id="fontScaleValue">100%</div>
+        </div>
+        <div class="field">
           <label id="playerIconLabel">Player Icon</label>
           <div class="icon-picker" aria-labelledby="playerIconLabel">
             <button class="pill" type="button" id="playerIconPrev" aria-label="Previous player icon">&lt;</button>

--- a/dustland.css
+++ b/dustland.css
@@ -5,6 +5,11 @@
         --accent: #9ef7a0;
         --muted: #7a8a7a;
         --panelW: 440px;
+        --font-scale: 1;
+    }
+
+    html {
+        font-size: calc(16px * var(--font-scale));
     }
 
     input::placeholder,
@@ -39,7 +44,9 @@ input[type="range"] {
         background: radial-gradient(circle at top, #141614 0%, var(--bg) 70%);
         color: var(--ink);
         overscroll-behavior-y: none;
-        font: 14px/1.5 'Pixelify Sans', sans-serif;
+        font-family: 'Pixelify Sans', sans-serif;
+        font-size: 0.875rem;
+        line-height: 1.5;
     }
 
     .wrap {
@@ -89,7 +96,7 @@ input[type="range"] {
     }
 
     .panel h1 {
-        font-size: 18px;
+        font-size: 1.125rem;
         margin: 0;
         padding: 10px 12px;
         background: #0f120f;
@@ -113,7 +120,7 @@ input[type="range"] {
 
     .weather-banner {
         text-align: center;
-        font-size: 13px;
+        font-size: 0.8125rem;
         margin-bottom: 4px
     }
 
@@ -133,7 +140,7 @@ input[type="range"] {
 
     .hud .hydration {
         margin-left: 4px;
-        font-size: 12px;
+        font-size: 0.75rem;
     }
 
     .hudbar {
@@ -282,7 +289,7 @@ input[type="range"] {
         color: var(--ink);
         cursor: pointer;
         transition: background 0.2s ease, border-color 0.2s ease, transform 0.1s ease;
-        font-size: 14px;
+        font-size: 0.875rem;
         font-family: inherit;
     }
 
@@ -391,7 +398,7 @@ input[type="range"] {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  font-size: 10px;
+  font-size: 0.625rem;
   color: #fff;
 }
 
@@ -472,7 +479,7 @@ input[type="range"] {
         #panelToggle {
             display: block;
             padding: 12px;
-            font-size: 24px;
+            font-size: 1.5rem;
         }
         :root { --ctrlH: 180px; }
         body.mobile-on .wrap { height: calc(100% - var(--ctrlH)); }
@@ -542,7 +549,7 @@ input[type="range"] {
   color:#0f120f;
   border-radius:8px;
   padding:2px 4px;
-  font-size:10px;
+  font-size: 0.625rem;
   line-height:1;
   box-shadow:0 0 4px #8bd98d;
 }
@@ -640,7 +647,7 @@ input[type="range"] {
   border-radius:6px;
   min-width:120px;
   font-family:system-ui, sans-serif;
-  font-size:14px;
+  font-size: 0.875rem;
   color:#fff;
   box-shadow:0 0 8px #000 inset;
 }
@@ -655,7 +662,7 @@ input[type="range"] {
     }
 
     .small {
-        font-size: 12px;
+        font-size: 0.75rem;
         color: #9ab09a
     }
 
@@ -804,7 +811,7 @@ input[type="range"] {
   list-style: none;
   margin: 4px 0 0;
   padding: 0;
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
 .slot-list {
@@ -1005,7 +1012,7 @@ input[type="range"] {
     }
 
     #settings .field--toggle label {
-        font-size: 14px;
+        font-size: 0.875rem;
         color: #c8f7c9
     }
 
@@ -1029,7 +1036,7 @@ input[type="range"] {
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: 18px;
+        font-size: 1.125rem;
         line-height: 1
     }
 
@@ -1129,7 +1136,7 @@ input[type="range"] {
         gap: 6px;
         align-items: center;
         z-index: 40;
-        font-size: 12px
+        font-size: 0.75rem
     }
 
     .nano-progress {
@@ -1280,7 +1287,7 @@ input[type="range"] {
         border-radius: 6px;
         background: #121712;
         color: var(--ink);
-        font-size: 13px;
+        font-size: 0.8125rem;
         font-weight: 600;
     }
 

--- a/dustland.html
+++ b/dustland.html
@@ -78,6 +78,11 @@
         <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
         <button class="btn" id="tileCharToggle">ASCII Tiles: On</button>
         <div class="field">
+          <label for="fontScale">Font Scale</label>
+          <input type="range" id="fontScale" min="1" max="1.75" step="0.05" value="1" />
+          <div class="small" id="fontScaleValue">100%</div>
+        </div>
+        <div class="field">
           <label id="playerIconLabel">Player Icon</label>
           <div class="icon-picker" aria-labelledby="playerIconLabel">
             <button class="pill" type="button" id="playerIconPrev" aria-label="Previous player icon">&lt;</button>

--- a/game.html
+++ b/game.html
@@ -606,6 +606,11 @@
         <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
         <button class="btn" id="tileCharToggle">ASCII Tiles: On</button>
         <div class="field">
+          <label for="fontScale">Font Scale</label>
+          <input type="range" id="fontScale" min="1" max="1.75" step="0.05" value="1" />
+          <div class="small" id="fontScaleValue">100%</div>
+        </div>
+        <div class="field">
           <label id="playerIconLabel">Player Icon</label>
           <div class="icon-picker" aria-labelledby="playerIconLabel">
             <button class="pill" type="button" id="playerIconPrev" aria-label="Previous player icon">&lt;</button>

--- a/test/font-scale.test.js
+++ b/test/font-scale.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
+const code = full.split('// ===== Boot =====')[0];
+
+class AudioCtx {
+  createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
+  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
+  get destination(){ return {}; }
+  get currentTime(){ return 0; }
+}
+
+test('font scale slider updates CSS variable and localStorage', async () => {
+  const document = makeDocument();
+  const localStore = new Map();
+  const localStorage = {
+    getItem: key => (localStore.has(key) ? localStore.get(key) : null),
+    setItem: (key, value) => { localStore.set(key, value); }
+  };
+  const window = {
+    document,
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    HTMLCanvasElement: class {},
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  window.HTMLCanvasElement.prototype.getContext = () => ({ });
+  const context = {
+    window,
+    document,
+    requestAnimationFrame: () => 0,
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    Audio: class { constructor(){ this.addEventListener = () => {}; } cloneNode(){ return new this.constructor(); } },
+    EventBus: { on: () => {}, emit: () => {} },
+    Dustland: { eventBus: { on: () => {}, emit: () => {} } },
+    NanoDialog: { enabled: true },
+    location: { hash: '' },
+    move: () => {},
+    interact: () => {},
+    takeNearestItem: () => {},
+    save: () => {},
+    load: () => {},
+    resetAll: () => {},
+    console,
+    localStorage,
+    globalThis: null
+  };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(code, context);
+
+  const initialScale = document.body.style.getPropertyValue('--font-scale');
+  assert.strictEqual(initialScale, '1');
+  const slider = document.getElementById('fontScale');
+  slider.value = '1.5';
+  slider.dispatchEvent({ type: 'input' });
+  const updated = document.body.style.getPropertyValue('--font-scale');
+  assert.strictEqual(updated, '1.5');
+  const readout = document.getElementById('fontScaleValue');
+  assert.strictEqual(readout.textContent, '150%');
+  assert.strictEqual(localStore.get('fontScale'), '1.5');
+});


### PR DESCRIPTION
## Summary
- add a font scale slider to the settings UI across the CRT and neon layouts
- drive typography through a `--font-scale` CSS variable with rem units so text grows uniformly
- persist the chosen scale, expose it via Dustland globals, and cover it with a dedicated test

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cb6867c1c083289ff7a97ae9f7b78b