### PR TITLE
Fix wand interaction for Glasswing Pride

### DIFF
--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -534,6 +534,17 @@ function useItem(invIndex){
     if (bonus > 0 && !it.use.text) log('Lucky boost!');
     if (typeof toast === 'function') toast(it.use.text || `${who.name} +${healed} HP`);
     emit('sfx','tick');
+    if (it.id === 'wand'){
+      const label = it.use?.label || it.name;
+      const defeated = globalThis.defeatEnemiesByRequirement?.('wand', {
+        attacker: who,
+        label,
+        itemLabel: label
+      }) || [];
+      if (defeated.length){
+        emit('sfx','damage');
+      }
+    }
     maybeConsumeItem(it, invIndex);
     player.hp = party[0] ? party[0].hp : player.hp;
     if(typeof updateHUD === 'function') updateHUD();


### PR DESCRIPTION
## Summary
- add a combat helper to defeat requirement-gated enemies when a special item triggers
- wire the wand heal action to eliminate enemies that require the wand during combat and play a damage cue

## Testing
- `npm test`
- `node scripts/supporting/presubmit.js`
- `node scripts/supporting/balance-tester-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_68d3495053588328991111f99e99f7ae