### PR TITLE
fix: stabilize multiplayer invite harness

### DIFF
--- a/multiplayer.html
+++ b/multiplayer.html
@@ -18,6 +18,11 @@
     label { display: block; font-weight: 600; margin: 16px 0 8px; }
     .hidden { display: none !important; }
     .flow { margin-top: 16px; }
+    .invite-card { border: 1px solid #2f3b2f; padding: 12px; border-radius: 6px; background: rgba(12, 20, 12, 0.6); }
+    .invite-card + .invite-card { margin-top: 16px; }
+    .invite-card textarea { min-height: 72px; }
+    .invite-card label { margin: 12px 0 6px; }
+    .invite-card .status { margin-top: 8px; min-height: 20px; color: #9ec2a4; }
   </style>
 </head>
 <body>
@@ -36,21 +41,30 @@
   <section class="section hidden" id="hostSection">
     <h2>Host a Session</h2>
     <p class="muted">We'll spin up a room and produce a host code. Share it with your friend, then paste their answer code to finish linking.</p>
-    <div id="hostCodeGroup" class="flow hidden">
-      <label for="hostCode">Host Code</label>
-      <textarea id="hostCode" readonly placeholder="Generating host code..."></textarea>
+    <div id="inviteControls" class="flow">
       <div class="controls">
-        <button class="btn" id="copyHost" disabled>Copy Host Code</button>
-        <button class="btn" id="newInvite" disabled>Generate New Host Code</button>
+        <button class="btn" id="newInvite" disabled>Generate Host Code</button>
       </div>
+      <p class="muted">Each host code links one player. Generate invites ahead of time so everyone can join without waiting.</p>
     </div>
-    <div id="hostAnswerGroup" class="flow hidden">
-      <label for="answerInput">Answer Code</label>
-      <textarea id="answerInput" placeholder="Paste the answer code from your friend" disabled></textarea>
-      <div class="controls">
-        <button class="btn" id="linkPlayer" disabled>Link Player</button>
+    <div id="inviteDeck" class="flow hidden">
+      <p class="muted" id="inviteEmpty">No active invites yet. Generate a host code to begin.</p>
+    </div>
+    <template id="inviteTemplate">
+      <div class="invite-card">
+        <label>Host Code</label>
+        <textarea class="host-code" readonly placeholder="Host code appears here"></textarea>
+        <div class="controls">
+          <button class="btn copy-host">Copy Host Code</button>
+        </div>
+        <label>Answer Code</label>
+        <textarea class="answer-input" placeholder="Paste the answer code from your friend"></textarea>
+        <div class="controls">
+          <button class="btn link-player">Link Player</button>
+        </div>
+        <div class="status invite-status"></div>
       </div>
-    </div>
+    </template>
     <div class="peer-list" id="peerList">No players linked yet.</div>
     <div class="status" id="hostStatus"></div>
   </section>

--- a/test/multiplayer-lobby-errors.test.js
+++ b/test/multiplayer-lobby-errors.test.js
@@ -9,28 +9,100 @@ const code = await fs.readFile(new URL('../scripts/supporting/multiplayer-lobby.
 function buildDom(){
   const document = makeDocument();
   const body = document.body;
-  const config = {
-    startHost: 'button',
-    newInvite: 'button',
-    linkPlayer: 'button',
-    copyHost: 'button',
-    hostCode: 'textarea',
-    answerInput: 'textarea',
-    hostStatus: 'div',
-    peerList: 'div',
-    joinCode: 'textarea',
-    connectBtn: 'button',
-    answerCode: 'textarea',
-    copyAnswer: 'button',
-    joinStatus: 'div'
-  };
-  Object.entries(config).forEach(([id, tag]) => {
-    const el = document.createElement(tag);
-    if (tag === 'textarea') el.value = '';
-    el.id = id;
-    if (id === 'hostCode' || id === 'answerCode') el.readOnly = true;
-    body.appendChild(el);
+  const sections = {};
+  ['modeSection', 'hostSection', 'joinSection'].forEach(id => {
+    const section = document.getElementById(id);
+    sections[id] = section;
+    body.appendChild(section);
   });
+
+  const hostSection = sections.hostSection;
+  const joinSection = sections.joinSection;
+
+  const startHost = document.getElementById('startHost');
+  body.appendChild(startHost);
+
+  const newInvite = document.getElementById('newInvite');
+  newInvite.disabled = true;
+  hostSection.appendChild(newInvite);
+
+  const inviteDeck = document.getElementById('inviteDeck');
+  inviteDeck.classList.add('hidden');
+  hostSection.appendChild(inviteDeck);
+
+  const inviteEmpty = document.getElementById('inviteEmpty');
+  inviteDeck.appendChild(inviteEmpty);
+
+  const inviteTemplate = document.getElementById('inviteTemplate');
+  function buildInviteTemplate(){
+    const card = document.createElement('div');
+    card.classList.add('invite-card');
+    const hostField = document.createElement('textarea');
+    hostField.classList.add('host-code');
+    card.appendChild(hostField);
+    const copyBtn = document.createElement('button');
+    copyBtn.classList.add('copy-host');
+    card.appendChild(copyBtn);
+    const answerField = document.createElement('textarea');
+    answerField.classList.add('answer-input');
+    card.appendChild(answerField);
+    const linkBtn = document.createElement('button');
+    linkBtn.classList.add('link-player');
+    card.appendChild(linkBtn);
+    const status = document.createElement('div');
+    status.classList.add('invite-status');
+    card.appendChild(status);
+    return card;
+  }
+  function cloneTree(node){
+    const clone = document.createElement(node.tagName.toLowerCase());
+    clone.className = node.className;
+    clone.value = node.value;
+    clone.textContent = node.textContent;
+    node.children.forEach(child => clone.appendChild(cloneTree(child)));
+    return clone;
+  }
+  const templateCard = buildInviteTemplate();
+  templateCard.cloneNode = () => cloneTree(templateCard);
+  inviteTemplate.content = { firstElementChild: templateCard };
+  hostSection.appendChild(inviteTemplate);
+
+  const hostStatus = document.getElementById('hostStatus');
+  hostSection.appendChild(hostStatus);
+
+  const peerList = document.getElementById('peerList');
+  hostSection.appendChild(peerList);
+
+  const joinAnswerGroup = document.getElementById('joinAnswerGroup');
+  joinAnswerGroup.classList.add('hidden');
+  joinSection.appendChild(joinAnswerGroup);
+
+  const joinCode = document.getElementById('joinCode');
+  joinCode.value = '';
+  joinSection.appendChild(joinCode);
+
+  const connectBtn = document.getElementById('connectBtn');
+  connectBtn.disabled = true;
+  joinSection.appendChild(connectBtn);
+
+  const answerCode = document.getElementById('answerCode');
+  answerCode.value = '';
+  answerCode.readOnly = true;
+  joinSection.appendChild(answerCode);
+
+  const copyAnswer = document.getElementById('copyAnswer');
+  copyAnswer.disabled = true;
+  joinSection.appendChild(copyAnswer);
+
+  const joinStatus = document.getElementById('joinStatus');
+  joinSection.appendChild(joinStatus);
+
+  const chooseHost = document.getElementById('chooseHost');
+  body.appendChild(chooseHost);
+
+  const chooseJoin = document.getElementById('chooseJoin');
+  body.appendChild(chooseJoin);
+
   return document;
 }
 
@@ -60,4 +132,44 @@ test('generate answer handles invalid host code', async () => {
   document.getElementById('joinCode').value = 'foo';
   await document.getElementById('connectBtn').onclick();
   assert.ok(document.getElementById('joinStatus').textContent.includes('bad code'));
+});
+
+test('host can juggle multiple invites', async () => {
+  const document = buildDom();
+  const created = [];
+  const accepted = [];
+  const room = {
+    async createOffer(){
+      const ticket = { id: `t${created.length}`, code: `CODE-${created.length}` };
+      created.push(ticket);
+      return ticket;
+    },
+    async acceptAnswer(id, answer){
+      accepted.push({ id, answer });
+    },
+    onPeers(fn){ fn([]); return () => {}; },
+    close(){}
+  };
+  const context = {
+    document,
+    navigator: {},
+    Dustland: { multiplayer: { startHost: async () => room } }
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+
+  await document.getElementById('startHost').onclick();
+  await document.getElementById('newInvite').onclick();
+  await document.getElementById('newInvite').onclick();
+
+  const invitesBefore = document.querySelectorAll('.invite-card');
+  assert.equal(invitesBefore.length, 2);
+
+  const first = invitesBefore[0];
+  first.querySelector('.answer-input').value = 'ANSWER-1';
+  await first.querySelector('.link-player').onclick();
+
+  assert.equal(accepted.length, 1);
+  assert.deepEqual(accepted[0], { id: 't0', answer: 'ANSWER-1' });
+  assert.equal(document.querySelectorAll('.invite-card').length, 1);
 });

--- a/test/test-harness.js
+++ b/test/test-harness.js
@@ -67,7 +67,13 @@ class Elem {
     evt.target ??= this;
     (this.listeners[evt.type]||[]).forEach(fn=>fn.call(this, evt));
   }
-  remove(){ }
+  remove(){
+    const parent = this.parentElement;
+    if (!parent) return;
+    const idx = parent.children.indexOf(this);
+    if (idx !== -1) parent.children.splice(idx, 1);
+    this.parentElement = undefined;
+  }
 }
 
 class CanvasElem extends Elem {


### PR DESCRIPTION
## Summary
- mount fake DOM elements via getElementById so lobby code manipulates the same nodes that tests inspect
- teach the test harness Elem.remove helper to detach cards when invites close so DOM assertions pass
- exercise the multi-invite flow to prove hosts can juggle multiple offers while linking peers

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cc6921dfb083289cd0098f6f49cc22