### PR TITLE
fix: allow clients to leave multiplayer

### DIFF
--- a/test/multiplayer-lobby-errors.test.js
+++ b/test/multiplayer-lobby-errors.test.js
@@ -111,6 +111,7 @@ test('start host surfaces errors and re-enables button', async () => {
   const context = {
     document,
     navigator: {},
+    sessionStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
     Dustland: { multiplayer: { startHost: async () => { throw new Error('no rtc'); } } }
   };
   vm.createContext(context);
@@ -125,6 +126,7 @@ test('generate answer handles invalid host code', async () => {
   const context = {
     document,
     navigator: {},
+    sessionStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
     Dustland: { multiplayer: { connect: async () => { throw new Error('bad code'); } } }
   };
   vm.createContext(context);
@@ -153,6 +155,7 @@ test('host can juggle multiple invites', async () => {
   const context = {
     document,
     navigator: {},
+    sessionStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
     Dustland: { multiplayer: { startHost: async () => room } }
   };
   vm.createContext(context);


### PR DESCRIPTION
## Summary
- disable module picker controls for joined clients, listen for host broadcasts, and provide a leave option so clients can drop back to offline play
- broadcast module selection events from the host and prevent clients from emitting them
- persist multiplayer roles in the lobby so Dustland knows which side to enforce, plus new tests

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cccb5c0b0083288cc193d8e8c13a2b