### PR TITLE
feat: gate strong weapons behind level requirements

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -516,6 +516,17 @@ input[type="range"] {
         background: #003300;
     }
 
+    .slot.level-locked {
+        border-color: #7a2d2d;
+        background: #210808;
+        color: #ffb8b8;
+    }
+
+    .slot.level-locked .level-locked-label {
+        color: #ff9d9d;
+        font-weight: 600;
+    }
+
     .slot.clickable {
         cursor: pointer;
     }


### PR DESCRIPTION
## Summary
- infer a minimum level for powerful weapons and expose equip restriction helpers through the inventory module
- surface level locks in the inventory UI with red styling, detailed tooltips, and button disabling
- cover level gating with a new inventory highlight test alongside existing harness adjustments

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d36857026c8328b4632562ab27f20c