### PR TITLE
fix: point mask personas to bundled portraits

### DIFF
--- a/scripts/core/personas.js
+++ b/scripts/core/personas.js
@@ -7,21 +7,21 @@
     'mara.masked': {
       id: 'mara.masked',
       label: 'Masked Mara',
-      portrait: 'assets/portraits/hidden_hermit_4.png',
+      portrait: 'assets/portraits/dustland-module/hidden_hermit_4.png',
       portraitPrompt: 'Cinematic digital painting of Mara, a weathered navigator in scavenged desert armor, wearing a cracked porcelain mask with thin gold inlay, warm campfire lighting, windswept hair, determined expression, post-apocalyptic wasteland backdrop.',
       mods: { AGI: 1 }
     },
     'jax.patchwork': {
       id: 'jax.patchwork',
       label: 'Patchwork Jax',
-      portrait: 'assets/portraits/iron_brute_4.png',
+      portrait: 'assets/portraits/dustland-module/iron_brute_4.png',
       portraitPrompt: 'Gritty concept art portrait of Jax, a muscular scavenger with a patchwork mask welded from mismatched metal plates, neon welding glow reflections, improvised armor straps, cybernetic arm details, ruined factory background, dramatic rim lighting.',
       mods: { STR: 1 }
     },
     'nyx.veiled': {
       id: 'nyx.veiled',
       label: 'Veiled Nyx',
-      portrait: 'assets/portraits/nora_4.png',
+      portrait: 'assets/portraits/dustland-module/nora_4.png',
       portraitPrompt: 'Moody illustration of Nyx, a lithe mystic draped in layered dusk-blue robes, translucent veil mask stitched with glowing threads, bioluminescent tattoos, twilight storm clouds behind her, soft moonlit highlights, enigmatic calm expression.',
       mods: { INT: 1 }
     }


### PR DESCRIPTION
## Summary
- update the mask persona templates to point at the portraits that ship in the dustland module assets so the HUD can load them

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d2e24ba3688328a6772fc7d869d0c2