### PR TITLE
fix: collapse controls panel

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -124,6 +124,28 @@ input[type="range"] {
         gap: 12px;
     }
 
+    .panel-section__toggle {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        padding: 4px 10px;
+        background: #101410;
+        color: var(--ink);
+    }
+
+    .panel-section__toggle:hover,
+    .panel-section__toggle:focus-visible {
+        background: #121812;
+        outline: none;
+    }
+
+    .panel-section__toggle-icon {
+        transition: transform 0.2s ease;
+    }
+
     .panel-section__title {
         margin: 0;
         font-size: 0.875rem;
@@ -145,6 +167,18 @@ input[type="range"] {
 
     .panel-section__content--flush {
         gap: 8px;
+    }
+
+    .panel-section--collapsed {
+        gap: 8px;
+    }
+
+    .panel-section--collapsed .panel-section__content {
+        display: none;
+    }
+
+    .panel-section--collapsed .panel-section__toggle-icon {
+        transform: rotate(180deg);
     }
 
     #panelToggle {

--- a/dustland.html
+++ b/dustland.html
@@ -61,8 +61,12 @@
         <section class="panel-section panel-section--controls">
           <header class="panel-section__header">
             <h2 class="panel-section__title">Controls</h2>
+            <button class="pill panel-section__toggle" type="button" id="controlsToggle" aria-expanded="true" aria-controls="controlsContent">
+              <span class="panel-section__toggle-icon" aria-hidden="true">▾</span>
+              <span class="panel-section__toggle-text">Hide</span>
+            </button>
           </header>
-          <div class="panel-section__content">
+          <div class="panel-section__content" id="controlsContent">
             <div class="control-grid">
               <div class="control-grid__item"><span class="control-grid__keys">WASD / Arrows</span><span class="control-grid__desc">Move</span></div>
               <div class="control-grid__item"><span class="control-grid__keys">E / Space</span><span class="control-grid__desc">Interact, doors, take nearby</span></div>
@@ -376,6 +380,7 @@
           const settingsBtn = document.getElementById('settingsBtn');
           if (settingsBtn) UI.hide('settingsBtn');
         }
+      setupControlsToggle();
       const modeScript = document.createElement('script');
       modeScript.defer = true;
       modeScript.src = isAck ? './scripts/ack-player.js' : './scripts/module-picker.js';
@@ -391,6 +396,24 @@
         if (e.target.closest('.panel .content')) return;
         if (window.scrollY === 0 && y > startY) e.preventDefault();
       }, {passive: false});
+    }
+    function setupControlsToggle() {
+      const section = document.querySelector('.panel-section--controls');
+      if (!section) return;
+      const toggle = section.querySelector('.panel-section__toggle');
+      const content = section.querySelector('.panel-section__content');
+      if (!toggle || !content) return;
+      const label = toggle.querySelector('.panel-section__toggle-text');
+      const setCollapsed = collapsed => {
+        section.classList.toggle('panel-section--collapsed', collapsed);
+        toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        if (label) label.textContent = collapsed ? 'Show' : 'Hide';
+      };
+      toggle.addEventListener('click', () => {
+        const nextCollapsed = !section.classList.contains('panel-section--collapsed');
+        setCollapsed(nextCollapsed);
+      });
+      setCollapsed(true);
     }
     function warnOnUnload() {
       window.addEventListener('beforeunload', e => {


### PR DESCRIPTION
## Summary
- add an expand/collapse toggle to the controls panel header in the CRT UI
- hide the controls grid by default and update the toggle text/aria state when expanded
- style the new toggle pill and rotate its indicator while collapsed

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68ce070842f88328afef7466d6b32b05