### PR TITLE
feat: add minigun to Cass's inventory

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -774,6 +774,25 @@
       "tags": [
         "pass"
       ]
+    },
+    {
+      "id": "minigun",
+      "type": "weapon",
+      "baseId": "wand",
+      "rarity": "legendary",
+      "scrap": 10000,
+      "value": 40780,
+      "mods": {
+        "ATK": 10,
+        "ADR": 45
+      },
+      "name": "Helix Minigun",
+      "desc": "Bunker-forged rotary cannon that chews through anything.",
+      "tags": [
+        "ranged",
+        "heavy",
+        "wand"
+      ]
     }
   ],
   "quests": [
@@ -1963,6 +1982,12 @@
             "cadence": "weekly",
             "refreshHours": 168,
             "scarcity": "rare"
+          },
+          {
+            "id": "minigun",
+            "rarity": "legendary",
+            "cadence": "weekly",
+            "refreshHours": 168
           }
         ],
         "refresh": 24

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -777,6 +777,25 @@ const DATA = `
       "tags": [
         "pass"
       ]
+    },
+    {
+      "id": "minigun",
+      "type": "weapon",
+      "baseId": "wand",
+      "rarity": "legendary",
+      "scrap": 10000,
+      "value": 40780,
+      "mods": {
+        "ATK": 10,
+        "ADR": 45
+      },
+      "name": "Helix Minigun",
+      "desc": "Bunker-forged rotary cannon that chews through anything.",
+      "tags": [
+        "ranged",
+        "heavy",
+        "wand"
+      ]
     }
   ],
   "quests": [
@@ -1966,6 +1985,12 @@ const DATA = `
             "cadence": "weekly",
             "refreshHours": 168,
             "scarcity": "rare"
+          },
+          {
+            "id": "minigun",
+            "rarity": "legendary",
+            "cadence": "weekly",
+            "refreshHours": 168
           }
         ],
         "refresh": 24

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -189,7 +189,14 @@ test('trader patrols east-west with basic goods', () => {
     { x: 110, y: 44 }
   ]);
   const invIds = trader.shop?.inv?.map(i => i.id);
-  assert.deepStrictEqual(invIds, ['pipe_rifle', 'leather_jacket', 'water_flask', 'frag_grenade', 'incendiary_grenade']);
+  assert.deepStrictEqual(invIds, [
+    'pipe_rifle',
+    'leather_jacket',
+    'water_flask',
+    'frag_grenade',
+    'incendiary_grenade',
+    'minigun'
+  ]);
 });
 
 test('vortex sends player to world map', () => {

--- a/test/trader-price-scan.test.js
+++ b/test/trader-price-scan.test.js
@@ -22,11 +22,22 @@ test('collectPricingData summarizes dustland traders and scrap', () => {
   const trader = moduleReport.vendors.find(v => v.name === 'Cass the Trader');
   assert.ok(trader);
   const ids = trader.items.map(it => it.id);
-  assert.deepStrictEqual(ids, ['pipe_rifle', 'leather_jacket', 'water_flask', 'frag_grenade', 'incendiary_grenade']);
+  assert.deepStrictEqual(ids, [
+    'pipe_rifle',
+    'leather_jacket',
+    'water_flask',
+    'frag_grenade',
+    'incendiary_grenade',
+    'minigun'
+  ]);
   const pipeRifle = trader.items.find(it => it.id === 'pipe_rifle');
   assert.ok(pipeRifle);
   assert.strictEqual(pipeRifle.price, 232);
   assert.ok(pipeRifle.needsValue);
+  const minigun = trader.items.find(it => it.id === 'minigun');
+  assert.ok(minigun);
+  assert.strictEqual(minigun.price, 10000);
+  assert.ok(!minigun.needsValue);
 
   let moduleData;
   try {
@@ -43,7 +54,11 @@ test('collectPricingData summarizes dustland traders and scrap', () => {
     assert.ok(entry.cadence, `Missing cadence on ${entry.id}`);
     if (entry.cadence === 'weekly') {
       assert.strictEqual(entry.refreshHours, 168);
-      assert.ok(entry.rarity === 'rare' || entry.rarity === 'epic');
+      assert.ok(
+        entry.rarity === 'rare' ||
+        entry.rarity === 'epic' ||
+        entry.rarity === 'legendary'
+      );
     } else {
       assert.strictEqual(entry.refreshHours, 24);
     }
@@ -55,5 +70,6 @@ test('formatReport emits readable summary', () => {
   const text = formatReport(report);
   assert.ok(text.includes('Cass the Trader'));
   assert.ok(text.includes('pipe_rifle'));
+  assert.ok(text.includes('minigun'));
   assert.ok(text.includes('Scrap: min 3'));
 });


### PR DESCRIPTION
## Summary
- add the Helix Minigun as a legendary weapon that shares the wand base id
- stock the minigun in Cass the Trader's weekly inventory with a 10k scrap price point
- extend module pricing tests to cover the new weapon and allow legendary weekly stock

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3471692b48328b33152c448e339af