### PR TITLE
fix: tag Cass trader stock with refresh metadata

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -1819,21 +1819,39 @@
         "markup": 1,
         "inv": [
           {
-            "id": "pipe_rifle"
+            "id": "pipe_rifle",
+            "rarity": "common",
+            "cadence": "daily",
+            "refreshHours": 24
           },
           {
-            "id": "leather_jacket"
+            "id": "leather_jacket",
+            "rarity": "common",
+            "cadence": "daily",
+            "refreshHours": 24
           },
           {
-            "id": "water_flask"
+            "id": "water_flask",
+            "rarity": "common",
+            "cadence": "daily",
+            "refreshHours": 24
           },
           {
-            "id": "frag_grenade"
+            "id": "frag_grenade",
+            "rarity": "rare",
+            "cadence": "weekly",
+            "refreshHours": 168,
+            "scarcity": "scarce"
           },
           {
-            "id": "incendiary_grenade"
+            "id": "incendiary_grenade",
+            "rarity": "epic",
+            "cadence": "weekly",
+            "refreshHours": 168,
+            "scarcity": "rare"
           }
-        ]
+        ],
+        "refresh": 24
       },
       "symbol": "!"
     },

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -1937,21 +1937,39 @@ const DATA = `
         "markup": 1,
         "inv": [
           {
-            "id": "pipe_rifle"
+            "id": "pipe_rifle",
+            "rarity": "common",
+            "cadence": "daily",
+            "refreshHours": 24
           },
           {
-            "id": "leather_jacket"
+            "id": "leather_jacket",
+            "rarity": "common",
+            "cadence": "daily",
+            "refreshHours": 24
           },
           {
-            "id": "water_flask"
+            "id": "water_flask",
+            "rarity": "common",
+            "cadence": "daily",
+            "refreshHours": 24
           },
           {
-            "id": "frag_grenade"
+            "id": "frag_grenade",
+            "rarity": "rare",
+            "cadence": "weekly",
+            "refreshHours": 168,
+            "scarcity": "scarce"
           },
           {
-            "id": "incendiary_grenade"
+            "id": "incendiary_grenade",
+            "rarity": "epic",
+            "cadence": "weekly",
+            "refreshHours": 168,
+            "scarcity": "rare"
           }
-        ]
+        ],
+        "refresh": 24
       },
       "symbol": "!"
     },


### PR DESCRIPTION
## Summary
- annotate Cass the Trader's inventory with refresh cadence, rarity, and scarcity metadata in the module data
- update the trader price scan test to check for the new metadata and fall back to the module definition when the JSON export is missing

## Testing
- npm test
- node --test test/trader-price-scan.test.js
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68cf2b6a7d5483288e3a4cdf630cce5f