### PR TITLE
fix: flag multiplayer module selections

### DIFF
--- a/scripts/module-picker.js
+++ b/scripts/module-picker.js
@@ -328,8 +328,12 @@ function showModulePicker(){
 
   if (mpBridge?.subscribe && pickerBus?.emit) {
     mpBridge.subscribe('module-picker:select', payload => {
+      let message = payload;
+      if (payload && typeof payload === 'object') {
+        message = { ...payload, [NET_FLAG]: true };
+      }
       try {
-        pickerBus.emit('module-picker:select', payload);
+        pickerBus.emit('module-picker:select', message);
       } catch (err) {
         /* ignore */
       }


### PR DESCRIPTION
## Summary
- ensure module picker relays multiplayer selections with a network flag so clients load chosen modules

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d216da00288328813163ecbae58757