### PR TITLE
feat: mask persona configuration in Adventure Kit

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -564,6 +564,17 @@
             <div id="modBuilder"></div>
           </div>
           <label>Equip<textarea id="itemEquip" rows="2"></textarea></label>
+          <div id="itemPersonaSection" style="display:none">
+            <label>Persona ID<input id="itemPersonaId" placeholder="mara.masked" /></label>
+            <label>Persona Label<input id="itemPersonaLabel" placeholder="Masked persona label" /></label>
+            <div class="portrait" id="itemPersonaPort"></div>
+            <div class="row" style="margin:8px 0">
+              <span class="pill" id="itemPersonaPrev">&lt;</span>
+              <span class="pill">Mask Portrait</span>
+              <span class="pill" id="itemPersonaNext">&gt;</span>
+            </div>
+            <label>Custom Portrait<input id="itemPersonaPortraitPath" placeholder="assets/portraits/custom.png" /></label>
+          </div>
           <label>Value<input id="itemValue" type="number" min="0" /></label>
           <label>Fuel<input id="itemFuel" type="number" min="0" /></label>
           <label>Use Type<select id="itemUseType"><option value="">(none)</option><option value="heal">Heal</option><option value="boost">Boost</option></select></label>

--- a/test/persona-hud.test.js
+++ b/test/persona-hud.test.js
@@ -23,3 +23,33 @@ test('renderParty reflects persona portrait and label', async () => {
   const portrait = card.children[0].style.backgroundImage;
   assert.ok(portrait.includes('hidden_hermit_4.png'));
 });
+
+test('renderParty uses module persona overrides', async () => {
+  const party = [
+    { id:'mara', name:'Mara', role:'Scout', lvl:1, hp:5, maxHp:5, adr:0, stats:{}, equip:{ weapon:null, armor:null, trinket:null }, _bonus:{}, portraitSheet:'assets/portraits/portrait_1000.png', xp:0 }
+  ];
+  const { context, document } = createGameProxy(party);
+  const gs = await fs.readFile(new URL('../scripts/game-state.js', import.meta.url), 'utf8');
+  vm.runInContext(gs, context);
+  const ps = await fs.readFile(new URL('../scripts/core/personas.js', import.meta.url), 'utf8');
+  vm.runInContext(ps, context);
+  context.itemDrops = [];
+  context.ITEMS = {};
+  context.quests = {};
+  const core = await fs.readFile(new URL('../scripts/dustland-core.js', import.meta.url), 'utf8');
+  vm.runInContext(core, context);
+  context.applyModule({
+    seed: 1,
+    world: [[context.TILE?.SAND ?? 7]],
+    personas: { 'mara.masked': { label: 'Echo Mara', portrait: 'assets/portraits/portrait_1005.png' } }
+  }, { fullReset: true });
+  context.EventBus.emit('item:picked', { tags:['mask'], persona:'mara.masked' });
+  context.Dustland.gameState.updateState(s => { s.party = party; });
+  context.Dustland.gameState.applyPersona('mara', 'mara.masked');
+  context.renderParty();
+  const card = document.getElementById('party').children[0];
+  const html = card.innerHTML || card._innerHTML || '';
+  assert.ok(html.includes('Echo Mara'));
+  const portrait = card.children[0].style.backgroundImage;
+  assert.ok(portrait.includes('portrait_1005.png'));
+});


### PR DESCRIPTION
## Summary
- add mask persona editing fields to the Adventure Kit item editor and persist selections
- ensure persona overrides are stored, cleaned before export, and merged into runtime persona templates
- cover the new mask persona workflow with ACK, core, and HUD tests

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cc6d9b5f5c8328bdeb1c4a6c372c97