### PR TITLE
feat: hidden hermit warns about howlers

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -1656,7 +1656,7 @@ const DATA = `
       "portraitSheet": "assets/portraits/dustland-module/hidden_hermit_4.png",
       "tree": {
         "start": {
-          "text": "Didn't expect company twice.",
+          "text": "Didn't expect company twice. If you're trekking near those Ashen pits, remember Ashen Howlers hate getting stunned—clip on a Stun Gear Harness trinket and their chorus falls apart.",
           "choices": [
             {
               "label": "(Leave)",

--- a/modules/edge.module.js
+++ b/modules/edge.module.js
@@ -52,7 +52,7 @@ const DATA = `
       "y": 45,
       "tree": {
         "start": {
-          "text": "",
+          "text": "Ashen Howlers layer their howls into solid walls if you let them. Stun gear short-circuits the chorus—equip a trinket like the Stun Gear Harness before you step into their pit.",
           "choices": [
             {
               "label": "(Leave)",


### PR DESCRIPTION
## Summary
- update the Dustland module's Hidden Hermit to warn about Ashen Howlers and recommend equipping the Stun Gear Harness trinket

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68cc2c62b2f08328a5ecde90ad038065