### PR TITLE
fix: ensure font scaling reaches all text

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -13,7 +13,7 @@
       background: #000;
       color: #c8f7c9;
       font-family: 'Pixelify Sans', sans-serif;
-      font-size: 14px;
+      font-size: 0.875rem;
       line-height: 1.5;
       position: relative;
       min-height: 100vh;
@@ -45,7 +45,7 @@
     }
 
     .list {
-      font-size: 13px;
+      font-size: 0.8125rem;
       max-height: 200px;
       overflow-y: auto;
     }
@@ -64,7 +64,7 @@
     label {
       display: block;
       margin-top: 4px;
-      font-size: 12px;
+      font-size: 0.75rem;
     }
 
     input,
@@ -76,7 +76,7 @@
       border: 1px solid #2b3b2b;
       color: #c8f7c9;
       font-family: inherit;
-      font-size: 13px;
+      font-size: 0.8125rem;
       border-radius: 4px;
     }
 
@@ -118,11 +118,11 @@
 
     button.btn {
       margin-top: 6px;
-      font-size: 14px;
+      font-size: 0.875rem;
     }
 
     .btn-group .btn {
-      font-size: 13px;
+      font-size: 0.8125rem;
     }
 
     #stampWindow {
@@ -150,14 +150,14 @@
     }
 
     #stampWindow #nanoStampBtn {
-      font-size: 12px;
+      font-size: 0.75rem;
       margin: 4px auto 0;
       display: block;
       padding: 2px 4px;
     }
 
     legend {
-      font-size: 16px;
+      font-size: 1rem;
       font-weight: 600;
     }
 
@@ -739,7 +739,7 @@
         <button class="btn" type="button" id="closeDialogModal">Close</button>
       </div>
       <div id="treeEditor"></div>
-      <div id="treeWarning" style="color:#fc0;font-size:12px;margin-top:4px"></div>
+      <div id="treeWarning" style="color:#fc0;font-size:0.75rem;margin-top:4px"></div>
       <button class="btn" type="button" id="addNode">Add Node</button>
       <datalist id="choiceFlagList"></datalist>
     </div>

--- a/dustland.css
+++ b/dustland.css
@@ -830,7 +830,7 @@ input[type="range"] {
         border-radius: 14px;
         box-shadow: 0 20px 80px rgba(0, 0, 0, .7);
         overflow: hidden;
-        font-size: 16px;
+        font-size: 1rem;
         line-height: 1.6
     }
 
@@ -840,11 +840,11 @@ input[type="range"] {
         justify-content: space-between;
         padding: 12px 16px;
         border-bottom: 1px solid #223022;
-        font-size: 18px
+        font-size: 1.125rem
     }
 
     #creator .small {
-        font-size: 14px
+        font-size: 0.875rem
     }
 
     #creator main {
@@ -892,7 +892,7 @@ input[type="range"] {
         align-items: center;
         justify-content: center;
         font-weight: 800;
-        font-size: 20px
+        font-size: 1.25rem
     }
 
     .grid {

--- a/multiplayer.html
+++ b/multiplayer.html
@@ -7,11 +7,11 @@
   <style>
     body { max-width: 780px; margin: 40px auto; padding: 0 20px; font-family: 'Pixelify Sans', sans-serif; }
     h1, h2 { text-transform: uppercase; letter-spacing: 2px; }
-    textarea { width: 100%; box-sizing: border-box; min-height: 80px; font-family: monospace; font-size: 13px; padding: 8px; }
+    textarea { width: 100%; box-sizing: border-box; min-height: 80px; font-family: monospace; font-size: 0.8125rem; padding: 8px; }
     .row { margin-bottom: 24px; }
-    .status { font-size: 14px; color: #9ec2a4; margin-top: 8px; min-height: 20px; }
-    .muted { color: #9ea5a1; font-size: 14px; }
-    .peer-list { font-size: 14px; color: #d4f3d8; margin-top: 8px; }
+    .status { font-size: 0.875rem; color: #9ec2a4; margin-top: 8px; min-height: 20px; }
+    .muted { color: #9ea5a1; font-size: 0.875rem; }
+    .peer-list { font-size: 0.875rem; color: #d4f3d8; margin-top: 8px; }
     .section { border: 1px solid #2f3b2f; padding: 16px; border-radius: 6px; background: rgba(15, 24, 15, 0.6); margin-bottom: 20px; }
     .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
     .controls .btn { flex: 0 0 auto; }

--- a/music-demo.html
+++ b/music-demo.html
@@ -11,8 +11,8 @@
     body { margin: 0; background: #000; color: var(--ink); font-family: 'Pixelify Sans', sans-serif; }
     .wrap { padding: 16px; gap: 16px; display: flex; }
     .panel { width: var(--panelW); }
-    .controls .btn { font-size: 14px; }
-    .small { font-size: 12px; color: var(--muted); }
+    .controls .btn { font-size: 0.875rem; }
+    .small { font-size: 0.75rem; color: var(--muted); }
     .mood-list { display: grid; grid-template-columns: repeat(2, 1fr); gap: 6px; }
     .mood-btn { cursor: pointer; padding: 6px 8px; border: 1px solid #283228; border-radius: 6px; background: #0e110e; text-align: center; }
     .mood-btn.active { outline: 1px solid var(--accent); box-shadow: 0 0 8px #000, 0 0 8px rgba(158,247,160,.3); }
@@ -201,7 +201,7 @@
 
         <fieldset style="margin-top:10px" class="card">
           <legend>JSON Config</legend>
-          <pre id="jsonOut" style="white-space:pre-wrap; word-break:break-word; font-size:12px; margin:0 0 6px 0"></pre>
+          <pre id="jsonOut" style="white-space:pre-wrap; word-break:break-word; font-size:0.75rem; margin:0 0 6px 0"></pre>
           <div class="btn-group">
             <button id="downloadJsonBtn" class="btn">Download JSON</button>
             <button id="loadJsonBtn" class="btn">Load JSON</button>

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -192,7 +192,7 @@ function setMobileControls(on){
       const mk=(name,t,fn)=>{
         const b=document.createElement('button');
         b.textContent=t;
-        b.style.cssText='width:48px;height:48px;border:2px solid #0f0;border-radius:8px;background:#000;color:#0f0;font-size:20px;user-select:none;outline:none;touch-action:manipulation;';
+        b.style.cssText='width:48px;height:48px;border:2px solid #0f0;border-radius:8px;background:#000;color:#0f0;font-size:1.25rem;user-select:none;outline:none;touch-action:manipulation;';
         b.onclick=fn;
         b.onpointerdown=()=>{
           b.style.background='#0f0';
@@ -337,7 +337,14 @@ function updateFontScaleUI(scale){
 function applyFontScale(scale){
   fontScale = scale;
   const rootStyle = getFontScaleRootStyle();
-  rootStyle?.setProperty('--font-scale', formatFontScale(scale));
+  const value = formatFontScale(scale);
+  rootStyle?.setProperty('--font-scale', value);
+  if(typeof document !== 'undefined'){
+    const bodyStyle = document.body?.style;
+    if(bodyStyle && bodyStyle !== rootStyle){
+      bodyStyle.setProperty('--font-scale', value);
+    }
+  }
   updateFontScaleUI(scale);
 }
 function setFontScale(scale, opts = {}){
@@ -938,7 +945,7 @@ if(typeof window !== 'undefined' && window.addEventListener){
 updateCanvasStretch();
 
 // Font init (prevents invisible glyphs on some canvases)
-sctx.font = `${12 / RENDER_SCALE}px system-ui, sans-serif`;
+sctx.font = `${(12 * fontScale) / RENDER_SCALE}px system-ui, sans-serif`;
 
 let camX=0, camY=0, showMini=true;
 let _lastTime=0;
@@ -1036,7 +1043,7 @@ function render(gameState=state, dt){
   ctx.save();
   ctx.scale(RENDER_SCALE, RENDER_SCALE);
   ctx.imageSmoothingEnabled = false;
-  ctx.font = `${12 / RENDER_SCALE}px system-ui, sans-serif`;
+  ctx.font = `${(12 * fontScale) / RENDER_SCALE}px system-ui, sans-serif`;
   ctx.fillStyle='#000';
   ctx.fillRect(0,0,BASE_CANVAS_WIDTH,BASE_CANVAS_HEIGHT);
 

--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -147,7 +147,7 @@ function showModulePicker(){
   ackBtn.id = 'ackGlyph';
   ackBtn.textContent = '✎';
   ackBtn.title = 'Adventure Kit';
-  ackBtn.style = 'position:absolute;top:10px;right:10px;z-index:1;color:#0f0;font-size:24px;cursor:pointer';
+  ackBtn.style = 'position:absolute;top:10px;right:10px;z-index:1;color:#0f0;font-size:1.5rem;cursor:pointer';
   ackBtn.onclick = () => { window.location.href = 'adventure-kit.html'; };
   overlay.appendChild(ackBtn);
 
@@ -155,7 +155,7 @@ function showModulePicker(){
   mpBtn.id = 'mpGlyph';
   mpBtn.textContent = '⇆';
   mpBtn.title = 'Multiplayer';
-  mpBtn.style = 'position:absolute;top:44px;right:10px;z-index:1;color:#0f0;font-size:24px;cursor:pointer';
+  mpBtn.style = 'position:absolute;top:44px;right:10px;z-index:1;color:#0f0;font-size:1.5rem;cursor:pointer';
   mpBtn.onclick = () => { window.location.href = 'multiplayer.html'; };
   overlay.appendChild(mpBtn);
 
@@ -168,7 +168,7 @@ function showModulePicker(){
   const title = document.createElement('div');
   title.id = 'gameTitle';
   title.textContent = 'Dustland CRT';
-  title.style = 'position:relative;z-index:1;color:#0f0;text-shadow:0 0 10px #0f0;font-size:32px;margin-bottom:20px;animation:pulse 2s infinite';
+  title.style = 'position:relative;z-index:1;color:#0f0;text-shadow:0 0 10px #0f0;font-size:2rem;margin-bottom:20px;animation:pulse 2s infinite';
 
   const win = document.createElement('div');
   win.className = 'win';

--- a/scripts/ui/world-map.js
+++ b/scripts/ui/world-map.js
@@ -172,6 +172,7 @@
           text.setAttribute('x', x + 10);
           text.setAttribute('y', y + 4);
           text.setAttribute('fill', '#fff');
+          text.style.fontSize = '0.875rem';
           if(i === 0){
             text.style.fontWeight = 'bold';
             text.textContent = `Current: ${b.name ?? b.id}`;


### PR DESCRIPTION
## Summary
- apply the font scale CSS variable to both the root and body styles and scale canvas text rendering
- switch inline font sizes in UI pages and module picker buttons to rem units so the slider resizes them live
- update creator and world map styles to rely on rem units for consistent scaling

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cbf1eafbec83288dda59aba9915805