### PR TITLE
fix: render water tiles as floor in beholder view

### DIFF
--- a/game-beholder.html
+++ b/game-beholder.html
@@ -682,9 +682,12 @@
           ctx.stroke();
         }
       }
+      function isWaterTile(tile) {
+        return tile?.value === 1 || tile?.label === 'Water';
+      }
       function isWallTile(tile) {
         if (!tile) return false;
-        return !tile.walkable;
+        return !tile.walkable && !isWaterTile(tile);
       }
       function drawFloorSurface(segment, tile, depthIndex, offset) {
         if (!tile) return;
@@ -722,7 +725,7 @@
         drawPolygon([leftNear, rightNear, rightFar, leftFar], shadeColor(baseColor, shade));
       }
       function drawSideWall(side, segment, tile, depthIndex) {
-        if (!tile || tile.walkable) {
+        if (!tile || tile.walkable || isWaterTile(tile)) {
           drawOpenEdge(side, segment);
           return;
         }
@@ -751,7 +754,7 @@
         ctx.stroke();
       }
       function drawFrontWall(segment, tile, depthIndex) {
-        if (!tile || tile.walkable) return;
+        if (!tile || tile.walkable || isWaterTile(tile)) return;
         const z = segmentFarZ(segment.depth);
         const bottomLeft = projectPoint(-HALF_WIDTH, 0, z);
         const bottomRight = projectPoint(HALF_WIDTH, 0, z);


### PR DESCRIPTION
## Summary
- avoid treating water tiles as walls in the beholder viewer so they render as floor panels
- keep water impassable by limiting the change to rendering helpers

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cbf14a10c8832892db78bda7bf954a