### PR TITLE
feat: add modular save format

### DIFF
--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1770,8 +1770,12 @@ test('save serializes party when map method is shadowed', () => {
   assert.doesNotThrow(() => save());
   global.localStorage = orig;
   const saved = JSON.parse(store['dustland_crt']);
-  assert.strictEqual(saved.party[0].id, 'p1');
-  assert.strictEqual(saved.party.length, 1);
+  assert.strictEqual(saved.format, 'dustland.v2');
+  const savedParty = Array.isArray(saved.party) ? saved.party : saved.party?.members;
+  assert.ok(Array.isArray(savedParty));
+  assert.strictEqual(savedParty[0].id, 'p1');
+  assert.strictEqual(savedParty.length, 1);
+  assert.strictEqual(saved.party.map, 'world');
 });
 
 test('save/load preserves NPC loops', () => {


### PR DESCRIPTION
## Summary
- introduce a `dustland.v2` save payload that captures world diffs, party data, quests, flags, fast travel, and NPC patches while keeping legacy loading in place
- reload the active module during modern loads before applying saved diffs to rebuild interiors, items, portals, NPCs, and fast-travel data
- update the serialization regression test to expect the new format metadata while still guarding against `party.map` shadowing

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cc1423d41083288f6fe9c422019449