### PR TITLE
fix: keep interior loot within bounds

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -649,7 +649,7 @@ const DATA = `
       "desc": "Ceremonial armor woven with mnemonic threads for sermon-weaving.",
       "map": "echoes_atrium",
       "x": 6,
-      "y": 9,
+      "y": 5,
       "rarity": "legendary",
       "mods": {
         "DEF": 3,
@@ -669,7 +669,7 @@ const DATA = `
       "desc": "A reliquary that hums with persuasive echoes.",
       "map": "echoes_archive",
       "x": 5,
-      "y": 10,
+      "y": 5,
       "rarity": "legendary",
       "mods": {
         "CHA": 1,
@@ -689,7 +689,7 @@ const DATA = `
       "desc": "Cogwitch mantle anchored by gyroscopic bracework.",
       "map": "echoes_workshop",
       "x": 7,
-      "y": 8,
+      "y": 5,
       "rarity": "legendary",
       "mods": {
         "DEF": 3,

--- a/scripts/supporting/placement-check.js
+++ b/scripts/supporting/placement-check.js
@@ -23,6 +23,7 @@ const grids = {};
 (data.interiors || []).forEach(int => {
   grids[int.id] = int.grid;
 });
+const interiorIds = new Set(Object.keys(grids));
 
 function tileAt(map, x, y) {
   const grid = grids[map];
@@ -38,6 +39,11 @@ function check(kind, obj) {
   if (typeof obj.x !== 'number' || typeof obj.y !== 'number') return;
   if (!obj.map) return;
   const tile = tileAt(obj.map, obj.x, obj.y);
+  if (interiorIds.has(obj.map) && tile == null) {
+    console.error(`${kind} ${obj.id || '?'} is outside ${obj.map} at (${obj.x},${obj.y})`);
+    errors++;
+    return;
+  }
   if (tile === '🧱' || tile === '🌊') {
     console.error(`${kind} ${obj.id || '?'} is on ${tile} at ${obj.map} (${obj.x},${obj.y})`);
     errors++;


### PR DESCRIPTION
## Summary
- reposition the legendary loot in the echoes interiors so their coordinates stay inside the rooms
- extend placement-check to fail when items or NPCs are outside interior grids

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68cf70d31f808328adba0a943a37e6a4