### PR TITLE
fix: clamp quest xp rewards

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -707,7 +707,7 @@
               </div>
             </div>
           </div>
-          <label>XP Reward<input id="questXP" type="number" min="0" /></label>
+          <label>XP Reward<input id="questXP" type="number" min="10" max="100" value="10" /></label>
           <label>NPC<select id="questNPC">
               <option value="">(none)</option>
             </select></label>

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -4009,7 +4009,7 @@ function resetQuestRewardFields() {
   const itemId = document.getElementById('questRewardItemId');
   if (itemId) itemId.value = '';
   const xp = document.getElementById('questRewardXP');
-  if (xp) xp.value = 0;
+  if (xp) xp.value = 10;
   const scrap = document.getElementById('questRewardScrap');
   if (scrap) scrap.value = 0;
   const customId = document.getElementById('questRewardCustomId');
@@ -4108,7 +4108,7 @@ function startNewQuest() {
   document.getElementById('questDesc').value = '';
   document.getElementById('questItem').value = '';
   resetQuestRewardFields();
-  document.getElementById('questXP').value = 0;
+  document.getElementById('questXP').value = 10;
   document.getElementById('questNPC').value = '';
   document.getElementById('addQuest').textContent = 'Add Quest';
   document.getElementById('delQuest').style.display = 'none';
@@ -4126,7 +4126,10 @@ function addQuest() {
     return;
   }
   const xpValue = parseInt(document.getElementById('questXP').value, 10);
-  const xp = Number.isFinite(xpValue) ? xpValue : 0;
+  let xp = Number.isFinite(xpValue) ? xpValue : 10;
+  xp = Math.round(xp);
+  if (xp < 10) xp = 10;
+  else if (xp > 100) xp = 100;
   const quest = { id, title, desc, xp };
   if (item) quest.item = item;
   if (typeof rewardResult.reward !== 'undefined') quest.reward = rewardResult.reward;
@@ -4171,7 +4174,9 @@ function editQuest(i) {
   document.getElementById('questDesc').value = q.desc;
   document.getElementById('questItem').value = q.item || '';
   setQuestRewardFields(q.reward);
-  document.getElementById('questXP').value = q.xp || 0;
+  const questXP = typeof q.xp === 'number' ? q.xp : parseInt(q.xp, 10);
+  const sanitizedQuestXP = Number.isFinite(questXP) ? Math.min(Math.max(Math.round(questXP), 10), 100) : 10;
+  document.getElementById('questXP').value = sanitizedQuestXP;
   const npc = moduleData.npcs.find(n => Array.isArray(n.quests) ? n.quests.includes(q.id) : n.questId === q.id);
   document.getElementById('questNPC').value = npc ? npc.id : '';
   document.getElementById('addQuest').textContent = 'Update Quest';

--- a/scripts/core/quests.js
+++ b/scripts/core/quests.js
@@ -219,7 +219,11 @@ function defaultQuestProcessor(npc, nodeId) {
           const rewardIt = resolveItem(meta.reward);
           if (rewardIt) addToInv(rewardIt);
         }
-        const xp = meta.xp ?? 5;
+        let xp = typeof meta.xp === 'number' ? meta.xp : Number.parseInt(meta.xp, 10);
+        if (!Number.isFinite(xp)) xp = 10;
+        xp = Math.round(xp);
+        if (xp < 10) xp = 10;
+        else if (xp > 100) xp = 100;
         party.forEach(p => awardXP(p, xp));
         if (meta.moveTo) { npc.x = meta.moveTo.x; npc.y = meta.moveTo.y; }
         if (Array.isArray(npc.quests)) {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -926,7 +926,7 @@ test('quest tag turn-in handles partial counts', () => {
   choicesEl.innerHTML = '';
 });
 
-test('quest turn-in awards XP once', () => {
+test('quest turn-in enforces minimum XP baseline', () => {
   for (const k in quests) delete quests[k];
   NPCS.length = 0;
   party.length = 0;
@@ -935,7 +935,20 @@ test('quest turn-in awards XP once', () => {
   const quest = new Quest('q_xp', 'Quest', '', { xp: 4 });
   const npc = { quest };
   defaultQuestProcessor(npc, 'do_turnin');
-  assert.strictEqual(char.xp, 4);
+  assert.strictEqual(char.xp, 10);
+});
+
+test('quest turn-in caps XP rewards at 100', () => {
+  for (const k in quests) delete quests[k];
+  NPCS.length = 0;
+  party.length = 0;
+  const char = new Character('g', 'Gil', 'Role');
+  party.join(char);
+  const quest = new Quest('q_xp_cap', 'Quest', '', { xp: 150 });
+  const npc = { quest };
+  defaultQuestProcessor(npc, 'do_turnin');
+  assert.strictEqual(char.lvl, 2);
+  assert.strictEqual(char.xp, 0);
 });
 
 test('turn-in choice appears immediately after accepting', () => {


### PR DESCRIPTION
## Summary
- clamp quest XP turn-ins to a 10–100 range so simple quests still reward meaningful progress
- update the Adventure Kit quest editor to default to 10 XP and restrict saved values to the same bounds
- cover the new behavior with quest XP baseline and cap tests

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d343c282f08328a5f4d7ea4addb02e