### PR TITLE
feat: refresh CRT sidebar layout

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -80,6 +80,73 @@ input[type="range"] {
         image-rendering: pixelated;
     }
 
+    .panel__header {
+        padding: 12px;
+        background: linear-gradient(180deg, #121612 0%, #0d100d 100%);
+        border-bottom: 1px solid #1a1f1a;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .panel__subtitle {
+        margin: 0;
+        font-size: 0.75rem;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--muted);
+    }
+
+    .panel__body {
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        overflow-y: auto;
+        flex: 1;
+    }
+
+    .panel-section {
+        border: 1px solid #1f261f;
+        border-radius: 12px;
+        background: linear-gradient(180deg, rgba(18, 22, 18, 0.9) 0%, rgba(11, 13, 11, 0.95) 100%);
+        box-shadow: inset 0 0 0 1px rgba(40, 50, 40, 0.2);
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .panel-section__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+    }
+
+    .panel-section__title {
+        margin: 0;
+        font-size: 0.875rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .panel-section__meta {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .panel-section__content {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .panel-section__content--flush {
+        gap: 8px;
+    }
+
     #panelToggle {
         position: fixed;
         top: 50%;
@@ -98,12 +165,9 @@ input[type="range"] {
     .panel h1 {
         font-size: 1.125rem;
         margin: 0;
-        padding: 10px 12px;
-        background: #0f120f;
-        border-bottom: 1px solid #1a1f1a;
         color: #c7ff9e;
         font-weight: 800;
-        letter-spacing: .6px;
+        letter-spacing: 0.1em;
     }
 
     .panel .content {
@@ -120,8 +184,77 @@ input[type="range"] {
 
     .weather-banner {
         text-align: center;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        padding: 2px 10px;
+        border-radius: 999px;
+        border: 1px solid #283228;
+        background: #121612;
+        color: var(--accent);
+        margin-bottom: 4px;
+        white-space: nowrap;
+    }
+
+    .panel-section__meta .weather-banner {
+        margin-bottom: 0;
+    }
+
+    .panel-section--log #log {
+        background: rgba(5, 6, 5, 0.9);
+        border: 1px solid #1d221d;
+        border-radius: 10px;
+        padding: 10px;
+        min-height: 160px;
+        max-height: 220px;
+        overflow-y: auto;
         font-size: 0.8125rem;
-        margin-bottom: 4px
+        line-height: 1.4;
+        box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.4);
+    }
+
+    .panel-section--log .panel-section__content {
+        gap: 0;
+    }
+
+    .control-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 8px;
+    }
+
+    .control-grid__item {
+        background: rgba(12, 15, 12, 0.75);
+        border: 1px solid #1f281f;
+        border-radius: 8px;
+        padding: 8px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .control-grid__keys {
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        color: var(--accent);
+        text-transform: uppercase;
+        font-size: 0.75rem;
+    }
+
+    .control-grid__desc {
+        font-size: 0.75rem;
+        color: var(--muted);
+    }
+
+    .button-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 8px;
+    }
+
+    .button-grid .btn {
+        width: 100%;
+        margin: 0;
     }
 
     .badge {

--- a/dustland.html
+++ b/dustland.html
@@ -19,49 +19,100 @@
       </div>
     </div>
     <aside class="panel">
-      <h1 id="title">DUSTLAND // CRT</h1>
-      <div class="content" id="log"></div>
-      <div class="content">
-        <div class="hud">
-          <div id="weatherBanner" class="weather-banner" hidden></div>
-          <div class="badge">
-            <div class="label">HP <span id="hp">10</span><span id="hydrationMeter" class="hydration" hidden></span></div>
-            <div class="hudbar" id="hpBar" role="progressbar" aria-label="Health" aria-valuemin="0" aria-valuemax="10" aria-valuenow="10">
-              <div class="ghost" id="hpGhost"></div>
-              <div class="fill" id="hpFill"></div>
+      <header class="panel__header">
+        <h1 id="title">DUSTLAND // CRT</h1>
+        <p class="panel__subtitle">Expedition Console</p>
+      </header>
+      <div class="panel__body">
+        <section class="panel-section panel-section--log">
+          <header class="panel-section__header">
+            <h2 class="panel-section__title">Signal Log</h2>
+          </header>
+          <div class="panel-section__content">
+            <div id="log"></div>
+          </div>
+        </section>
+        <section class="panel-section panel-section--status">
+          <header class="panel-section__header">
+            <h2 class="panel-section__title">Vitals</h2>
+            <div class="panel-section__meta">
+              <div id="weatherBanner" class="weather-banner" hidden></div>
             </div>
-            <div class="status-row" id="statusIcons"></div>
+          </header>
+          <div class="panel-section__content">
+            <div class="hud">
+              <div class="badge">
+                <div class="label">HP <span id="hp">10</span><span id="hydrationMeter" class="hydration" hidden></span></div>
+                <div class="hudbar" id="hpBar" role="progressbar" aria-label="Health" aria-valuemin="0" aria-valuemax="10" aria-valuenow="10">
+                  <div class="ghost" id="hpGhost"></div>
+                  <div class="fill" id="hpFill"></div>
+                </div>
+                <div class="status-row" id="statusIcons"></div>
+              </div>
+              <div class="badge">
+                <div class="label">Adrenaline</div>
+                <div class="hudbar adr" id="adrBar" role="progressbar" aria-label="Adrenaline" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="fill" id="adrFill"></div></div>
+              </div>
+              <div class="badge">Scrap: <span id="scrap">0</span></div>
+              <div class="badge">Map: <span id="mapname">—</span></div>
+            </div>
           </div>
-          <div class="badge">
-            <div class="label">Adrenaline</div>
-            <div class="hudbar adr" id="adrBar" role="progressbar" aria-label="Adrenaline" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="fill" id="adrFill"></div></div>
+        </section>
+        <section class="panel-section panel-section--controls">
+          <header class="panel-section__header">
+            <h2 class="panel-section__title">Controls</h2>
+          </header>
+          <div class="panel-section__content">
+            <div class="control-grid">
+              <div class="control-grid__item"><span class="control-grid__keys">WASD / Arrows</span><span class="control-grid__desc">Move</span></div>
+              <div class="control-grid__item"><span class="control-grid__keys">E / Space</span><span class="control-grid__desc">Interact, doors, take nearby</span></div>
+              <div class="control-grid__item"><span class="control-grid__keys">T / G</span><span class="control-grid__desc">Take item</span></div>
+              <div class="control-grid__item"><span class="control-grid__keys">I</span><span class="control-grid__desc">Inventory</span></div>
+              <div class="control-grid__item"><span class="control-grid__keys">P</span><span class="control-grid__desc">Party</span></div>
+              <div class="control-grid__item"><span class="control-grid__keys">Q</span><span class="control-grid__desc">Quests</span></div>
+              <div class="control-grid__item"><span class="control-grid__keys">O</span><span class="control-grid__desc">Audio</span></div>
+              <div class="control-grid__item"><span class="control-grid__keys">C</span><span class="control-grid__desc">Mobile controls</span></div>
+              <div class="control-grid__item"><span class="control-grid__keys">M</span><span class="control-grid__desc">Minimap</span></div>
+              <div class="control-grid__item"><span class="control-grid__keys">Esc</span><span class="control-grid__desc">Close menus</span></div>
+            </div>
           </div>
-          <div class="badge">Scrap: <span id="scrap">0</span></div>
-          <div class="badge">Map: <span id="mapname">—</span></div>
-        </div>
-        <p class="muted" style="margin-top:10px">Controls: <b>WASD/Arrows</b> move • <b>E/Space</b> interact/door & take nearby item • <b>T/G</b> take item • <b>I</b> Inventory • <b>P</b> Party • <b>Q</b> Quests • <b>O</b> audio • <b>C</b> mobile controls • <b>M</b> minimap • <b>Esc</b> close</p>
-        <div class="tabs" role="tablist">
-          <div class="tab active" id="tabInv" role="tab" tabindex="0" aria-label="Inventory" aria-selected="true">Inventory</div>
-          <div class="tab" id="tabParty" role="tab" tabindex="0" aria-label="Party" aria-selected="false">Party</div>
-          <div class="tab" id="tabQuests" role="tab" tabindex="0" aria-label="Quests" aria-selected="false">Quests</div>
-        </div>
-        <div class="tabwrap" id="tabWrap">
-          <div id="inv"></div>
-          <div id="party" style="display:none"></div>
-          <div id="quests" style="display:none"></div>
-        </div>
-        <div style="margin-top:8px" id="mainButtons">
-          <button class="btn" id="saveBtn">Save</button>
-          <button class="btn" id="loadBtn">Load</button>
-          <button class="btn" id="clearBtn">Clear Save</button>
-          <button class="btn" id="resetBtn">Reset</button>
-          <button class="btn" id="settingsBtn">Settings</button>
-          <button class="btn" id="debugBtn">Debug</button>
-          <button class="btn" id="campBtn">Camp</button>
-          <button class="btn" id="screenshotBtn" hidden>Screenshot</button>
-        </div>
-        </div>
-      </aside>
+        </section>
+        <section class="panel-section panel-section--tabs">
+          <header class="panel-section__header">
+            <h2 class="panel-section__title">Crew & Tasks</h2>
+          </header>
+          <div class="panel-section__content panel-section__content--flush">
+            <div class="tabs" role="tablist">
+              <div class="tab active" id="tabInv" role="tab" tabindex="0" aria-label="Inventory" aria-selected="true">Inventory</div>
+              <div class="tab" id="tabParty" role="tab" tabindex="0" aria-label="Party" aria-selected="false">Party</div>
+              <div class="tab" id="tabQuests" role="tab" tabindex="0" aria-label="Quests" aria-selected="false">Quests</div>
+            </div>
+            <div class="tabwrap" id="tabWrap">
+              <div id="inv"></div>
+              <div id="party" style="display:none"></div>
+              <div id="quests" style="display:none"></div>
+            </div>
+          </div>
+        </section>
+        <section class="panel-section panel-section--actions">
+          <header class="panel-section__header">
+            <h2 class="panel-section__title">Systems</h2>
+          </header>
+          <div class="panel-section__content">
+            <div id="mainButtons" class="button-grid">
+              <button class="btn" id="saveBtn">Save</button>
+              <button class="btn" id="loadBtn">Load</button>
+              <button class="btn" id="clearBtn">Clear Save</button>
+              <button class="btn" id="resetBtn">Reset</button>
+              <button class="btn" id="settingsBtn">Settings</button>
+              <button class="btn" id="debugBtn">Debug</button>
+              <button class="btn" id="campBtn">Camp</button>
+              <button class="btn" id="screenshotBtn" hidden>Screenshot</button>
+            </div>
+          </div>
+        </section>
+      </div>
+    </aside>
     </div>
 
   <div id="panelToggle">☰</div>


### PR DESCRIPTION
## Summary
- reorganize the CRT sidebar into named sections for the log, vitals, controls, tabs, and system actions
- refresh the sidebar visuals with a retro header treatment, weather badge, control grid, and responsive button layout for consistency

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cdfeadf768832898dcb83098f86f81