### PR TITLE
feat: add quick sell actions for junk and caches

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -976,6 +976,18 @@ input[type="range"] {
   margin-left: 8px;
 }
 
+.shop-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.shop-actions .btn {
+  flex: 1;
+  min-width: 120px;
+}
+
 #personaOverlay .persona-window {
   width: 260px;
   background: #0f120f;

--- a/dustland.html
+++ b/dustland.html
@@ -459,6 +459,10 @@
         </div>
         <div class="player-inv">
           <h2>Sell</h2>
+          <div id="shopSellActions" class="shop-actions">
+            <button id="sellJunkBtn" class="btn">Sell Junk</button>
+            <button id="sellCachesBtn" class="btn">Sell Caches</button>
+          </div>
           <div id="shopSell" class="slot-list"></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add quick sell buttons to the shop interface for junk and cache items
- boost spoils cache resale values and expose helper logic for reuse
- update shop unit tests to cover quick-sell behavior and new markup

## Testing
- npm test
- node scripts/supporting/presubmit.js


------
https://chatgpt.com/codex/tasks/task_e_68d33c419a7c8328896abddd2229cbbd