### PR TITLE
fix: remove dustland wand post load hook

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -15568,48 +15568,7 @@ const DATA = `
 }
 `;
 
-const DUSTLAND_WAND_ID = 'wand';
-let ensureWandTurnHandler = null;
-
-function ensureWandInInventory(moduleName) {
-  const currentModule = globalThis.Dustland?.currentModule;
-  if (moduleName && currentModule && currentModule !== moduleName) return;
-  if (typeof hasItem !== 'function' || typeof addToInv !== 'function') return;
-  if (hasItem(DUSTLAND_WAND_ID)) return;
-  if (!globalThis.player || !Array.isArray(globalThis.player.inv)) return;
-  const wand = typeof getItem === 'function' ? getItem(DUSTLAND_WAND_ID) : null;
-  if (!wand) return;
-  addToInv(wand);
-}
-
-function postLoad(module) {
-  const moduleName = module?.name || 'dustland-module';
-  const bus = globalThis.EventBus;
-  if (ensureWandTurnHandler && typeof bus?.off === 'function') {
-    bus.off('movement:player', ensureWandTurnHandler);
-  }
-  ensureWandTurnHandler = () => ensureWandInInventory(moduleName);
-  bus?.on?.('movement:player', ensureWandTurnHandler);
-  const scheduleInitialCheck = () => {
-    if (typeof queueMicrotask === 'function') {
-      queueMicrotask(() => ensureWandInInventory(moduleName));
-      return;
-    }
-    if (typeof Promise !== 'undefined' && typeof Promise.resolve === 'function') {
-      Promise.resolve().then(() => ensureWandInInventory(moduleName));
-      return;
-    }
-    if (typeof globalThis.setTimeout === 'function') {
-      globalThis.setTimeout(() => ensureWandInInventory(moduleName), 0);
-      return;
-    }
-    ensureWandInInventory(moduleName);
-  };
-  scheduleInitialCheck();
-}
-
 globalThis.DUSTLAND_MODULE = JSON.parse(DATA);
-globalThis.DUSTLAND_MODULE.postLoad = postLoad;
 
 startGame = function () {
   DUSTLAND_MODULE.postLoad?.(DUSTLAND_MODULE, { phase: 'beforeApply' });


### PR DESCRIPTION
## Summary
- remove the dustland module postLoad hook that automatically granted a wand

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68d36892b76c8328aaaf2d5c9c2cdb21