### PR TITLE
fix: keep wand after using

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -378,7 +378,8 @@
       "use": {
         "type": "heal",
         "amount": 0,
-        "text": "You wave the wand."
+        "text": "You wave the wand.",
+        "consume": false
       }
     },
     {

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -381,7 +381,8 @@ const DATA = `
       "use": {
         "type": "heal",
         "amount": 0,
-        "text": "You wave the wand."
+        "text": "You wave the wand.",
+        "consume": false
       }
     },
     {

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -267,6 +267,11 @@ function removeFromInv(invIndex, quantity) {
   notifyInventoryChanged();
 }
 
+function maybeConsumeItem(it, invIndex) {
+  if (it?.use?.consume === false) return;
+  removeFromInv(invIndex);
+}
+
 // Drop multiple items from inventory as a single cache on the ground
 /**
  * @param {number[]} indices
@@ -529,7 +534,7 @@ function useItem(invIndex){
     if (bonus > 0 && !it.use.text) log('Lucky boost!');
     if (typeof toast === 'function') toast(it.use.text || `${who.name} +${healed} HP`);
     emit('sfx','tick');
-    removeFromInv(invIndex);
+    maybeConsumeItem(it, invIndex);
     player.hp = party[0] ? party[0].hp : player.hp;
     if(typeof updateHUD === 'function') updateHUD();
     emit(`used:${it.id}`, { item: it });
@@ -546,7 +551,7 @@ function useItem(invIndex){
     const msg = it.use.text || `${who.name} drinks ${it.name}.`;
     log(msg);
     if(typeof toast==='function') toast(it.use.text || `${who.name} +${who.hydration - before} HYD`);
-    removeFromInv(invIndex);
+    maybeConsumeItem(it, invIndex);
     globalThis.updateHUD?.();
     emit('sfx','tick');
     emit(`used:${it.id}`, { item: it });
@@ -561,7 +566,7 @@ function useItem(invIndex){
     log(msg);
     if(typeof toast==='function') toast(msg);
     emit('sfx','tick');
-    removeFromInv(invIndex);
+    maybeConsumeItem(it, invIndex);
     emit(`used:${it.id}`, { item: it });
     return true;
   }
@@ -590,7 +595,7 @@ function useItem(invIndex){
       globalThis.renderCombat?.();
     }
     emit('sfx','damage');
-    removeFromInv(invIndex);
+    maybeConsumeItem(it, invIndex);
     emit(`used:${it.id}`, { item: it });
     return true;
   }
@@ -604,7 +609,7 @@ function useItem(invIndex){
     log(msg);
     if(typeof toast==='function') toast(it.use.text || `${who.name} is cleansed`);
     emit('sfx','tick');
-    removeFromInv(invIndex);
+    maybeConsumeItem(it, invIndex);
     emit(`used:${it.id}`, { item: it });
     return true;
   }
@@ -630,7 +635,7 @@ function useItem(invIndex){
   }
   if (effectList.length) {
     globalThis.Dustland?.effects?.apply?.(effectList, { player, party, item: it });
-    if (it.use.consume !== false) removeFromInv(invIndex);
+    maybeConsumeItem(it, invIndex);
     const msg = it.use.text || `Used ${it.name}`;
     log(msg);
     if (typeof toast === 'function') toast(it.use.toast || msg);
@@ -641,7 +646,7 @@ function useItem(invIndex){
   if(typeof it.use.onUse === 'function'){
     const ok = it.use.onUse({player, party, log, toast});
     if(ok!==false){
-        removeFromInv(invIndex);
+        maybeConsumeItem(it, invIndex);
         const msg = it.use.text || `Used ${it.name}`;
         log(msg);
         if(typeof toast==='function') toast(msg);

--- a/test/zone-use-item-event.test.js
+++ b/test/zone-use-item-event.test.js
@@ -46,7 +46,7 @@ vm.runInThisContext(invCode, { filename: 'core/inventory.js' });
 registerItem({ id:'mystic_key', name:'Mystic Key', type:'consumable', use:{ type:'heal', amount:0, text:'The key glows.' } });
 registerZoneEffects([{ map:'world', x:0, y:0, w:1, h:1, useItem:{ id:'mystic_key', reward:'scrap 5', once:true } }]);
 
-registerItem({ id:'wand', name:'Wand', type:'consumable', use:{ type:'heal', amount:0, text:'You wave the wand.' } });
+registerItem({ id:'wand', name:'Wand', type:'consumable', use:{ type:'heal', amount:0, text:'You wave the wand.', consume:false } });
 registerZoneEffects([{ map:'world', x:1, y:0, w:1, h:1, useItem:{ id:'wand', reward:'scrap 5', once:true } }]);
 
 test('zone rewards on item use and only once', () => {
@@ -72,4 +72,6 @@ test('wand triggers zone reward and logs use', () => {
   useItem(0);
   assert.strictEqual(player.scrap, 5);
   assert.ok(logs.includes('You wave the wand.'));
+  assert.strictEqual(player.inv.length, 1);
+  assert.strictEqual(player.inv[0].id, 'wand');
 });


### PR DESCRIPTION
## Summary
- allow healing-style items to opt out of consumption via `use.consume === false`
- mark the hall wand as non-consuming so it survives use
- cover the wand scenario with a test that asserts it stays in inventory

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3455f3c488328bce0e25d8d1f75d3