### PR TITLE
feat: add antidote workbench recipe

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -421,6 +421,15 @@ const DATA = `
       "id": "copper_cog",
       "name": "Copper Cog",
       "type": "quest"
+    },
+    {
+      "id": "antidote",
+      "name": "Antidote",
+      "type": "consumable",
+      "use": {
+        "type": "cleanse",
+        "text": "You feel the toxins fade away."
+      }
     }
   ],
   "quests": [

--- a/scripts/workbench.js
+++ b/scripts/workbench.js
@@ -50,6 +50,24 @@
     log('Crafted a bandage.');
   }
 
+  function craftAntidote(){
+    if (!hasItem('plant_fiber')){
+      log('Need plant fiber.');
+      return;
+    }
+    if (!hasItem('water_flask')){
+      log('Need a water flask.');
+      return;
+    }
+    let idx = findItemIndex('plant_fiber');
+    if (idx >= 0) removeFromInv(idx);
+    idx = findItemIndex('water_flask');
+    if (idx >= 0) removeFromInv(idx);
+    addToInv('antidote');
+    bus?.emit('craft:antidote');
+    log('Crafted an antidote.');
+  }
+
   function openWorkbench(){
     const overlay = document.getElementById('workbenchOverlay');
     const list = document.getElementById('workbenchRecipes');
@@ -88,6 +106,14 @@
           craft: craftBandage,
           requirements: [
             { label: 'Plant Fiber', key: 'plant_fiber', amount: 1, type: 'item' }
+          ]
+        },
+        {
+          name: 'Antidote',
+          craft: craftAntidote,
+          requirements: [
+            { label: 'Plant Fiber', key: 'plant_fiber', amount: 1, type: 'item' },
+            { label: 'Water Flask', key: 'water_flask', amount: 1, type: 'item' }
           ]
         }
       ];
@@ -151,6 +177,6 @@
     overlay.focus();
   }
 
-  Dustland.workbench = { craftSignalBeacon, craftSolarTarp, craftBandage };
+  Dustland.workbench = { craftSignalBeacon, craftSolarTarp, craftBandage, craftAntidote };
   Dustland.openWorkbench = openWorkbench;
 })();

--- a/test/workbench-crafting.test.js
+++ b/test/workbench-crafting.test.js
@@ -49,7 +49,7 @@ test('craftSolarTarp uses cloth and scrap', () => {
   assert.ok(!context.player.inv.some(i => i.id === 'cloth'));
 });
 
-test('craftBandage consumes plant fiber', () => { 
+test('craftBandage consumes plant fiber', () => {
   const context = {
     Dustland: {},
     EventBus: { emit: () => {} },
@@ -73,4 +73,31 @@ test('craftBandage consumes plant fiber', () => {
   context.Dustland.workbench.craftBandage();
   assert.ok(context.player.inv.some(i => i.id === 'bandage'));
   assert.ok(!context.player.inv.some(i => i.id === 'plant_fiber'));
+});
+
+test('craftAntidote consumes plant fiber and water flask', () => {
+  const context = {
+    Dustland: {},
+    EventBus: { emit: () => {} },
+    player: { scrap: 0, inv: [{ id: 'plant_fiber' }, { id: 'water_flask' }] },
+    addToInv: id => { context.player.inv.push({ id }); return true; },
+    hasItem: id => context.player.inv.some(i => i.id === id),
+    findItemIndex: id => context.player.inv.findIndex(i => i.id === id),
+    removeFromInv: (idx, qty = 1) => {
+      const item = context.player.inv[idx];
+      if (!item) return;
+      const count = Number.isFinite(item?.count) ? item.count : 1;
+      if (count > qty) {
+        item.count = count - qty;
+      } else {
+        context.player.inv.splice(idx, 1);
+      }
+    },
+    log: () => {}
+  };
+  vm.runInNewContext(src, context);
+  context.Dustland.workbench.craftAntidote();
+  assert.ok(context.player.inv.some(i => i.id === 'antidote'));
+  assert.ok(!context.player.inv.some(i => i.id === 'plant_fiber'));
+  assert.ok(!context.player.inv.some(i => i.id === 'water_flask'));
 });

--- a/test/workbench.ui.test.js
+++ b/test/workbench.ui.test.js
@@ -35,12 +35,14 @@ test('workbench shows requirement counts for recipes you lack', async () => {
 
   Dustland.openWorkbench();
   const rows = dom.window.document.querySelectorAll('#workbenchRecipes .slot');
-  assert.strictEqual(rows.length, 3);
+  assert.strictEqual(rows.length, 4);
   assert.match(rows[0].textContent, /Scrap: 0\/5/i);
   assert.match(rows[0].textContent, /Fuel: 0\/50/i);
   assert.match(rows[1].textContent, /Scrap: 0\/3/i);
   assert.match(rows[1].textContent, /Cloth: 0\/1/i);
   assert.match(rows[2].textContent, /Plant Fiber: 0\/1/i);
+  assert.match(rows[3].textContent, /Plant Fiber: 0\/1/i);
+  assert.match(rows[3].textContent, /Water Flask: 0\/1/i);
   const buttons = dom.window.document.querySelectorAll('#workbenchRecipes .slot button');
   assert.strictEqual(buttons.length, 0);
 });
@@ -48,7 +50,7 @@ test('workbench shows requirement counts for recipes you lack', async () => {
 test('arrow keys in workbench do not bubble to window', async () => {
   const dom = new JSDOM('<div id="workbenchOverlay"><div class="workbench-window"><header><button id="closeWorkbenchBtn"></button></header><div id="workbenchRecipes"></div></div></div>');
   await loadWorkbench(dom);
-  global.player = { scrap: 5, fuel: 50, inv: [ { id: 'cloth' }, { id: 'plant_fiber' } ] };
+  global.player = { scrap: 5, fuel: 50, inv: [ { id: 'cloth' }, { id: 'plant_fiber' }, { id: 'water_flask' } ] };
   global.hasItem = id => player.inv.some(i => i.id === id);
   global.findItemIndex = id => player.inv.findIndex(i => i.id === id);
   global.removeFromInv = (idx, qty = 1) => {
@@ -72,5 +74,5 @@ test('arrow keys in workbench do not bubble to window', async () => {
   overlay.dispatchEvent(evt);
   assert.strictEqual(moved, 0);
   const buttons = dom.window.document.querySelectorAll('#workbenchRecipes .slot button');
-  assert.strictEqual(buttons.length, 3);
+  assert.strictEqual(buttons.length, 4);
 });


### PR DESCRIPTION
## Summary
- add an antidote crafting option that consumes plant fiber and a water flask
- register the antidote consumable so it cleanses poison when used
- update workbench tests to cover the new recipe

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68cc13b91110832880ca2a2ddf41e031