### PR TITLE
fix: map mobile buttons to creator navigation

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -189,6 +189,17 @@ function setMobileControls(on){
       mobileWrap.id='mobileControls';
       mobileWrap.style.cssText='position:fixed;left:0;right:0;bottom:0;height:180px;display:flex;justify-content:space-between;padding:20px;z-index:1000;touch-action:manipulation;';
       document.body.appendChild(mobileWrap);
+      const tryCreatorNav = (btnId) => {
+        const creatorEl=document.getElementById('creator');
+        if(creatorEl?.style?.display==='flex'){
+          const btn=document.getElementById(btnId);
+          if(btn && !btn.disabled){
+            if(typeof btn.click==='function') btn.click(); else btn.onclick?.();
+          }
+          return true;
+        }
+        return false;
+      };
       const mk=(name,t,fn)=>{
         const b=document.createElement('button');
         b.textContent=t;
@@ -236,6 +247,9 @@ function setMobileControls(on){
       mobileAB=document.createElement('div');
       mobileAB.style.cssText='display:flex;gap:10px;user-select:none;';
       mobileAB.appendChild(mk('A','A',()=>{
+        if(tryCreatorNav('ccNext')){
+          return;
+        }
         if(overlay?.classList?.contains('shown')){
           handleDialogKey?.({ key:'Enter' });
         } else if(document.getElementById('combatOverlay')?.classList?.contains('shown')){
@@ -246,6 +260,9 @@ function setMobileControls(on){
       }));
       mobileAB.appendChild(mk('B','B',()=>{
         const shop = document.getElementById('shopOverlay');
+        if(tryCreatorNav('ccBack')){
+          return;
+        }
         if(overlay?.classList?.contains('shown')){
           closeDialog?.();
         } else if(document.getElementById('combatOverlay')?.classList?.contains('shown')){

--- a/test/mobile-controls.test.js
+++ b/test/mobile-controls.test.js
@@ -85,3 +85,33 @@ test('mobile B flees combat', async () => {
   b.onclick();
   assert.deepStrictEqual(keys, ['Escape']);
 });
+
+test('mobile A advances character creator', async () => {
+  let interacted = false;
+  let nextCalls = 0;
+  const { context, document } = await setup({
+    interact: () => { interacted = true; }
+  });
+  const creator = document.getElementById('creator');
+  creator.style.display = 'flex';
+  const nextBtn = document.getElementById('ccNext');
+  nextBtn.disabled = false;
+  nextBtn.onclick = () => { nextCalls += 1; };
+  const { A: a } = context.setMobileControls(true);
+  a.onclick();
+  assert.strictEqual(nextCalls, 1);
+  assert.ok(!interacted);
+});
+
+test('mobile B goes back in character creator', async () => {
+  let backCalls = 0;
+  const { context, document } = await setup();
+  const creator = document.getElementById('creator');
+  creator.style.display = 'flex';
+  const backBtn = document.getElementById('ccBack');
+  backBtn.disabled = false;
+  backBtn.onclick = () => { backCalls += 1; };
+  const { B: b } = context.setMobileControls(true);
+  b.onclick();
+  assert.strictEqual(backCalls, 1);
+});


### PR DESCRIPTION
## Summary
- route the mobile A/B controls to the character creator next/back buttons when the creator is open
- add tests covering the character creator navigation shortcuts for the mobile buttons

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68ccb2cfa7c08328ae81831366a636f9