### PR TITLE
Fix modern save loader compatibility

### DIFF
--- a/test/fixtures/dustland.save.v2.json
+++ b/test/fixtures/dustland.save.v2.json
@@ -1,0 +1,25 @@
+{
+  "format": "dustland.save.v2",
+  "version": 2,
+  "module": "{\"id\":\"fixture_mod\",\"name\":\"Fixture Mod\"}",
+  "worldSeed": 123456,
+  "world": [],
+  "player": { "inv": [] },
+  "state": { "map": "world" },
+  "buildings": [],
+  "interiors": {},
+  "itemDrops": [],
+  "npcs": [],
+  "quests": {},
+  "party": { "members": [], "map": "world", "x": 0, "y": 0, "flags": {}, "fallen": [] },
+  "worldFlags": {},
+  "bunkers": [],
+  "gameState": {
+    "difficulty": "normal",
+    "flags": {},
+    "clock": 0,
+    "personas": {},
+    "npcMemory": {},
+    "effectPacks": {}
+  }
+}


### PR DESCRIPTION
## Summary
- treat future `dustland.save.v*` payloads as modern saves without changing the stored identifier
- resolve module identifiers from legacy string blobs before falling back to the current module
- add a regression test and fixture that confirm v2 saves use the modern loader

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cc2501c1248328aa6d103b7c0c82f9