### PR TITLE
fix: restore party health on entrance respawn

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -264,12 +264,15 @@ function closeCombat(result = 'flee'){
 
   party.restore();
 
-  if(result === 'bruise' && state.mapEntry){
-    const entry = state.mapEntry;
-    log?.('You wake up at the entrance.');
-    if(typeof toast==='function') toast('You wake up at the entrance.');
-    if(typeof setMap==='function') setMap(entry.map);
-    setPartyPos?.(entry.x, entry.y);
+  if(result === 'bruise'){
+    if(state.mapEntry){
+      const entry = state.mapEntry;
+      log?.('You wake up at the entrance.');
+      if(typeof toast==='function') toast('You wake up at the entrance.');
+      if(typeof setMap==='function') setMap(entry.map);
+      setPartyPos?.(entry.x, entry.y);
+    }
+    party.healAll?.();
   }
 
   const duration = Date.now() - combatState.startTime;

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -249,8 +249,7 @@ function applyZones(map,x,y){
       setPartyPos(entry.x, entry.y);
     }
     centerCamera?.(party.x, party.y, state.map);
-    (party||[]).forEach(m=>{ m.hp = 1; });
-    renderParty?.(); updateHUD?.();
+    party?.healAll?.();
   }
 }
 


### PR DESCRIPTION
## Summary
- fully heal the party when a combat defeat returns them to the entrance
- restore party health after collapsing from environmental damage before resuming play

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cc02ef704083288cb3a379fda96f0e