### PR TITLE
feat: scale guard stance and reflect damage

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -52,6 +52,20 @@ function recordCombatEvent(ev, relay = true){
 }
 globalThis.EventBus?.on?.('combat:event', ev => recordCombatEvent(ev, false));
 
+function guardStrengthFor(member){
+  const rawLvl = Number(member?.lvl ?? 1);
+  const lvl = Number.isFinite(rawLvl) ? Math.max(1, Math.floor(rawLvl)) : 1;
+  const scaling = Math.floor((lvl - 1) / 3);
+  return 1 + scaling;
+}
+
+function enterGuardStance(member){
+  if (!member) return 0;
+  const value = guardStrengthFor(member);
+  member.guard = value;
+  return value;
+}
+
 function hasStatusImmunity(target, type){
   if(!target || !type) return false;
   const key = `${type}_immune`;
@@ -266,7 +280,7 @@ function openCombat(enemies){
     (party || []).forEach(m => {
       m.maxAdr = m.maxAdr || 100;
       m.applyCombatMods?.();
-      m.guard = false;
+      m.guard = 0;
       m.cooldowns = m.cooldowns || {};
     });
 
@@ -1029,8 +1043,8 @@ function doSpecial(idx){
   }
 
   if (spec.guard){
-    m.guard = true;
-    log?.(`${m.name} takes a defensive stance.`);
+    const guardValue = enterGuardStance(m);
+    log?.(`${m.name} takes a defensive stance (${guardValue} guard).`);
     nextCombatant?.();
     return;
   }
@@ -1247,9 +1261,43 @@ function enemyAttack(){
   const minB = Math.max(1, base - 3);
   let dmg = Math.floor(Math.random() * (base - minB + 1)) + minB;
   if (target.guard){
-    target.guard = false;
-    dmg = Math.max(0, dmg - 1);
-    log?.(`${target.name} guards against the attack.`);
+    const guardValue = typeof target.guard === 'number' ? target.guard : guardStrengthFor(target);
+    target.guard = 0;
+    const blocked = Math.min(dmg, guardValue);
+    dmg = Math.max(0, dmg - guardValue);
+    log?.(`${target.name} guards against the attack, blocking ${blocked} damage.`);
+
+    const overflow = guardValue - blocked;
+    if (overflow > 0){
+      const beforeHp = typeof enemy.hp === 'number' ? enemy.hp : 0;
+      const reflected = Math.min(overflow, Math.max(beforeHp, 0));
+      enemy.hp = Math.max(0, beforeHp - overflow);
+      recordCombatEvent?.({
+        type: 'player',
+        actor: target.name,
+        action: 'guard-counter',
+        target: enemy.name,
+        damage: reflected,
+        targetHp: enemy.hp
+      });
+      log?.(`${enemy.name} is staggered by the counter and takes ${reflected} damage.`);
+      if (enemy.hp <= 0){
+        if (handleEnemyDefeat(target, enemy, `${target.name}'s guard`)){
+          combatState.enemies.splice(combatState.active,1);
+        }
+        renderCombat?.();
+        if (combatState.enemies.length === 0){
+          log?.('Victory!');
+          closeCombat('loot');
+        } else if (combatState.active < combatState.enemies.length){
+          highlightActive?.();
+          setTimeout(enemyAttack, 300);
+        } else {
+          startPartyTurn();
+        }
+        return;
+      }
+    }
   }
   dmg = Math.max(0, dmg - (target._bonus?.DEF || 0));
   const luck = (target.stats?.LCK || 0) + (target._bonus?.LCK || 0);
@@ -1277,5 +1325,5 @@ function getCombatLog(){
   return combatState.log.slice();
 }
 
-const combatExports = { openCombat, closeCombat, handleCombatKey, getCombatLog, addStatus, tickStatuses, __testAttack: testAttack, __combatState: combatState, playerItemAOEDamage, defeatEnemiesByRequirement };
+const combatExports = { openCombat, closeCombat, handleCombatKey, getCombatLog, addStatus, tickStatuses, __testAttack: testAttack, __combatState: combatState, __enemyAttack: enemyAttack, __enterGuardStance: enterGuardStance, playerItemAOEDamage, defeatEnemiesByRequirement };
 Object.assign(globalThis, combatExports);

--- a/scripts/core/party.js
+++ b/scripts/core/party.js
@@ -51,7 +51,7 @@ class Character {
     this.adrGenMod = 1;
     this.adrDmgMod = 1;
     this.cooldowns = {};
-    this.guard = false;
+    this.guard = 0;
     this.statusEffects = [];
     if(globalThis.Dustland?.status?.init){
       globalThis.Dustland.status.init(this);

--- a/test/guard-mechanics.test.js
+++ b/test/guard-mechanics.test.js
@@ -1,0 +1,152 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import './fast-timeouts.js';
+
+function stubEl(){
+  const el = {
+    style: {
+      display: '',
+      _props: {},
+      setProperty(k, v){ this._props[k] = v; },
+      getPropertyValue(k){ return this._props[k] || ''; }
+    },
+    classList: {
+      _set: new Set(),
+      add(c){ this._set.add(c); },
+      remove(c){ this._set.delete(c); },
+      toggle(c, force){
+        if (force === undefined){
+          this._set.has(c) ? this._set.delete(c) : this._set.add(c);
+        } else if (force){
+          this._set.add(c);
+        } else {
+          this._set.delete(c);
+        }
+      },
+      contains(c){ return this._set.has(c); }
+    },
+    textContent: '',
+    onclick: null,
+    children: [],
+    parentElement: null,
+    appendChild(child){
+      this.children.push(child);
+      child.parentElement = this;
+      return child;
+    },
+    prepend(child){
+      this.children.unshift(child);
+      child.parentElement = this;
+      return child;
+    },
+    querySelector(){ return stubEl(); },
+    querySelectorAll(){ return []; },
+    addEventListener(){},
+    removeEventListener(){},
+    setAttribute(){},
+    getBoundingClientRect(){ return { x:0, y:0, width:0, height:0 }; }
+  };
+  Object.defineProperty(el, 'innerHTML', {
+    get(){ return this._innerHTML || ''; },
+    set(v){ this._innerHTML = v; this.children = []; }
+  });
+  return el;
+}
+
+const combatOverlay = stubEl();
+const combatEnemies = stubEl();
+const combatParty = stubEl();
+const combatCmd = stubEl();
+const turnIndicator = stubEl();
+
+global.document = {
+  getElementById: (id) => ({
+    combatOverlay,
+    combatEnemies,
+    combatParty,
+    combatCmd,
+    turnIndicator
+  })[id] || stubEl(),
+  createElement: () => stubEl()
+};
+
+global.window = global;
+global.window.addEventListener = () => {};
+
+global.log = () => {};
+global.toast = () => {};
+global.renderInv = () => {};
+global.renderParty = () => {};
+global.updateHUD = () => {};
+global.player = { inv: [], hp: 10 };
+
+global.EventBus = { emit: () => {}, on: () => {} };
+
+await import('../scripts/core/party.js');
+await import('../scripts/core/combat.js');
+
+const { party, makeMember, openCombat, closeCombat, __combatState, __enemyAttack, __enterGuardStance } = globalThis;
+
+test('guard stance scales with level', () => {
+  const novice = makeMember('novice', 'Novice', 'Scout');
+  const veteran = makeMember('veteran', 'Veteran', 'Scout');
+  novice.lvl = 1;
+  veteran.lvl = 10;
+
+  const noviceGuard = __enterGuardStance(novice);
+  const veteranGuard = __enterGuardStance(veteran);
+
+  assert.ok(veteranGuard > noviceGuard);
+});
+
+test('guard overflow reflects damage to the attacker', async () => {
+  party.length = 0;
+  const hero = makeMember('hero', 'Hero', 'Scout');
+  hero.lvl = 4;
+  hero.maxHp = 12;
+  hero.hp = hero.maxHp;
+  party.push(hero);
+
+  const enemy = { name: 'Raider', hp: 5, maxHp: 5, ATK: 4 };
+  const combatPromise = openCombat([enemy]);
+
+  __enterGuardStance(hero);
+  __combatState.phase = 'enemy';
+  __combatState.active = 0;
+
+  const rand = Math.random;
+  Math.random = () => 0;
+  __enemyAttack();
+  Math.random = rand;
+
+  assert.strictEqual(hero.hp, hero.maxHp);
+  assert.strictEqual(__combatState.enemies[0].hp, 4);
+
+  closeCombat('flee');
+  await combatPromise;
+});
+
+test('guard reflection can defeat an attacker', async () => {
+  party.length = 0;
+  const hero = makeMember('guardian', 'Guardian', 'Sentinel');
+  hero.lvl = 10;
+  hero.maxHp = 18;
+  hero.hp = hero.maxHp;
+  party.push(hero);
+
+  const enemy = { name: 'Shade', hp: 3, maxHp: 3, ATK: 3 };
+  const combatPromise = openCombat([enemy]);
+
+  __enterGuardStance(hero);
+  __combatState.phase = 'enemy';
+  __combatState.active = 0;
+
+  const rand = Math.random;
+  Math.random = () => 0;
+  __enemyAttack();
+  Math.random = rand;
+
+  const result = await combatPromise;
+  assert.strictEqual(result.result, 'loot');
+  assert.strictEqual(party.length, 1);
+});


### PR DESCRIPTION
## Summary
- scale guard stance effectiveness with character level and reflect excess protection back onto attackers
- expose guard helpers for tests and update combat logging to describe blocked and counter damage
- cover guard scaling and reflection with new guard mechanics tests

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/balance-tester-agent.js

------
https://chatgpt.com/codex/tasks/task_e_68d3e2c336708328bc9538bcebc9e21d