### PR TITLE
feat: auto-inject leave options and quest dialog text

### DIFF
--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -279,30 +279,8 @@ const OFFICE_IMPL = (() => {
       questId: 'q_card',
       tree: () =>
         flagValue('visited_forest')
-          ? {
-              start: {
-                text: 'Glad you made it back from the forest.',
-                choices: [ { label: '(Chat later)', to: 'bye' } ]
-              }
-            }
-          : {
-              start: {
-                text: 'Ready for the sim once you get the card.',
-                choices: [
-                  { label: '(Where do I get one?)', to: 'accept', q: 'accept' },
-                  { label: '(I have the card)', to: 'do_turnin', q: 'turnin' },
-                  { label: '(Leave)', to: 'bye' }
-                ]
-              },
-              accept: {
-                text: 'Security downstairs hoards spares.',
-                choices: [ { label: '(Thanks)', to: 'bye' } ]
-              },
-              do_turnin: {
-                text: 'Jen hands you a battered VR headset.',
-                choices: [ { label: '(Continue)', to: 'bye' } ]
-              }
-            }
+          ? { start: { text: 'Glad you made it back from the forest.' } }
+          : { start: { text: '' } }
     },
     {
       id: 'friend2',
@@ -329,35 +307,7 @@ const OFFICE_IMPL = (() => {
       portraitSheet: portraits.toll,
       questId: 'q_toll',
       tree: {
-        start: {
-          text: 'Pay a trinket to cross.',
-          choices: [
-            {
-              label: '(Accept quest)',
-              to: 'accept',
-              q: 'accept'
-            },
-            {
-              label: '(Pay)',
-              to: 'do_turnin',
-              q: 'turnin',
-              costSlot: 'trinket',
-              success: '',
-              failure: 'You have no trinket.'
-            },
-            { label: '(Leave)', to: 'bye' }
-          ]
-        },
-        accept: { text: 'Bring me a trinket and you may cross.', choices: [ { label: '(Leave)', to: 'bye' } ] },
-        do_turnin: {
-          text: 'The toll keeper steps aside.',
-          choices: [
-            {
-              label: '(Continue)',
-              to: 'bye'
-            }
-          ]
-        }
+        start: { text: 'Pay a trinket to cross.' }
       }
     },
     {
@@ -579,13 +529,41 @@ const OFFICE_IMPL = (() => {
           id: 'q_card',
           title: 'Access Granted',
           desc: 'Convince security to lend you an access card and join Jen in the sim.',
-          reward: 'cursed_vr_helmet'
+          reward: 'cursed_vr_helmet',
+          dialog: {
+            offer: {
+              text: 'Ready for the sim once you get the card.',
+              choice: { label: '(Where do I get one?)' }
+            },
+            accept: { text: 'Security downstairs hoards spares.' },
+            turnIn: {
+              text: 'Jen hands you a battered VR headset.',
+              choice: { label: '(I have the card)' }
+            },
+            completed: { text: 'Glad you made it back from the forest.' }
+          }
         },
         {
           id: 'q_toll',
           title: 'Bridge Tax',
           desc: 'Pay the Toll Keeper with a trinket.',
-          moveTo: { x: WORLD_MID + 2, y: WORLD_MIDY }
+          moveTo: { x: WORLD_MID + 2, y: WORLD_MIDY },
+          dialog: {
+            offer: {
+              text: 'Pay a trinket to cross.',
+              choice: { label: '(Accept quest)' }
+            },
+            accept: { text: 'Bring me a trinket and you may cross.' },
+            turnIn: {
+              text: 'The toll keeper steps aside.',
+              choice: {
+                label: '(Pay)',
+                costSlot: 'trinket',
+                success: '',
+                failure: 'You have no trinket.'
+              }
+            }
+          }
         }
       ],
     npcs,

--- a/scripts/core/quests.js
+++ b/scripts/core/quests.js
@@ -42,7 +42,9 @@ class Quest {
     this.pinned = meta.pinned || false;
     this.givers = Array.isArray(meta.givers) ? meta.givers.map(g => ({ ...g })) : [];
     this.itemLocation = meta.itemLocation ? { ...meta.itemLocation } : null;
+    const rawDialog = meta.dialog ? JSON.parse(JSON.stringify(meta.dialog)) : null;
     Object.assign(this, meta);
+    this.dialog = rawDialog ?? (this.dialog ? JSON.parse(JSON.stringify(this.dialog)) : null);
     if (Array.isArray(this.givers)) {
       this.givers = this.givers.map(g => ({ ...g }));
     } else {

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -563,7 +563,9 @@ function applyModule(data = {}, options = {}) {
           reward: q.reward,
           xp: q.xp,
           moveTo: q.moveTo,
-          itemLocation: q.item && questItemLocations[q.item] ? questItemLocations[q.item] : null
+          itemLocation: q.item && questItemLocations[q.item] ? questItemLocations[q.item] : null,
+          dialog: q.dialog,
+          progressText: q.progressText
         }
       );
     });

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -954,14 +954,14 @@ test('turn-in choice appears immediately after accepting', () => {
   NPCS.push(npc);
 
   openDialog(npc);
-  let labels = choicesEl.children.map(c => c.textContent);
-  assert.ok(!labels.includes('turn in'));
+  let labels = choicesEl.children.map(c => c.textContent.toLowerCase());
+  assert.ok(!labels.some(l => l.includes('turn in')));
 
   // accept quest
   choicesEl.children[0].onclick();
 
-  labels = choicesEl.children.map(c => c.textContent);
-  assert.ok(labels.includes('turn in'));
+  labels = choicesEl.children.map(c => c.textContent.toLowerCase());
+  assert.ok(labels.some(l => l.includes('turn in')));
   closeDialog();
 });
 


### PR DESCRIPTION
## Summary
- automatically inject a default leave choice for dialog nodes unless they opt out with `noLeave`
- wire quest dialogs and choices directly from quest metadata and adjust the editor plus core quest plumbing
- update the office module to supply quest dialog text instead of manual tree branches

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/office.module.js

------
https://chatgpt.com/codex/tasks/task_e_68d08e2fe90083288ae6e613de0fce82