### PR TITLE
fix: keep items off water and disable boss cave battles

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -549,13 +549,6 @@ const DATA = `
       ]
     },
     {
-      "id": "travel_pass",
-      "name": "Travel Pass",
-      "type": "quest",
-      "desc": "Stamped permit waiving bunker fuel fees.",
-      "tags": [
-        "pass"
-      ],
       "id": "scavenger_warlord_rig",
       "name": "Scrap Warlord Rig",
       "type": "armor",
@@ -750,7 +743,7 @@ const DATA = `
       "desc": "Self-stabilizing compass that hums toward safe footing.",
       "map": "world",
       "x": 22,
-      "y": 65,
+      "y": 68,
       "rarity": "legendary",
       "mods": {
         "PER": 1,
@@ -762,6 +755,15 @@ const DATA = `
           "role": "Wanderer"
         }
       }
+    },
+    {
+      "id": "travel_pass",
+      "name": "Travel Pass",
+      "type": "quest",
+      "desc": "Stamped permit waiving bunker fuel fees.",
+      "tags": [
+        "pass"
+      ]
     }
   ],
   "quests": [
@@ -4067,6 +4069,14 @@ const DATA = `
         "south": true,
         "east": true
       },
+      "noEncounters": true
+    },
+    {
+      "map": "room_oc3abv",
+      "x": 0,
+      "y": 0,
+      "w": 114,
+      "h": 50,
       "noEncounters": true
     }
   ],

--- a/scripts/module-tools/delete.js
+++ b/scripts/module-tools/delete.js
@@ -1,0 +1,34 @@
+import { readModule, getByPath } from './utils.js';
+
+const [file, path] = process.argv.slice(2);
+if (!file || !path) {
+  console.error('Usage: node scripts/module-tools/delete.js <moduleFile> <path>');
+  process.exit(1);
+}
+
+const mod = readModule(file);
+const parts = path.split('.');
+const key = parts.pop();
+const parentPath = parts.join('.');
+const parent = parentPath ? getByPath(mod.data, parentPath) : mod.data;
+if (parent == null) {
+  console.error('Parent path not found');
+  process.exit(1);
+}
+
+if (Array.isArray(parent)) {
+  const index = Number(key);
+  if (!Number.isInteger(index)) {
+    console.error('Array index must be a number');
+    process.exit(1);
+  }
+  if (index < 0 || index >= parent.length) {
+    console.error('Array index out of range');
+    process.exit(1);
+  }
+  parent.splice(index, 1);
+} else {
+  delete parent[key];
+}
+
+mod.write(mod.data);


### PR DESCRIPTION
## Summary
- move the wayfarer gyroscope onto dry terrain and keep travel_pass as a dedicated quest item entry
- add a no-encounter zone covering room_oc3abv so boss fights come from their red NPC markers
- add a CLI helper for deleting module properties when normalizing DATA blocks

## Testing
- `npm test`
- `node scripts/supporting/placement-check.js modules/dustland.module.js`
- `node scripts/supporting/presubmit.js`


------
https://chatgpt.com/codex/tasks/task_e_68cf72177d308328b8536127617276b3