### PR TITLE
feat: render svg item glyphs in retro mode

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -291,6 +291,8 @@ let retroNpcArtEnabled = false;
 const retroNpcArtCache = new Map();
 let retroPlayerSprite = null;
 let retroPlayerSpriteIndex = -1;
+let retroItemSprite = null;
+let retroItemCacheSprite = null;
 const DEFAULT_NPC_COLOR = '#9ef7a0';
 const xmlEscapeMap = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
 xmlEscapeMap['"'] = '&quot;';
@@ -365,6 +367,8 @@ function setRetroNpcArt(on, skipStorage){
   }
   retroPlayerSprite = null;
   retroPlayerSpriteIndex = -1;
+  retroItemSprite = null;
+  retroItemCacheSprite = null;
   if(!retroNpcArtEnabled){
     retroNpcArtCache.clear();
   }
@@ -636,6 +640,72 @@ function getRetroNpcSprite(n){
   return sprite;
 }
 
+function buildRetroItemGlyphSvg(){
+  const base = '#050805';
+  const inner = '#111b12';
+  const glowA = '#c8ffbf';
+  const glowB = '#64f0ff';
+  const accent = '#ffe59a';
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" shape-rendering="geometricPrecision">
+  <defs>
+    <radialGradient id="retroItemGlyphAura" cx="50%" cy="45%" r="55%">
+      <stop offset="0" stop-color="${glowA}" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="${inner}" stop-opacity="0.1"/>
+    </radialGradient>
+    <linearGradient id="retroItemGlyphBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="${glowA}" stop-opacity="0.95"/>
+      <stop offset="0.55" stop-color="${glowA}" stop-opacity="0.75"/>
+      <stop offset="1" stop-color="${glowB}" stop-opacity="0.65"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="6" fill="${base}"/>
+  <rect x="1.5" y="1.5" width="29" height="29" rx="6" fill="${inner}" stroke="${glowB}" stroke-width="1.5" opacity="0.92"/>
+  <circle cx="16" cy="14.5" r="10.5" fill="url(#retroItemGlyphAura)" opacity="0.85"/>
+  <path d="M11 12.5l2.8-4.2h4.4l2.8 4.2" fill="none" stroke="${glowB}" stroke-width="1.2" stroke-linecap="round"/>
+  <path d="M9.5 14h13l-1 11.2c-0.2 1.9-1.7 3.3-3.6 3.3h-3.8c-1.9 0-3.4-1.4-3.6-3.3z" fill="url(#retroItemGlyphBody)" stroke="${glowB}" stroke-width="1" stroke-linejoin="round"/>
+  <path d="M12.2 18.3h7.6" stroke="${accent}" stroke-width="1.2" stroke-linecap="round" opacity="0.85"/>
+  <circle cx="16" cy="21" r="1.5" fill="${accent}" stroke="${glowB}" stroke-width="0.7"/>
+  <path d="M12.7 22.8l-1 2.6" stroke="${accent}" stroke-width="0.9" stroke-linecap="round" opacity="0.9"/>
+  <path d="M19.3 22.8l1 2.6" stroke="${accent}" stroke-width="0.9" stroke-linecap="round" opacity="0.9"/>
+</svg>`;
+}
+
+function buildRetroItemCacheSvg(){
+  const base = '#050805';
+  const inner = '#1a130a';
+  const glowA = '#ffcd7a';
+  const glowB = '#ff7f6a';
+  const accent = '#fff4cc';
+  const edge = '#7f3b16';
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" shape-rendering="geometricPrecision">
+  <defs>
+    <radialGradient id="retroItemCacheAura" cx="50%" cy="40%" r="60%">
+      <stop offset="0" stop-color="${glowA}" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="${inner}" stop-opacity="0.05"/>
+    </radialGradient>
+    <linearGradient id="retroItemCacheLid" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="${glowA}" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="${glowB}" stop-opacity="0.9"/>
+    </linearGradient>
+    <linearGradient id="retroItemCacheFront" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="${glowA}" stop-opacity="0.85"/>
+      <stop offset="1" stop-color="${glowB}" stop-opacity="0.75"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="6" fill="${base}"/>
+  <rect x="1.5" y="1.5" width="29" height="29" rx="6" fill="${inner}" stroke="${glowA}" stroke-width="1.5" opacity="0.93"/>
+  <circle cx="16" cy="15" r="11.5" fill="url(#retroItemCacheAura)" opacity="0.82"/>
+  <rect x="8" y="9.5" width="16" height="7.5" rx="2.5" fill="url(#retroItemCacheLid)" stroke="${edge}" stroke-width="1"/>
+  <rect x="9.5" y="14" width="13" height="9.5" rx="2.5" fill="url(#retroItemCacheFront)" stroke="${edge}" stroke-width="1"/>
+  <path d="M9.5 16.5h13" stroke="${edge}" stroke-width="1.1" stroke-linecap="round" opacity="0.85"/>
+  <path d="M14.5 9.5l-2 3" stroke="${edge}" stroke-width="1.1" stroke-linecap="round" opacity="0.75"/>
+  <path d="M17.5 9.5l2 3" stroke="${edge}" stroke-width="1.1" stroke-linecap="round" opacity="0.75"/>
+  <circle cx="16" cy="18.8" r="1.6" fill="${accent}" stroke="${edge}" stroke-width="0.8"/>
+  <path d="M12.2 20.8l-1.4 3" stroke="${accent}" stroke-width="1" stroke-linecap="round" opacity="0.8"/>
+  <path d="M19.8 20.8l1.4 3" stroke="${accent}" stroke-width="1" stroke-linecap="round" opacity="0.8"/>
+</svg>`;
+}
+
 function buildRetroPlayerSvg(){
   const base = '#0b141a';
   const innerField = '#09121a';
@@ -697,6 +767,32 @@ function getRetroPlayerSprite(){
   sprite.src = url;
   retroPlayerSprite = sprite;
   retroPlayerSpriteIndex = -2;
+  return sprite;
+}
+
+function getRetroItemSprite(){
+  const Img = globalThis.Image;
+  if(typeof Img !== 'function') return null;
+  if(retroItemSprite) return retroItemSprite;
+  const svg = buildRetroItemGlyphSvg();
+  const url = svgToDataUrl(svg);
+  const sprite = new Img();
+  sprite.decoding = 'sync';
+  sprite.src = url;
+  retroItemSprite = sprite;
+  return sprite;
+}
+
+function getRetroItemCacheSprite(){
+  const Img = globalThis.Image;
+  if(typeof Img !== 'function') return null;
+  if(retroItemCacheSprite) return retroItemCacheSprite;
+  const svg = buildRetroItemCacheSvg();
+  const url = svgToDataUrl(svg);
+  const sprite = new Img();
+  sprite.decoding = 'sync';
+  sprite.src = url;
+  retroItemCacheSprite = sprite;
   return sprite;
 }
 function sfxTick(){
@@ -1096,7 +1192,21 @@ function render(gameState=state, dt){
         if(it.map!==activeMap) continue;
         if(it.x>=camX&&it.y>=camY&&it.x<camX+vW&&it.y<camY+vH){
           const vx=(it.x-camX+offX)*TS, vy=(it.y-camY+offY)*TS;
-          if(Array.isArray(it.items) && it.items.length>1){
+          const multi = Array.isArray(it.items) && it.items.length>1;
+          if(retroNpcArtEnabled){
+            const sprite = multi ? getRetroItemCacheSprite() : getRetroItemSprite();
+            if(sprite?.complete){
+              if(multi){
+                const a=0.7+0.3*Math.sin(Date.now()/300);
+                ctx.globalAlpha=a;
+              }
+              ctx.drawImage(sprite, vx, vy, TS, TS);
+              ctx.globalAlpha=1;
+              continue;
+            }
+          }
+          ctx.globalAlpha = 1;
+          if(multi){
             const a=0.7+0.3*Math.sin(Date.now()/300);
             ctx.fillStyle='#ffb347';
             ctx.globalAlpha=a;
@@ -1886,7 +1996,9 @@ globalThis.Dustland = globalThis.Dustland || {};
 globalThis.Dustland.openShop = openShop;
 globalThis.Dustland.retroNpcArt = {
   isEnabled: () => retroNpcArtEnabled,
-  setEnabled: setRetroNpcArt
+  setEnabled: setRetroNpcArt,
+  getItemGlyph: () => getRetroItemSprite(),
+  getItemCacheGlyph: () => getRetroItemCacheSprite()
 };
 globalThis.Dustland.font = {
   getScale: () => fontScale,

--- a/test/retro-item-glyph.test.js
+++ b/test/retro-item-glyph.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { createGameProxy } from './test-harness.js';
+
+test('retro art exposes item glyph sprites', () => {
+  const { context } = createGameProxy([]);
+
+  class RetroImage {
+    constructor(){
+      this.complete = false;
+      this._src = '';
+    }
+    set src(value){
+      this._src = value;
+      this.complete = true;
+    }
+    get src(){
+      return this._src;
+    }
+  }
+
+  context.Image = RetroImage;
+  context.window.Image = RetroImage;
+
+  const glyph = context.Dustland.retroNpcArt.getItemGlyph();
+  assert.ok(glyph instanceof RetroImage, 'single item glyph uses Image sprite');
+  assert.ok(glyph.src.includes('retroItemGlyph'), 'single item glyph uses custom SVG data');
+
+  const cacheGlyph = context.Dustland.retroNpcArt.getItemCacheGlyph();
+  assert.ok(cacheGlyph instanceof RetroImage, 'cache glyph uses Image sprite');
+  assert.ok(cacheGlyph.src.includes('retroItemCache'), 'cache glyph uses cache SVG data');
+
+  assert.strictEqual(context.Dustland.retroNpcArt.getItemGlyph(), glyph, 'single glyph cached instance reused');
+  assert.strictEqual(context.Dustland.retroNpcArt.getItemCacheGlyph(), cacheGlyph, 'cache glyph cached instance reused');
+});


### PR DESCRIPTION
## Summary
- generate dedicated SVG art for single drops and cache piles when the retro SVG renderer is enabled
- reuse the new glyph sprites during item rendering and expose accessors on `Dustland.retroNpcArt`
- cover the glyph helpers with a new unit test that stubs the `Image` loader

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cbf21b15ec8328ba401a4d840d6876