### PR TITLE
feat: stage dustland oc3abv finale

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2604,6 +2604,214 @@ const DATA = `
         }
       },
       "symbol": "?"
+    },
+    {
+      "id": "oc3abv_siltpack",
+      "map": "room_oc3abv",
+      "x": 24,
+      "y": 46,
+      "color": "#f66",
+      "name": "Siltpack Ravener",
+      "title": "Ambush Brood",
+      "desc": "Dust-choked hunters sniffing out living heat.",
+      "prompt": "Pack of dust-choked hunters ready to pounce",
+      "portraitSheet": "assets/portraits/dustland-module/scrap_mutt_4.png",
+      "portraitLock": false,
+      "symbol": "!",
+      "tree": {
+        "start": {
+          "text": "Dust-raw beasts skitter from the dunes, circling the entry.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 14,
+        "ATK": 4,
+        "DEF": 1,
+        "count": 3,
+        "requires": "tag:ranged",
+        "special": {
+          "cue": "spews toxic grit!",
+          "dmg": 3,
+          "poison": {
+            "strength": 2,
+            "duration": 3
+          },
+          "spread": true,
+          "delay": 600
+        },
+        "challenge": 18,
+        "loot": "frag_grenade",
+        "lootChance": 0.35,
+        "scrap": {
+          "min": 6,
+          "max": 9
+        }
+      }
+    },
+    {
+      "id": "oc3abv_grinders",
+      "map": "room_oc3abv",
+      "x": 24,
+      "y": 42,
+      "color": "#f66",
+      "name": "Grinder Matriarchs",
+      "title": "Shrapnel Choir",
+      "desc": "Armored shriekers plated in scavenged sawblades.",
+      "prompt": "Saw-edged matriarchs screaming for blood",
+      "portraitSheet": "assets/portraits/dustland-module/iron_brute_4.png",
+      "portraitLock": false,
+      "symbol": "!",
+      "tree": {
+        "start": {
+          "text": "Shrieking matriarchs rake the stone, demanding tribute.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 22,
+        "ATK": 5,
+        "DEF": 2,
+        "count": 4,
+        "requires": "artifact_blade",
+        "special": {
+          "cue": "unleashes a shrapnel howl!",
+          "dmg": 4,
+          "stun": 1,
+          "delay": 700
+        },
+        "challenge": 24,
+        "loot": "armor_polish",
+        "lootChance": 0.4,
+        "scrap": {
+          "min": 7,
+          "max": 11
+        }
+      }
+    },
+    {
+      "id": "oc3abv_glasspride",
+      "map": "room_oc3abv",
+      "x": 24,
+      "y": 38,
+      "color": "#f66",
+      "name": "Glasswing Pride",
+      "title": "Phase Predators",
+      "desc": "Shimmering beasts phasing between realities.",
+      "prompt": "Glassy predators rippling in and out of phase",
+      "portraitSheet": "assets/portraits/dustland-module/vine_creature_4.png",
+      "portraitLock": false,
+      "symbol": "!",
+      "tree": {
+        "start": {
+          "text": "Glasswing predators flicker through the air ahead.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 28,
+        "ATK": 6,
+        "DEF": 3,
+        "count": 5,
+        "requires": "wand",
+        "special": {
+          "cue": "rends reality with shrieking arcs!",
+          "dmg": 5,
+          "spread": true,
+          "delay": 650
+        },
+        "challenge": 32,
+        "loot": "adrenaline_shot",
+        "lootChance": 0.5,
+        "scrap": {
+          "min": 8,
+          "max": 12
+        }
+      }
+    },
+    {
+      "id": "oc3abv_sovereign",
+      "map": "room_oc3abv",
+      "x": 30,
+      "y": 3,
+      "color": "#ff3366",
+      "name": "Sovereign of Dust",
+      "title": "Warden of the Hollow",
+      "desc": "A colossal warform woven from every ruin the Dustland devoured.",
+      "prompt": "Towering dust-forged warform crowned with razorsand",
+      "portraitSheet": "assets/portraits/dustland-module/dune_reaper_4.png",
+      "portraitLock": false,
+      "symbol": "!",
+      "tree": {
+        "start": {
+          "text": "The Dustland Sovereign drifts above the altar, eyes blazing.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 160,
+        "ATK": 12,
+        "DEF": 6,
+        "boss": true,
+        "requires": [
+          "artifact_blade",
+          "epic_blade"
+        ],
+        "special": {
+          "cue": "erupts into a storm of razorsand!",
+          "dmg": 12,
+          "poison": {
+            "strength": 3,
+            "duration": 3
+          },
+          "stun": 1,
+          "spread": true,
+          "delay": 500
+        },
+        "challenge": 45,
+        "loot": "epic_armor",
+        "lootChance": 0.9,
+        "scrap": {
+          "min": 15,
+          "max": 25
+        }
+      }
     }
   ],
   "events": [

--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -580,9 +580,30 @@ function doAttack(dmg, type = 'basic'){
 
     // Required weapon gate
     const req = target.requires;
-    if (req && (!weapon || weapon.id !== req)){
-      tDmg = 0;
-      log?.(`${attacker.name}'s attacks can't harm ${target.name}. Equip ${req}.`);
+    if (req){
+      const reqList = Array.isArray(req) ? req : [req];
+      const weaponId = weapon?.id;
+      const weaponTags = Array.isArray(weapon?.tags) ? weapon.tags : [];
+      let meetsRequirement = false;
+      for (const entry of reqList){
+        if (typeof entry === 'string' && entry.startsWith('tag:')){
+          const tag = entry.slice(4);
+          if (weaponTags.includes(tag)){ meetsRequirement = true; break; }
+        } else if (entry && weaponId === entry){
+          meetsRequirement = true;
+          break;
+        }
+      }
+      if (!meetsRequirement){
+        const label = reqList
+          .map(entry => typeof entry === 'string' && entry.startsWith('tag:')
+            ? `${entry.slice(4)} weapon`
+            : entry)
+          .filter(Boolean)
+          .join(' or ') || 'the required weapon';
+        tDmg = 0;
+        log?.(`${attacker.name}'s attacks can't harm ${target.name}. Equip ${label}.`);
+      }
     }
 
     // Immunity to basic attacks


### PR DESCRIPTION
## Summary
- add three escalating monster packs and a Sovereign boss to room_oc3abv with bespoke dialog, loot, and combat stats
- require specific weapon ids or tags for the new encounters to reward prior upgrades and vary their special attacks
- allow combat weapon requirements to accept arrays and tag-based checks so modules can express broader vulnerabilities

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js
- node - <<'NODE'
  global.SpoilsCache = { rollDrop: () => null };
  require('./scripts/supporting/balance-tester-agent.js');
  NODE

------
https://chatgpt.com/codex/tasks/task_e_68cc073185708328a485a9e6cd1f745e