### PR TITLE
fix: surface persona stat bonuses in camp overlay

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -807,6 +807,23 @@ input[type="range"] {
   color: #c8d3c8;
 }
 
+#personaOverlay .persona-mods {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  font-size: 0.75rem;
+  color: #d4e4d0;
+}
+
+#personaOverlay .persona-mods li {
+  background: #1d231d;
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
 #personaOverlay .persona-card .btn {
   margin-top: 4px;
 }

--- a/scripts/camp-persona.js
+++ b/scripts/camp-persona.js
@@ -79,6 +79,21 @@
           prompt.textContent = data.portraitPrompt;
           card.appendChild(prompt);
         }
+        const mods = data.mods;
+        if (mods && typeof mods === 'object') {
+          const entries = Object.entries(mods).filter(([, value]) => typeof value === 'number' && value !== 0);
+          if (entries.length) {
+            const listEl = document.createElement('ul');
+            listEl.className = 'persona-mods';
+            for (const [stat, value] of entries) {
+              const item = document.createElement('li');
+              const prefix = value > 0 ? '+' : '';
+              item.textContent = `${prefix}${value} ${stat}`;
+              listEl.appendChild(item);
+            }
+            card.appendChild(listEl);
+          }
+        }
         if (currentId === id) {
           const status = document.createElement('div');
           status.className = 'persona-status';

--- a/test/camp.test.js
+++ b/test/camp.test.js
@@ -15,7 +15,7 @@ test('camp:open heals party and shows persona menu', async () => {
   const healAll = () => { healed = true; };
   const log = m => { msg = m; };
   const gs = {
-    getState: () => ({ party: [{ id: 'p1', name: 'Hero' }], personas: { a: { label: 'Mask A', portraitPrompt: 'AI prompt text' } } }),
+    getState: () => ({ party: [{ id: 'p1', name: 'Hero' }], personas: { a: { label: 'Mask A', portraitPrompt: 'AI prompt text', mods: { STR: 2, AGI: -1 } } } }),
     applyPersona: (pid, id) => { applied = id; }
   };
   const party = [{ id: 'p1', name: 'Hero', hydration: 0 }];
@@ -40,7 +40,12 @@ test('camp:open heals party and shows persona menu', async () => {
   assert.equal(msg, 'You rest until healed.');
   const overlay = document.getElementById('personaOverlay');
   assert.ok(overlay.classList.contains('shown'));
-  assert.match(document.getElementById('personaList').textContent, /AI prompt text/);
+  const listText = document.getElementById('personaList').textContent;
+  assert.match(listText, /AI prompt text/);
+  assert.match(listText, /\+2 STR/);
+  assert.match(listText, /-1 AGI/);
+  const modsEl = document.querySelector('.persona-mods');
+  assert.ok(modsEl);
   const btn = document.querySelector('#personaList .btn');
   assert.ok(btn);
   btn.click();


### PR DESCRIPTION
## Summary
- show persona stat bonuses next to the camp persona selection buttons
- add overlay styling for the stat modifier list
- extend the camp overlay test to cover the new stats copy

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cc29613bfc832881cfadf99756153f