### PR TITLE
feat: replace scavenger rat NPC with encounter zone

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -1,0 +1,3902 @@
+{
+  "seed": "dustland",
+  "start": {
+    "map": "hall",
+    "x": 15,
+    "y": 18
+  },
+  "items": [
+    {
+      "id": "rusted_key",
+      "name": "Rusted Key",
+      "type": "quest",
+      "tags": [
+        "key"
+      ]
+    },
+    {
+      "id": "toolkit",
+      "name": "Toolkit",
+      "type": "quest",
+      "tags": [
+        "tool"
+      ]
+    },
+    {
+      "id": "signal_beacon",
+      "name": "Signal Beacon",
+      "type": "quest"
+    },
+    {
+      "id": "fuel_cell",
+      "name": "Fuel Cell",
+      "type": "quest",
+      "fuel": 50
+    },
+    {
+      "map": "world",
+      "x": 8,
+      "y": 45,
+      "id": "pipe_rifle",
+      "name": "Pipe Rifle",
+      "type": "weapon",
+      "mods": {
+        "ATK": 2,
+        "ADR": 15
+      },
+      "tags": [
+        "ranged"
+      ]
+    },
+    {
+      "map": "world",
+      "x": 10,
+      "y": 45,
+      "id": "leather_jacket",
+      "name": "Leather Jacket",
+      "type": "armor",
+      "mods": {
+        "DEF": 1
+      }
+    },
+    {
+      "map": "world",
+      "x": 12,
+      "y": 45,
+      "id": "lucky_bottlecap",
+      "name": "Lucky Bottlecap",
+      "type": "trinket",
+      "mods": {
+        "LCK": 1
+      }
+    },
+    {
+      "map": "world",
+      "x": 33,
+      "y": 19,
+      "id": "crowbar",
+      "name": "Crowbar",
+      "type": "weapon",
+      "mods": {
+        "ATK": 1,
+        "ADR": 10
+      }
+    },
+    {
+      "map": "world",
+      "x": 30,
+      "y": 63,
+      "id": "rebar_club",
+      "name": "Rebar Club",
+      "type": "weapon",
+      "mods": {
+        "ATK": 1,
+        "ADR": 10
+      }
+    },
+    {
+      "map": "world",
+      "x": 77,
+      "y": 36,
+      "id": "kevlar_scrap_vest",
+      "name": "Kevlar Scrap Vest",
+      "type": "armor",
+      "mods": {
+        "DEF": 2
+      }
+    },
+    {
+      "map": "world",
+      "x": 93,
+      "y": 19,
+      "id": "goggles",
+      "name": "Goggles",
+      "type": "trinket",
+      "mods": {
+        "PER": 1
+      }
+    },
+    {
+      "map": "world",
+      "x": 83,
+      "y": 43,
+      "id": "wrench",
+      "name": "Wrench",
+      "type": "trinket",
+      "mods": {
+        "INT": 1
+      }
+    },
+    {
+      "map": "world",
+      "x": 95,
+      "y": 47,
+      "id": "lucky_rabbit_foot",
+      "name": "Lucky Rabbit Foot",
+      "type": "trinket",
+      "mods": {
+        "LCK": 1
+      }
+    },
+    {
+      "map": "world",
+      "x": 26,
+      "y": 69,
+      "id": "water_flask",
+      "name": "Water Flask",
+      "type": "consumable",
+      "use": {
+        "type": "heal",
+        "amount": 3
+      }
+    },
+    {
+      "map": "world",
+      "x": 80,
+      "y": 42,
+      "id": "medkit",
+      "name": "Medkit",
+      "type": "consumable",
+      "use": {
+        "type": "heal",
+        "amount": 10
+      }
+    },
+    {
+      "map": "world",
+      "x": 31,
+      "y": 70,
+      "id": "adrenaline_shot",
+      "name": "Adrenaline Shot",
+      "type": "consumable",
+      "use": {
+        "type": "boost",
+        "stat": "ATK",
+        "amount": 2,
+        "duration": 3,
+        "text": "Power surges through you."
+      }
+    },
+    {
+      "map": "world",
+      "x": 50,
+      "y": 32,
+      "id": "armor_polish",
+      "name": "Armor Polish",
+      "type": "consumable",
+      "use": {
+        "type": "boost",
+        "stat": "DEF",
+        "amount": 2,
+        "duration": 3,
+        "text": "You feel protected."
+      }
+    },
+    {
+      "id": "frag_grenade",
+      "name": "Frag Grenade",
+      "type": "consumable",
+      "use": {
+        "type": "grenade",
+        "amount": 6,
+        "text": "You pull the pin and lob the grenade!"
+      },
+      "scrap": 300,
+      "value": 300,
+      "tags": [
+        "grenade"
+      ]
+    },
+    {
+      "id": "incendiary_grenade",
+      "name": "Incendiary Grenade",
+      "type": "consumable",
+      "use": {
+        "type": "grenade",
+        "amount": 5,
+        "text": "Flames burst across the battlefield."
+      },
+      "scrap": 300,
+      "value": 300,
+      "tags": [
+        "grenade",
+        "fire"
+      ]
+    },
+    {
+      "map": "world",
+      "x": 18,
+      "y": 43,
+      "id": "valve",
+      "name": "Valve",
+      "type": "quest"
+    },
+    {
+      "map": "world",
+      "x": 25,
+      "y": 56,
+      "id": "lost_satchel",
+      "name": "Lost Satchel",
+      "type": "quest"
+    },
+    {
+      "map": "world",
+      "x": 88,
+      "y": 17,
+      "id": "rust_idol",
+      "name": "Rust Idol",
+      "type": "quest",
+      "tags": [
+        "idol"
+      ]
+    },
+    {
+      "map": "world",
+      "x": 44,
+      "y": 80,
+      "id": "cloth",
+      "name": "Cloth",
+      "type": "quest"
+    },
+    {
+      "map": "world",
+      "x": 46,
+      "y": 80,
+      "id": "plant_fiber",
+      "name": "Plant Fiber",
+      "type": "quest"
+    },
+    {
+      "id": "bandage",
+      "name": "Bandage",
+      "type": "consumable",
+      "use": {
+        "type": "heal",
+        "amount": 6
+      }
+    },
+    {
+      "id": "raider_knife",
+      "name": "Raider Knife",
+      "type": "weapon",
+      "mods": {
+        "ATK": 1,
+        "ADR": 10
+      }
+    },
+    {
+      "map": "world",
+      "x": 98,
+      "y": 62,
+      "id": "artifact_blade",
+      "name": "Artifact Blade",
+      "type": "weapon",
+      "mods": {
+        "ATK": 5,
+        "ADR": 20
+      }
+    },
+    {
+      "map": "world",
+      "x": 65,
+      "y": 18,
+      "id": "signal_fragment_a",
+      "name": "Signal Fragment",
+      "type": "quest",
+      "tags": [
+        "signal_fragment"
+      ]
+    },
+    {
+      "map": "world",
+      "x": 63,
+      "y": 22,
+      "id": "signal_fragment_b",
+      "name": "Signal Fragment",
+      "type": "quest",
+      "tags": [
+        "signal_fragment"
+      ]
+    },
+    {
+      "map": null,
+      "x": null,
+      "y": null,
+      "id": "signal_fragment_c",
+      "name": "Signal Fragment",
+      "type": "quest",
+      "tags": [
+        "signal_fragment"
+      ]
+    },
+    {
+      "id": "epic_blade",
+      "name": "Epic Blade",
+      "type": "weapon",
+      "rarity": "epic",
+      "mods": {
+        "ATK": 5
+      },
+      "value": 500
+    },
+    {
+      "id": "epic_armor",
+      "name": "Epic Armor",
+      "type": "armor",
+      "rarity": "epic",
+      "mods": {
+        "DEF": 5
+      },
+      "value": 500
+    },
+    {
+      "map": "hall",
+      "x": 9,
+      "y": 18,
+      "id": "glinting_key",
+      "name": "Glinting Key",
+      "type": "quest",
+      "tags": [
+        "key"
+      ],
+      "use": {
+        "effect": "vision"
+      }
+    },
+    {
+      "map": "hall",
+      "x": 16,
+      "y": 8,
+      "id": "wand",
+      "name": "Wand",
+      "type": "quest",
+      "use": {
+        "type": "heal",
+        "amount": 0,
+        "text": "You wave the wand."
+      }
+    },
+    {
+      "map": "echoes_atrium",
+      "x": 3,
+      "y": 2,
+      "id": "spark_key",
+      "name": "Spark Key",
+      "type": "quest",
+      "tags": [
+        "key"
+      ]
+    },
+    {
+      "map": "echoes_workshop",
+      "x": 4,
+      "y": 5,
+      "id": "cog_key",
+      "name": "Cog Key",
+      "type": "quest",
+      "tags": [
+        "key"
+      ]
+    },
+    {
+      "map": "echoes_archive",
+      "x": 8,
+      "y": 4,
+      "id": "sun_charm",
+      "name": "Sun Charm",
+      "type": "trinket",
+      "mods": {
+        "LCK": 1
+      }
+    },
+    {
+      "id": "rat_tail",
+      "name": "Rat Tail",
+      "type": "quest"
+    },
+    {
+      "id": "copper_cog",
+      "name": "Copper Cog",
+      "type": "quest"
+    },
+    {
+      "id": "antidote",
+      "name": "Antidote",
+      "type": "consumable",
+      "use": {
+        "type": "cleanse",
+        "text": "You feel the toxins fade away."
+      }
+    },
+    {
+      "id": "sunflare_bazooka",
+      "name": "Sunflare Bazooka",
+      "type": "weapon",
+      "rarity": "epic",
+      "mods": {
+        "ATK": 8,
+        "ADR": 45
+      },
+      "tags": [
+        "ranged",
+        "heavy"
+      ],
+      "desc": "Archivist rocket launcher packed with sunfire ordnance."
+    },
+    {
+      "map": "world",
+      "x": 14,
+      "y": 45,
+      "id": "sealed_hazard_suit",
+      "name": "Sealed Hazard Suit",
+      "type": "armor",
+      "desc": "Reinforced suit with detox canisters. Grants poison immunity.",
+      "mods": {
+        "DEF": 4,
+        "poison_immune": 1
+      },
+      "tags": [
+        "poison_immune"
+      ]
+    },
+    {
+      "map": "world",
+      "x": 16,
+      "y": 45,
+      "id": "antitoxin_locket",
+      "name": "Antitoxin Locket",
+      "type": "trinket",
+      "desc": "A sealed charm that scrubs toxins from your blood.",
+      "mods": {
+        "LCK": 1,
+        "poison_immune": 1
+      },
+      "tags": [
+        "poison_immune"
+      ]
+    },
+    {
+      "map": "world",
+      "x": 18,
+      "y": 45,
+      "id": "venom_sensor_band",
+      "name": "Venom Sensor Band",
+      "type": "trinket",
+      "desc": "Sensor mesh that warns of toxins and purges venom.",
+      "mods": {
+        "PER": 1,
+        "poison_immune": 1
+      },
+      "tags": [
+        "poison_immune"
+      ]
+    },
+    {
+      "id": "thornlash_whip",
+      "name": "Thornlash Whip",
+      "type": "weapon",
+      "mods": {
+        "ATK": 1,
+        "ADR": 12
+      }
+    },
+    {
+      "id": "sap_poultice",
+      "name": "Sap Poultice",
+      "type": "consumable",
+      "use": {
+        "type": "heal",
+        "amount": 5,
+        "text": "Sweet sap knits your wounds."
+      }
+    },
+    {
+      "id": "patchwork_plate",
+      "name": "Patchwork Plate",
+      "type": "armor",
+      "mods": {
+        "DEF": 1,
+        "HP": 2
+      }
+    },
+    {
+      "id": "corroded_hatchet",
+      "name": "Corroded Hatchet",
+      "type": "weapon",
+      "mods": {
+        "ATK": 2,
+        "ADR": 9
+      }
+    },
+    {
+      "map": "room_oc3abv",
+      "x": 25,
+      "y": 46,
+      "id": "stun_gear",
+      "name": "Stun Gear Harness",
+      "type": "trinket",
+      "desc": "Insulated coils to diffuse concussive howls.",
+      "mods": {
+        "RES": 2
+      },
+      "tags": [
+        "stun",
+        "tech"
+      ]
+    }
+  ],
+  "quests": [
+    {
+      "id": "q_hall_key",
+      "title": "Find the Rusted Key",
+      "desc": "Search the hall for a Rusted Key to unlock the exit.",
+      "item": "rusted_key"
+    },
+    {
+      "id": "q_waterpump",
+      "title": "Water for the Pump",
+      "desc": "Find a Valve and help Nila restart the pump.",
+      "item": "valve",
+      "reward": {
+        "id": "rusted_badge",
+        "name": "Rusted Badge",
+        "type": "trinket",
+        "slot": "trinket",
+        "mods": {
+          "LCK": 1
+        }
+      },
+      "xp": 4
+    },
+    {
+      "id": "q_recruit_grin",
+      "title": "Recruit Grin",
+      "desc": "Convince or pay Grin to join."
+    },
+    {
+      "id": "q_postal",
+      "title": "Lost Parcel",
+      "desc": "Find and return the Lost Satchel to Ivo.",
+      "item": "lost_satchel",
+      "reward": {
+        "id": "brass_stamp",
+        "name": "Brass Stamp",
+        "type": "trinket",
+        "slot": "trinket",
+        "mods": {
+          "LCK": 1
+        }
+      },
+      "xp": 4
+    },
+    {
+      "id": "q_tower",
+      "title": "Dead Air",
+      "desc": "Repair the radio tower console (Toolkit helps).",
+      "item": "toolkit",
+      "reward": {
+        "id": "tuner_charm",
+        "name": "Tuner Charm",
+        "type": "trinket",
+        "slot": "trinket",
+        "mods": {
+          "PER": 1
+        }
+      },
+      "xp": 5
+    },
+    {
+      "id": "q_idol",
+      "title": "Rust Idol",
+      "desc": "Recover the Rust Idol from roadside ruins.",
+      "item": "rust_idol",
+      "reward": {
+        "id": "pilgrim_thread",
+        "name": "Pilgrim Thread",
+        "type": "trinket",
+        "slot": "trinket",
+        "mods": {
+          "CHA": 1
+        }
+      },
+      "xp": 5
+    },
+    {
+      "id": "q_toll",
+      "title": "Toll-Booth Etiquette",
+      "desc": "You met the Duchess on the road.",
+      "xp": 2
+    },
+    {
+      "id": "q_signal",
+      "title": "Broken Signal",
+      "desc": "Collect three signal fragments in the wastes.",
+      "item": "signal_fragment",
+      "count": 3,
+      "xp": 3
+    },
+    {
+      "id": "q_spark",
+      "title": "Spark the Way",
+      "desc": "Find the Spark Key to open the workshop.",
+      "item": "spark_key"
+    },
+    {
+      "id": "q_cog",
+      "title": "Unlock the Archive",
+      "desc": "Find the Cog Key to reach the beacon.",
+      "item": "cog_key"
+    },
+    {
+      "id": "q_beacon",
+      "title": "Light the Beacon",
+      "desc": "Defeat the Gear Ghoul and claim hope."
+    },
+    {
+      "id": "q_solar_alignment",
+      "title": "Align the Sun",
+      "desc": "Deliver the Sun Charm to the Archivist in the Hall so he can decode the broadcast and chart a path to the missing fragment.",
+      "item": "sun_charm",
+      "reward": "sun_charm",
+      "xp": 4
+    },
+    {
+      "id": "q_solar_signal",
+      "title": "Resonate the Signal",
+      "desc": "Recover Signal Fragment C from the echo relay hidden in the far northeast so the Archivist can finish the broadcast and unlock the Epic Blade.",
+      "item": "signal_fragment_c",
+      "reward": "epic_blade",
+      "xp": 8
+    }
+  ],
+  "npcs": [
+    {
+      "id": "dust_storm_entrance",
+      "map": "world",
+      "x": 10,
+      "y": 10,
+      "color": "#225a20",
+      "name": "Strange Vortex",
+      "title": "A swirling vortex of dust and sand.",
+      "desc": "You feel a strange pull towards it.",
+      "portraitSheet": "assets/portraits/dustland-module/strange_vortex_4.png",
+      "tree": {
+        "start": {
+          "text": "A swirling vortex of dust and sand blocks your path.",
+          "choices": [
+            {
+              "label": "(Enter the vortex)",
+              "to": "enter"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "enter": {
+          "text": "You are pulled into the vortex.",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye",
+              "goto": {
+                "map": "world",
+                "x": 10,
+                "y": 18
+              }
+            }
+          ]
+        }
+      },
+      "symbol": "?"
+    },
+    {
+      "id": "hidden_crate",
+      "map": "world",
+      "x": 12,
+      "y": 12,
+      "color": "#225a20",
+      "name": "Buried Crate",
+      "desc": "Sand conceals a supply crate.",
+      "portraitSheet": "assets/portraits/dustland-module/buried_crate_4.png",
+      "portraitLock": false,
+      "prompt": "Crate half-buried under shifting sand",
+      "hintSound": true,
+      "tree": {
+        "start": {
+          "text": "You sense something under the sand.",
+          "choices": [
+            {
+              "label": "(Dig)",
+              "to": "dig",
+              "once": true
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "dig": {
+          "text": "You uncover a supply crate packed with scrap.",
+          "choices": [
+            {
+              "label": "(Take Scrap)",
+              "to": "empty",
+              "reward": "SCRAP 5",
+              "effects": [
+                {
+                  "effect": "removeSoundSource",
+                  "id": "hidden_crate"
+                }
+              ]
+            }
+          ]
+        },
+        "empty": {
+          "text": "Just disturbed sand remains.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "?"
+    },
+    {
+      "id": "tape_sage",
+      "map": "hall",
+      "x": 20,
+      "y": 15,
+      "color": "#9ef7a0",
+      "name": "Archivist",
+      "title": "Memory Keeper",
+      "portraitSheet": "assets/portraits/dustland-module/archivist_4.png",
+      "portraitLock": false,
+      "desc": "Curious about recorded tales.",
+      "prompt": "Elder hunched over reels of magnetic tape",
+      "tree": {
+        "start": {
+          "text": "The Archivist taps a reel. 'The Sun Charm hums with a lost broadcast. Bring it so I can hear the dawn.'",
+          "choices": [
+            {
+              "label": "(Offer help decoding)",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Deliver requested item)",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "Ask about his tapes",
+              "to": "_chat__mff7uw9d_start"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "_chat__mff7uw9d_start": {
+          "text": "The Archivist peers up, tape spooling through his fingers. 'Every scrap of sound is a life. What do you bring?'",
+          "choices": [
+            {
+              "label": "Who are you?",
+              "to": "_chat__mff7uw9d_who"
+            },
+            {
+              "label": "Why tapes?",
+              "to": "_chat__mff7uw9d_why"
+            },
+            {
+              "label": "No stories today",
+              "to": "bye"
+            }
+          ]
+        },
+        "_chat__mff7uw9d_who": {
+          "text": "'Just a keeper of ghosts.' He taps a stack of reels. 'These hold the before-times.'",
+          "choices": [
+            {
+              "label": "Sounds lonely",
+              "to": "_chat__mff7uw9d_lonely"
+            },
+            {
+              "label": "Back",
+              "to": "_chat__mff7uw9d_start"
+            }
+          ]
+        },
+        "_chat__mff7uw9d_lonely": {
+          "text": "'Lonely? Maybe. But the past whispers company if you listen.'",
+          "choices": [
+            {
+              "label": "Back",
+              "to": "_chat__mff7uw9d_start"
+            }
+          ]
+        },
+        "_chat__mff7uw9d_why": {
+          "text": "'Tape endures where memory fades. Magnetics don't judge.'",
+          "choices": [
+            {
+              "label": "Got any stories?",
+              "to": "_chat__mff7uw9d_story"
+            },
+            {
+              "label": "Back",
+              "to": "_chat__mff7uw9d_start"
+            }
+          ]
+        },
+        "_chat__mff7uw9d_story": {
+          "text": "He feeds a reel into a rusty player. A raspy voice tells of caravans lost in sand.",
+          "choices": [
+            {
+              "label": "(Listen)",
+              "to": "_chat__mff7uw9d_listen"
+            },
+            {
+              "label": "(Enough)",
+              "to": "_chat__mff7uw9d_start"
+            }
+          ]
+        },
+        "_chat__mff7uw9d_listen": {
+          "text": "The tale winds down. 'Keep it,' he says, handing you the reel.",
+          "choices": [
+            {
+              "label": "(Thank him)",
+              "to": "bye",
+              "reward": "XP 5"
+            }
+          ]
+        },
+        "accept": {
+          "text": "The Archivist threads a fresh reel and nods. 'I'll be ready when you return—the completed broadcast will temper the epic blade you'll need for the Sovereign.'",
+          "choices": [
+            {
+              "label": "(I'll be back)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "The Archivist extends both hands, waiting for the artifact.",
+          "choices": [
+            {
+              "label": "(Place it in his hands)",
+              "to": "do_turnin"
+            }
+          ]
+        },
+        "do_turnin": {
+          "text": "He sets the reels spinning, translating the tones into words of gratitude that harden into an epic blade's blueprint.",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "!",
+      "quests": [
+        "q_solar_alignment",
+        "q_solar_signal"
+      ],
+      "dialogs": [
+        "The Archivist taps a reel. 'The Sun Charm hums with a lost broadcast. Bring it so I can hear the dawn.'",
+        "The Archivist squints at the receiver. 'I traced the pattern, but Signal Fragment C will complete the chorus.'",
+        "The Archivist lets the reels spin freely. 'The message sings thanks to you. Stay and listen.'"
+      ]
+    },
+    {
+      "id": "exitdoor",
+      "map": "hall",
+      "x": 15,
+      "y": 17,
+      "color": "#9ef7a0",
+      "name": "Caretaker Kesh",
+      "title": "Hall Steward",
+      "desc": "Weary caretaker guarding the hall's chained exit.",
+      "portraitSheet": "assets/portraits/kesh_4.png",
+      "questId": "q_hall_key",
+      "tree": {
+        "start": {
+          "text": "Caretaker Kesh eyes the chained exit.",
+          "choices": [
+            {
+              "label": "(Search for key)",
+              "to": "accept",
+              "q": "accept",
+              "setFlag": {
+                "flag": "q_hall_key_active",
+                "op": "set",
+                "value": 1
+              }
+            },
+            {
+              "label": "(Use Rusted Key)",
+              "to": "do_turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Use Glinting Key)",
+              "to": "glint_fail",
+              "if": {
+                "flag": "q_hall_key_active",
+                "op": ">=",
+                "value": 1
+              }
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Try the crates. This hall sheltered survivors once. Don’t scuff the floor.",
+          "choices": [
+            {
+              "label": "(Okay)",
+              "to": "bye"
+            }
+          ]
+        },
+        "glint_fail": {
+          "text": "Kesh squints at the glinting key. Shiny things aren't always the best in this place.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "do_turnin": {
+          "text": "Kesh unlocks the chain. “Off you go.”",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye",
+              "goto": {
+                "map": "world",
+                "x": 2,
+                "y": 45
+              }
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "keycrate",
+      "map": "hall",
+      "x": 17,
+      "y": 18,
+      "color": "#225a20",
+      "name": "Dusty Crate",
+      "title": "",
+      "desc": "A dusty crate that might hide something useful.",
+      "portraitSheet": "assets/portraits/crate_4.png",
+      "portraitLock": false,
+      "tree": {
+        "start": {
+          "text": "A dusty crate rests here.",
+          "choices": [
+            {
+              "label": "(Open)",
+              "to": "open",
+              "once": true
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "open": {
+          "text": "Inside you find a Rusted Key.",
+          "choices": [
+            {
+              "label": "(Take Rusted Key)",
+              "to": "empty",
+              "reward": "rusted_key"
+            }
+          ]
+        },
+        "empty": {
+          "text": "An empty crate.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "?"
+    },
+    {
+      "id": "hallflavor",
+      "map": "hall",
+      "x": 11,
+      "y": 17,
+      "color": "#9ef7a0",
+      "name": "Lone Drifter",
+      "title": "Mutters",
+      "desc": "A drifter muttering to themselves.",
+      "portraitSheet": "assets/portraits/drifter_4.png",
+      "tree": {
+        "start": {
+          "text": "Dust gets in everything.",
+          "choices": [
+            {
+              "label": "(Nod)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "hall_rotwalker",
+      "map": "hall",
+      "x": 15,
+      "y": 2,
+      "color": "#f66",
+      "name": "Rotwalker",
+      "title": "Test Monster",
+      "desc": "A shambler posted here for practice.",
+      "portraitSheet": "assets/portraits/dustland-module/rotwalker_4.png",
+      "portraitLock": false,
+      "tree": {
+        "start": {
+          "text": "A rotwalker lurches at you."
+        }
+      },
+      "combat": {
+        "HP": 6,
+        "ATK": 1,
+        "loot": "water_flask",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        },
+        "auto": true
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "party_mira",
+      "map": "world",
+      "x": 16,
+      "y": 55,
+      "color": "#ff0000",
+      "name": "Mira",
+      "title": "Blade Dancer",
+      "desc": "A lithe fighter ready to strike back.",
+      "portraitSheet": "assets/portraits/dustland-module/mira_4.png",
+      "tree": {
+        "start": {
+          "text": "Mira sizes you up.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 8,
+        "ATK": 3,
+        "DEF": 1,
+        "counterBasic": {
+          "dmg": 2
+        },
+        "auto": true
+      },
+      "symbol": "!",
+      "overrideColor": true
+    },
+    {
+      "id": "party_nora",
+      "map": "world",
+      "x": 15,
+      "y": 21,
+      "color": "#ff0000",
+      "name": "Nora",
+      "title": "Storm Caller",
+      "desc": "Crackling energy dances across her gauntlet.",
+      "portraitSheet": "assets/portraits/dustland-module/nora_4.png",
+      "tree": {
+        "start": {
+          "text": "Nora steps forward, eyes sparking.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 8,
+        "ATK": 2,
+        "DEF": 1,
+        "special": {
+          "cue": "releases a stunning arc!",
+          "dmg": 2,
+          "stun": 1,
+          "delay": 800
+        },
+        "auto": true
+      },
+      "symbol": "!",
+      "overrideColor": true
+    },
+    {
+      "id": "party_tess",
+      "map": "world",
+      "x": 15,
+      "y": 21,
+      "color": "#f66",
+      "name": "Tess",
+      "title": "Venom Rogue",
+      "desc": "She twirls a dagger dripping with toxins.",
+      "portraitSheet": "assets/portraits/dustland-module/tess_4.png",
+      "tree": {
+        "start": {
+          "text": "Tess grins wickedly.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 8,
+        "ATK": 2,
+        "DEF": 1,
+        "special": {
+          "cue": "flings poisoned knives everywhere!",
+          "dmg": 2,
+          "poison": {
+            "strength": 1,
+            "duration": 3
+          },
+          "spread": true,
+          "delay": 800
+        },
+        "auto": true
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "road_sign",
+      "map": "world",
+      "x": 6,
+      "y": 45,
+      "color": "#225a20",
+      "name": "Worn Sign",
+      "title": "Warning",
+      "desc": "Faded letters warn travelers.",
+      "portraitSheet": "assets/portraits/dustland-module/worn_sign_4.png",
+      "symbol": "?",
+      "tree": {
+        "start": {
+          "text": "Rust storms east. Shelter west. Far northeast, a relay waits for the Sun Charm—Archivist sends seekers there for a blade of legend.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "pump",
+      "map": "world",
+      "x": 14,
+      "y": 35,
+      "color": "#9ef7a0",
+      "name": "Nila the Pump-Keeper",
+      "title": "Parched Farmer",
+      "desc": "Sunburnt hands, hopeful eyes. Smells faintly of mud.",
+      "portraitSheet": "assets/portraits/mara_4.png",
+      "questId": "q_waterpump",
+      "tree": {
+        "start": {
+          "text": "I can hear the pump wheeze. Need a Valve to breathe again.,Pump’s choking on sand. Only a Valve will save it.",
+          "choices": [
+            {
+              "label": "(Accept) I will find a Valve.",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Hand Over Valve)",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Bless. Try the roadside ruins.",
+          "choices": [
+            {
+              "label": "(Ok)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "Let me see...",
+          "choices": [
+            {
+              "label": "(Give Valve)",
+              "to": "do_turnin"
+            }
+          ]
+        },
+        "do_turnin": {
+          "text": "It fits! Water again. Take this.",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "grin",
+      "map": "world",
+      "x": 22,
+      "y": 45,
+      "color": "#9ef7a0",
+      "name": "Grin",
+      "title": "Scav-for-Hire",
+      "desc": "Lean scav with a crowbar and half a smile.",
+      "portraitSheet": "assets/portraits/grin_4.png",
+      "questId": "q_recruit_grin",
+      "tree": {
+        "start": {
+          "text": [
+            "Got two hands and a crowbar. You got a plan?",
+            "Crowbar’s itching for work. You hiring?"
+          ],
+          "choices": [
+            {
+              "label": "(Recruit) Join me.",
+              "to": "rec",
+              "ifOnce": {
+                "node": "rec",
+                "label": "(CHA) Talk up the score"
+              }
+            },
+            {
+              "label": "(Recruit) Got a trinket?",
+              "to": "rec_fail",
+              "ifOnce": {
+                "node": "rec",
+                "label": "(CHA) Talk up the score",
+                "used": true
+              }
+            },
+            {
+              "label": "(Chat)",
+              "to": "chat"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "chat": {
+          "text": [
+            "Keep to the road. The sand eats soles and souls.",
+            "Stay off the dunes. Sand chews boots.",
+            "If you're chasing Sun Charm whispers, the relay past the far northeast ruin spits out some epic blade."
+          ],
+          "choices": [
+            {
+              "label": "(Nod)",
+              "to": "bye"
+            }
+          ]
+        },
+        "rec": {
+          "text": "Convince me. Or pay me.",
+          "choices": [
+            {
+              "label": "(CHA) Talk up the score",
+              "check": {
+                "stat": "CHA",
+                "dc": 10
+              },
+              "success": "Grin smirks: Alright.",
+              "failure": "Grin shrugs: Not buying it.",
+              "join": {
+                "id": "grin",
+                "name": "Grin",
+                "role": "Scavenger"
+              },
+              "once": true
+            },
+            {
+              "label": "(Pay) Give 1 trinket as hire bonus",
+              "costSlot": "trinket",
+              "success": "Deal.",
+              "failure": "You have no trinket to pay with.",
+              "join": {
+                "id": "grin",
+                "name": "Grin",
+                "role": "Scavenger"
+              }
+            },
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        },
+        "rec_fail": {
+          "text": "Charm didn't work. Got a trinket?",
+          "choices": [
+            {
+              "label": "(Pay) Give 1 trinket as hire bonus",
+              "costSlot": "trinket",
+              "success": "Deal.",
+              "failure": "You have no trinket to pay with.",
+              "join": {
+                "id": "grin",
+                "name": "Grin",
+                "role": "Scavenger"
+              }
+            },
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "post",
+      "map": "world",
+      "x": 31,
+      "y": 25,
+      "color": "#9ef7a0",
+      "name": "Postmaster Ivo",
+      "title": "Courier of Dust",
+      "desc": "Dusty courier seeking a lost parcel.",
+      "portraitSheet": "assets/portraits/ivo_4.png",
+      "questId": "q_postal",
+      "tree": {
+        "start": {
+          "text": "Lost a courier bag on the road. Grey canvas. Reward if found.",
+          "choices": [
+            {
+              "label": "(Accept) I will look.",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Turn in Satchel)",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Much obliged.",
+          "choices": [
+            {
+              "label": "(Ok)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "You got it?",
+          "choices": [
+            {
+              "label": "(Give Lost Satchel)",
+              "to": "do_turnin"
+            }
+          ]
+        },
+        "do_turnin": {
+          "text": "Mail moves again. Take this stamp. Worth more than water.",
+          "choices": [
+            {
+              "label": "(Ok)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "tower",
+      "map": "world",
+      "x": 29,
+      "y": 19,
+      "color": "#9ef7a0",
+      "name": "Rella",
+      "title": "Radio Tech",
+      "desc": "Tower technician with grease-stained hands.",
+      "portraitSheet": "assets/portraits/rella_4.png",
+      "questId": "q_tower",
+      "tree": {
+        "start": {
+          "text": "Tower’s console fried. If you got a Toolkit and brains, lend both. Archivist keeps pinging me—Sun Charm wakes some relay far northeast that’s supposed to gift an edge against the Sovereign of Dust.",
+          "choices": [
+            {
+              "label": "(Accept) I will help.",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Repair) INT check with Toolkit",
+              "check": {
+                "stat": "INT"
+              },
+              "success": "Static fades. The tower hums.",
+              "failure": "You cross a wire and pop a fuse.",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "I owe you static and thanks. When the tower purrs again, follow its tone north; the Archivist tunes it toward that relay and the blade he keeps raving about.",
+          "choices": [
+            {
+              "label": "(Ok)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "hermit",
+      "map": "world",
+      "x": 80,
+      "y": 21,
+      "color": "#9ef7a0",
+      "name": "The Shifting Hermit",
+      "title": "Pilgrim",
+      "desc": "A cloaked hermit murmuring about rusted idols.",
+      "portraitSheet": "assets/portraits/pilgrim_4.png",
+      "questId": "q_idol",
+      "tree": {
+        "start": {
+          "text": "Something rust-holy sits in the ruins. Bring the Idol.",
+          "choices": [
+            {
+              "label": "(Accept)",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Offer Rust Idol)",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "The sand will guide or bury you. Pilgrims whisper that the Sun Charm opens the far northeast ruin where the Archivist forges a blade fit for dust-born kings.",
+          "choices": [
+            {
+              "label": "(Ok)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "Do you carry grace?",
+          "choices": [
+            {
+              "label": "(Give Idol)",
+              "to": "do_turnin"
+            }
+          ]
+        },
+        "do_turnin": {
+          "text": "The idol warms. You are seen.",
+          "choices": [
+            {
+              "label": "(Ok)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "duchess",
+      "map": "world",
+      "x": 59,
+      "y": 27,
+      "color": "#9ef7a0",
+      "name": "Scrap Duchess",
+      "title": "Toll-Queen",
+      "desc": "A crown of bottlecaps; eyes like razors.",
+      "portraitSheet": "assets/portraits/scrap_4.png",
+      "questId": "q_toll",
+      "tree": {
+        "start": {
+          "text": [
+            "Road tax or road rash.",
+            "Coins or cuts. Your pick."
+          ],
+          "choices": [
+            {
+              "label": "(Pay) Nod and pass",
+              "to": "pay",
+              "q": "turnin"
+            },
+            {
+              "label": "(Refuse)",
+              "to": "ref",
+              "q": "turnin"
+            },
+            {
+              "label": "(Rumors)",
+              "to": "rumors"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "pay": {
+          "text": "Wise. Move along.",
+          "choices": [
+            {
+              "label": "(Ok)",
+              "to": "bye"
+            }
+          ]
+        },
+        "ref": {
+          "text": "Brave. Or foolish.",
+          "choices": [
+            {
+              "label": "(Ok)",
+              "to": "bye"
+            }
+          ]
+        },
+        "rumors": {
+          "text": "Radio crackles from the north; idol whispers from the south. Archivist’s Sun Charm is the key—wake that far-northeast relay and it spits an epic blade to cleave the Sovereign.",
+          "choices": [
+            {
+              "label": "(Thanks)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "hidden_hermit",
+      "hidden": true,
+      "map": "world",
+      "x": 20,
+      "y": 47,
+      "color": "#9ef7a0",
+      "name": "Hidden Hermit",
+      "title": "Lurker",
+      "desc": "A hermit steps out when you return.",
+      "portraitSheet": "assets/portraits/dustland-module/hidden_hermit_4.png",
+      "tree": {
+        "start": {
+          "text": "Didn't expect company twice. If you're trekking near those Ashen pits, remember Ashen Howlers hate getting stunned—clip on a Stun Gear Harness trinket and their chorus falls apart.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "reveal": {
+        "flag": "visits@world@20,47",
+        "op": ">=",
+        "value": 2
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "signal_tech",
+      "map": "world",
+      "x": 23,
+      "y": 28,
+      "color": "#9ef7a0",
+      "name": "Signal Tech",
+      "title": "Tinkerer",
+      "desc": "Fiddles with a busted radio.",
+      "prompt": "Grease-streaked tinkerer fixing a busted radio",
+      "portraitSheet": "assets/portraits/dustland-module/signal_tech_4.png",
+      "portraitLock": true,
+      "questId": "q_signal",
+      "tree": {
+        "start": {
+          "text": "Radio's dead. Need fragments to spark it. Archivist in the Test Hall swears the last shard hums in that northeast relay sealed behind the old tower.",
+          "choices": [
+            {
+              "label": "(Accept)",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Turn in fragments)",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Try the dunes; bits wash up there. When you nab the Sun Charm, take it northeast and wake the relay so the Archivist can catch the broadcast.",
+          "choices": [
+            {
+              "label": "(Ok)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "Got the pieces?",
+          "choices": [
+            {
+              "label": "(Give fragments)",
+              "to": "do_turnin"
+            }
+          ]
+        },
+        "do_turnin": {
+          "text": "Signal hums again. Nice work. Archivist said that resonance forges blades fit to carve dust-kings.",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "raider",
+      "map": "world",
+      "x": 71,
+      "y": 27,
+      "color": "#f66",
+      "name": "Road Raider",
+      "title": "Bandit",
+      "desc": "Scarred scav looking for trouble.",
+      "portraitSheet": "assets/portraits/raider_4.png",
+      "portraitLock": false,
+      "tree": {
+        "start": {
+          "text": "A raider blocks the path, eyeing your gear.",
+          "choices": [
+            {
+              "label": "(Talk) Stand down",
+              "check": {
+                "stat": "CHA",
+                "dc": 10
+              },
+              "success": "He grunts and lets you pass.",
+              "failure": "He tightens his grip.",
+              "to": "bye"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "ATK": 4,
+        "DEF": 5,
+        "loot": "raider_knife",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "trader",
+      "map": "world",
+      "x": 49,
+      "y": 25,
+      "color": "#9ef7a0",
+      "name": "Cass the Trader",
+      "title": "Shopkeep",
+      "desc": "A roving merchant weighing your wares.",
+      "portraitSheet": "assets/portraits/cass_4.png",
+      "tree": {
+        "start": {
+          "text": "Got goods to sell? I pay in scrap.",
+          "choices": [
+            {
+              "label": "Browse goods",
+              "to": "buy"
+            },
+            {
+              "label": "(Sell items)",
+              "to": "sell"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "loop": [
+        {
+          "x": 10,
+          "y": 44
+        },
+        {
+          "x": 110,
+          "y": 44
+        }
+      ],
+      "shop": {
+        "markup": 1,
+        "inv": [
+          {
+            "id": "pipe_rifle"
+          },
+          {
+            "id": "leather_jacket"
+          },
+          {
+            "id": "water_flask"
+          },
+          {
+            "id": "frag_grenade"
+          },
+          {
+            "id": "incendiary_grenade"
+          }
+        ]
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "tess_patrol",
+      "map": "world",
+      "x": 14,
+      "y": 44,
+      "color": "#9ef7a0",
+      "name": "Tess the Scout",
+      "title": "Water Runner",
+      "desc": "She checks the pump then the far ridge.",
+      "portraitSheet": "assets/portraits/dustland-module/tess_4.png",
+      "tree": {
+        "start": {
+          "text": "Tess strides past on her rounds.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "loop": [
+        {
+          "x": 14,
+          "y": 44
+        },
+        {
+          "x": 80,
+          "y": 49
+        }
+      ],
+      "symbol": "!"
+    },
+    {
+      "id": "scrap_mutt",
+      "map": "world",
+      "x": 18,
+      "y": 43,
+      "color": "#f66",
+      "name": "Scrap Mutt",
+      "title": "Mangy Hound",
+      "desc": "A feral mutt snarling over junk.",
+      "portraitSheet": "assets/portraits/dustland-module/scrap_mutt_4.png",
+      "portraitLock": false,
+      "tree": {
+        "start": {
+          "text": "The mutt bares its teeth.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 5,
+        "ATK": 1,
+        "loot": "water_flask",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        },
+        "auto": true
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "rust_bandit",
+      "map": "world",
+      "x": 40,
+      "y": 24,
+      "color": "#f66",
+      "name": "Rust Bandit",
+      "title": "Scav Raider",
+      "desc": "A bandit prowling for easy loot.",
+      "portraitSheet": "assets/portraits/dustland-module/rust_bandit_4.png",
+      "portraitLock": false,
+      "tree": {
+        "start": {
+          "text": "The bandit sizes you up.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 6,
+        "ATK": 1,
+        "loot": "raider_knife",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        },
+        "auto": true
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "feral_nomad",
+      "map": "world",
+      "x": 78,
+      "y": 27,
+      "color": "#f66",
+      "name": "Feral Nomad",
+      "title": "Mad Drifter",
+      "desc": "A wild-eyed drifter muttering to himself.",
+      "portraitSheet": "assets/portraits/dustland-module/feral_nomad_4.png",
+      "portraitLock": false,
+      "tree": {
+        "start": {
+          "text": "He lunges without warning.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 6,
+        "ATK": 2,
+        "loot": "medkit",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        },
+        "auto": true
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "waste_ghoul",
+      "map": "world",
+      "x": 82,
+      "y": 41,
+      "color": "#f66",
+      "name": "Waste Ghoul",
+      "title": "Rotwalker",
+      "desc": "A decayed wanderer hungry for flesh.",
+      "portraitSheet": "assets/portraits/dustland-module/waste_ghoul_4.png",
+      "portraitLock": false,
+      "tree": {
+        "start": {
+          "text": "It shambles toward you.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 7,
+        "ATK": 2,
+        "loot": "goggles",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        },
+        "auto": true
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "iron_brute",
+      "name": "Iron Brute",
+      "desc": "A hulking brute plated in scrap.",
+      "color": "#f66",
+      "symbol": "!",
+      "map": "world",
+      "x": 92,
+      "y": 68,
+      "tree": {
+        "start": {
+          "text": "The brute roars.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "do_fight": {
+          "text": "",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "questId": "",
+      "loop": [
+        {
+          "x": 120,
+          "y": 37
+        },
+        {
+          "x": 124,
+          "y": 37
+        },
+        {
+          "x": 124,
+          "y": 33
+        },
+        {
+          "x": 120,
+          "y": 33
+        }
+      ],
+      "combat": {
+        "HP": 15,
+        "ATK": 3,
+        "DEF": 2,
+        "loot": "raider_knife",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      },
+      "portraitSheet": "assets/portraits/dustland-module/iron_brute_4.png",
+      "portraitLock": false
+    },
+    {
+      "id": "stalker_patrol",
+      "map": "world",
+      "x": 90,
+      "y": 47,
+      "color": "#f66",
+      "name": "Grit Stalker",
+      "title": "Wasteland Hunter",
+      "desc": "A ruthless drifter prowling for prey.",
+      "portraitSheet": "assets/portraits/portrait_1079.png",
+      "portraitLock": false,
+      "tree": {
+        "start": {
+          "text": "The stalker circles the wastes.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "loop": [
+        {
+          "x": 90,
+          "y": 47
+        },
+        {
+          "x": 110,
+          "y": 47
+        },
+        {
+          "x": 110,
+          "y": 39
+        },
+        {
+          "x": 90,
+          "y": 39
+        }
+      ],
+      "combat": {
+        "HP": 7,
+        "ATK": 2,
+        "DEF": 1,
+        "loot": "raider_knife",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        },
+        "auto": true
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "trainer_power",
+      "map": "world",
+      "x": 12,
+      "y": 37,
+      "color": "#9ef7a0",
+      "name": "Brakk",
+      "title": "Power Trainer",
+      "desc": "A former arena champ teaching raw strength.",
+      "portraitSheet": "assets/portraits/dustland-module/brakk_4.png",
+      "trainer": "power",
+      "tree": {
+        "start": {
+          "text": "Brakk cracks his knuckles.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            },
+            {
+              "label": "(Upgrade Skills)",
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "showTrainer",
+                  "trainer": "power"
+                }
+              ]
+            }
+          ]
+        },
+        "train": {
+          "text": "Push your limits.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "trainer_endurance",
+      "map": "world",
+      "x": 14,
+      "y": 37,
+      "color": "#9ef7a0",
+      "name": "Rusty",
+      "title": "Endurance Trainer",
+      "desc": "A grizzled scavenger preaching survival.",
+      "portraitSheet": "assets/portraits/dustland-module/rusty_4.png",
+      "trainer": "endurance",
+      "tree": {
+        "start": {
+          "text": "Rusty studies your stance.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            },
+            {
+              "label": "(Upgrade Skills)",
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "showTrainer",
+                  "trainer": "endurance"
+                }
+              ]
+            }
+          ]
+        },
+        "train": {
+          "text": "Breathe deep and endure.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "trainer_tricks",
+      "map": "world",
+      "x": 16,
+      "y": 37,
+      "color": "#FF0000",
+      "name": "Mira",
+      "title": "Tricks Trainer",
+      "desc": "A nimble tinkerer teaching odd moves.",
+      "portraitSheet": "assets/portraits/dustland-module/mira_4.png",
+      "trainer": "tricks",
+      "tree": {
+        "start": {
+          "text": "Mira twirls a coin.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            },
+            {
+              "label": "(Upgrade Skills)",
+              "to": "train",
+              "effects": [
+                {
+                  "effect": "showTrainer",
+                  "trainer": "tricks"
+                }
+              ]
+            }
+          ]
+        },
+        "train": {
+          "text": "Learn a new trick.",
+          "choices": [
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "respec_vendor",
+      "map": "world",
+      "x": 94,
+      "y": 50,
+      "color": "#9ef7a0",
+      "name": "Nora",
+      "title": "Worm Seller",
+      "desc": "She trades memory worms for scrap.",
+      "portraitSheet": "assets/portraits/dustland-module/nora_4.png",
+      "tree": {
+        "start": {
+          "text": "Fresh worms for fading sins.",
+          "choices": [
+            {
+              "label": "Buy Memory Worm (500 Scrap)",
+              "to": "buy"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "buy": {
+          "text": "One bite resets the mind.",
+          "choices": [
+            {
+              "label": "(Buy)",
+              "to": "start",
+              "effects": [
+                {
+                  "effect": "buyMemoryWorm"
+                }
+              ]
+            },
+            {
+              "label": "(Back)",
+              "to": "start"
+            }
+          ]
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "slots",
+      "map": "slot_shack",
+      "x": 3,
+      "y": 2,
+      "color": "#225a20",
+      "name": "One-Armed Bandit",
+      "title": "Slot Machine",
+      "desc": "It wheezes, eager for scrap.",
+      "portraitSheet": "assets/portraits/dustland-module/slot_machine.png",
+      "symbol": "?",
+      "tree": {
+        "start": {
+          "text": "Lights sputter behind cracked glass.",
+          "choices": [
+            {
+              "label": "(1 scrap)",
+              "to": "start",
+              "effects": [
+                {
+                  "effect": "pullSlots",
+                  "cost": 1,
+                  "payouts": [
+                    0,
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "label": "(5 scrap)",
+              "to": "start",
+              "effects": [
+                {
+                  "effect": "pullSlots",
+                  "cost": 5,
+                  "payouts": [
+                    0,
+                    3,
+                    5,
+                    6,
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "label": "(25 scrap)",
+              "to": "start",
+              "effects": [
+                {
+                  "effect": "pullSlots",
+                  "cost": 25,
+                  "payouts": [
+                    0,
+                    10,
+                    25,
+                    35,
+                    50
+                  ]
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "workbench",
+      "map": "workshop",
+      "x": 2,
+      "y": 2,
+      "color": "#225a20",
+      "name": "Workbench",
+      "title": "Crafter",
+      "desc": "Tools litter the surface.",
+      "prompt": "Cluttered workbench stacked with tools",
+      "workbench": true,
+      "symbol": "?"
+    },
+    {
+      "id": "scrap_behemoth",
+      "name": "Scrap Behemoth",
+      "desc": "A towering mass of twisted metal.",
+      "color": "#f66",
+      "symbol": "!",
+      "map": "world",
+      "x": 91,
+      "y": 62,
+      "tree": {
+        "start": {
+          "text": "The behemoth looms.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "do_fight": {
+          "text": "",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "questId": "",
+      "combat": {
+        "HP": 30,
+        "ATK": 3,
+        "DEF": 2,
+        "loot": "raider_knife",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        },
+        "boss": true,
+        "special": {
+          "cue": "crackles with energy!",
+          "dmg": 5,
+          "delay": 1000
+        }
+      },
+      "portraitSheet": "assets/portraits/portrait_1084.png",
+      "portraitLock": false
+    },
+    {
+      "id": "sparkcrate",
+      "map": "echoes_atrium",
+      "x": 3,
+      "y": 2,
+      "color": "#225a20",
+      "name": "Sparking Crate",
+      "desc": "Faint humming echoes from inside.",
+      "prompt": "Crate sparking with bottled energy",
+      "tree": {
+        "start": {
+          "text": "A crate vibrates with energy.",
+          "choices": [
+            {
+              "label": "(Open)",
+              "to": "open",
+              "once": true
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "open": {
+          "text": "Inside you find a Spark Key.",
+          "choices": [
+            {
+              "label": "(Take Key)",
+              "to": "empty",
+              "reward": "spark_key"
+            }
+          ]
+        },
+        "empty": {
+          "text": "An empty crate.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "?"
+    },
+    {
+      "id": "door_workshop",
+      "map": "echoes_atrium",
+      "x": 14,
+      "y": 4,
+      "color": "#225a20",
+      "name": "Humming Door",
+      "title": "To Workshop",
+      "desc": "Its lock crackles for a Spark Key.",
+      "prompt": "Metal door glowing with static lock",
+      "questId": "q_spark",
+      "tree": {
+        "start": {
+          "text": "The door is sealed.",
+          "choices": [
+            {
+              "label": "(Search for Spark Key)",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Use Spark Key)",
+              "to": "do_turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Its lock crackles for a Spark Key.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "do_turnin": {
+          "text": "The door slides aside.",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye",
+              "goto": {
+                "map": "echoes_workshop",
+                "x": 1,
+                "y": 4
+              }
+            }
+          ]
+        }
+      },
+      "symbol": "?"
+    },
+    {
+      "id": "cogcrate",
+      "map": "echoes_workshop",
+      "x": 4,
+      "y": 5,
+      "color": "#225a20",
+      "name": "Gear Crate",
+      "desc": "Loose gears rattle within.",
+      "prompt": "Heavy crate packed with gears",
+      "tree": {
+        "start": {
+          "text": "The crate is heavy with metal.",
+          "choices": [
+            {
+              "label": "(Open)",
+              "to": "open",
+              "once": true
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "open": {
+          "text": "Among the gears is a Cog Key.",
+          "choices": [
+            {
+              "label": "(Take Key)",
+              "to": "empty",
+              "reward": "cog_key"
+            }
+          ]
+        },
+        "empty": {
+          "text": "Only scraps remain.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "symbol": "?"
+    },
+    {
+      "id": "door_archive",
+      "map": "echoes_workshop",
+      "x": 14,
+      "y": 4,
+      "color": "#225a20",
+      "name": "Rust Door",
+      "title": "To Archive",
+      "desc": "Its hinges await a Cog Key.",
+      "prompt": "Rusted door with cracked hinges",
+      "questId": "q_cog",
+      "tree": {
+        "start": {
+          "text": "The door is locked tight.",
+          "choices": [
+            {
+              "label": "(Search for Cog Key)",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Use Cog Key)",
+              "to": "do_turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Its hinges await a Cog Key.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "do_turnin": {
+          "text": "The door creaks open.",
+          "choices": [
+            {
+              "label": "(Continue)",
+              "to": "bye",
+              "goto": {
+                "map": "echoes_archive",
+                "x": 1,
+                "y": 4
+              }
+            }
+          ]
+        }
+      },
+      "symbol": "?"
+    },
+    {
+      "id": "rat",
+      "map": "echoes_atrium",
+      "x": 7,
+      "y": 4,
+      "color": "#f66",
+      "name": "Dust Rat",
+      "title": "Menace",
+      "desc": "A rat swollen with dust.",
+      "prompt": "Dust-swollen rat baring teeth",
+      "tree": {
+        "start": {
+          "text": "The rat bares its teeth.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 5,
+        "ATK": 2,
+        "DEF": 1,
+        "loot": "rat_tail",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "ghoul",
+      "map": "echoes_archive",
+      "x": 7,
+      "y": 4,
+      "color": "#f66",
+      "name": "Gear Ghoul",
+      "title": "Guardian",
+      "desc": "A whirring husk hungry for scraps.",
+      "prompt": "Whirring metal ghoul hungry for scrap",
+      "questId": "q_beacon",
+      "tree": {
+        "start": {
+          "text": "The ghoul clanks forward.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 8,
+        "ATK": 3,
+        "DEF": 2,
+        "loot": "copper_cog",
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      },
+      "symbol": "!"
+    },
+    {
+      "id": "beacon",
+      "map": "echoes_archive",
+      "x": 13,
+      "y": 4,
+      "color": "#225a20",
+      "name": "Hope Beacon",
+      "title": "Lightbringer",
+      "desc": "A small lamp pulsing warmly.",
+      "prompt": "Warm lamp shining hope",
+      "tree": {
+        "start": {
+          "text": "The beacon glows, promising brighter days.",
+          "choices": [
+            {
+              "label": "(Take Sun Charm)",
+              "to": "reward",
+              "reward": "sun_charm"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "reward": {
+          "text": "You pocket the charm. The light feels hopeful.",
+          "choices": [
+            {
+              "label": "(Step outside)",
+              "to": "bye",
+              "goto": {
+                "map": "world",
+                "x": 2,
+                "y": 45
+              }
+            }
+          ]
+        }
+      },
+      "symbol": "?"
+    },
+    {
+      "id": "oc3abv_siltpack",
+      "map": "room_oc3abv",
+      "x": 24,
+      "y": 44,
+      "color": "#f66",
+      "name": "Siltpack Ravener",
+      "title": "Ambush Brood",
+      "desc": "Dust-choked hunters sniffing out living heat.",
+      "prompt": "Pack of dust-choked hunters ready to pounce",
+      "portraitSheet": "assets/portraits/dustland-module/scrap_mutt_4.png",
+      "portraitLock": false,
+      "symbol": "!",
+      "tree": {
+        "start": {
+          "text": "Dust-raw beasts prowl the outer ring, sniffing for intruders.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 14,
+        "ATK": 4,
+        "DEF": 1,
+        "count": 3,
+        "requires": "tag:ranged",
+        "special": {
+          "cue": "spews toxic grit!",
+          "dmg": 3,
+          "poison": {
+            "strength": 2,
+            "duration": 3
+          },
+          "spread": true,
+          "delay": 600
+        },
+        "challenge": 18,
+        "loot": "frag_grenade",
+        "lootChance": 0.35,
+        "scrap": {
+          "min": 6,
+          "max": 9
+        }
+      }
+    },
+    {
+      "id": "oc3abv_grinders",
+      "map": "room_oc3abv",
+      "x": 24,
+      "y": 36,
+      "color": "#f66",
+      "name": "Grinder Matriarchs",
+      "title": "Shrapnel Choir",
+      "desc": "Armored shriekers plated in scavenged sawblades.",
+      "prompt": "Saw-edged matriarchs screaming for blood",
+      "portraitSheet": "assets/portraits/dustland-module/iron_brute_4.png",
+      "portraitLock": false,
+      "symbol": "!",
+      "tree": {
+        "start": {
+          "text": "Shrieking matriarchs rake the stone, demanding tribute.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 22,
+        "ATK": 5,
+        "DEF": 2,
+        "count": 4,
+        "requires": "artifact_blade",
+        "special": {
+          "cue": "unleashes a shrapnel howl!",
+          "dmg": 4,
+          "stun": 1,
+          "delay": 700
+        },
+        "challenge": 24,
+        "loot": "armor_polish",
+        "lootChance": 0.4,
+        "scrap": {
+          "min": 7,
+          "max": 11
+        }
+      }
+    },
+    {
+      "id": "oc3abv_glasspride",
+      "map": "room_oc3abv",
+      "x": 26,
+      "y": 30,
+      "color": "#f66",
+      "name": "Glasswing Pride",
+      "title": "Phase Predators",
+      "desc": "Shimmering beasts phasing between realities.",
+      "prompt": "Glassy predators rippling in and out of phase",
+      "portraitSheet": "assets/portraits/dustland-module/vine_creature_4.png",
+      "portraitLock": false,
+      "symbol": "!",
+      "tree": {
+        "start": {
+          "text": "Glasswing predators flicker through the air ahead.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 28,
+        "ATK": 6,
+        "DEF": 3,
+        "count": 5,
+        "requires": "wand",
+        "special": {
+          "cue": "rends reality with shrieking arcs!",
+          "dmg": 5,
+          "spread": true,
+          "delay": 650
+        },
+        "challenge": 32,
+        "loot": "adrenaline_shot",
+        "lootChance": 0.5,
+        "scrap": {
+          "min": 8,
+          "max": 12
+        }
+      }
+    },
+    {
+      "id": "oc3abv_sovereign",
+      "map": "room_oc3abv",
+      "x": 30,
+      "y": 3,
+      "color": "#ff3366",
+      "name": "Sovereign of Dust",
+      "title": "Warden of the Hollow",
+      "desc": "A colossal warform woven from every ruin the Dustland devoured.",
+      "prompt": "Towering dust-forged warform crowned with razorsand",
+      "portraitSheet": "assets/portraits/dustland-module/dune_reaper_4.png",
+      "portraitLock": false,
+      "symbol": "!",
+      "tree": {
+        "start": {
+          "text": "The Dustland Sovereign drifts above the altar, eyes blazing.",
+          "choices": [
+            {
+              "label": "(Fight)",
+              "to": "do_fight"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      },
+      "combat": {
+        "HP": 160,
+        "ATK": 12,
+        "DEF": 6,
+        "boss": true,
+        "requires": [
+          "artifact_blade",
+          "epic_blade"
+        ],
+        "special": {
+          "cue": "erupts into a storm of razorsand!",
+          "dmg": 12,
+          "poison": {
+            "strength": 3,
+            "duration": 3
+          },
+          "stun": 1,
+          "spread": true,
+          "delay": 500
+        },
+        "challenge": 45,
+        "loot": "epic_armor",
+        "lootChance": 0.9,
+        "scrap": {
+          "min": 15,
+          "max": 25
+        }
+      }
+    },
+    {
+      "id": "echo_relay",
+      "map": "room_oc3abv",
+      "x": 25,
+      "y": 44,
+      "color": "#225a20",
+      "name": "Echo Relay",
+      "title": "Signal Lattice",
+      "desc": "Cracked relay thrumming with stored light.",
+      "prompt": "Cracked lattice humming with trapped signal",
+      "questId": "q_solar_signal",
+      "symbol": "?",
+      "tree": {
+        "start": {
+          "text": "A cracked relay trembles atop the altar. Archivist schematics are etched around a Sun Charm-shaped cradle.",
+          "choices": [
+            {
+              "label": "(Study the schematics)",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Resonate Sun Charm)",
+              "to": "resonate",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Diagrams glow faintly, tracing a path from the Archivist's hall to this relay. Only the Sun Charm's light will wake it.",
+          "choices": [
+            {
+              "label": "(Step back)",
+              "to": "bye"
+            }
+          ]
+        },
+        "resonate": {
+          "text": "The relay's coils flare when the Sun Charm draws close, begging to drink in its dawnlight.",
+          "choices": [
+            {
+              "label": "(Let the charm sing)",
+              "to": "grant",
+              "reward": "signal_fragment_c"
+            }
+          ]
+        },
+        "grant": {
+          "text": "Light floods the relay and condenses into a prismatic shard. Signal Fragment C thrums warm in your grip.",
+          "choices": [
+            {
+              "label": "(Pocket the fragment)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "map": "hall",
+      "x": 14,
+      "y": 18,
+      "events": [
+        {
+          "when": "enter",
+          "effect": "toast",
+          "msg": "You smell rot."
+        }
+      ]
+    }
+  ],
+  "zones": [
+    {
+      "map": "world",
+      "x": 0,
+      "y": 0,
+      "w": 120,
+      "h": 5,
+      "perStep": {
+        "hp": -1,
+        "msg": "Nanite swarm!"
+      },
+      "negate": "mask"
+    },
+    {
+      "map": "hall",
+      "x": 16,
+      "y": 18,
+      "w": 2,
+      "h": 1,
+      "useItem": {
+        "id": "wand",
+        "reward": "scrap 5",
+        "once": true
+      }
+    },
+    {
+      "map": "world",
+      "x": 8,
+      "y": 32,
+      "w": 14,
+      "h": 11,
+      "walled": true,
+      "entrances": {
+        "south": true,
+        "east": true
+      },
+      "noEncounters": true
+    }
+  ],
+  "name": "dustland-module",
+  "templates": [
+    {
+      "id": "rotwalker",
+      "name": "Rotwalker",
+      "portraitSheet": "assets/portraits/dustland-module/rotwalker_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 6,
+        "ATK": 2,
+        "DEF": 0,
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      }
+    },
+    {
+      "id": "scavenger",
+      "name": "Scavenger",
+      "portraitSheet": "assets/portraits/dustland-module/scavenger_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 5,
+        "ATK": 2,
+        "DEF": 0,
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      }
+    },
+    {
+      "id": "vine_creature",
+      "name": "Vine Creature",
+      "portraitSheet": "assets/portraits/dustland-module/vine_creature_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 4,
+        "ATK": 1,
+        "DEF": 0,
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      }
+    },
+    {
+      "id": "sand_titan",
+      "name": "Sand Titan",
+      "portraitSheet": "assets/portraits/dustland-module/sand_titan.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 20,
+        "ATK": 6,
+        "DEF": 4,
+        "challenge": 9,
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      }
+    },
+    {
+      "id": "dune_reaper",
+      "name": "Dune Reaper",
+      "portraitSheet": "assets/portraits/dustland-module/dune_reaper_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 90,
+        "ATK": 8,
+        "DEF": 7,
+        "challenge": 32,
+        "special": {
+          "cue": "lashes the wind with scythes!",
+          "dmg": 10
+        },
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      }
+    },
+    {
+      "id": "sand_colossus",
+      "name": "Sand Colossus",
+      "portraitSheet": "assets/portraits/dustland-module/sand_colossus_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 120,
+        "ATK": 10,
+        "DEF": 8,
+        "challenge": 36,
+        "requires": "artifact_blade",
+        "special": {
+          "cue": "shakes the desert!",
+          "dmg": 12
+        },
+        "scrap": {
+          "min": 3,
+          "max": 5
+        }
+      }
+    },
+    {
+      "id": "ashen_howler",
+      "name": "Ashen Howler",
+      "portraitSheet": "assets/portraits/dustland-module/scrap_mutt_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 36,
+        "ATK": 7,
+        "DEF": 3,
+        "challenge": 30,
+        "special": {
+          "cue": "lets loose a concussive howl!",
+          "dmg": 6,
+          "spread": true,
+          "stun": 1,
+          "delay": 550
+        },
+        "scrap": {
+          "min": 12,
+          "max": 16
+        }
+      }
+    },
+    {
+      "id": "slag_legionnaire",
+      "name": "Slag Legionnaire",
+      "portraitSheet": "assets/portraits/dustland-module/iron_brute_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 42,
+        "ATK": 8,
+        "DEF": 5,
+        "challenge": 34,
+        "special": {
+          "cue": "slams molten shields!",
+          "dmg": 8,
+          "stun": 1,
+          "delay": 600
+        },
+        "scrap": {
+          "min": 18,
+          "max": 24
+        }
+      }
+    },
+    {
+      "id": "venom_choirist",
+      "name": "Venom Choir",
+      "portraitSheet": "assets/portraits/dustland-module/vine_creature_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 50,
+        "ATK": 9,
+        "DEF": 6,
+        "challenge": 38,
+        "special": {
+          "cue": "chants a venomous chorus!",
+          "dmg": 9,
+          "delay": 600,
+          "poison": {
+            "strength": 3,
+            "duration": 4
+          },
+          "spread": true
+        },
+        "scrap": {
+          "min": 24,
+          "max": 32
+        }
+      }
+    },
+    {
+      "id": "cinder_tyrant",
+      "name": "Cinder Tyrant",
+      "portraitSheet": "assets/portraits/dustland-module/sand_colossus_4.png",
+      "portraitLock": false,
+      "combat": {
+        "HP": 190,
+        "ATK": 12,
+        "DEF": 8,
+        "challenge": 50,
+        "boss": true,
+        "special": {
+          "cue": "erupts in a cinder storm!",
+          "dmg": 14,
+          "delay": 500,
+          "spread": true,
+          "stun": 1,
+          "poison": {
+            "strength": 2,
+            "duration": 3
+          }
+        },
+        "scrap": {
+          "min": 45,
+          "max": 60
+        },
+        "loot": "sunflare_bazooka",
+        "lootChance": 1
+      }
+    }
+  ],
+  "portals": [
+    {
+      "map": "portal_hut",
+      "x": 2,
+      "y": 1,
+      "toMap": "hall",
+      "toX": 15,
+      "toY": 18
+    },
+    {
+      "map": "room_oc3abv",
+      "x": 39,
+      "y": 48,
+      "toMap": "world",
+      "toX": 110,
+      "toY": 87
+    }
+  ],
+  "encounters": {
+    "world": [
+      {
+        "templateId": "vine_creature",
+        "loot": "plant_fiber",
+        "lootChance": 0.25,
+        "maxDist": 20
+      },
+      {
+        "templateId": "rotwalker",
+        "loot": "water_flask",
+        "lootChance": 0.25,
+        "maxDist": 24
+      },
+      {
+        "templateId": "scavenger",
+        "loot": "raider_knife",
+        "lootChance": 0.75,
+        "maxDist": 36
+      },
+      {
+        "templateId": "sand_titan",
+        "loot": "artifact_blade",
+        "lootChance": 0.75,
+        "minDist": 30
+      },
+      {
+        "templateId": "dune_reaper",
+        "loot": "artifact_blade",
+        "lootChance": 0.75,
+        "minDist": 40
+      },
+      {
+        "templateId": "sand_colossus",
+        "loot": "artifact_blade",
+        "lootChance": 0.75,
+        "minDist": 44
+      },
+      {
+        "templateId": "vine_creature",
+        "loot": "thornlash_whip",
+        "lootChance": 0.18,
+        "maxDist": 20
+      },
+      {
+        "templateId": "vine_creature",
+        "loot": "sap_poultice",
+        "lootChance": 0.3,
+        "maxDist": 20
+      },
+      {
+        "templateId": "rotwalker",
+        "loot": "patchwork_plate",
+        "lootChance": 0.2,
+        "maxDist": 24
+      },
+      {
+        "templateId": "rotwalker",
+        "loot": "corroded_hatchet",
+        "lootChance": 0.16,
+        "maxDist": 24
+      }
+    ],
+    "room_oc3abv": [
+      {
+        "templateId": "ashen_howler",
+        "count": 3,
+        "challenge": 32
+      }
+    ]
+  },
+  "world": [
+    "🌊🏝🏝🏝🏝🏝🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏚🏝🏝🏝🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🏚🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏠🏠🏠",
+    "🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏚🏚🏚🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🏚🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏠🏠🏠🏠",
+    "🌿🏝🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🏝🏝🏝🏚🏝🌿🌿🌿🏚🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏚🏚🏝🏝🏝🏝🏝🏝🏚🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🏚🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🌿🌿🌿🌿🏠🏠🚪🏠",
+    "🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🏚🏚🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏚🏝🏝🏚🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏠🚪🏠🏝",
+    "🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🌿🌿🏚🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝",
+    "🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝",
+    "🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🏚🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏚🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏚🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🏝🏝",
+    "🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🏚🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏚🏝🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🏚🏝",
+    "🌿🌿🌿🌿🏝🏝🏝🛣🛣🛣🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🏝",
+    "🌿🌿🌿🌿🏝🏝🏝🛣🛣🛣🛣🛣🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🏚🏚🌿🌿🌿🌿🌿🌿🌿🏝🏝",
+    "🌿🌿🌿🌿🏝🏝🏝🏝🛣🛣🛣🛣🛣🛣🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🌿🌿🌿🏝🏝🏝🏝🏝🏝🛣🛣🛣🛣🛣🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🛣🛣🛣🛣🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🏚🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🌊🌊🌊🏝🏚🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🌿🌿🌿🌿🏚🌿🌿🏝🏝🏝🏝🏝🏚🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏚🏚🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏚🏝🏝🏝🏝🌿🌿🌿🌿🏚🪨🪨🪨🪨🪨🌿🌿🏚🌿🌿🏝🏝🏝🏝🏝🏚🏚🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🏚🏚🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏚🏚🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🌿🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🏚🪨🪨🪨🪨🌿🌿🌿🏚🌿🏝🏝🏝🏝🏝🏚🏚🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝🛣🛣🛣🛣🛣🛣🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏚🏚🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🏝🛣🛣🛣🛣🛣🛣🛣🛣🛣🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🛣🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🌿🌿🌿🌿🌿🏝🛣🛣🛣🛣🛣🛣🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🌿🌿",
+    "🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🛣🛣🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🛣🛣🛣🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏚🏝🏝🏝🏝🏚🏝🏚🏝🌿🌿🌿🌿🌿🌿🌿🌿🏚🏚🌿🌿",
+    "🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🛣🛣🛣🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏚🏝🏚🏝🏝🏝🏝🏚🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🛣🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🏝🛣🛣🛣🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🏝🏝🛣🛣🛣🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🪨🪨🪨🪨🪨🌿🌿🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🌿🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🏝🏝🏝🛣🛣🛣🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🪨🪨🪨🪨🪨🪨🌿🌿🏚🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🌿🌿🌿🌿🌿🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🛣🛣🏝🏚🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿",
+    "🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🛣🏝🏚🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿",
+    "🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿",
+    "🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿🌿🛣🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🌿🌿",
+    "🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🛣🏝🏝🏝🏝🏝🏝🏚🏝🏝🏚🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝",
+    "🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🛣🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🏚🏚🌿🌿🪨🏚🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🪨🪨🪨🪨🌿🌿🌿🌿🪨🪨🏠🏠🏠🪨🌿🌿🏠🏠🏠🌿🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🏚🌿🌿🪨🪨🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏠🏠🏠🌿🌿🌿🏠🏠🏠🌿🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🏚🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝",
+    "🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏠🚪🏠🌿🌿🌿🏠🚪🏠🌿🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🏚🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🌿🌿🌿🌿🌿🌿🏚🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🏚🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🏚🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🌿🌿🏝🌿🌿🌿🌿🌿🏚🌿🏠🚪🏠🌿🌿🌿🏠🚪🏠🏚🏚🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🏚🌿🌿🌿🌿🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏠🏠🏠🏝🏝🏝🏠🏠🏠🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🏚🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🏚🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏠🏠🏠🏝🏝🏝🏠🏠🏠🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🏚🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊",
+    "🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🏚🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🏚🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🏚🌿🌿🌿🌿🌿🌿🌿🏚🏚🌿🌿🌿🪨🪨🌿🌿🏚🏚🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊",
+    "🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🏚🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🌿🌿🌿🏚🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🌿🌿🌿🌿🏚🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊",
+    "🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🛣🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🌿🏚🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🏚🌿🌿🌿🌿🏝🏚🏝🏝🏝🏝🏝🏝🌊🌊🌊",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏚🌿🌿🌿🌿🌿🌿🌿🪨🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊",
+    "🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🏚🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🛣🏝🏝🏝🏝🏚🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊",
+    "🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🏚🏚🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊",
+    "🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🏚🪨🪨🪨🪨🪨🪨🏚🪨🪨🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊",
+    "🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏚🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🏚🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🛣🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊",
+    "🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏚🏚🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🏝🏝🏚🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🛣🏝🏝🏝🏝🏝🏝🏚🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊",
+    "🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🛣🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏚🏝🏝🌊🌊",
+    "🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏚🏝🏝🛣🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏚🏝🏝🌊",
+    "🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏚🏝🏝🏝🛣🏝🏝🏝🌿🌿🌿🪨🪨🪨🏚🏚🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏚🏝🏝",
+    "🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🛣🏝🏝🏝🌿🌿🌿🪨🪨🪨🏚🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🏝🏝🏝🏝🏝",
+    "🪨🪨🪨🪨🏚🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🏚🌿🌿🌿🏝🏝🏝🏝",
+    "🪨🪨🏚🏚🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🏝🏝🏝🏝🛣🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🏚🏚🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🏚🪨🏚🌿🌿🏝🏝🏝",
+    "🪨🪨🏚🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🛣🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🛣🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🏚🪨🌿🌿🌿🏝🏝",
+    "🪨🪨🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🛣🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🛣🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝",
+    "🪨🏚🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🛣🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🛣🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🏚🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿",
+    "🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🛣🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🛣🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🏚🏚🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿",
+    "🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🛣🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏝🏝🏝🛣🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🏚🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿",
+    "🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏚🏚🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿",
+    "🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🏚🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿",
+    "🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🛣🏝🌿🌿🏚🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿",
+    "🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🏚🏚🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🛣🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🏚🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🏚🏚🪨🪨🪨🪨🪨🪨🪨🪨🏚🏚🏚🪨🪨🪨🪨🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏚🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🏚🪨🪨🪨🪨🪨🪨🪨🪨🪨🏚🏚🪨🪨🪨🪨🪨🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏚🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🏚🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🏚🪨🪨🪨🪨🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🏚🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏝🏝🏝🌿🌿🏚🏚🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🏚🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🏚🌿🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝",
+    "🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🏚🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝",
+    "🏝🏝🏚🏝🏝🏝🏝🏝🏝🏚🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🌿🏝🏝",
+    "🏚🏚🏚🏚🏝🏝🏝🏝🏝🏚🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🌿🏝🏝🏝",
+    "🏝🏚🏝🏝🏝🏝🏝🏝🌿🏚🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🏚🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🛣🛣🛣🛣🛣🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🛣🛣🛣🛣🛣🛣🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🛣🛣🛣🛣🛣🛣🛣🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🏚🌿🌿🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🪨🌿🌿🌿🌿🌿🏚🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏚🏚🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🏚🌿🌿🌿🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏠🏠🏝🏝🏝🏝",
+    "🌿🌿🌿🌿🌿🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏚🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🏚🏝🏝🏝🏝🏝🏝🏝🏝🏚🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏠🏠🏠🏝🏝🏝",
+    "🌿🌿🌿🌿🏚🏚🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏚🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🏚🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏚🏝🏠🏠🏠🏠🏠🏝🏝",
+    "🌿🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🏚🏚🏚🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🏚🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏠🏠🏠🏠🏠🏠🏝🏝",
+    "🌿🌿🌿🌿🌿🪨🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🏚🏚🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🏚🪨🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏠🏠🏠🚪🏠🏠🏝🏝",
+    "🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏚🏝🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🏚🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏚🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🪨🪨🪨🪨🪨🪨🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+    "🌿🌿🌿🌿🌿🪨🪨🪨🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🌊🌊🌊🌊🌊🌊🌊🏝🏝🏝🏝🏝🏚🌿🌿🌿🌿🌿🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🌿🏝🏝🏝🏚🏝🏚🏝🏝🏝🏝🏚🏚🏝🏝🌿🌿🌿🪨🪨🪨🪨🪨🪨🪨🪨🌿🌿🏚🌿🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝"
+  ],
+  "buildings": [
+    {
+      "x": 10,
+      "y": 34,
+      "w": 3,
+      "h": 3,
+      "doorX": 11,
+      "doorY": 36,
+      "interiorId": "slot_shack",
+      "boarded": false,
+      "grid": [
+        [
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          8,
+          9
+        ]
+      ]
+    },
+    {
+      "x": 16,
+      "y": 34,
+      "w": 3,
+      "h": 3,
+      "doorX": 17,
+      "doorY": 36,
+      "interiorId": "workshop",
+      "boarded": false,
+      "grid": [
+        [
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          8,
+          9
+        ]
+      ]
+    },
+    {
+      "x": 117,
+      "y": 0,
+      "w": 3,
+      "h": 3,
+      "doorX": 118,
+      "doorY": 2,
+      "interiorId": "portal_hut",
+      "boarded": false,
+      "grid": [
+        [
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          8,
+          9
+        ]
+      ]
+    },
+    {
+      "x": 10,
+      "y": 39,
+      "w": 3,
+      "h": 3,
+      "doorX": 11,
+      "doorY": 39,
+      "interiorId": "echoes_atrium",
+      "boarded": false,
+      "grid": [
+        [
+          9,
+          8,
+          9
+        ],
+        [
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          9,
+          9
+        ]
+      ]
+    },
+    {
+      "x": 16,
+      "y": 39,
+      "w": 3,
+      "h": 3,
+      "doorX": 17,
+      "doorY": 39,
+      "interiorId": "town_house",
+      "boarded": false,
+      "grid": [
+        [
+          9,
+          8,
+          9
+        ],
+        [
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          9,
+          9
+        ]
+      ]
+    },
+    {
+      "x": 112,
+      "y": 83,
+      "w": 6,
+      "h": 5,
+      "doorX": 115,
+      "doorY": 87,
+      "interiorId": "room_oc3abv",
+      "boarded": false,
+      "grid": [
+        [
+          null,
+          null,
+          9,
+          9,
+          null,
+          null
+        ],
+        [
+          null,
+          null,
+          9,
+          9,
+          9,
+          null
+        ],
+        [
+          null,
+          9,
+          9,
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          9,
+          9,
+          9,
+          9,
+          9
+        ],
+        [
+          9,
+          9,
+          9,
+          8,
+          9,
+          9
+        ]
+      ]
+    }
+  ],
+  "interiors": [
+    {
+      "id": "hall",
+      "w": 30,
+      "h": 22,
+      "grid": [
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜🧱🧱🧱🌿🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🌿🧱🧱🧱⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🌿🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 15,
+      "entryY": 18
+    },
+    {
+      "id": "slot_shack",
+      "w": 7,
+      "h": 7,
+      "grid": [
+        "🧱🧱🧱🧱🧱🧱🧱",
+        "🧱⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜🧱",
+        "🧱🧱🧱🚪🧱🧱🧱"
+      ],
+      "entryX": 3,
+      "entryY": 5
+    },
+    {
+      "id": "workshop",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱⬜⬜⬜🧱",
+        "🧱⬜⬜⬜🧱",
+        "🧱⬜⬜⬜🧱",
+        "🧱🧱🧱🚪🧱"
+      ],
+      "entryX": 2,
+      "entryY": 3
+    },
+    {
+      "id": "portal_hut",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱⬜🌀⬜🧱",
+        "🧱⬜⬜⬜🧱",
+        "🧱⬜⬜⬜🧱",
+        "🧱🧱🧱🚪🧱"
+      ],
+      "entryX": 2,
+      "entryY": 3
+    },
+    {
+      "id": "echo_chamber",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🪨🪨🪨🪨🪨",
+        "🪨⬜⬜⬜🪨",
+        "🪨⬜🌟⬜🪨",
+        "🪨⬜⬜⬜🪨",
+        "🪨🪨🪨🪨🪨"
+      ],
+      "entryX": 2,
+      "entryY": 2
+    },
+    {
+      "id": "echoes_atrium",
+      "w": 16,
+      "h": 8,
+      "grid": [
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🚪🧱🧱🧱🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 7,
+      "entryY": 6
+    },
+    {
+      "id": "echoes_workshop",
+      "w": 16,
+      "h": 8,
+      "grid": [
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🚪🧱🧱🧱🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 1,
+      "entryY": 4
+    },
+    {
+      "id": "echoes_archive",
+      "w": 16,
+      "h": 8,
+      "grid": [
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🚪🧱🧱🧱🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 1,
+      "entryY": 4
+    },
+    {
+      "id": "town_house",
+      "w": 5,
+      "h": 5,
+      "grid": [
+        "🧱🧱🧱🧱🧱",
+        "🧱⬜⬜⬜🧱",
+        "🧱⬜⬜⬜🧱",
+        "🧱⬜⬜⬜🧱",
+        "🧱🧱🚪🧱🧱"
+      ],
+      "entryX": 2,
+      "entryY": 3
+    },
+    {
+      "w": 57,
+      "h": 50,
+      "grid": [
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱",
+        "🧱🧱🧱🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+        "🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+        "🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🧱🏝🧱🧱🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝",
+        "🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🏝🧱🧱🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝",
+        "🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝",
+        "🧱🧱🧱🧱🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🏝🏝🏝🧱🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱",
+        "🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱",
+        "🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱",
+        "🧱🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱",
+        "🧱⬜🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🏝🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱",
+        "🧱⬜🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱",
+        "🧱🏝⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🧱🧱🧱🧱🧱🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🏝🏝🧱🧱🧱⬜🏝🏝🏝🏝⬜🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝⬜⬜⬜⬜🧱🧱🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱",
+        "🧱🧱🧱🧱🧱🧱🏝🏝⬜🏝🏝⬜⬜⬜🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝⬜⬜⬜⬜⬜⬜⬜⬜🏝🏝🏝🏝⬜🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱",
+        "🧱🧱🧱🧱🧱🏝🏝🏝⬜⬜⬜⬜⬜⬜🏝🏝🏝🏝🏝🏝🏝🧱🧱⬜⬜⬜⬜⬜⬜🧱🧱🧱⬜🏝🏝🏝🏝⬜⬜🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱",
+        "🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜⬜🧱🧱🧱🧱🧱🧱🏝🏝🏝⬜⬜🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱",
+        "🧱⬜🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱🏝🏝⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱",
+        "🧱⬜🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱",
+        "🧱⬜🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🧱🧱🧱🧱🧱🧱",
+        "🧱🏝🏝🏝🏝🏝🧱🧱🧱🧱🧱🧱🏝🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜🧱🏝🏝🏝🏝🏝🏝🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜⬜⬜⬜🧱🧱🧱🧱🧱⬜⬜⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜⬜⬜⬜⬜🧱🧱🧱🧱⬜⬜⬜⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱⬜⬜⬜⬜⬜⬜⬜🧱🧱🧱🧱⬜⬜🚪⬜⬜🧱🧱🧱🧱🧱🧱🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🧱🧱🧱🏝🏝🏝🏝🏝🏝🏝🏝🏝🧱",
+        "🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱🧱"
+      ],
+      "entryX": 25,
+      "entryY": 47,
+      "id": "room_oc3abv"
+    }
+  ],
+  "zoneEffects": [
+    {
+      "map": "world",
+      "x": 19,
+      "y": 56,
+      "w": 21,
+      "h": 21,
+      "minSteps": 1,
+      "maxSteps": 3,
+      "spawns": [
+        {
+          "id": "scavenger_rat",
+          "name": "Scavenger Rat",
+          "HP": 4,
+          "ATK": 1,
+          "DEF": 0,
+          "portraitSheet": "assets/portraits/dustland-module/scavenger_rat_4.png",
+          "loot": "water_flask",
+          "scrap": {
+            "min": 3,
+            "max": 5
+          },
+          "auto": true,
+          "prob": 1
+        }
+      ]
+    }
+  ],
+  "module": "modules/dustland.module.js"
+}

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -1907,41 +1907,6 @@ const DATA = `
       "symbol": "!"
     },
     {
-      "id": "scavenger_rat",
-      "map": "world",
-      "x": 29,
-      "y": 66,
-      "color": "#ff0000",
-      "name": "Scavenger Rat",
-      "title": "Vermin",
-      "desc": "A giant rat rooting through scraps.",
-      "portraitSheet": "assets/portraits/dustland-module/scavenger_rat_4.png",
-      "portraitLock": false,
-      "tree": {
-        "start": {
-          "text": "It hisses.",
-          "choices": [
-            {
-              "label": "(Leave)",
-              "to": "bye"
-            }
-          ]
-        }
-      },
-      "combat": {
-        "HP": 4,
-        "ATK": 1,
-        "loot": "water_flask",
-        "scrap": {
-          "min": 3,
-          "max": 5
-        },
-        "auto": true
-      },
-      "symbol": "!",
-      "overrideColor": true
-    },
-    {
       "id": "rust_bandit",
       "map": "world",
       "x": 40,
@@ -14796,6 +14761,34 @@ const DATA = `
       "entryX": 25,
       "entryY": 47,
       "id": "room_oc3abv"
+    }
+  ],
+  "zoneEffects": [
+    {
+      "map": "world",
+      "x": 19,
+      "y": 56,
+      "w": 21,
+      "h": 21,
+      "minSteps": 1,
+      "maxSteps": 3,
+      "spawns": [
+        {
+          "id": "scavenger_rat",
+          "name": "Scavenger Rat",
+          "HP": 4,
+          "ATK": 1,
+          "DEF": 0,
+          "portraitSheet": "assets/portraits/dustland-module/scavenger_rat_4.png",
+          "loot": "water_flask",
+          "scrap": {
+            "min": 3,
+            "max": 5
+          },
+          "auto": true,
+          "prob": 1
+        }
+      ]
     }
   ]
 }

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -3976,6 +3976,7 @@ function applyLoadedModule(data) {
   moduleData.events = data.events || [];
   moduleData.templates = data.templates || [];
   moduleData.zones = data.zones || [];
+  moduleData.zoneEffects = (data.zoneEffects || []).map(z => ({ ...z }));
   moduleData.encounters = [];
   if (data.encounters) {
     Object.entries(data.encounters).forEach(([map, list]) => {
@@ -4119,6 +4120,9 @@ function saveModule() {
     if (moduleData[k] !== undefined) base[k] = moduleData[k];
   });
   if (moduleData._origKeys?.includes('encounters') || Object.keys(enc).length) base.encounters = enc;
+  if (moduleData._origKeys?.includes('zoneEffects') || (moduleData.zoneEffects && moduleData.zoneEffects.length)) {
+    base.zoneEffects = moduleData.zoneEffects.map(z => ({ ...z }));
+  }
   base.world = gridToEmoji(world);
   if (moduleData._origKeys?.includes('buildings') || bldgs.length) base.buildings = bldgs;
   if (moduleData._origKeys?.includes('interiors') || ints.length) base.interiors = ints;
@@ -4141,10 +4145,11 @@ function playtestModule() {
     (enc[map] ||= []).push(rest);
   });
   const zones = moduleData.zones ? moduleData.zones.map(z => ({ ...z })) : [];
+  const zoneEffects = moduleData.zoneEffects ? moduleData.zoneEffects.map(z => ({ ...z })) : [];
   const hasProps = Object.keys(moduleData.props || {}).length > 0;
   const moduleBase = { ...moduleData };
   if(!hasProps) delete moduleBase.props;
-  const data = { ...moduleBase, encounters: enc, world: gridToEmoji(world), buildings: bldgs, interiors: ints, zones };
+  const data = { ...moduleBase, encounters: enc, world: gridToEmoji(world), buildings: bldgs, interiors: ints, zones, zoneEffects };
   localStorage.setItem(PLAYTEST_KEY, JSON.stringify(data));
   window.open('dustland.html?ack-player=1#play', '_blank');
 }


### PR DESCRIPTION
## Summary
- convert the scavenger rat from a fixed NPC into a world zone effect spawn that keeps its water flask loot, scrap, and portrait while covering the wider encounter zone
- update the adventure kit loader/save/playtest flows so zone effects persist during edits

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68cc5c9ec4b0832897ca399e4b33afe9