### PR TITLE
feat: differentiate loot glyphs

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -811,7 +811,7 @@ function handleEnemyDefeat(attacker, target, sourceLabel){
     const cache = SpoilsCache.rollDrop?.(desertProphet ? challenge + 1 : challenge);
     if (cache){
       const registered = typeof registerItem === 'function' ? registerItem(cache) : cache;
-      itemDrops?.push?.({ id: registered.id, map: party.map, x: party.x, y: party.y });
+      itemDrops?.push?.({ id: registered.id, map: party.map, x: party.x, y: party.y, dropType: 'loot' });
       log?.(`The ground coughs up a ${registered.name}.`);
       if (desertProphet) log?.('A prophetic vision hinted at this cache.');
       globalThis.EventBus?.emit?.('spoils:drop', { cache: registered, target });
@@ -1075,7 +1075,7 @@ function enemyAttack(){
       const cache = SpoilsCache.rollDrop?.(enemy.challenge);
       if (cache){
         const registered = typeof registerItem === 'function' ? registerItem(cache) : cache;
-        itemDrops?.push?.({ id: registered.id, map: party.map, x: party.x, y: party.y });
+        itemDrops?.push?.({ id: registered.id, map: party.map, x: party.x, y: party.y, dropType: 'loot' });
         log?.(`The ground coughs up a ${registered.name}.`);
         globalThis.EventBus?.emit?.('spoils:drop', { cache: registered, target: enemy });
       }

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -20,6 +20,7 @@
  * @property {number} y
  * @property {string} [id]
  * @property {string[]} [items]
+ * @property {'world'|'loot'} [dropType]
  */
 
 globalThis.Dustland = globalThis.Dustland || {};

--- a/test/retro-item-glyph.test.js
+++ b/test/retro-item-glyph.test.js
@@ -26,10 +26,15 @@ test('retro art exposes item glyph sprites', () => {
   assert.ok(glyph instanceof RetroImage, 'single item glyph uses Image sprite');
   assert.ok(glyph.src.includes('retroItemGlyph'), 'single item glyph uses custom SVG data');
 
+  const lootGlyph = context.Dustland.retroNpcArt.getLootGlyph();
+  assert.ok(lootGlyph instanceof RetroImage, 'enemy loot glyph uses Image sprite');
+  assert.ok(lootGlyph.src.includes('retroLootGlyph'), 'enemy loot glyph uses loot SVG data');
+
   const cacheGlyph = context.Dustland.retroNpcArt.getItemCacheGlyph();
   assert.ok(cacheGlyph instanceof RetroImage, 'cache glyph uses Image sprite');
   assert.ok(cacheGlyph.src.includes('retroItemCache'), 'cache glyph uses cache SVG data');
 
   assert.strictEqual(context.Dustland.retroNpcArt.getItemGlyph(), glyph, 'single glyph cached instance reused');
+  assert.strictEqual(context.Dustland.retroNpcArt.getLootGlyph(), lootGlyph, 'loot glyph cached instance reused');
   assert.strictEqual(context.Dustland.retroNpcArt.getItemCacheGlyph(), cacheGlyph, 'cache glyph cached instance reused');
 });


### PR DESCRIPTION
## Summary
- tag enemy spoils cache drops with a loot dropType so renderers can distinguish them from placed items
- add a dedicated retro loot glyph sprite and new non-retro styling for enemy loot pickups
- extend retro item glyph tests to cover the new loot glyph helper

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d33afd39cc832886f6f2dc64fbd6a1