### PR TITLE
feat: add camp chest storage

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -1058,6 +1058,63 @@ input[type="range"] {
   color: #d4e4d0;
 }
 
+#campChestOverlay .camp-chest-window {
+  width: min(680px, 94vw);
+  max-height: 80vh;
+  background: #0f120f;
+  border: 1px solid #2b3b2b;
+  border-radius: 10px;
+  box-shadow: 0 0 24px rgba(0, 0, 0, 0.7);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+#campChestOverlay .camp-chest-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+#campChestOverlay .camp-chest-panels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+#campChestOverlay .camp-chest-panel {
+  flex: 1 1 260px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+#campChestOverlay .camp-chest-panel h3 {
+  margin: 0;
+}
+
+#campChestOverlay .camp-chest-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#campChestOverlay .camp-chest-name {
+  flex: 1;
+  min-width: 0;
+}
+
+#campChestOverlay .camp-chest-empty {
+  font-style: italic;
+  color: #9aa79a;
+}
+
+#campChestOverlay .camp-chest-row .btn {
+  flex-shrink: 0;
+}
+
 #personaOverlay .persona-mods li {
   background: #1d231d;
   border-radius: 4px;

--- a/dustland.html
+++ b/dustland.html
@@ -431,7 +431,26 @@
       <div id="personaList" class="persona-list"></div>
       <div class="persona-actions">
         <button id="campFastTravelBtn" class="btn">Fast Travel</button>
+        <button id="campChestBtn" class="btn">Camp Chest</button>
         <button id="closePersonaBtn" class="btn">Close</button>
+      </div>
+    </div>
+  </div>
+  <div class="overlay" id="campChestOverlay" role="dialog" aria-modal="true" tabindex="-1">
+    <div class="camp-chest-window">
+      <header class="camp-chest-header">
+        <h2>Camp Chest</h2>
+        <button id="closeCampChestBtn" class="btn">Close</button>
+      </header>
+      <div class="camp-chest-panels">
+        <section class="camp-chest-panel">
+          <h3>Stored Items</h3>
+          <div id="campChestList" class="slot-list"></div>
+        </section>
+        <section class="camp-chest-panel">
+          <h3>Inventory</h3>
+          <div id="campChestInventoryList" class="slot-list"></div>
+        </section>
       </div>
     </div>
   </div>

--- a/scripts/camp-persona.js
+++ b/scripts/camp-persona.js
@@ -7,6 +7,14 @@
   const list = document.getElementById('personaList');
   const closeBtn = document.getElementById('closePersonaBtn');
   const fastTravelBtn = document.getElementById('campFastTravelBtn');
+  const chestBtn = document.getElementById('campChestBtn');
+  const chestOverlay = document.getElementById('campChestOverlay');
+  const chestList = document.getElementById('campChestList');
+  const chestInvList = document.getElementById('campChestInventoryList');
+  const closeChestBtn = document.getElementById('closeCampChestBtn');
+  const inventory = globalThis.Dustland?.inventory;
+  const CAMP_CHEST_COST = 20000;
+  let reopenPersonaAfterChest = false;
   if (btn) btn.addEventListener('click', () => bus.emit('camp:open'));
   if (closeBtn && overlay) {
     closeBtn.addEventListener('click', () => overlay.classList.remove('shown'));
@@ -18,7 +26,158 @@
       globalThis.openWorldMap?.('camp');
     });
   }
+  const formatScrap = value => {
+    if (typeof value !== 'number') return String(value ?? '');
+    try {
+      return value.toLocaleString('en-US');
+    } catch (err) {
+      return String(value);
+    }
+  };
+  const describeItem = it => {
+    if (!it) return '';
+    const name = it.name || it.id || 'Unknown item';
+    const qty = Math.max(1, Number.isFinite(it.count) ? it.count : 1);
+    return qty > 1 ? `${name} x${qty}` : name;
+  };
+  function renderCampChest() {
+    if (!inventory || !chestList || !chestInvList) return;
+    const chestItems = inventory.getCampChest?.() || [];
+    chestList.innerHTML = '';
+    if (!Array.isArray(chestItems) || chestItems.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'camp-chest-empty';
+      empty.textContent = 'Chest empty';
+      chestList.appendChild(empty);
+    } else {
+      chestItems.forEach((item, idx) => {
+        const row = document.createElement('div');
+        row.className = 'slot camp-chest-row';
+        const label = document.createElement('div');
+        label.className = 'camp-chest-name';
+        label.textContent = describeItem(item);
+        row.appendChild(label);
+        const takeBtn = document.createElement('button');
+        takeBtn.className = 'btn';
+        takeBtn.textContent = 'Take';
+        takeBtn.addEventListener('click', () => {
+          const ok = inventory.withdrawCampChestItem?.(idx);
+          renderCampChest();
+          if (ok) {
+            globalThis.renderInv?.();
+          }
+        });
+        row.appendChild(takeBtn);
+        chestList.appendChild(row);
+      });
+    }
+    const inv = Array.isArray(globalThis.player?.inv) ? globalThis.player.inv : [];
+    chestInvList.innerHTML = '';
+    if (inv.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'camp-chest-empty';
+      empty.textContent = 'Inventory empty';
+      chestInvList.appendChild(empty);
+    } else {
+      inv.forEach((item, idx) => {
+        const row = document.createElement('div');
+        row.className = 'slot camp-chest-row';
+        const label = document.createElement('div');
+        label.className = 'camp-chest-name';
+        label.textContent = describeItem(item);
+        row.appendChild(label);
+        const storeBtn = document.createElement('button');
+        storeBtn.className = 'btn';
+        storeBtn.textContent = 'Store';
+        storeBtn.addEventListener('click', () => {
+          const ok = inventory.storeCampChestItem?.(idx);
+          renderCampChest();
+          if (ok) {
+            globalThis.renderInv?.();
+          }
+        });
+        row.appendChild(storeBtn);
+        chestInvList.appendChild(row);
+      });
+    }
+  }
+  function closeCampChest(restorePersona) {
+    if (!chestOverlay) return;
+    chestOverlay.classList.remove('shown');
+    if (restorePersona && reopenPersonaAfterChest && overlay) {
+      overlay.classList.add('shown');
+    }
+    reopenPersonaAfterChest = false;
+  }
+  function openCampChest(fromPersonaOverlay) {
+    if (!inventory || !chestOverlay) return;
+    reopenPersonaAfterChest = !!fromPersonaOverlay;
+    renderCampChest();
+    chestOverlay.classList.add('shown');
+  }
+  function updateCampChestButton() {
+    if (!chestBtn) return;
+    if (!inventory) {
+      chestBtn.style.display = 'none';
+      return;
+    }
+    chestBtn.style.display = '';
+    const unlocked = inventory.isCampChestUnlocked?.();
+    if (unlocked) {
+      chestBtn.textContent = 'Camp Chest';
+      chestBtn.disabled = false;
+      chestBtn.title = '';
+    } else {
+      chestBtn.textContent = `Buy Camp Chest (${formatScrap(CAMP_CHEST_COST)} Scrap)`;
+      chestBtn.disabled = false;
+      chestBtn.title = 'Costs scrap to set up a permanent stash.';
+    }
+  }
+  if (closeChestBtn) {
+    closeChestBtn.addEventListener('click', () => closeCampChest(true));
+  }
+  if (chestBtn) {
+    chestBtn.addEventListener('click', () => {
+      if (!inventory) return;
+      const unlocked = inventory.isCampChestUnlocked?.();
+      if (!unlocked) {
+        const player = globalThis.player || {};
+        const scrap = Number.isFinite(player.scrap) ? player.scrap : 0;
+        if (scrap < CAMP_CHEST_COST) {
+          globalThis.log?.('Not enough scrap.');
+          if (typeof globalThis.toast === 'function') globalThis.toast('Not enough scrap.');
+          return;
+        }
+        player.scrap = scrap - CAMP_CHEST_COST;
+        inventory.unlockCampChest?.();
+        globalThis.updateHUD?.();
+        globalThis.log?.('Camp chest assembled.');
+        if (typeof globalThis.toast === 'function') globalThis.toast('Camp chest assembled.');
+        updateCampChestButton();
+        const fromPersona = overlay?.classList.contains('shown');
+        if (fromPersona) overlay.classList.remove('shown');
+        openCampChest(fromPersona);
+        return;
+      }
+      const fromPersona = overlay?.classList.contains('shown');
+      if (fromPersona) overlay.classList.remove('shown');
+      openCampChest(fromPersona);
+    });
+  }
+  if (bus && inventory) {
+    bus.on('inventory:changed', () => {
+      updateCampChestButton();
+      if (chestOverlay?.classList.contains('shown')) renderCampChest();
+    });
+    bus.on('campChest:changed', () => {
+      updateCampChestButton();
+      if (chestOverlay?.classList.contains('shown')) renderCampChest();
+    });
+  }
+  updateCampChestButton();
   bus.on('camp:open', () => {
+    closeCampChest(false);
+    updateCampChestButton();
     const pos = globalThis.party;
     const map = globalThis.state?.map || 'world';
     const zones = globalThis.Dustland?.zoneEffects || [];

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -337,7 +337,7 @@ function registerZoneEffects(list){
   });
 }
 const state = { map:'world', mapFlags: {} }; // default map
-const player = { hp:10, inv:[], scrap:0 };
+const player = { hp:10, inv:[], scrap:0, campChest: [], campChestUnlocked: false };
 if (typeof registerItem === 'function') {
   registerItem({
     id: 'memory_worm',
@@ -1437,6 +1437,8 @@ function loadModernSave(d){
   party.fallen = deepClone(Array.isArray(partyData.fallen) ? partyData.fallen : []);
   Object.assign(player, d.player || {});
   if(!Array.isArray(player.inv)) player.inv = [];
+  if(!Array.isArray(player.campChest)) player.campChest = [];
+  player.campChestUnlocked = !!player.campChestUnlocked;
   Object.keys(state).forEach(k => delete state[k]);
   Object.assign(state, d.state || {});
   state.map = state.map || 'world';
@@ -1531,7 +1533,7 @@ if (startContinue) startContinue.onclick = () => { load(); hideStart(); };
 if (startNew) startNew.onclick = () => { hideStart(); resetAll(); };
 
 function resetAll(){
-  party.length=0; player.inv=[]; party.flags={}; player.scrap=0;
+  party.length=0; player.inv=[]; party.flags={}; player.scrap=0; player.campChest=[]; player.campChestUnlocked=false;
   Object.keys(worldFlags).forEach(k => delete worldFlags[k]);
   built = [];
   state.map='creator'; openCreator();

--- a/test/camp-chest.inventory.test.js
+++ b/test/camp-chest.inventory.test.js
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const invCode = await fs.readFile(new URL('../scripts/core/inventory.js', import.meta.url), 'utf8');
+
+const original = {
+  EventBus: global.EventBus,
+  Dustland: global.Dustland,
+  player: global.player,
+  party: global.party,
+  log: global.log,
+  toast: global.toast
+};
+
+const events = [];
+global.EventBus = { emit: (evt, payload) => events.push({ evt, payload }) };
+global.Dustland = global.Dustland || {};
+global.player = { inv: [], campChest: [], campChestUnlocked: false };
+global.party = { length: 1 };
+global.log = () => {};
+global.toast = () => {};
+
+vm.runInThisContext(invCode, { filename: 'core/inventory.js' });
+
+registerItem({ id: 'medkit', name: 'Medkit', type: 'supply', maxStack: 3 });
+registerItem({ id: 'relic_blade', name: 'Relic Blade', type: 'weapon' });
+
+test('storeCampChestItem requires unlocked chest', () => {
+  player.inv = [getItem('medkit')];
+  player.inv[0].count = 2;
+  player.campChestUnlocked = false;
+  const ok = storeCampChestItem(0);
+  assert.equal(ok, false);
+  assert.equal(player.inv.length, 1);
+  assert.equal(player.campChest.length, 0);
+});
+
+test('storeCampChestItem splits stacks across chest slots', () => {
+  events.length = 0;
+  player.campChestUnlocked = true;
+  player.campChest = [];
+  const bundle = getItem('medkit');
+  bundle.count = 5;
+  bundle.maxStack = 3;
+  player.inv = [bundle];
+  const ok = storeCampChestItem(0);
+  assert.equal(ok, true);
+  assert.equal(player.inv.length, 0);
+  assert.equal(player.campChest.length, 2);
+  assert.deepEqual(player.campChest.map(it => it.count || 1), [3, 2]);
+  assert.equal(events.some(e => e.evt === 'campChest:changed'), true);
+});
+
+test('withdrawCampChestItem merges stacks into inventory', () => {
+  events.length = 0;
+  player.inv = [];
+  player.campChest = [
+    { id: 'medkit', name: 'Medkit', type: 'supply', count: 3 },
+    { id: 'medkit', name: 'Medkit', type: 'supply', count: 2 }
+  ];
+  const first = withdrawCampChestItem(0);
+  assert.equal(first, true);
+  assert.equal(player.inv.length, 1);
+  assert.equal(player.inv[0].count, 3);
+  assert.equal(player.campChest.length, 1);
+  const second = withdrawCampChestItem(0);
+  assert.equal(second, true);
+  assert.equal(player.campChest.length, 0);
+  assert.equal(player.inv.length, 1);
+  assert.equal(player.inv[0].count, 5);
+  assert.equal(events.filter(e => e.evt === 'campChest:changed').length >= 2, true);
+});
+
+test('non-stackable items retain identity when stored', () => {
+  player.campChest = [];
+  player.inv = [getItem('relic_blade')];
+  const relic = player.inv[0];
+  relic.signature = 'etched';
+  const stored = storeCampChestItem(0);
+  assert.equal(stored, true);
+  assert.equal(player.inv.length, 0);
+  assert.equal(player.campChest.length, 1);
+  assert.equal(player.campChest[0].signature, 'etched');
+  const withdrawn = withdrawCampChestItem(0);
+  assert.equal(withdrawn, true);
+  assert.equal(player.inv.length, 1);
+  assert.equal(player.inv[0].signature, 'etched');
+});
+
+test('withdrawCampChestItem fails when inventory full', () => {
+  const capacity = getPartyInventoryCapacity();
+  player.inv = Array.from({ length: capacity }, (_, i) => ({ id: `junk_${i}` }));
+  player.campChest = [{ id: 'medkit', name: 'Medkit', type: 'supply', count: 1 }];
+  const messages = [];
+  global.log = msg => messages.push(msg);
+  const ok = withdrawCampChestItem(0);
+  assert.equal(ok, false);
+  assert.equal(player.campChest.length, 1);
+  assert.ok(messages.includes('Inventory full.'));
+  global.log = () => {};
+});
+
+test('unlockCampChest marks state and emits change', () => {
+  events.length = 0;
+  player.campChestUnlocked = false;
+  const result = unlockCampChest();
+  assert.equal(result, true);
+  assert.equal(player.campChestUnlocked, true);
+  assert.equal(events.some(e => e.evt === 'campChest:changed'), true);
+});
+
+test.after(() => {
+  if (original.EventBus === undefined) delete global.EventBus; else global.EventBus = original.EventBus;
+  if (original.Dustland === undefined) delete global.Dustland; else global.Dustland = original.Dustland;
+  if (original.player === undefined) delete global.player; else global.player = original.player;
+  if (original.party === undefined) delete global.party; else global.party = original.party;
+  if (original.log === undefined) delete global.log; else global.log = original.log;
+  if (original.toast === undefined) delete global.toast; else global.toast = original.toast;
+});


### PR DESCRIPTION
## Summary
- add camp chest state management helpers and exports to the inventory module and ensure the player save data includes the unlocked chest
- extend the camp UI with a purchase button and chest overlay so players can buy storage and move items between the chest and inventory
- cover the new chest flow and inventory helpers with focused tests

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3db77ba0883288d956fc8766d0e7c