### PR TITLE
docs: add dustland expedition narrative and plot bible

### DIFF
--- a/docs/world/dustland-expedition-plot-bible.md
+++ b/docs/world/dustland-expedition-plot-bible.md
@@ -1,0 +1,120 @@
+# Dustland Expedition Narrative & Plot Bible
+
+## Narrative: "Dawn Over the Relay"
+Three figures stood on the precipice of the only world they had ever known, backs to the barricaded Hall and faces to a dust-swept horizon.
+
+Nora tightened the cracked leather strap across her rebar club and breathed through the copper tang of the storm. She heard the static of a dozen dead broadcasts in every gust. The Archivist had taught her to read the hum of signals, but the Hall's walls had kept her from ever chasing them. "Out there's where the rest of the song is," she murmured, thinking of the lullabies her sister used to sing before the storms took her.
+
+"Song or no song, I'm freezing," Tess said, rolling her shoulders so the tattered leather jacket settled into place. She flashed the grin that had carried her through a lifetime of scav-run bluffs. "We walk, we keep warm. Besides, Kesh already barred the door. We're committed." She tapped the Glinting Key at her belt—the Hall's last gift—and nodded toward the gate.
+
+Grin hefted his crowbar with a grunt. The tool was scarred from years of prying salvage loose for other people, for other dreams. "Archivist pays in rations and radios if we bring him that Sun Charm. That's more than I ever got swinging for the Duchess," he said. His voice was gravel, but the promise of a future beyond hired muscle set a quiet fire in his eyes. "Let's move before the dust gets thicker."
+
+The Hall door clanged shut behind them, sealing the life they knew. The wind outside tasted of rust and old rain, and the first thing they saw was a worn sign half-buried in dune grit. Rust storms east. Shelter west. Far northeast, a relay waits for the Sun Charm—Archivist sends seekers there for a blade of legend. The words etched a map straight into their bones.
+
+### Roads of Relics
+Days bled together as they trekked north along the broken road. Every mile carried the scent of ozone and hot metal, every night the hiss of sand against their shelter tarps. Their first encounter was a water runner—another Tess—who saluted with a canteen. "Stay close to the wells if the sky turns green," she warned. Nora traded radio tips for fresh water, grounding the group in camaraderie instead of paranoia.
+
+At a junkyard choke point, a Scrap Mutt lunged. Tess rolled beneath its jaws, flipping the Stun Gear Harness she'd scavenged around its neck. "Down, cur!" she barked. A crackle of electricity stunned the beast long enough for Grin's crowbar to knock it senseless. Nora laughed breathlessly. "Archivist said the harness would matter. Guess the old man knows things." That shared victory welded the trio together.
+
+Their path was a scavenger's litany. They recovered Postmaster Ivo's lost satchel from a collapsed courier tower. "That's Ivo's bag all right," Grin said, running fingers over the stitched initials. "Always said he'd pay double for loyalty." They siphoned a Valve from a derelict refinery, delivering it to Nila the Pump-Keeper. "Bless the grit you walk on," Nila told them, pressing a sack of fresh radish chips into Tess's hands. Every trade proved they were more than errand runners—they were mending the Dustland's frayed seams.
+
+Cass the Trader's stall glowed with lantern light when they reached the market crossroads. "Scrap for supplies?" Cass asked. Tess leaned across the table. "And stories," she added, recounting the mutt fight. Cass's booming laugh earned them an extra clip of pipe rifle ammo. Later, they huddled beneath a skeletal radio tower while Rella cursed the fried console. "Toolkit and brains, remember?" Nora said, sliding in beside her. The two women rewired the panel until a weak signal crackled through. "That's the Archivist's ping," Nora whispered, the sound lighting up her nerves.
+
+### Descent into Echoes
+The desert finally yielded to a ruin scarred by lightning strikes: the Echoes Atrium. A vortex of swirling dust churned at its heart, the air cold and sour. "Smells like wet copper," Grin muttered, nostrils flaring. Tess shivered as static raised goosebumps along her arms. "This place remembers storms," she said.
+
+Inside, arc lights flickered over murals of sunbursts and circuitry. A Sparking Crate spat blue arcs until Nora calmed it with a gentle touch and pulled free the Spark Key. "Easy, friend," she cooed, treating the machinery like a feral animal. Deeper in the complex, a Gear Ghoul clanked forward, gears grinding like distant thunder. "Stay behind me," Grin ordered. He met the machine head-on, crowbar wedging into a knee joint while Tess sliced wiring bundles. Nora slammed the Cog Key into a control panel and cut power, dropping the guardian with a groan of failing hydraulics.
+
+Beyond the archive door, an amber glow bathed the Sun Charm resting on its pedestal. Nora lifted it reverently. The medallion hummed with layered voices, a choir of lost broadcasts. She pressed it to her chest, and for a moment the voices aligned into a lullaby she hadn't heard since childhood. Tears pricked her eyes. "For you, Mara," she whispered to the sister whose last lullaby had been swallowed by static.
+
+### The Relay and the Sovereign
+Their final approach to the relay felt like climbing the spine of a fallen titan. The arena walls were ribbed with rusted support beams, and every footstep echoed with ghostly howls. Siltpack Raveners stalked the outer ring, their hides glittering with mica dust. Tess sprinted ahead, drawing them into the open while Grin provided cover fire with the pipe rifle. "Keep moving!" he shouted over the roar of the wind. Nora set the Sun Charm against her palm, sending pulses of light that disoriented the pack. The beasts fled, blinded by sunfire.
+
+Higher still, Grinder Matriarchs rained shrapnel from their perches. Tess rolled through the shards, laughing wildly. "You call that tribute?" she shouted, hurling flash charges. Grin used his crowbar as a shield, sparks spraying with every impact. Nora's voice cut through the chaos as she tuned the Charm. "Harmonics at twenty-three megahertz—now!" Tess and Grin struck in sync, silencing the shriekers.
+
+At the altar, the Echo Relay awaited—a cracked lattice etched with schematics. Nora fit the Sun Charm into its cradle. The device roared to life, flooding the arena with golden light and a broadcast older than the Dustland itself. The melody carried scents of petrichor and fresh-cut wheat, sounds of laughter layered with the chime of windbells. For a heartbeat, the Dustland remembered rain.
+
+Then the Sovereign of Dust descended. It was a storm given form: tendrils of grit orbiting a core of molten glass, eyes blazing with indigo fire. The air tasted of ozone and bitterness. "Remember the Archivist's note," Grin said, voice steady. "Sun Charm weakens the shell; blade finishes the heart."
+
+Tess clipped the Stun Gear Harness across her chest, arcs of electricity dancing along her arms. "I'll draw its fury," she said. She darted forward, baiting the Sovereign into unleashing a cyclone of shards. Lightning leapt from her harness, wrapping the storm in crackling chains. "Now, Nora!"
+
+Nora raised the Sun Charm, channeling the broadcast into a focused beam. The song became a piercing note that shattered the Sovereign's outer shroud. "For Mara, for the Hall!" she cried. Cracks spiderwebbed across the creature's core.
+
+Grin charged through the falling dust, crowbar knocking aside debris until he reached the altar. There, resting in the newborn sunlight, lay the Artifact Blade—its edge forged from reclaimed satellite panels, its hilt wrapped in synth-leather. Grin seized it and drove the blade into the Sovereign's exposed heart. The creature howled, its voice a thousand storm sirens, then imploded into a cascade of glittering sand.
+
+The broadcast stabilized, projecting a map of clean water basins and dormant power grids across the arena wall. Nora sagged with relief. Tess whooped, spinning beneath the rain of dust. Grin planted the blade tip-first in the stone, head bowed. "We did it," he said softly. "No more swinging for hire."
+
+### Resolution
+When the wind settled, they gathered the Artifact Blade, the stabilized Sun Charm, and schematics from the relay. "Archivist is going to lose his mind," Tess said, wiping grit from her cheeks.
+
+They descended the arena with new purpose. At the crossroads, they returned Ivo's satchel, earning gratitude and a promise to rebuild the courier routes. Nila's pump roared back to life, filling basins with clear water. Cass the Trader hosted a feast lit by newly powered streetlamps, playing the recovered broadcast through salvaged speakers. The Dustland's night sky shimmered with possibilities.
+
+Back at the Hall, Caretaker Kesh opened the gates to welcome them home. The Archivist wept openly as the Sun Charm's song filled the memory reels. "You brought dawn to the Dustland," he said.
+
+Nora set up a radio array atop the Hall, determined to map every echo the Charm revealed. Tess organized scav runs to the newly charted basins, no longer content with drifting alone. Grin, Artifact Blade at his side, trained volunteers to defend the caravans. They were no longer survivors reacting to the Dustland—they were architects of its future.
+
+---
+
+## Plot Bible
+
+### Core Premise
+- **Hook:** Archivist dispatches Nora, Tess, and Grin to align the Sun Charm with the Echo Relay to unlock a lost broadcast and the Artifact Blade capable of defeating the Sovereign of Dust.
+- **Promise:** A journey from the safety of the Hall through the Dustland's settlements, ruins, and arena, culminating in a showdown that reshapes the region's future.
+
+### Setting & Atmosphere
+- **Hall:** Claustrophobic refuge of rusted walls and humming reels; leaving feels like stepping from a tomb into a storm.
+- **World Map:** Sand-scoured highways, scav markets lit by lanterns, and side quests that reveal the community's interdependence.
+- **Echoes Chain:** Technological catacombs humming with static; key-gated progression reinforces escalating stakes.
+- **Arena/Relay:** Vertical ruin haunted by howler packs; golden broadcast light provides contrast to the oppressive dust.
+
+### Player Journey Beats
+1. **Departure:** Convince Caretaker Kesh, receive Glinting Key, heed Worn Sign's warning.
+2. **Road Quests:** Aid Postmaster Ivo, Nila, and Cass; recruit Grin; collect Sun Charm hints from Rella, Hidden Hermit, and Signal Tech.
+3. **Echoes Keys:** Secure Spark and Cog Keys, defeat Gear Ghoul, recover Sun Charm.
+4. **Relay Assault:** Use Stun Gear Harness against howler packs, slot Sun Charm into relay, battle Sovereign of Dust.
+5. **Resolution:** Restore broadcast, claim Artifact Blade, return hope (and new infrastructure plans) to the Hall and its neighbors.
+
+### Protagonists
+- **Nora (Storm Caller):** Radio engineer motivated by the memory of her sister and the dream of restoring the world's song; wields rebar club and Sun Charm harmonics.
+- **Tess (Venom Rogue/Water Runner):** Drifter seeking belonging and a community worth defending; agile fighter leveraging the Stun Gear Harness and scav cunning.
+- **Grin (Scav-for-Hire):** Former mercenary tired of serving tyrants; finds purpose as protector wielding crowbar and Artifact Blade.
+
+### Key Allies & NPCs
+- **Archivist:** Quest giver, provides Sun Charm lore and broadcast schematics.
+- **Postmaster Ivo, Nila the Pump-Keeper, Cass the Trader:** Side quest anchors who showcase Dustland's interlinked needs and reward support with tangible upgrades.
+- **Rella & Signal Tech:** Relay foreshadowing; escalate knowledge without redundant exposition.
+- **Hidden Hermit & Shifting Hermit:** Spiritual guides pointing toward Idol lore and arena secrets.
+
+### Antagonists & Threats
+- **Scrap Duchess & Road Raider:** Social and physical obstacles along the main road.
+- **Gear Ghoul & Arena Packs:** Mechanical and feral guardians requiring varied tactics (stun gear, harmonics, teamwork).
+- **Sovereign of Dust:** Climactic boss weakened by Sun Charm resonance and finished with Artifact Blade.
+
+### Signature Artifacts
+- **Sun Charm:** Resonates with broadcasts; functions as puzzle key, narrative symbol, and combat utility.
+- **Stun Gear Harness:** Tactical tool against howler-type enemies; foreshadowed by Hidden Hermit advice.
+- **Artifact Blade:** Post-battle reward that empowers Grin and future missions.
+
+### Themes & Motifs
+- Reclaiming lost technology to rebuild community.
+- Found family forged through shared battles.
+- Songs, broadcasts, and storms as sensory throughlines.
+- Dustland as both adversary and archive of memories.
+
+### Future Hooks & Improvements
+- **Post-Quest States:** Update NPC dialogues (Nila, Ivo, Hermits) to reflect restored water, courier routes, and awakened relay.
+- **Training Integration:** Tie Rusty, Brakk, and Mira lessons to upcoming threats (e.g., warnings about Sovereign resistances).
+- **Expanded Broadcast Quests:** Use the relay's map output to seed new expeditions to water basins and power grids.
+- **Character Epilogues:** Track Nora's radio network, Tess's caravan guild, and Grin's defender corps in subsequent modules.
+
+### Sensory Palette Reference
+- **Scent:** Ozone before storms, coppery dust in ruins, petrichor from restored relay.
+- **Sound:** Static hums, howler choruses, relay's dawn melody, laughter in revived markets.
+- **Touch:** Sandblasted wind, vibration of the Sun Charm, electric snap of the harness, weight of Artifact Blade.
+
+### Narrative Tone Targets
+- **Early Acts:** Determined, hopeful tension; discovery-driven dialogue.
+- **Echoes Segment:** Awe mixed with dread; whispers of forgotten tech.
+- **Finale:** Triumphant, kinetic action punctuated by moments of vulnerability.
+- **Epilogue:** Warm resilience; celebration tempered with plans for rebuilding.
+


### PR DESCRIPTION
## Summary
- add a polished "Dawn Over the Relay" short story that follows Nora, Tess, and Grin through the Dustland expedition
- capture the Dustland plot bible with core beats, characters, artifacts, themes, and future hooks for follow-up content

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68cdc684c3c483289902614e06fefd04