### PR TITLE
feat: add stun gear advantage for ashen howler

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -482,6 +482,22 @@ const DATA = `
         "ATK": 2,
         "ADR": 9
       }
+    },
+    {
+      "map": "room_oc3abv",
+      "x": 25,
+      "y": 46,
+      "id": "stun_gear",
+      "name": "Stun Gear Harness",
+      "type": "trinket",
+      "desc": "Insulated coils to diffuse concussive howls.",
+      "mods": {
+        "RES": 2
+      },
+      "tags": [
+        "stun",
+        "tech"
+      ]
     }
   ],
   "quests": [
@@ -14899,14 +14915,14 @@ function postLoad(module) {
         templateId: 'ashen_howler',
         count: 3,
         bankChallenge: 32,
-        announce: 'Ashen Howlers erupt from the pit, their throats crackling with static. Stun gear can short their chorus.',
+        announce: 'Ashen Howlers erupt from the pit, their throats crackling with static. Stun gear harnesses can short their chorus.',
         toast: 'Wave 1: Ashen Howlers',
         vulnerability: {
-          check: () => hasUpgrade('stun_baton'),
+          check: () => hasUpgrade('stun_gear') || hasUpgrade('stun_baton'),
           onMatch(enemy) { adjustDefense(enemy, -2); },
           onMiss(enemy) { adjustDefense(enemy, 2); },
-          successMsg: 'Your stun weaponry rattles the pack and strips away their guard.',
-          failMsg: 'Without stun tech the howlers harden into concussion shields.'
+          successMsg: 'Your stun harness crackles and rattles the pack, stripping away their guard.',
+          failMsg: 'Without stun insulation the howlers harden into concussion shields.'
         }
       },
       {


### PR DESCRIPTION
## Summary
- add a Stun Gear Harness pickup inside the Dustland pit to prepare for the Ashen Howlers
- refresh the wave vulnerability logic so the arena recognizes the new gear (and existing stun baton) while updating the messaging

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js
- node scripts/supporting/balance-tester-agent.js *(fails: SpoilsCache is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2a044c588328963996501d7a9fd2