### PR TITLE
feat: add persona portrait prompts and unequip flow

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -778,6 +778,39 @@ input[type="range"] {
   width: 100%;
 }
 
+#personaOverlay .persona-card {
+  border: 1px solid #2b3b2b;
+  border-radius: 6px;
+  padding: 8px;
+  background: #141814;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#personaOverlay .persona-title {
+  font-weight: 600;
+  color: #eef0e8;
+}
+
+#personaOverlay .persona-status {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8fd3a5;
+}
+
+#personaOverlay .persona-prompt {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: #c8d3c8;
+}
+
+#personaOverlay .persona-card .btn {
+  margin-top: 4px;
+}
+
 #workbenchOverlay .workbench-window {
   width: 300px;
   background: #0f120f;

--- a/scripts/camp-persona.js
+++ b/scripts/camp-persona.js
@@ -46,7 +46,19 @@
     if (!member?.id || !overlay || !list) return;
     const personas = state.personas || {};
     const ids = Object.keys(personas);
+    const currentId = member.persona;
     list.innerHTML = '';
+    if (currentId && typeof gs.clearPersona === 'function') {
+      const unequip = document.createElement('button');
+      unequip.className = 'btn';
+      unequip.dataset.action = 'unequip';
+      unequip.textContent = 'Unequip mask';
+      unequip.addEventListener('click', () => {
+        overlay.classList.remove('shown');
+        gs.clearPersona(member.id);
+      }, { once: true });
+      list.appendChild(unequip);
+    }
     if (!ids.length) {
       const msg = document.createElement('div');
       msg.className = 'muted';
@@ -54,14 +66,40 @@
       list.appendChild(msg);
     } else {
       ids.forEach(id => {
+        const data = personas[id] || {};
+        const card = document.createElement('div');
+        card.className = 'persona-card';
+        const title = document.createElement('div');
+        title.className = 'persona-title';
+        title.textContent = data.label || id;
+        card.appendChild(title);
+        if (data.portraitPrompt) {
+          const prompt = document.createElement('p');
+          prompt.className = 'persona-prompt';
+          prompt.textContent = data.portraitPrompt;
+          card.appendChild(prompt);
+        }
+        if (currentId === id) {
+          const status = document.createElement('div');
+          status.className = 'persona-status';
+          status.textContent = 'Currently equipped';
+          card.appendChild(status);
+        }
         const b = document.createElement('button');
         b.className = 'btn';
-        b.textContent = personas[id]?.label || id;
-        b.addEventListener('click', () => {
-          overlay.classList.remove('shown');
-          gs.applyPersona(member.id, id);
-        }, { once: true });
-        list.appendChild(b);
+        b.dataset.personaId = id;
+        if (currentId === id) {
+          b.textContent = 'Equipped';
+          b.disabled = true;
+        } else {
+          b.textContent = 'Equip mask';
+          b.addEventListener('click', () => {
+            overlay.classList.remove('shown');
+            gs.applyPersona(member.id, id);
+          }, { once: true });
+        }
+        card.appendChild(b);
+        list.appendChild(card);
       });
     }
     overlay.classList.add('shown');

--- a/scripts/core/personas.js
+++ b/scripts/core/personas.js
@@ -4,9 +4,27 @@
   const bus = globalThis.EventBus;
   if(!gs?.setPersona || !bus?.on) return;
   const templates = {
-    'mara.masked': { id: 'mara.masked', label: 'Masked Mara', portrait: 'assets/portraits/hidden_hermit_4.png', mods: { AGI: 1 } },
-    'jax.patchwork': { id: 'jax.patchwork', label: 'Patchwork Jax', portrait: 'assets/portraits/iron_brute_4.png', mods: { STR: 1 } },
-    'nyx.veiled': { id: 'nyx.veiled', label: 'Veiled Nyx', portrait: 'assets/portraits/nora_4.png', mods: { INT: 1 } }
+    'mara.masked': {
+      id: 'mara.masked',
+      label: 'Masked Mara',
+      portrait: 'assets/portraits/hidden_hermit_4.png',
+      portraitPrompt: 'Cinematic digital painting of Mara, a weathered navigator in scavenged desert armor, wearing a cracked porcelain mask with thin gold inlay, warm campfire lighting, windswept hair, determined expression, post-apocalyptic wasteland backdrop.',
+      mods: { AGI: 1 }
+    },
+    'jax.patchwork': {
+      id: 'jax.patchwork',
+      label: 'Patchwork Jax',
+      portrait: 'assets/portraits/iron_brute_4.png',
+      portraitPrompt: 'Gritty concept art portrait of Jax, a muscular scavenger with a patchwork mask welded from mismatched metal plates, neon welding glow reflections, improvised armor straps, cybernetic arm details, ruined factory background, dramatic rim lighting.',
+      mods: { STR: 1 }
+    },
+    'nyx.veiled': {
+      id: 'nyx.veiled',
+      label: 'Veiled Nyx',
+      portrait: 'assets/portraits/nora_4.png',
+      portraitPrompt: 'Moody illustration of Nyx, a lithe mystic draped in layered dusk-blue robes, translucent veil mask stitched with glowing threads, bioluminescent tattoos, twilight storm clouds behind her, soft moonlit highlights, enigmatic calm expression.',
+      mods: { INT: 1 }
+    }
   };
   globalThis.Dustland.personaTemplates = templates;
   bus.on('item:picked', it => {

--- a/scripts/game-state.js
+++ b/scripts/game-state.js
@@ -58,5 +58,18 @@
     if (typeof renderParty === 'function') renderParty();
     if (typeof updateHUD === 'function') updateHUD();
   }
-  Dustland.gameState = { getState, updateState, getDifficulty, setDifficulty, setPersona, getPersona, applyPersona, addEffectPack, loadEffectPacks, rememberNPC, recallNPC, forgetNPC };
+  function clearPersona(memberId){
+    const member = state.party.find(m => m.id === memberId);
+    if (!member) return;
+    const prev = member.persona;
+    if (!prev) return;
+    globalThis.Dustland?.profiles?.remove?.(member, prev);
+    member.persona = undefined;
+    if (typeof member.applyEquipmentStats === 'function') member.applyEquipmentStats();
+    if (typeof member.applyCombatMods === 'function') member.applyCombatMods();
+    globalThis.EventBus?.emit('persona:unequip', { memberId, personaId: prev });
+    if (typeof renderParty === 'function') renderParty();
+    if (typeof updateHUD === 'function') updateHUD();
+  }
+  Dustland.gameState = { getState, updateState, getDifficulty, setDifficulty, setPersona, getPersona, applyPersona, clearPersona, addEffectPack, loadEffectPacks, rememberNPC, recallNPC, forgetNPC };
 })();


### PR DESCRIPTION
## Summary
- add portrait prompt strings to persona templates for mask-inspired AI art direction
- surface the prompts and current status in the camp persona overlay with cards
- allow equipped personas to be unequipped from camp via game state support and new UI

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cc21d7ea1c8328b75fd0c7ed8242c9