### PR TITLE
feat: let extreme luck one-shot enemies

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -685,6 +685,12 @@ function doAttack(dmg, type = 'basic'){
       log?.('Lucky strike!');
     }
 
+    const instantKillChance = Math.min(0.25, Math.max(0, eff - 12) * 0.01);
+    if (tDmg > 0 && target.hp > 0 && instantKillChance > 0 && Math.random() < instantKillChance){
+      tDmg = Math.max(tDmg, target.hp);
+      log?.(`${attacker.name}'s incredible luck fells ${target.name} instantly!`);
+    }
+
     target.hp -= tDmg;
 
     recordCombatEvent?.({

--- a/test/luck-effects.test.js
+++ b/test/luck-effects.test.js
@@ -103,3 +103,18 @@ test('luck can reduce damage taken', () => {
   assert.ok(logMessages.some(m => m.includes('Luck')));
   closeCombat('flee');
 });
+
+test('extreme luck can instantly defeat enemies', () => {
+  logMessages.length = 0;
+  hero.stats.LCK = 20;
+  hero.hp = hero.maxHp;
+  const enemy = { name:'Brute', hp: 30, maxHp:30 };
+  const r = Math.random; Math.random = () => 0;
+  openCombat([enemy]);
+  doAttack(1);
+  Math.random = r;
+  assert.strictEqual(combatState.enemies.length, 0);
+  assert.ok(logMessages.some(m => m.includes('instantly')));
+  closeCombat('flee');
+  hero.stats.LCK = 10;
+});


### PR DESCRIPTION
## Summary
- allow very high luck attackers to occasionally defeat an enemy instantly
- cover the new luck burst in luck-effects tests

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d33e2c2f3883288538526ee3fba949