### PR TITLE
feat: add sunflare bazooka arena reward

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -430,6 +430,21 @@ const DATA = `
         "type": "cleanse",
         "text": "You feel the toxins fade away."
       }
+    },
+    {
+      "id": "sunflare_bazooka",
+      "name": "Sunflare Bazooka",
+      "type": "weapon",
+      "rarity": "epic",
+      "mods": {
+        "ATK": 8,
+        "ADR": 45
+      },
+      "tags": [
+        "ranged",
+        "heavy"
+      ],
+      "desc": "Archivist rocket launcher packed with sunfire ordnance."
     }
   ],
   "quests": [
@@ -3202,7 +3217,7 @@ const DATA = `
           "min": 45,
           "max": 60
         },
-        "loot": "epic_blade",
+        "loot": "sunflare_bazooka",
         "lootChance": 1
       }
     }
@@ -14961,8 +14976,8 @@ function postLoad(module) {
         } else {
           arenaState.cleared = true;
           ensureBank(-1);
-          if (typeof log === 'function') log('The Cinder Tyrant collapses, showering the arena in blazing scrap!');
-          if (typeof toast === 'function') toast('Arena complete! The Cinder Tyrant drops an epic weapon.');
+          if (typeof log === 'function') log('The Cinder Tyrant collapses, showering the arena in blazing scrap and salvaging the Sunflare Bazooka!');
+          if (typeof toast === 'function') toast('Arena complete! The Cinder Tyrant drops the Sunflare Bazooka.');
         }
       } else {
         resetArena();

--- a/scripts/module-tools/utils.js
+++ b/scripts/module-tools/utils.js
@@ -14,9 +14,24 @@ function readModule(file) {
   const start = text.indexOf(token);
   if (start === -1) throw new Error('DATA block not found');
   const jsonStart = start + token.length;
-  const jsonEnd = text.lastIndexOf('`');
+  let jsonEnd = -1;
+  let suffixStart = -1;
+  let searchFrom = jsonStart;
+  while (jsonEnd === -1 && searchFrom < text.length) {
+    const tick = text.indexOf('`', searchFrom);
+    if (tick === -1) break;
+    let cursor = tick + 1;
+    while (cursor < text.length && /\s/.test(text[cursor])) cursor += 1;
+    if (text[cursor] === ';') {
+      jsonEnd = tick;
+      suffixStart = tick;
+      break;
+    }
+    searchFrom = tick + 1;
+  }
+  if (jsonEnd === -1) throw new Error('DATA block end not found');
   const prefix = text.slice(0, jsonStart);
-  const suffix = text.slice(jsonEnd);
+  const suffix = text.slice(suffixStart);
   const jsonText = text.slice(jsonStart, jsonEnd);
   return {
     data: JSON.parse(jsonText),


### PR DESCRIPTION
## Summary
- add an epic Sunflare Bazooka item to the Dustland module data
- award the bazooka when the Cinder Tyrant falls and update arena messaging
- make the module CLI tolerate additional template literals after the DATA block

## Testing
- node scripts/supporting/placement-check.js modules/dustland.module.js
- node scripts/supporting/presubmit.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc22d21f6483288ecc65d3a9baefef