### PR TITLE
fix: clarify glinting key exit

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -365,7 +365,7 @@
         "map": "echo_chamber",
         "x": 2,
         "y": 2,
-        "log": "A vision of a shining world surrounds you."
+        "log": "A vision of a shining world surrounds you. Press interact to leave."
       }
     },
     {
@@ -3830,6 +3830,15 @@
       "toMap": "world",
       "toX": 110,
       "toY": 87
+    },
+    {
+      "map": "echo_chamber",
+      "x": 2,
+      "y": 2,
+      "toMap": "world",
+      "toX": 2,
+      "toY": 45,
+      "desc": "The vision releases you back to the wastes."
     }
   ],
   "encounters": {

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -368,7 +368,7 @@ const DATA = `
         "map": "echo_chamber",
         "x": 2,
         "y": 2,
-        "log": "A vision of a shining world surrounds you."
+        "log": "A vision of a shining world surrounds you. Press interact to leave."
       }
     },
     {
@@ -3850,6 +3850,15 @@ const DATA = `
       "toMap": "world",
       "toX": 110,
       "toY": 87
+    },
+    {
+      "map": "echo_chamber",
+      "x": 2,
+      "y": 2,
+      "toMap": "world",
+      "toX": 2,
+      "toY": 45,
+      "desc": "The vision releases you back to the wastes."
     }
   ],
   "encounters": {

--- a/test/glinting-key.test.js
+++ b/test/glinting-key.test.js
@@ -53,7 +53,7 @@ test('glinting key triggers vision', async () => {
   context.Dustland.effects.apply([key.use], { player: context.player, party: context.party });
   assert.strictEqual(context.map, 'echo_chamber');
   assert.deepEqual(context.pos, { x: 2, y: 2 });
-  assert.strictEqual(context.logged, 'A vision of a shining world surrounds you.');
+  assert.strictEqual(context.logged, 'A vision of a shining world surrounds you. Press interact to leave.');
 });
 
 test('exit door remarks on glinting key', async () => {


### PR DESCRIPTION
## Summary
- explain the glinting key vision prompt to tell players to press interact to leave
- add a return portal in the echo chamber that leads back to the wastes
- update the glinting key regression test for the new log copy

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js data/modules/dustland.json

------
https://chatgpt.com/codex/tasks/task_e_68d1763087c08328ae54814bcd563941