### PR TITLE
feat: add compass and dynamic quest guidance

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -418,11 +418,64 @@ input[type="range"] {
         border: 1px solid #273027;
         border-radius: 8px;
         background: #0f120f;
-        padding: 8px
+        padding: 8px;
+        display: flex;
+        gap: 8px;
+        align-items: flex-start
     }
 
     .q .status {
         color: #9ab09a
+    }
+
+    .quest-info {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        flex: 1 1 auto
+    }
+
+    .quest-header {
+        display: flex;
+        align-items: baseline;
+        gap: 8px
+    }
+
+    .quest-title {
+        font-weight: bold
+    }
+
+    .quest-progress {
+        color: #8bd98d;
+        font-size: .75rem
+    }
+
+    .quest-desc {
+        color: #c7e0c7
+    }
+
+    .quest-target {
+        color: #7fbf7f;
+        font-size: .75rem
+    }
+
+    .quest-compass {
+        flex: 0 0 48px;
+        width: 48px;
+        height: 48px;
+        background: #050805;
+        border: 2px solid #1c2b1c;
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        image-rendering: pixelated
+    }
+
+    .quest-compass canvas {
+        width: 44px;
+        height: 44px;
+        image-rendering: pixelated
     }
 
     @media (min-width: 1600px) {

--- a/scripts/core/quests.js
+++ b/scripts/core/quests.js
@@ -18,8 +18,10 @@
  * @property {string|GameItem} [reward]
  * @property {number} [xp]
  * @property {{x:number,y:number}} [moveTo]
+ * @property {{map:string,x:number,y:number,name?:string,id?:string}[]} [givers]
+ * @property {{map:string,x:number,y:number}} [itemLocation]
  * @property {string} [outcome]
- * @property {Quest[]} [quests]
+  * @property {Quest[]} [quests]
  */
 
 class Quest {
@@ -35,7 +37,12 @@ class Quest {
     this.desc = desc;
     this.status = 'available';
     this.pinned = meta.pinned || false;
+    this.givers = Array.isArray(meta.givers) ? meta.givers.map(g => ({ ...g })) : [];
+    this.itemLocation = meta.itemLocation ? { ...meta.itemLocation } : null;
     Object.assign(this, meta);
+    if (!Array.isArray(this.givers)) this.givers = this.givers ? [{ ...this.givers }] : [];
+    if (this.itemLocation) this.itemLocation = { ...this.itemLocation };
+    if (typeof this.progress !== 'number') this.progress = 0;
   }
   complete(outcome) {
     if (this.status !== 'completed') {

--- a/test/quest-progress.test.js
+++ b/test/quest-progress.test.js
@@ -4,24 +4,92 @@ import { JSDOM } from 'jsdom';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
 
-async function loadRender(ctx){
+async function loadRender(ctx) {
   const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
   const start = full.indexOf('function renderQuests');
   const end = full.indexOf('function renderParty');
   vm.runInContext(full.slice(start, end), ctx);
 }
 
-test('quest indicator shows item count', async () => {
+function installCanvasStub(dom) {
+  dom.window.HTMLCanvasElement.prototype.getContext = () => ({
+    clearRect() {},
+    fillRect() {},
+    strokeRect() {},
+    beginPath() {},
+    arc() {},
+    stroke() {},
+    moveTo() {},
+    lineTo() {},
+    closePath() {},
+    fill() {},
+    save() {},
+    restore() {},
+    translate() {},
+    rotate() {},
+    set lineWidth(_) {},
+    set strokeStyle(_) {},
+    set fillStyle(_) {}
+  });
+}
+
+test('quest progress combines turned-in and carried items', async () => {
   const dom = new JSDOM('<div id="quests"></div>');
+  installCanvasStub(dom);
   const ctx = {
     window: dom.window,
     document: dom.window.document,
-    quests: { q1: { id: 'q1', title: 'Collect Stuff', desc: '', status: 'active', item: 'frag', count: 3 } },
-    countItems: () => 2
+    quests: {
+      q1: {
+        id: 'q1',
+        title: 'Collect Stuff',
+        desc: '',
+        status: 'active',
+        item: 'frag',
+        count: 3,
+        progress: 1
+      }
+    },
+    countItems: () => 1,
+    itemDrops: [],
+    ITEMS: { frag: { id: 'frag', name: 'Fragment', tags: [] } },
+    party: { x: 0, y: 0, map: 'world' },
+    state: { map: 'world' }
   };
   vm.createContext(ctx);
   await loadRender(ctx);
   ctx.renderQuests();
-  const text = dom.window.document.querySelector('.q b').textContent;
-  assert.equal(text, 'Collect Stuff (2/3)');
+  const progress = dom.window.document.querySelector('.quest-progress').textContent;
+  assert.equal(progress, '2/3');
+});
+
+test('quest description changes when objective ready to turn in', async () => {
+  const dom = new JSDOM('<div id="quests"></div>');
+  installCanvasStub(dom);
+  const quest = {
+    id: 'q_valve',
+    title: 'Water for the Pump',
+    desc: 'Find the Valve.',
+    status: 'active',
+    item: 'valve',
+    count: 1,
+    givers: [{ id: 'pump', name: 'Nila the Pump-Keeper', map: 'world', x: 10, y: 10 }]
+  };
+  const ctx = {
+    window: dom.window,
+    document: dom.window.document,
+    quests: { q_valve: quest },
+    countItems: () => 1,
+    itemDrops: [],
+    ITEMS: { valve: { id: 'valve', name: 'Valve', tags: [] } },
+    party: { x: 0, y: 0, map: 'world' },
+    state: { map: 'world' }
+  };
+  vm.createContext(ctx);
+  await loadRender(ctx);
+  ctx.renderQuests();
+  const desc = dom.window.document.querySelector('.quest-desc').textContent;
+  assert.equal(desc, 'Return the Valve to Nila the Pump-Keeper.');
+  const target = dom.window.document.querySelector('.quest-target').textContent;
+  assert.equal(target, 'Return to Nila the Pump-Keeper');
 });


### PR DESCRIPTION
## Summary
- add a pixel-art compass and richer layout to the quest panel, pointing players toward objectives
- enrich quest metadata with quest giver and item location details to support the new guidance
- update quest rendering logic and its unit tests to cover progress aggregation and turn-in messaging

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/balance-tester-agent.js (fails: ReferenceError: SpoilsCache is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68cdffc3ea6c83289694f8d266008a70