### PR TITLE
fix: refresh inventory highlights when cycling leader

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2686,6 +2686,7 @@ function runTests(){
         if (party.length>0){
           selectedMember = (selectedMember + 1) % party.length;
           renderParty();
+          if (typeof globalThis.renderInv === 'function') globalThis.renderInv();
           toast(`Leader: ${party[selectedMember].name}`);
         }
         break;


### PR DESCRIPTION
## Summary
- refresh the inventory list after cycling the party leader with Tab so upgrade suggestions stay current

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d2dca9521483288ba99b61270ccedd