### PR TITLE
fix: rebalance dustland equipment tiers

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -41,8 +41,8 @@
       "name": "Pipe Rifle",
       "type": "weapon",
       "mods": {
-        "ATK": 2,
-        "ADR": 15
+        "ATK": 3,
+        "ADR": 18
       },
       "tags": [
         "ranged"
@@ -79,7 +79,7 @@
       "type": "weapon",
       "mods": {
         "ATK": 1,
-        "ADR": 10
+        "ADR": 9
       }
     },
     {
@@ -90,8 +90,8 @@
       "name": "Rebar Club",
       "type": "weapon",
       "mods": {
-        "ATK": 1,
-        "ADR": 10
+        "ATK": 2,
+        "ADR": 12
       }
     },
     {
@@ -280,8 +280,8 @@
       "name": "Raider Knife",
       "type": "weapon",
       "mods": {
-        "ATK": 1,
-        "ADR": 10
+        "ATK": 3,
+        "ADR": 14
       }
     },
     {
@@ -293,7 +293,7 @@
       "type": "weapon",
       "mods": {
         "ATK": 5,
-        "ADR": 20
+        "ADR": 22
       }
     },
     {
@@ -335,7 +335,8 @@
       "type": "weapon",
       "rarity": "epic",
       "mods": {
-        "ATK": 5
+        "ATK": 6,
+        "ADR": 25
       },
       "value": 500
     },
@@ -434,8 +435,8 @@
       "type": "weapon",
       "rarity": "epic",
       "mods": {
-        "ATK": 8,
-        "ADR": 45
+        "ATK": 5,
+        "ADR": 35
       },
       "tags": [
         "ranged",
@@ -496,8 +497,8 @@
       "name": "Thornlash Whip",
       "type": "weapon",
       "mods": {
-        "ATK": 1,
-        "ADR": 12
+        "ATK": 3,
+        "ADR": 18
       }
     },
     {
@@ -515,7 +516,7 @@
       "name": "Patchwork Plate",
       "type": "armor",
       "mods": {
-        "DEF": 1,
+        "DEF": 3,
         "HP": 2
       }
     },
@@ -524,8 +525,8 @@
       "name": "Corroded Hatchet",
       "type": "weapon",
       "mods": {
-        "ATK": 2,
-        "ADR": 9
+        "ATK": 4,
+        "ADR": 16
       }
     },
     {

--- a/docs/balance/dustland-balance-report.md
+++ b/docs/balance/dustland-balance-report.md
@@ -1,5 +1,5 @@
 # Dustland Combat Balance Report: dustland-module
-_Generated 2025-09-19T21:19:45.067Z_
+_Generated 2025-09-20T00:19:18.552Z_
 
 This report estimates how Dustland combatants perform using deterministic averages drawn from the current data files. It considers party builds at multiple levels and equipment tiers, then compares their expected output against enemies found in the module.
 
@@ -7,36 +7,39 @@ This report estimates how Dustland combatants perform using deterministic averag
 
 ## Weapon Tiers
 ### Melee Weapons
-| Tier | Items | Avg ATK | Avg ADR | Avg Adr Gain | Adr Dmg Mod | Notable Tags |
+| Tier | Items | Avg ATK | Avg ADR | Avg ADR Gain | ADR Dmg Mod | Notable Tags |
 | --- | --- | --- | --- | --- | --- | --- |
-| T1 | 5 | 1 | 11.4 | 2.85 | 1.04 | — |
-| T2 | 2 | 2 | 10.5 | 2.63 | 1 | — |
-| T3 | 2 | 5 | 10 | 2.5 | 1 | — |
+| T1 | 2 | 1 | 12 | 3.3 | 1.1 | — |
+| T2 | 2 | 2 | 12 | 3 | 1 | — |
+| T3 | 2 | 3 | 16 | 4 | 1 | — |
+| T4 | 1 | 4 | 16 | 4 | 1 | — |
+| T5 | 1 | 5 | 22 | 5.5 | 1 | — |
+| T6 | 1 | 6 | 25 | 6.25 | 1 | — |
 
 ### Ranged Weapons
-| Tier | Items | Avg ATK | Avg ADR | Avg Adr Gain | Adr Dmg Mod | Notable Tags |
+| Tier | Items | Avg ATK | Avg ADR | Avg ADR Gain | ADR Dmg Mod | Notable Tags |
 | --- | --- | --- | --- | --- | --- | --- |
-| T1 | 1 | 2 | 15 | 3.75 | 1 | ranged |
-| T2 | 1 | 8 | 45 | 11.25 | 1 | heavy, ranged |
+| T1 | 1 | 3 | 18 | 4.5 | 1 | ranged |
+| T2 | 1 | 5 | 35 | 8.75 | 1 | heavy, ranged |
 
 ## Armor Tiers
-| Tier | Items | Avg DEF | Adr Gen Mod | Adr Dmg Mod |
+| Tier | Items | Avg DEF | ADR Gen Mod | ADR Dmg Mod |
 | --- | --- | --- | --- | --- |
-| T1 | 3 | 1 | 1.03 | 1 |
+| T1 | 2 | 1 | 1.05 | 1 |
 | T2 | 1 | 2 | 1 | 1 |
-| T3 | 1 | 3 | 0.9 | 1 |
+| T3 | 2 | 3 | 0.95 | 1 |
 | T4 | 1 | 4 | 1 | 1 |
 | T5 | 1 | 5 | 1 | 1 |
 
 ## Party Damage Benchmarks
 | Archetype | Level | Weapon Tier | Armor Tier | Primary Stat | ATK Bonus | DEF Bonus | ADR Gain/Attack | Attacks to Fill ADR | Avg Damage (0/50/100%) |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | STR 4 | 1 | 1 | 3.06 | 33 | 0%: 1.5<br>50%: 2.28<br>100%: 3.06 |
-| Ranged | 1 | T1 | T1 | AGI 4 | 2 | 1 | 3.88 | 26 | 0%: 2<br>50%: 3<br>100%: 4 |
-| Melee | 4 | T2 | T3 | STR 7 | 2 | 3 | 2.36 | 43 | 0%: 4.5<br>50%: 6.75<br>100%: 9 |
-| Ranged | 4 | T2 | T3 | AGI 7 | 8 | 3 | 10.13 | 10 | 0%: 10.5<br>50%: 15.75<br>100%: 21 |
-| Melee | 7 | T3 | T5 | STR 10 | 5 | 5 | 2.5 | 40 | 0%: 10.5<br>50%: 15.75<br>100%: 21 |
-| Ranged | 7 | T2 | T5 | AGI 10 | 8 | 5 | 11.25 | 9 | 0%: 13.5<br>50%: 20.25<br>100%: 27 |
+| Melee | 1 | T1 | T1 | STR 4 | 1 | 1 | 3.47 | 29 | 0%: 1.5<br>50%: 2.33<br>100%: 3.15 |
+| Ranged | 1 | T1 | T1 | AGI 4 | 3 | 1 | 4.73 | 22 | 0%: 2.5<br>50%: 3.75<br>100%: 5 |
+| Melee | 4 | T3 | T3 | STR 7 | 3 | 3 | 3.8 | 27 | 0%: 5.5<br>50%: 8.25<br>100%: 11 |
+| Ranged | 4 | T2 | T3 | AGI 7 | 5 | 3 | 8.31 | 13 | 0%: 7.5<br>50%: 11.25<br>100%: 15 |
+| Melee | 7 | T6 | T5 | STR 10 | 6 | 5 | 6.25 | 16 | 0%: 11.5<br>50%: 17.25<br>100%: 23 |
+| Ranged | 7 | T2 | T5 | AGI 10 | 5 | 5 | 8.75 | 12 | 0%: 10.5<br>50%: 15.75<br>100%: 21 |
 
 ## Enemy Overview
 | Enemy | HP | ATK | DEF | Counter | Immune | Requires | Special |
@@ -72,48 +75,48 @@ This report estimates how Dustland combatants perform using deterministic averag
 ### Rotwalker
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 1.5 | 2.28 | 3.06 | 2 | 0 | — | — |
-| Ranged | 1 | T1 | T1 | 2 | 3 | 4 | 2 | 0 | — | — |
-| Melee | 4 | T2 | T3 | 4.5 | 6.75 | 9 | 1 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 13.5 | 20.25 | 27 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 1.5 | 2.33 | 3.15 | 2 | 0 | — | — |
+| Ranged | 1 | T1 | T1 | 2.5 | 3.75 | 5 | 2 | 0 | — | — |
+| Melee | 4 | T3 | T3 | 5.5 | 8.25 | 11 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 7.5 | 11.25 | 15 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 11.5 | 17.25 | 23 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Mira
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 0.5 | 1.28 | 2.06 | 4 | 1 | 10 | 2 |
-| Ranged | 1 | T1 | T1 | 1 | 2 | 3 | 3 | 1 | 10 | 2 |
-| Melee | 4 | T2 | T3 | 3.5 | 5.75 | 8 | 1 | 0 | — | 2 |
-| Ranged | 4 | T2 | T3 | 9.5 | 14.75 | 20 | 1 | 0 | — | 2 |
-| Melee | 7 | T3 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | 2 |
-| Ranged | 7 | T2 | T5 | 12.5 | 19.25 | 26 | 1 | 0 | — | 2 |
+| Melee | 1 | T1 | T1 | 0.5 | 1.33 | 2.15 | 4 | 1 | 10 | 2 |
+| Ranged | 1 | T1 | T1 | 1.5 | 2.75 | 4 | 2 | 1 | 10 | 2 |
+| Melee | 4 | T3 | T3 | 4.5 | 7.25 | 10 | 1 | 0 | — | 2 |
+| Ranged | 4 | T2 | T3 | 6.5 | 10.25 | 14 | 1 | 0 | — | 2 |
+| Melee | 7 | T6 | T5 | 10.5 | 16.25 | 22 | 1 | 0 | — | 2 |
+| Ranged | 7 | T2 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | 2 |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Nora
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 0.5 | 1.28 | 2.06 | 4 | 0.5 | 20 | — |
-| Ranged | 1 | T1 | T1 | 1 | 2 | 3 | 3 | 0.5 | 20 | — |
-| Melee | 4 | T2 | T3 | 3.5 | 5.75 | 8 | 1 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 12.5 | 19.25 | 26 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 0.5 | 1.33 | 2.15 | 4 | 0.5 | 20 | — |
+| Ranged | 1 | T1 | T1 | 1.5 | 2.75 | 4 | 2 | 0.5 | 20 | — |
+| Melee | 4 | T3 | T3 | 4.5 | 7.25 | 10 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 6.5 | 10.25 | 14 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 10.5 | 16.25 | 22 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Tess
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 0.5 | 1.28 | 2.06 | 4 | 0.5 | 20 | — |
-| Ranged | 1 | T1 | T1 | 1 | 2 | 3 | 3 | 0.5 | 20 | — |
-| Melee | 4 | T2 | T3 | 3.5 | 5.75 | 8 | 1 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 12.5 | 19.25 | 26 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 0.5 | 1.33 | 2.15 | 4 | 0.5 | 20 | — |
+| Ranged | 1 | T1 | T1 | 1.5 | 2.75 | 4 | 2 | 0.5 | 20 | — |
+| Melee | 4 | T3 | T3 | 4.5 | 7.25 | 10 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 6.5 | 10.25 | 14 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 10.5 | 16.25 | 22 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
@@ -122,116 +125,116 @@ Effective HP bar: █░░░░░░░░░░░
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Melee | 1 | T1 | T1 | 0 | 0 | 0 | — | 1.5 | 7 | — |
 | Ranged | 1 | T1 | T1 | 0 | 0 | 0 | — | 1.5 | 7 | — |
-| Melee | 4 | T2 | T3 | 0 | 1.75 | 4 | — | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 5.5 | 10.75 | 16 | — | 0 | — | — |
-| Melee | 7 | T3 | T5 | 5.5 | 10.75 | 16 | — | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 8.5 | 15.25 | 22 | — | 0 | — | — |
+| Melee | 4 | T3 | T3 | 0.5 | 3.25 | 6 | — | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 2.5 | 6.25 | 10 | — | 0 | — | — |
+| Melee | 7 | T6 | T5 | 6.5 | 12.25 | 18 | — | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 5.5 | 10.75 | 16 | — | 0 | — | — |
 
 ### Scrap Mutt
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 1.5 | 2.28 | 3.06 | 2 | 0 | — | — |
-| Ranged | 1 | T1 | T1 | 2 | 3 | 4 | 2 | 0 | — | — |
-| Melee | 4 | T2 | T3 | 4.5 | 6.75 | 9 | 1 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 13.5 | 20.25 | 27 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 1.5 | 2.33 | 3.15 | 2 | 0 | — | — |
+| Ranged | 1 | T1 | T1 | 2.5 | 3.75 | 5 | 1 | 0 | — | — |
+| Melee | 4 | T3 | T3 | 5.5 | 8.25 | 11 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 7.5 | 11.25 | 15 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 11.5 | 17.25 | 23 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Rust Bandit
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 1.5 | 2.28 | 3.06 | 2 | 0 | — | — |
-| Ranged | 1 | T1 | T1 | 2 | 3 | 4 | 2 | 0 | — | — |
-| Melee | 4 | T2 | T3 | 4.5 | 6.75 | 9 | 1 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 13.5 | 20.25 | 27 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 1.5 | 2.33 | 3.15 | 2 | 0 | — | — |
+| Ranged | 1 | T1 | T1 | 2.5 | 3.75 | 5 | 2 | 0 | — | — |
+| Melee | 4 | T3 | T3 | 5.5 | 8.25 | 11 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 7.5 | 11.25 | 15 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 11.5 | 17.25 | 23 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Feral Nomad
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 1.5 | 2.28 | 3.06 | 2 | 0.5 | 20 | — |
-| Ranged | 1 | T1 | T1 | 2 | 3 | 4 | 2 | 0.5 | 20 | — |
-| Melee | 4 | T2 | T3 | 4.5 | 6.75 | 9 | 1 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 13.5 | 20.25 | 27 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 1.5 | 2.33 | 3.15 | 2 | 0.5 | 20 | — |
+| Ranged | 1 | T1 | T1 | 2.5 | 3.75 | 5 | 2 | 0.5 | 20 | — |
+| Melee | 4 | T3 | T3 | 5.5 | 8.25 | 11 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 7.5 | 11.25 | 15 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 11.5 | 17.25 | 23 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Waste Ghoul
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 1.5 | 2.28 | 3.06 | 3 | 0.5 | 20 | — |
-| Ranged | 1 | T1 | T1 | 2 | 3 | 4 | 2 | 0.5 | 20 | — |
-| Melee | 4 | T2 | T3 | 4.5 | 6.75 | 9 | 1 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 13.5 | 20.25 | 27 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 1.5 | 2.33 | 3.15 | 3 | 0.5 | 20 | — |
+| Ranged | 1 | T1 | T1 | 2.5 | 3.75 | 5 | 2 | 0.5 | 20 | — |
+| Melee | 4 | T3 | T3 | 5.5 | 8.25 | 11 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 7.5 | 11.25 | 15 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 11.5 | 17.25 | 23 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 10.5 | 15.75 | 21 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Iron Brute
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 0 | 0.28 | 1.06 | 15 | 1 | 10 | — |
-| Ranged | 1 | T1 | T1 | 0 | 1 | 2 | 8 | 1 | 10 | — |
-| Melee | 4 | T2 | T3 | 2.5 | 4.75 | 7 | 3 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 8.5 | 13.75 | 19 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 8.5 | 13.75 | 19 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 11.5 | 18.25 | 25 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 0 | 0.33 | 1.15 | 14 | 1 | 10 | — |
+| Ranged | 1 | T1 | T1 | 0.5 | 1.75 | 3 | 5 | 1 | 10 | — |
+| Melee | 4 | T3 | T3 | 3.5 | 6.25 | 9 | 2 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 5.5 | 9.25 | 13 | 2 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 9.5 | 15.25 | 21 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 8.5 | 13.75 | 19 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Grit Stalker
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 0.5 | 1.28 | 2.06 | 4 | 0.5 | 20 | — |
-| Ranged | 1 | T1 | T1 | 1 | 2 | 3 | 3 | 0.5 | 20 | — |
-| Melee | 4 | T2 | T3 | 3.5 | 5.75 | 8 | 1 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 12.5 | 19.25 | 26 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 0.5 | 1.33 | 2.15 | 4 | 0.5 | 20 | — |
+| Ranged | 1 | T1 | T1 | 1.5 | 2.75 | 4 | 2 | 0.5 | 20 | — |
+| Melee | 4 | T3 | T3 | 4.5 | 7.25 | 10 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 6.5 | 10.25 | 14 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 10.5 | 16.25 | 22 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Scrap Behemoth
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 0 | 0.28 | 1.06 | 29 | 1 | 10 | — |
-| Ranged | 1 | T1 | T1 | 0 | 1 | 2 | 15 | 1 | 10 | — |
-| Melee | 4 | T2 | T3 | 2.5 | 4.75 | 7 | 5 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 8.5 | 13.75 | 19 | 2 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 8.5 | 13.75 | 19 | 2 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 11.5 | 18.25 | 25 | 2 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 0 | 0.33 | 1.15 | 27 | 1 | 10 | — |
+| Ranged | 1 | T1 | T1 | 0.5 | 1.75 | 3 | 10 | 1 | 10 | — |
+| Melee | 4 | T3 | T3 | 3.5 | 6.25 | 9 | 4 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 5.5 | 9.25 | 13 | 3 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 9.5 | 15.25 | 21 | 2 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 8.5 | 13.75 | 19 | 2 | 0 | — | — |
 
 Effective HP bar: ██░░░░░░░░░░
 
 ### Dust Rat
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 0.5 | 1.28 | 2.06 | 3 | 0.5 | 20 | — |
-| Ranged | 1 | T1 | T1 | 1 | 2 | 3 | 2 | 0.5 | 20 | — |
-| Melee | 4 | T2 | T3 | 3.5 | 5.75 | 8 | 1 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 12.5 | 19.25 | 26 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 0.5 | 1.33 | 2.15 | 3 | 0.5 | 20 | — |
+| Ranged | 1 | T1 | T1 | 1.5 | 2.75 | 4 | 2 | 0.5 | 20 | — |
+| Melee | 4 | T3 | T3 | 4.5 | 7.25 | 10 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 6.5 | 10.25 | 14 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 10.5 | 16.25 | 22 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
 ### Gear Ghoul
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Melee | 1 | T1 | T1 | 0 | 0.28 | 1.06 | 8 | 1 | 10 | — |
-| Ranged | 1 | T1 | T1 | 0 | 1 | 2 | 4 | 1 | 10 | — |
-| Melee | 4 | T2 | T3 | 2.5 | 4.75 | 7 | 2 | 0 | — | — |
-| Ranged | 4 | T2 | T3 | 8.5 | 13.75 | 19 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 8.5 | 13.75 | 19 | 1 | 0 | — | — |
-| Ranged | 7 | T2 | T5 | 11.5 | 18.25 | 25 | 1 | 0 | — | — |
+| Melee | 1 | T1 | T1 | 0 | 0.33 | 1.15 | 7 | 1 | 10 | — |
+| Ranged | 1 | T1 | T1 | 0.5 | 1.75 | 3 | 3 | 1 | 10 | — |
+| Melee | 4 | T3 | T3 | 3.5 | 6.25 | 9 | 1 | 0 | — | — |
+| Ranged | 4 | T2 | T3 | 5.5 | 9.25 | 13 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 9.5 | 15.25 | 21 | 1 | 0 | — | — |
+| Ranged | 7 | T2 | T5 | 8.5 | 13.75 | 19 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
@@ -239,11 +242,11 @@ Effective HP bar: █░░░░░░░░░░░
 | Archetype | Level | Weapon Tier | Armor Tier | 0% | 50% | 100% | Atk to Kill | Enemy Dmg | Enemy Atk to Down | Counter |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Melee | 1 | T1 | T1 | 0 | 0 | 0 | Immune | 1.5 | 7 | Gear mismatch |
-| Ranged | 1 | T1 | T1 | 1 | 2 | 3 | 5 | 1.5 | 7 | — |
-| Melee | 4 | T2 | T3 | 0 | 0 | 0 | Immune | 0 | — | Gear mismatch |
-| Ranged | 4 | T2 | T3 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
-| Melee | 7 | T3 | T5 | 0 | 0 | 0 | Immune | 0 | — | Gear mismatch |
-| Ranged | 7 | T2 | T5 | 12.5 | 19.25 | 26 | 1 | 0 | — | — |
+| Ranged | 1 | T1 | T1 | 1.5 | 2.75 | 4 | 4 | 1.5 | 7 | — |
+| Melee | 4 | T3 | T3 | 0 | 0 | 0 | Immune | 0 | — | Gear mismatch |
+| Ranged | 4 | T2 | T3 | 6.5 | 10.25 | 14 | 1 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 0 | 0 | 0 | Immune | 0 | — | Gear mismatch |
+| Ranged | 7 | T2 | T5 | 9.5 | 14.75 | 20 | 1 | 0 | — | — |
 
 Effective HP bar: █░░░░░░░░░░░
 
@@ -252,9 +255,9 @@ Effective HP bar: █░░░░░░░░░░░
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Melee | 1 | T1 | T1 | 0 | 0 | 0 | Immune | 2.5 | 4 | Gear mismatch |
 | Ranged | 1 | T1 | T1 | 0 | 0 | 0 | Immune | 2.5 | 4 | Gear mismatch |
-| Melee | 4 | T2 | T3 | 0 | 0 | 0 | Immune | 0.5 | 80 | Gear mismatch |
+| Melee | 4 | T3 | T3 | 0 | 0 | 0 | Immune | 0.5 | 80 | Gear mismatch |
 | Ranged | 4 | T2 | T3 | 0 | 0 | 0 | Immune | 0.5 | 80 | Gear mismatch |
-| Melee | 7 | T3 | T5 | 8.5 | 13.75 | 19 | 2 | 0 | — | — |
+| Melee | 7 | T6 | T5 | 0 | 0 | 0 | Immune | 0 | — | Gear mismatch |
 | Ranged | 7 | T2 | T5 | 0 | 0 | 0 | Immune | 0 | — | Gear mismatch |
 
 Effective HP bar: ██░░░░░░░░░░
@@ -264,9 +267,9 @@ Effective HP bar: ██░░░░░░░░░░
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Melee | 1 | T1 | T1 | 0 | 0 | 0 | Immune | 3.5 | 3 | Gear mismatch |
 | Ranged | 1 | T1 | T1 | 0 | 0 | 0 | Immune | 3.5 | 3 | Gear mismatch |
-| Melee | 4 | T2 | T3 | 0 | 0 | 0 | Immune | 1.5 | 27 | Gear mismatch |
+| Melee | 4 | T3 | T3 | 0 | 0 | 0 | Immune | 1.5 | 27 | Gear mismatch |
 | Ranged | 4 | T2 | T3 | 0 | 0 | 0 | Immune | 1.5 | 27 | Gear mismatch |
-| Melee | 7 | T3 | T5 | 0 | 0 | 0 | Immune | 0 | — | Gear mismatch |
+| Melee | 7 | T6 | T5 | 0 | 0 | 0 | Immune | 0 | — | Gear mismatch |
 | Ranged | 7 | T2 | T5 | 0 | 0 | 0 | Immune | 0 | — | Gear mismatch |
 
 Effective HP bar: ██░░░░░░░░░░
@@ -276,9 +279,9 @@ Effective HP bar: ██░░░░░░░░░░
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Melee | 1 | T1 | T1 | 0 | 0 | 0 | Immune | 9.5 | 2 | Gear mismatch |
 | Ranged | 1 | T1 | T1 | 0 | 0 | 0 | Immune | 9.5 | 2 | Gear mismatch |
-| Melee | 4 | T2 | T3 | 0 | 0 | 0 | Immune | 7.5 | 6 | Gear mismatch |
+| Melee | 4 | T3 | T3 | 0 | 0 | 0 | Immune | 7.5 | 6 | Gear mismatch |
 | Ranged | 4 | T2 | T3 | 0 | 0 | 0 | Immune | 7.5 | 6 | Gear mismatch |
-| Melee | 7 | T3 | T5 | 4.5 | 9.75 | 15 | 11 | 5.5 | 13 | — |
+| Melee | 7 | T6 | T5 | 5.5 | 11.25 | 17 | 10 | 5.5 | 13 | — |
 | Ranged | 7 | T2 | T5 | 0 | 0 | 0 | Immune | 5.5 | 13 | Gear mismatch |
 
 Effective HP bar: ████████████

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -44,8 +44,8 @@ const DATA = `
       "name": "Pipe Rifle",
       "type": "weapon",
       "mods": {
-        "ATK": 2,
-        "ADR": 15
+        "ATK": 3,
+        "ADR": 18
       },
       "tags": [
         "ranged"
@@ -82,7 +82,7 @@ const DATA = `
       "type": "weapon",
       "mods": {
         "ATK": 1,
-        "ADR": 10
+        "ADR": 9
       }
     },
     {
@@ -93,8 +93,8 @@ const DATA = `
       "name": "Rebar Club",
       "type": "weapon",
       "mods": {
-        "ATK": 1,
-        "ADR": 10
+        "ATK": 2,
+        "ADR": 12
       }
     },
     {
@@ -283,8 +283,8 @@ const DATA = `
       "name": "Raider Knife",
       "type": "weapon",
       "mods": {
-        "ATK": 1,
-        "ADR": 10
+        "ATK": 3,
+        "ADR": 14
       }
     },
     {
@@ -296,7 +296,7 @@ const DATA = `
       "type": "weapon",
       "mods": {
         "ATK": 5,
-        "ADR": 20
+        "ADR": 22
       }
     },
     {
@@ -338,7 +338,8 @@ const DATA = `
       "type": "weapon",
       "rarity": "epic",
       "mods": {
-        "ATK": 5
+        "ATK": 6,
+        "ADR": 25
       },
       "value": 500
     },
@@ -437,8 +438,8 @@ const DATA = `
       "type": "weapon",
       "rarity": "epic",
       "mods": {
-        "ATK": 8,
-        "ADR": 45
+        "ATK": 5,
+        "ADR": 35
       },
       "tags": [
         "ranged",
@@ -499,8 +500,8 @@ const DATA = `
       "name": "Thornlash Whip",
       "type": "weapon",
       "mods": {
-        "ATK": 1,
-        "ADR": 12
+        "ATK": 3,
+        "ADR": 18
       }
     },
     {
@@ -518,7 +519,7 @@ const DATA = `
       "name": "Patchwork Plate",
       "type": "armor",
       "mods": {
-        "DEF": 1,
+        "DEF": 3,
         "HP": 2
       }
     },
@@ -527,8 +528,8 @@ const DATA = `
       "name": "Corroded Hatchet",
       "type": "weapon",
       "mods": {
-        "ATK": 2,
-        "ADR": 9
+        "ATK": 4,
+        "ADR": 16
       }
     },
     {

--- a/scripts/supporting/balance-report.cjs
+++ b/scripts/supporting/balance-report.cjs
@@ -524,11 +524,12 @@ function buildReport(data) {
   lines.push('## Weapon Tiers');
   for (const [type, info] of Object.entries(weaponsByType)) {
     lines.push(`### ${type === 'ranged' ? 'Ranged' : 'Melee'} Weapons`);
-    const headers = ['Tier', 'Items', 'Avg ATK', 'Avg ADR', 'Avg Adr Gain', 'Adr Dmg Mod', 'Notable Tags'];
+    const headers = ['Tier', 'Items', 'Avg ATK', 'Avg ADR', 'Avg ADR Gain', 'ADR Dmg Mod', 'Notable Tags'];
     const rows = info.groups.map(group => {
       const avgAtk = formatNumber(group.avgMods.ATK || 0, 2);
       const avgAdr = formatNumber(group.avgMods.ADR || 10, 2);
-      const adrGain = formatNumber(((group.avgMods.ADR ?? 10) / 4), 2);
+      const adrGainValue = ((group.avgMods.ADR ?? 10) / 4) * (group.avgMods.adrenaline_gen_mod || 1);
+      const adrGain = formatNumber(adrGainValue, 2);
       const dmgMod = formatNumber(group.avgMods.adrenaline_dmg_mod || 1, 2);
       const tags = group.tags.length ? group.tags.join(', ') : '—';
       return [group.key, `${group.count}`, avgAtk, avgAdr, adrGain, dmgMod, tags];
@@ -539,7 +540,7 @@ function buildReport(data) {
 
   lines.push('## Armor Tiers');
   if (armorTiers.groups.length) {
-    const headers = ['Tier', 'Items', 'Avg DEF', 'Adr Gen Mod', 'Adr Dmg Mod'];
+    const headers = ['Tier', 'Items', 'Avg DEF', 'ADR Gen Mod', 'ADR Dmg Mod'];
     const rows = armorTiers.groups.map(group => {
       const avgDef = formatNumber(group.avgMods.DEF || 0, 2);
       const genMod = formatNumber(group.avgMods.adrenaline_gen_mod || 1, 2);


### PR DESCRIPTION
## Summary
- retune Dustland melee and ranged weapon stats plus armor plate values to create steady attack and defense tier steps
- sync the module JSON definition with the updated stats for editor and tooling consumers
- regenerate the Dustland balance report so weapon, armor, and benchmark tables reflect the smoother progression

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js


------
https://chatgpt.com/codex/tasks/task_e_68cddca025ec83288f8c39c17f857536