### PR TITLE
feat: add codex task browser cli

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -10,3 +10,13 @@ Use these folders to find the right design reference quickly:
 - `narrative-world/` – story arcs, module breakdowns, and tonal guides.
 - `ui-accessibility/` – HUD, dialog flow, and interface polish work.
 - `dev-tools/` – editor direction, engine scaffolding, and authoring utilities.
+
+## Codex task snapshots
+
+The generated `codex-tasks.json` snapshot in this folder can feed directly into day-to-day planning.
+
+- Refresh the file when design checklists change: `node scripts/supporting/design-codex-tasks.js`.
+- Browse or filter the tasks without opening the JSON: `node scripts/supporting/codex-task-browser.js list trader`.
+- Inspect a specific entry for full context: `node scripts/supporting/codex-task-browser.js show docs/design/economy-progression/oasis-trader.md:35`.
+
+The CLI pulls titles, headings, and ancestor bullets from the snapshot so you can quickly jump from the design note to an actionable commit idea.

--- a/docs/design/codex-tasks.json
+++ b/docs/design/codex-tasks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-18T20:24:26.533Z",
+  "generatedAt": "2025-09-18T20:33:31.295Z",
   "taskCount": 122,
   "tasks": [
     {

--- a/scripts/supporting/codex-task-browser.js
+++ b/scripts/supporting/codex-task-browser.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const defaultTasksPath = path.join(repoRoot, 'docs', 'design', 'codex-tasks.json');
+
+export function loadCodexTasks(filePath = defaultTasksPath) {
+  const resolvedPath = path.resolve(filePath);
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  const payload = JSON.parse(raw);
+  if (!Array.isArray(payload?.tasks)) {
+    throw new Error('Invalid codex task payload: expected tasks array');
+  }
+  return {payload, resolvedPath};
+}
+
+export function normalizeTasks(tasks) {
+  return tasks.map(task => ({
+    id: task.id ?? '',
+    title: task.title ?? '',
+    codexCommand: Array.isArray(task.codexCommand) ? task.codexCommand : [],
+    source: {
+      file: task.source?.file ?? '',
+      line: task.source?.line ?? null,
+      headings: Array.isArray(task.source?.headings) ? task.source.headings : [],
+      ancestors: Array.isArray(task.source?.ancestors) ? task.source.ancestors : [],
+    },
+  }));
+}
+
+export function filterTasks(tasks, query) {
+  if (!query) return tasks;
+  const needle = query.toLowerCase();
+  return tasks.filter(task => {
+    const haystack = [
+      task.title,
+      task.id,
+      task.source?.file,
+      ...(task.source?.headings ?? []),
+      ...(task.source?.ancestors ?? []),
+      ...(Array.isArray(task.codexCommand) ? task.codexCommand : []),
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(needle);
+  });
+}
+
+export function pickTask(tasks, identifier) {
+  if (!identifier) return null;
+  const index = Number.parseInt(identifier, 10);
+  if (!Number.isNaN(index)) {
+    const task = tasks[index - 1];
+    return task ?? null;
+  }
+  return tasks.find(task => task.id === identifier) ?? null;
+}
+
+export function formatTask(task, index) {
+  if (!task) return '';
+  const prefix = typeof index === 'number' ? `${index + 1}.` : '-';
+  const lines = [`${prefix} ${task.title}`];
+  const metadata = [];
+  if (task.source?.file) {
+    const location = task.source.line ? `${task.source.file}:${task.source.line}` : task.source.file;
+    metadata.push(location);
+  }
+  if (task.id) metadata.push(task.id);
+  if (metadata.length) {
+    lines.push(`   ${metadata.join(' | ')}`);
+  }
+  if (task.codexCommand?.length) {
+    lines.push(`   Command: ${task.codexCommand.join(' ')}`);
+  }
+  if (task.source?.headings?.length) {
+    lines.push(`   Headings: ${task.source.headings.join(' > ')}`);
+  }
+  if (task.source?.ancestors?.length) {
+    lines.push(`   Ancestors: ${task.source.ancestors.join(' > ')}`);
+  }
+  return lines.join('\n');
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/supporting/codex-task-browser.js [options] [command]
+
+Commands:
+  list [query]      List tasks, optionally filtered by a search query.
+  show <id|index>  Show the full details for a single task by id or 1-based index.
+
+Options:
+  -f, --file <path>  Path to a codex-tasks.json file (defaults to docs/design/codex-tasks.json).
+  -h, --help         Show this message.
+`);
+}
+
+export function runCli(argv = process.argv.slice(2)) {
+  const options = {file: defaultTasksPath};
+  const positional = [];
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--file' || arg === '-f') {
+      index++;
+      if (index >= argv.length) {
+        throw new Error('Missing value after --file');
+      }
+      options.file = argv[index];
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      return 0;
+    }
+    positional.push(arg);
+  }
+
+  const command = positional.shift() ?? 'list';
+  const {payload, resolvedPath} = loadCodexTasks(options.file);
+  const tasks = normalizeTasks(payload.tasks);
+
+  if (command === 'list') {
+    const query = positional.shift() ?? '';
+    const filtered = filterTasks(tasks, query);
+    if (!filtered.length) {
+      console.log(`No codex tasks matched the query in ${path.relative(repoRoot, resolvedPath)}`);
+      return 0;
+    }
+    filtered.forEach((task, index) => {
+      console.log(formatTask(task, index));
+      if (index < filtered.length - 1) console.log('');
+    });
+    return 0;
+  }
+
+  if (command === 'show') {
+    const identifier = positional.shift();
+    if (!identifier) {
+      throw new Error('Missing task id or index for show command');
+    }
+    const task = pickTask(tasks, identifier);
+    if (!task) {
+      throw new Error(`Unable to find task '${identifier}' in ${path.relative(repoRoot, resolvedPath)}`);
+    }
+    console.log(formatTask(task));
+    return 0;
+  }
+
+  throw new Error(`Unknown command: ${command}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const exitCode = runCli();
+    process.exit(exitCode);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/test/codex-task-browser.test.js
+++ b/test/codex-task-browser.test.js
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {test} from 'node:test';
+import {
+  loadCodexTasks,
+  normalizeTasks,
+  filterTasks,
+  pickTask,
+  formatTask,
+} from '../scripts/supporting/codex-task-browser.js';
+
+test('loadCodexTasks reads and validates payload', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-task-browser-'));
+  const filePath = path.join(tempDir, 'codex-tasks.json');
+  const payload = {
+    generatedAt: '2025-01-01T00:00:00.000Z',
+    taskCount: 1,
+    tasks: [{
+      id: 'docs/design/sample.md:12',
+      title: 'Prototype scheduler',
+      codexCommand: ['codex', 'commit', 'Prototype scheduler'],
+      source: {file: 'docs/design/sample.md', line: 12, headings: ['Root'], ancestors: []},
+    }],
+  };
+  fs.writeFileSync(filePath, JSON.stringify(payload));
+
+  const {payload: loaded, resolvedPath} = loadCodexTasks(filePath);
+  assert.equal(resolvedPath, filePath);
+  assert.equal(loaded.tasks[0].title, 'Prototype scheduler');
+});
+
+test('normalizeTasks fills optional fields', () => {
+  const tasks = normalizeTasks([
+    {
+      id: 'docs/design/sample.md:5',
+      title: 'Add fast travel',
+      source: {file: 'docs/design/sample.md', line: 5},
+    },
+    {},
+  ]);
+
+  assert.equal(tasks[0].codexCommand.length, 0);
+  assert.deepEqual(tasks[0].source.headings, []);
+  assert.equal(tasks[1].id, '');
+  assert.equal(tasks[1].title, '');
+});
+
+test('filterTasks matches across metadata', () => {
+  const tasks = normalizeTasks([
+    {
+      id: 'docs/design/a.md:3',
+      title: 'Tune scrap rewards',
+      codexCommand: ['codex', 'commit', 'Tune scrap rewards'],
+      source: {file: 'docs/design/a.md', headings: ['Economy'], ancestors: []},
+    },
+    {
+      id: 'docs/design/b.md:7',
+      title: 'Improve trader grudge system',
+      source: {file: 'docs/design/b.md', headings: ['Vendors'], ancestors: ['Tune scrap rewards']},
+    },
+  ]);
+
+  const filtered = filterTasks(tasks, 'grudge');
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0].id, 'docs/design/b.md:7');
+
+  const ancestorFiltered = filterTasks(tasks, 'scrap rewards');
+  assert.equal(ancestorFiltered.length, 2);
+});
+
+test('pickTask resolves indexes and ids', () => {
+  const tasks = normalizeTasks([
+    {id: 'alpha', title: 'A'},
+    {id: 'beta', title: 'B'},
+  ]);
+
+  assert.equal(pickTask(tasks, '1').id, 'alpha');
+  assert.equal(pickTask(tasks, 'beta').title, 'B');
+  assert.equal(pickTask(tasks, '3'), null);
+});
+
+test('formatTask prints multi-line summary', () => {
+  const task = normalizeTasks([{
+    id: 'docs/design/sample.md:10',
+    title: 'Document scheduler API',
+    codexCommand: ['codex', 'commit', 'Document scheduler API'],
+    source: {
+      file: 'docs/design/sample.md',
+      line: 10,
+      headings: ['Reactive Systems'],
+      ancestors: ['Build scheduler'],
+    },
+  }])[0];
+
+  const output = formatTask(task, 0);
+  assert.match(output, /^1\. Document scheduler API/m);
+  assert.match(output, /docs\/design\/sample\.md:10/);
+  assert.match(output, /Command: codex commit Document scheduler API/);
+  assert.match(output, /Headings: Reactive Systems/);
+  assert.match(output, /Ancestors: Build scheduler/);
+});


### PR DESCRIPTION
## Summary
- add a codex task browser CLI that lists or inspects entries from docs/design/codex-tasks.json
- document how to refresh and query the snapshot from the design README
- cover the CLI helpers with unit tests for filtering, formatting, and lookup logic

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cc6c6dcab88328b362959c698fd375