### PR TITLE
feat: add debug menu with save import export

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -1013,6 +1013,38 @@ input[type="range"] {
         gap: 8px
     }
 
+    #debugMenu {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, .8);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        z-index: 45
+    }
+
+    #debugMenu .win {
+        width: min(320px, 92vw);
+        background: #0b0d0b;
+        border: 1px solid #2a382a;
+        border-radius: 12px;
+        box-shadow: 0 20px 80px rgba(0, 0, 0, .7);
+        overflow: hidden
+    }
+
+    #debugMenu header {
+        padding: 10px 12px;
+        border-bottom: 1px solid #223022;
+        font-weight: 700
+    }
+
+    #debugMenu main {
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px
+    }
+
     #settings .field--toggle {
         flex-direction: row;
         align-items: center;

--- a/dustland.html
+++ b/dustland.html
@@ -56,8 +56,7 @@
           <button class="btn" id="clearBtn">Clear Save</button>
           <button class="btn" id="resetBtn">Reset</button>
           <button class="btn" id="settingsBtn">Settings</button>
-          <button class="btn" id="fxBtn">FX</button>
-          <button class="btn" id="perfBtn">Perf</button>
+          <button class="btn" id="debugBtn">Debug</button>
           <button class="btn" id="campBtn">Camp</button>
           <button class="btn" id="screenshotBtn" hidden>Screenshot</button>
         </div>
@@ -98,6 +97,21 @@
           <input type="checkbox" id="retroNpcToggle" />
         </div>
         <button class="btn" id="settingsClose">Close</button>
+      </main>
+    </div>
+  </div>
+
+  <!-- Debug Menu -->
+  <div id="debugMenu">
+    <div class="win">
+      <header>Debug Tools</header>
+      <main>
+        <button class="btn" id="fxBtn">FX Tools</button>
+        <button class="btn" id="perfBtn">Performance Graph</button>
+        <button class="btn" id="exportSaveBtn">Export Save</button>
+        <button class="btn" id="importSaveBtn">Import Save</button>
+        <input type="file" id="importSaveInput" accept="application/json" hidden />
+        <button class="btn" id="debugClose">Close</button>
       </main>
     </div>
   </div>

--- a/game.html
+++ b/game.html
@@ -511,8 +511,7 @@
               <button class="btn" id="clearBtn">Clear Save</button>
               <button class="btn" id="resetBtn">Reset</button>
               <button class="btn" id="settingsBtn">Settings</button>
-              <button class="btn" id="fxBtn">FX</button>
-              <button class="btn" id="perfBtn">Perf</button>
+              <button class="btn" id="debugBtn">Debug</button>
               <button class="btn" id="campBtn">Camp</button>
               <button class="btn" id="screenshotBtn" hidden>Screenshot</button>
             </div>
@@ -543,6 +542,20 @@
           <button class="btn" id="startContinue">Continue</button>
           <button class="btn" id="startNew">New Game</button>
         </div>
+      </main>
+    </div>
+  </div>
+
+  <div id="debugMenu">
+    <div class="win">
+      <header>Debug Tools</header>
+      <main>
+        <button class="btn" id="fxBtn">FX Tools</button>
+        <button class="btn" id="perfBtn">Performance Graph</button>
+        <button class="btn" id="exportSaveBtn">Export Save</button>
+        <button class="btn" id="importSaveBtn">Import Save</button>
+        <input type="file" id="importSaveInput" accept="application/json" hidden />
+        <button class="btn" id="debugClose">Close</button>
       </main>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a modal debug menu that hosts FX/performance tools and new save import/export buttons
- style the debug menu so it matches the existing overlay windows
- hook up export/import handlers that download saves as JSON and restore them via load()

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cbdf0d830c8328a5795ac62c53904d