### PR TITLE
fix: apply overworld poison damage

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -74,8 +74,19 @@ function addStatus(target, status){
       log?.(`${target.name || 'Target'} resists the poison.`);
       return;
     }
-    target.statusEffects.push({ type:'poison', strength: status.strength|0, remaining: status.duration|0 });
-    log?.(`${target.name} is poisoned!`);
+    const rawStrength = status.strength ?? status.dmg ?? 0;
+    const rawDuration = status.duration ?? status.turns ?? status.remaining ?? 0;
+    const strength = Math.max(0, rawStrength | 0);
+    const duration = Math.max(0, rawDuration | 0);
+    const existing = target.statusEffects.find(s => s.type === 'poison');
+    if(existing){
+      existing.strength = Math.max(existing.strength | 0, strength);
+      existing.remaining = (existing.remaining | 0) + duration;
+      log?.(`${target.name || 'Target'} is further poisoned!`);
+      return;
+    }
+    target.statusEffects.push({ type:'poison', strength, remaining: duration });
+    log?.(`${target.name || 'Target'} is poisoned!`);
   }
 }
 

--- a/test/poison.effect.test.js
+++ b/test/poison.effect.test.js
@@ -4,7 +4,48 @@ import { JSDOM } from 'jsdom';
 
 global.log = () => {};
 global.toast = () => {};
-global.EventBus = { emit: () => {} };
+const busListeners = {};
+global.EventBus = {
+  emit: (evt, payload) => {
+    (busListeners[evt] || []).forEach(fn => fn(payload));
+  },
+  on: (evt, fn) => {
+    (busListeners[evt] = busListeners[evt] || []).push(fn);
+  }
+};
+global.Dustland = {
+  eventBus: global.EventBus,
+  effects: { tick: () => {} },
+  actions: { startCombat: () => {} },
+  path: { tickPathAI: () => {} }
+};
+global.TILE = { ROAD: 0 };
+global.walkable = { 0: true };
+global.world = [ [0,0], [0,0] ];
+global.itemDrops = [];
+global.NPCS = [];
+global.interiors = {};
+global.tileEvents = [];
+global.enemyBanks = { world: [] };
+global.WORLD_W = 10;
+global.WORLD_H = 10;
+global.state = { map: 'world' };
+global.player = { hp: 10, scrap: 0 };
+global.clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+global.setPartyPos = (x, y) => {
+  if(global.party){
+    global.party.x = x;
+    global.party.y = y;
+  }
+};
+global.footstepBump = () => {};
+global.checkAggro = () => {};
+global.checkRandomEncounter = () => {};
+global.updateHUD = () => {};
+global.centerCamera = () => {};
+global.updateZoneMsgs = () => {};
+global.applyZones = () => {};
+global.renderParty = () => {};
 
 const dom = new JSDOM(`<div id="combatOverlay"></div><div id="combatEnemies"></div><div id="combatParty"></div><div id="combatCmd"></div><div id="turnIndicator"></div>`);
 global.document = dom.window.document;
@@ -13,8 +54,9 @@ global.window = dom.window;
 await import('../scripts/core/party.js');
 await import('../scripts/core/combat.js');
 await import('../scripts/core/inventory.js');
+await import('../scripts/core/movement.js');
 
-const { addStatus, tickStatuses, registerItem, addToInv, useItem, equipItem, makeMember, party } = globalThis;
+const { addStatus, tickStatuses, registerItem, addToInv, useItem, equipItem, makeMember, party, move } = globalThis;
 
 test('poison deals damage over time', () => {
   const foe = { name: 'Foe', hp: 10, maxHp: 10 };
@@ -26,6 +68,15 @@ test('poison deals damage over time', () => {
   tickStatuses(foe);
   assert.strictEqual(foe.hp, 4);
   assert.strictEqual(foe.statusEffects.length, 0);
+});
+
+test('reapplying poison extends duration instead of stacking', () => {
+  const foe = { name: 'Stacked', hp: 12, maxHp: 12 };
+  addStatus(foe, { type: 'poison', strength: 1, duration: 2 });
+  addStatus(foe, { type: 'poison', strength: 3, duration: 4 });
+  assert.strictEqual(foe.statusEffects.length, 1);
+  assert.strictEqual(foe.statusEffects[0].strength, 3);
+  assert.strictEqual(foe.statusEffects[0].remaining, 6);
 });
 
 test('cleanse item clears poison', () => {
@@ -51,4 +102,20 @@ test('poison immunity prevents poison application', () => {
   equipItem(0, 0);
   addStatus(hero, { type: 'poison', strength: 2, duration: 4 });
   assert.strictEqual(hero.statusEffects.length, 0);
+});
+
+test('walking ticks poison damage outside combat', async () => {
+  party.length = 0;
+  party.x = 0;
+  party.y = 0;
+  globalThis.player = { inv: [], hp: 10, scrap: 0 };
+  globalThis.checkRandomEncounter = () => {};
+  const hero = makeMember('walker', 'Walker', 'Role');
+  hero.maxHp = 10;
+  hero.hp = 10;
+  party.push(hero);
+  addStatus(hero, { type: 'poison', strength: 2, duration: 2 });
+  await move(1, 0);
+  assert.strictEqual(hero.hp, 8);
+  assert.strictEqual(hero.statusEffects[0].remaining, 1);
 });


### PR DESCRIPTION
## Summary
- extend poison reapplications instead of stacking and normalize the log output
- tick poison statuses for party members while walking outside combat
- expand poison tests to cover duration refresh and overworld damage ticks

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node -e "global.SpoilsCache={rollDrop:()=>null}; require('./scripts/supporting/balance-tester-agent.js');"


------
https://chatgpt.com/codex/tasks/task_e_68cc6194bacc8328a27131dbd8ccc644