### PR TITLE
fix: use glinting key for dune reaper loot

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -4067,9 +4067,17 @@
       },
       {
         "templateId": "dune_reaper",
-        "loot": "artifact_blade",
-        "lootChance": 0.75,
-        "minDist": 40
+        "minDist": 40,
+        "lootTable": [
+          {
+            "item": "artifact_blade",
+            "chance": 0.75
+          },
+          {
+            "item": "glinting_key",
+            "chance": 0.25
+          }
+        ]
       },
       {
         "templateId": "sand_colossus",

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -4069,9 +4069,17 @@ const DATA = `
       },
       {
         "templateId": "dune_reaper",
-        "loot": "artifact_blade",
-        "lootChance": 0.75,
-        "minDist": 40
+        "minDist": 40,
+        "lootTable": [
+          {
+            "item": "artifact_blade",
+            "chance": 0.75
+          },
+          {
+            "item": "glinting_key",
+            "chance": 0.25
+          }
+        ]
       },
       {
         "templateId": "sand_colossus",


### PR DESCRIPTION
## Summary
- remove the custom glimmering key entry from the Dustland module data
- switch the dune reaper loot table to roll for the existing glinting key item

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d34db0bfc0832891cd0fc5d6cf6c25