### PR TITLE
feat: render remote parties in multiplayer

### DIFF
--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -611,7 +611,11 @@ const movement = {
   checkRandomEncounter,
   distanceToRoad
 };
-bus?.on?.('movement:player', ({ x, y }) => { setPartyPos(x, y); });
+bus?.on?.('movement:player', payload => {
+  if (!payload || payload.__fromNet) return;
+  const { x, y } = payload;
+  setPartyPos(x, y);
+});
 globalThis.Dustland = globalThis.Dustland || {};
 globalThis.Dustland.movement = movement;
 Object.assign(globalThis, movement);

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -1170,6 +1170,7 @@ function render(gameState=state, dt){
   const ps = gameState.portals || portals;
   const entities = gameState.entities || (typeof NPCS !== 'undefined' ? NPCS : []);
   const pos = gameState.party || party;
+  const remoteParties = globalThis.Dustland?.multiplayerParties?.list?.() || globalThis.Dustland?.multiplayerState?.remoteParties || [];
 
   // split entities into below/above
   const below = [], above = [];
@@ -1255,6 +1256,25 @@ function render(gameState=state, dt){
     }
     else if(layer==='entitiesBelow'){ drawEntities(ctx, below, offX, offY); }
     else if(layer==='player'){
+      if(Array.isArray(remoteParties) && remoteParties.length){
+        const now = Date.now();
+        for(const info of remoteParties){
+          if(!info || info.map !== activeMap) continue;
+          if(!Number.isFinite(info.x) || !Number.isFinite(info.y)) continue;
+          const rx=(info.x-camX+offX)*TS;
+          const ry=(info.y-camY+offY)*TS;
+          const age = info.updated ? Math.max(0, Math.min(8000, now - info.updated)) : 0;
+          const alpha = 0.35 + (Math.max(0, 8000 - age) / 8000) * 0.45;
+          ctx.save();
+          ctx.globalAlpha = alpha;
+          ctx.fillStyle='#64f0ff';
+          ctx.fillRect(rx+3,ry+3,TS-6,TS-6);
+          ctx.strokeStyle='#102c30';
+          ctx.lineWidth = 1;
+          ctx.strokeRect(rx+3,ry+3,TS-6,TS-6);
+          ctx.restore();
+        }
+      }
       const px=(pos.x-camX+offX)*TS, py=(pos.y-camY+offY)*TS;
       if(retroNpcArtEnabled){
         const sprite = getRetroPlayerSprite();

--- a/test/multiplayer-movement.test.js
+++ b/test/multiplayer-movement.test.js
@@ -1,4 +1,5 @@
 import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import vm from 'node:vm';
 
@@ -63,5 +64,62 @@ test('movement events propagate between clients', async () => {
 
   s1.close();
   s2.close();
+  room.close();
+});
+
+test('remote party positions sync to peers', async () => {
+  const shared = { offers: new Map(), answers: new Map(), nextOffer: 1, nextAnswer: 1 };
+  const { env: hostEnv, bus: hostBus } = ctx(shared);
+  const { env: clientA, bus: busA } = ctx(shared);
+  const { env: clientB, bus: busB } = ctx(shared);
+
+  const room = await hostEnv.Dustland.multiplayer.startHost();
+
+  const ticketA = await room.createOffer();
+  const socketA = await clientA.Dustland.multiplayer.connect({ code: ticketA.code });
+  await room.acceptAnswer(ticketA.id, socketA.answer);
+  await socketA.ready;
+
+  const ticketB = await room.createOffer();
+  const socketB = await clientB.Dustland.multiplayer.connect({ code: ticketB.code });
+  await room.acceptAnswer(ticketB.id, socketB.answer);
+  await socketB.ready;
+
+  const hostUpdate = new Promise(resolve => {
+    hostBus.on('multiplayer:party-sync', list => {
+      if (Array.isArray(list) && list.some(p => p.id === ticketA.id && p.x === 4 && p.y === 7)) resolve();
+    });
+  });
+
+  const peerUpdate = new Promise(resolve => {
+    busB.on('multiplayer:party-sync', list => {
+      if (Array.isArray(list) && list.some(p => p.id === ticketA.id && p.x === 4 && p.y === 7)) resolve();
+    });
+  });
+
+  busA.emit('movement:player', { x: 4, y: 7, map: 'world' });
+
+  await hostUpdate;
+  await peerUpdate;
+
+  const hostSnapshot = hostEnv.Dustland.multiplayerParties.list();
+  const peerSnapshot = clientB.Dustland.multiplayerParties.list();
+  assert.ok(hostSnapshot.some(p => p.id === ticketA.id && p.x === 4 && p.y === 7));
+  assert.ok(peerSnapshot.some(p => p.id === ticketA.id && p.x === 4 && p.y === 7));
+
+  const clientHostUpdate = new Promise(resolve => {
+    busA.on('multiplayer:party-sync', list => {
+      if (Array.isArray(list) && list.some(p => p.id === 'host' && p.x === 9 && p.y === 2)) resolve();
+    });
+  });
+
+  hostBus.emit('movement:player', { x: 9, y: 2, map: 'world' });
+  await clientHostUpdate;
+
+  const clientView = clientA.Dustland.multiplayerParties.list();
+  assert.ok(clientView.some(p => p.id === 'host' && p.x === 9 && p.y === 2));
+
+  socketA.close();
+  socketB.close();
   room.close();
 });


### PR DESCRIPTION
## Summary
- track remote peer locations in multiplayer and broadcast dedicated party position events
- skip applying networked movement to the local party while rendering remote parties in the main view
- cover party position syncing with a multiplayer test

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d2c95175448328ac83902ae2527255