### PR TITLE
feat: finalize bunker fast travel network

### DIFF
--- a/docs/design/core-systems/bunker-fast-travel.md
+++ b/docs/design/core-systems/bunker-fast-travel.md
@@ -33,24 +33,24 @@ that map rather than a raw reload of the module from the JS file?
 ## Implementation Sketch
 - [x] Create `scripts/core/fast-travel.js` handling node graphs and fuel costs.
 - [x] Hook into map UI in `scripts/ui/world-map.js` to select destinations.
-- [ ] Emit `travel:start` and `travel:end` events for mods.
+- [x] Emit `travel:start` and `travel:end` events for mods.
   - [x] Use the Manhattan distance between bunker coordinates from building definitions. Fuel cost scales as `BASE_COST + distance * FUEL_PER_TILE`, keeping math cheap on the grid.
-  - [ ] Implementation Sketch references `scripts/ui/world-map.js`
-  - [ ] fast travel Destination selection lives in a new `scripts/ui/world-map.js` overlay. It draws a rectangular, subway-style map with connected nodes for each unlocked bunker.
-  - [ ] The map functions as a hub above individual modules. Choosing a node loads that module while preserving party state and active quests.
-  - [ ] To verify cross-module travel, build a proof-of-concept `two-worlds` module:
+  - [x] Implementation Sketch references `scripts/ui/world-map.js`
+  - [x] fast travel Destination selection lives in a new `scripts/ui/world-map.js` overlay. It draws a rectangular, subway-style map with connected nodes for each unlocked bunker.
+  - [x] The map functions as a hub above individual modules. Choosing a node loads that module while preserving party state and active quests.
+  - [x] To verify cross-module travel, build a proof-of-concept `two-worlds` module:
     - [x] create a two worlds module added to module select
-    - [ ] create a world one module (not added to module select)
-    - [ ] create a world two module (not added to module select)
-    - [ ] in world one: add an NPC with item & item fetch quest
-    - [ ] in world two: add an NPC with item & item fetch quest
-    - [ ] add a fast travel destination bunker in each world
-    - [ ] in both worlds, seed hand-authored salvage caches and timed courier events that award enough power cells to demonstrate multi-hop travel without repetitive farming
-    - [ ] finishing the world 1 item fetch quest should unlock fast travel to world two by unboarding the door to the bunker (the bunker in world 2 should not ever be boarded)
-    - [ ] going into the bunker and choosing to fast travel should trigger a newly implemented scripts/ui/world-map.js
-    - [ ] scripts/ui/world-map.js should draw a rectangular subway-style map showing all unlocked fast travel nodes and allow for selection
-    - [ ] fast travelling between worlds should load the new map world, party and open quests should be retained across the module load boundary
-    - [ ] travelling back to the other world, completed quests/chosen dialog/taken item state should be preserved. perhaps a mechanism for this should be to generate a saved game when moving between maps and you travel back to a save of 
+    - [x] create a world one module (not added to module select)
+    - [x] create a world two module (not added to module select)
+    - [x] in world one: add an NPC with item & item fetch quest
+    - [x] in world two: add an NPC with item & item fetch quest
+    - [x] add a fast travel destination bunker in each world
+    - [x] in both worlds, seed hand-authored salvage caches and timed courier events that award enough power cells to demonstrate multi-hop travel without repetitive farming
+    - [x] finishing the world 1 item fetch quest should unlock fast travel to world two by unboarding the door to the bunker (the bunker in world 2 should not ever be boarded)
+    - [x] going into the bunker and choosing to fast travel should trigger a newly implemented scripts/ui/world-map.js
+    - [x] scripts/ui/world-map.js should draw a rectangular subway-style map showing all unlocked fast travel nodes and allow for selection
+    - [x] fast travelling between worlds should load the new map world, party and open quests should be retained across the module load boundary
+    - [x] travelling back to the other world, completed quests/chosen dialog/taken item state should be preserved. perhaps a mechanism for this should be to generate a saved game when moving between maps and you travel back to a save of
 > **Wing:** Make sure fuel costs scale with distance so speedrunners can't warp past the curve.
 
 ## Risks

--- a/modules/world-one.module.js
+++ b/modules/world-one.module.js
@@ -50,7 +50,11 @@ const DATA = `
       "id": "fuel_cell",
       "name": "Fuel Cell",
       "type": "quest",
-      "fuel": 50
+      "fuel": 50,
+      "map": "world",
+      "x": 0,
+      "y": 1,
+      "desc": "Packaged fuel cell tucked under debris."
     },
     {
       "id": "rusty_gear",
@@ -59,6 +63,33 @@ const DATA = `
       "map": "world",
       "x": 3,
       "y": 2
+    },
+    {
+      "id": "alpha_cache_one",
+      "name": "Salvage Cache (Alpha)",
+      "type": "quest",
+      "map": "world",
+      "x": 1,
+      "y": 3,
+      "fuel": 8,
+      "desc": "Hand-packed power cells ready for bunker jumps."
+    },
+    {
+      "id": "alpha_cache_two",
+      "name": "Salvage Cache (Alpha East)",
+      "type": "quest",
+      "map": "world",
+      "x": 3,
+      "y": 4,
+      "fuel": 6,
+      "desc": "Cache of scavenged cells near the bunker."
+    },
+    {
+      "id": "alpha_fuel",
+      "name": "Alpha Fuel Reserve",
+      "type": "quest",
+      "fuel": 12,
+      "desc": "Power cells gifted by the grateful mechanic."
     }
   ],
   "buildings": [
@@ -103,8 +134,25 @@ const DATA = `
           "text": "Perfect fit! Thanks.",
           "effects": [
             {
+              "effect": "toast",
+              "id": null,
+              "msg": "The bunker door slides open."
+            },
+            {
+              "effect": "unboardDoor",
+              "bunkerId": "alpha"
+            },
+            {
               "effect": "activateBunker",
-              "id": "beta"
+              "id": "alpha"
+            },
+            {
+              "effect": "addItem",
+              "id": "alpha_fuel"
+            },
+            {
+              "effect": "toast",
+              "msg": "Fuel +12 from the repaired rig."
             }
           ],
           "choices": [
@@ -186,6 +234,16 @@ const DATA = `
         "maxDist": 5
       }
     ]
+  },
+  "name": "world-one-module",
+  "props": {
+    "fastTravelModules": [
+      {
+        "script": "modules/world-two.module.js",
+        "global": "WORLD_TWO_MODULE",
+        "module": "world-two"
+      }
+    ]
   }
 }
 `;
@@ -209,6 +267,56 @@ function postLoad(module){
       });
     });
   });
+
+  const timers = module._timers || (module._timers = {});
+  function ensureCourier(flag, dropFactory, messageFactory, intervalMs){
+    if (!flag || typeof setTimeout !== 'function') return;
+    if (timers[flag]) return;
+    const interval = Math.max(1000, intervalMs || 20000);
+    party.flags = party.flags || {};
+    const last = Number(party.flags[flag]) || 0;
+    const now = Date.now();
+    const initialDelay = last ? Math.max(0, interval - (now - last)) : interval;
+    function schedule(delay){
+      timers[flag] = setTimeout(() => {
+        timers[flag] = null;
+        const drop = typeof dropFactory === 'function' ? dropFactory() : { ...dropFactory };
+        let added = false;
+        if (typeof addToInv === 'function') {
+          added = addToInv(drop);
+        }
+        if (!added && typeof dropItemNearParty === 'function') {
+          dropItemNearParty(drop);
+        }
+        party.flags[flag] = Date.now();
+        const msg = typeof messageFactory === 'function' ? messageFactory(drop) : messageFactory;
+        if (msg) {
+          if (typeof log === 'function') log(msg);
+          if (typeof toast === 'function') toast(msg);
+        }
+        Dustland.eventBus?.emit?.('courier:delivered', {
+          module: module.seed || module.name || 'world-one',
+          flag,
+          item: drop
+        });
+        schedule(interval);
+      }, Math.max(0, delay));
+    }
+    schedule(initialDelay);
+  }
+
+  ensureCourier(
+    'world_one_courier',
+    () => ({
+      id: 'world_one_courier_drop',
+      name: 'Courier Drop (Alpha Line)',
+      type: 'quest',
+      fuel: 8,
+      desc: 'Emergency cells routed to keep Alpha online.'
+    }),
+    drop => `Courier drop delivered ${drop.fuel ?? 0} fuel to Alpha.`,
+    20000
+  );
 }
 globalThis.WORLD_ONE_MODULE.postLoad = postLoad;
 

--- a/modules/world-two.module.js
+++ b/modules/world-two.module.js
@@ -78,7 +78,11 @@ const DATA = `
       "id": "fuel_cell",
       "name": "Fuel Cell",
       "type": "quest",
-      "fuel": 50
+      "fuel": 50,
+      "map": "world",
+      "x": 5,
+      "y": 5,
+      "desc": "Courier crate brimming with fuel cells."
     },
     {
       "id": "shiny_cog",
@@ -87,6 +91,33 @@ const DATA = `
       "map": "world",
       "x": 2,
       "y": 3
+    },
+    {
+      "id": "beta_cache_market",
+      "name": "Salvage Cache (Market)",
+      "type": "quest",
+      "map": "world",
+      "x": 1,
+      "y": 4,
+      "fuel": 7,
+      "desc": "Abandoned courier locker stuffed with cells."
+    },
+    {
+      "id": "beta_cache_rooftop",
+      "name": "Salvage Cache (Rooftop)",
+      "type": "quest",
+      "map": "world",
+      "x": 5,
+      "y": 1,
+      "fuel": 9,
+      "desc": "Wind-scoured cache lashed to the bunker roof."
+    },
+    {
+      "id": "beta_fuel",
+      "name": "Beta Fuel Dividend",
+      "type": "quest",
+      "fuel": 10,
+      "desc": "Courier thanks with fresh power cells."
     }
   ],
   "buildings": [
@@ -97,7 +128,7 @@ const DATA = `
       "h": 1,
       "doorX": 6,
       "doorY": 3,
-      "boarded": true,
+      "boarded": false,
       "bunker": true,
       "bunkerId": "beta"
     }
@@ -133,6 +164,16 @@ const DATA = `
             {
               "label": "(Leave)",
               "to": "bye"
+            }
+          ],
+          "effects": [
+            {
+              "effect": "addItem",
+              "id": "beta_fuel"
+            },
+            {
+              "effect": "toast",
+              "msg": "Fuel +10 from grateful courier."
             }
           ]
         }
@@ -208,6 +249,16 @@ const DATA = `
         "maxDist": 5
       }
     ]
+  },
+  "name": "world-two-module",
+  "props": {
+    "fastTravelModules": [
+      {
+        "script": "modules/world-one.module.js",
+        "global": "WORLD_ONE_MODULE",
+        "module": "world-one"
+      }
+    ]
   }
 }
 `;
@@ -231,6 +282,56 @@ function postLoad(module){
       });
     });
   });
+
+  const timers = module._timers || (module._timers = {});
+  function ensureCourier(flag, dropFactory, messageFactory, intervalMs){
+    if (!flag || typeof setTimeout !== 'function') return;
+    if (timers[flag]) return;
+    const interval = Math.max(1000, intervalMs || 22000);
+    party.flags = party.flags || {};
+    const last = Number(party.flags[flag]) || 0;
+    const now = Date.now();
+    const initialDelay = last ? Math.max(0, interval - (now - last)) : interval;
+    function schedule(delay){
+      timers[flag] = setTimeout(() => {
+        timers[flag] = null;
+        const drop = typeof dropFactory === 'function' ? dropFactory() : { ...dropFactory };
+        let added = false;
+        if (typeof addToInv === 'function') {
+          added = addToInv(drop);
+        }
+        if (!added && typeof dropItemNearParty === 'function') {
+          dropItemNearParty(drop);
+        }
+        party.flags[flag] = Date.now();
+        const msg = typeof messageFactory === 'function' ? messageFactory(drop) : messageFactory;
+        if (msg) {
+          if (typeof log === 'function') log(msg);
+          if (typeof toast === 'function') toast(msg);
+        }
+        Dustland.eventBus?.emit?.('courier:delivered', {
+          module: module.seed || module.name || 'world-two',
+          flag,
+          item: drop
+        });
+        schedule(interval);
+      }, Math.max(0, delay));
+    }
+    schedule(initialDelay);
+  }
+
+  ensureCourier(
+    'world_two_courier',
+    () => ({
+      id: 'world_two_courier_drop',
+      name: 'Courier Drop (Beta Line)',
+      type: 'quest',
+      fuel: 10,
+      desc: 'Beta line couriers stash fuel near the terminal.'
+    }),
+    drop => `Courier drop delivered ${drop.fuel ?? 0} fuel to Beta.`,
+    22000
+  );
 }
 globalThis.WORLD_TWO_MODULE.postLoad = postLoad;
 

--- a/scripts/ui/world-map.js
+++ b/scripts/ui/world-map.js
@@ -86,6 +86,12 @@
       overlay.style.alignItems = 'center';
       overlay.style.justifyContent = 'center';
 
+      const fuel = globalThis.player?.fuel ?? 0;
+      const fuelInfo = document.createElement('div');
+      fuelInfo.textContent = `Fuel available: ${fuel}`;
+      fuelInfo.style.marginBottom = '12px';
+      fuelInfo.style.fontSize = '0.95rem';
+
       const svgNS = 'http://www.w3.org/2000/svg';
       const width = 400;
       const height = 300;
@@ -107,47 +113,84 @@
       if(!originNode && fromId){
         originNode = { id: fromId, name: fromId, active: true, _skipEnsure: true };
       }
+      if(originNode && !originNode.module){
+        originNode.module = origin?.module ?? 'global';
+      }
       const nodes = dests.slice();
       if(originNode) nodes.unshift(originNode);
-      const coords = nodes.map((_, idx) => ({
-        x: (idx + 1) / (nodes.length + 1) * width,
-        y: height / 2
-      }));
-      nodes.forEach((b, i) => {
+
+      const groups = new Map();
+      nodes.forEach(node => {
+        const key = node.module ?? 'global';
+        if(!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(node);
+      });
+      const originModuleKey = originNode?.module ?? nodes[0]?.module ?? 'global';
+      const moduleOrder = Array.from(groups.keys());
+      moduleOrder.sort((a, b) => {
+        if(a === originModuleKey) return -1;
+        if(b === originModuleKey) return 1;
+        return a.localeCompare(b);
+      });
+      const margin = 40;
+      const innerWidth = width - margin * 2;
+      const innerHeight = height - margin * 2;
+      const coordsById = new Map();
+      moduleOrder.forEach((moduleName, idx) => {
+        const columnNodes = (groups.get(moduleName) || []).slice().sort((a, b) => {
+          if(a.id === originNode?.id) return -1;
+          if(b.id === originNode?.id) return 1;
+          const aLabel = a.name ?? a.id ?? '';
+          const bLabel = b.name ?? b.id ?? '';
+          return aLabel.localeCompare(bLabel);
+        });
+        const columnCount = Math.max(1, moduleOrder.length);
+        const xFraction = columnCount === 1 ? 0.5 : idx / (columnCount - 1);
+        const x = margin + innerWidth * xFraction;
+        columnNodes.forEach((node, rowIdx) => {
+          const rowCount = Math.max(1, columnNodes.length);
+          const yFraction = rowCount === 1 ? 0.5 : rowIdx / (rowCount - 1);
+          const y = margin + innerHeight * yFraction;
+          coordsById.set(node.id, { x, y });
+        });
+      });
+      const originPos = originNode ? coordsById.get(originNode.id) : null;
+
+      nodes.forEach(b => {
         const render = () => {
-          const { x, y } = coords[i] ?? { x: width / 2, y: height / 2 };
-          if(i > 0){
-            const prev = coords[i - 1];
-            if(prev){
-              const line = document.createElementNS(svgNS, 'line');
-              line.setAttribute('x1', prev.x);
-              line.setAttribute('y1', prev.y);
-              line.setAttribute('x2', x);
-              line.setAttribute('y2', y);
-              line.setAttribute('stroke', '#888');
-              line.setAttribute('stroke-width', '2');
-              svg.appendChild(line);
-            }
+          const pos = coordsById.get(b.id) || { x: width / 2, y: height / 2 };
+          const isOrigin = originNode && b.id === originNode.id;
+          if(!isOrigin && originNode && originPos){
+            const path = document.createElementNS(svgNS, 'path');
+            const pathData = `M${originPos.x},${originPos.y} H${pos.x} V${pos.y}`;
+            path.setAttribute('d', pathData);
+            path.setAttribute('fill', 'none');
+            path.setAttribute('stroke', '#666');
+            path.setAttribute('stroke-width', '2');
+            path.setAttribute('stroke-linecap', 'round');
+            svg.appendChild(path);
           }
           const circle = document.createElementNS(svgNS, 'circle');
-          circle.setAttribute('cx', x);
-          circle.setAttribute('cy', y);
-          const isOrigin = i === 0;
+          circle.setAttribute('cx', pos.x);
+          circle.setAttribute('cy', pos.y);
           circle.setAttribute('r', isOrigin ? 10 : 8);
-          circle.setAttribute('fill', isOrigin ? '#0ff' : '#fff');
+          const ftApi = globalThis.Dustland?.fastTravel;
+          const estimatedCost = isOrigin ? 0 : ftApi?.fuelCost?.(fromId, b.id);
+          const reachable = isOrigin || Number.isFinite(estimatedCost);
+          circle.setAttribute('fill', isOrigin ? '#0ff' : (reachable ? '#fff' : '#555'));
           if(isOrigin){
             circle.setAttribute('stroke', '#fff');
             circle.setAttribute('stroke-width', '2');
             circle.style.cursor = 'default';
           } else {
-            circle.style.cursor = 'pointer';
+            circle.style.cursor = reachable ? 'pointer' : 'not-allowed';
           }
           circle.title = b.name ?? b.id;
           if(!isOrigin){
             circle.onclick = () => {
               const ft = globalThis.Dustland?.fastTravel;
               const cost = ft?.fuelCost?.(fromId, b.id);
-              const fuel = globalThis.player?.fuel ?? 0;
+              const fuelAvailable = globalThis.player?.fuel ?? 0;
               const name = b.name ?? b.id;
               if(!Number.isFinite(cost)){
                 const msg = 'Fast travel destination unavailable.';
@@ -156,7 +199,7 @@
                 globalThis.Dustland?.eventBus?.emit?.('sfx', 'denied');
                 return;
               }
-              if(fuel < cost){
+              if(fuelAvailable < cost){
                 const msg = `Need ${cost} fuel to travel.`;
                 if(typeof log === 'function') log(msg);
                 if(typeof toast === 'function') toast(msg);
@@ -169,15 +212,17 @@
           svg.appendChild(circle);
 
           const text = document.createElementNS(svgNS, 'text');
-          text.setAttribute('x', x + 10);
-          text.setAttribute('y', y + 4);
+          text.setAttribute('x', pos.x + 12);
+          text.setAttribute('y', pos.y + 4);
           text.setAttribute('fill', '#fff');
           text.style.fontSize = '0.875rem';
-          if(i === 0){
+          const moduleLabel = b.module && b.module !== originNode?.module ? ` • ${b.module}` : '';
+          if(isOrigin){
             text.style.fontWeight = 'bold';
-            text.textContent = `Current: ${b.name ?? b.id}`;
+            text.textContent = `Current: ${b.name ?? b.id}${moduleLabel}`;
           } else {
-            text.textContent = b.name ?? b.id;
+            const status = Number.isFinite(estimatedCost) ? `Fuel ${estimatedCost}` : 'Locked';
+            text.textContent = `${b.name ?? b.id}${moduleLabel} — ${status}`;
           }
           svg.appendChild(text);
         };
@@ -188,6 +233,7 @@
         }
       });
 
+      overlay.appendChild(fuelInfo);
       overlay.appendChild(svg);
       const cancel = document.createElement('button');
       cancel.textContent = 'Cancel';

--- a/test/world-map.network.test.js
+++ b/test/world-map.network.test.js
@@ -14,7 +14,9 @@ test('open draws subway-style nodes for destinations', async () => {
   const context = { document, window: { document }, Dustland: { bunkers: [
     { id: 'home', active: true },
     { id: 'outpost', active: true }
-  ] } };
+  ], fastTravel: {
+    fuelCost(){ return 4; }
+  } } };
   vm.createContext(context);
   const code = await fs.readFile(new URL('../scripts/ui/world-map.js', import.meta.url), 'utf8');
   vm.runInContext(code, context);


### PR DESCRIPTION
## Summary
- rebuild the fast travel overlay to cluster bunkers by module, show fuel availability, and gray out locked destinations
- enrich the world one and world two proof-of-concept modules with fuel caches, quest rewards, bunker props, and courier drops
- mark the bunker fast travel design doc tasks as complete and adjust the network test to account for fuel cost checks

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/world-one.module.js
- node scripts/supporting/placement-check.js modules/world-two.module.js

------
https://chatgpt.com/codex/tasks/task_e_68d3dc4a23d48328abb640d4da55dd79