### PR TITLE
feat: seed camp chest with medkits

### DIFF
--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -223,7 +223,14 @@ function unlockCampChest(){
   if(!p) return false;
   if(!p.campChestUnlocked){
     p.campChestUnlocked = true;
-    ensureCampChest();
+    const chest = ensureCampChest();
+    if(Array.isArray(chest) && chest.length === 0){
+      const medkit = getItem('medkit');
+      if(medkit){
+        setStackCount(medkit, 10);
+        mergeIntoCampChest(medkit);
+      }
+    }
     emitCampChestChanged();
   }
   return true;

--- a/test/camp-chest.inventory.test.js
+++ b/test/camp-chest.inventory.test.js
@@ -102,13 +102,27 @@ test('withdrawCampChestItem fails when inventory full', () => {
   global.log = () => {};
 });
 
-test('unlockCampChest marks state and emits change', () => {
+test('unlockCampChest seeds medkits and emits change once', () => {
   events.length = 0;
   player.campChestUnlocked = false;
+  player.campChest = [];
   const result = unlockCampChest();
   assert.equal(result, true);
   assert.equal(player.campChestUnlocked, true);
   assert.equal(events.some(e => e.evt === 'campChest:changed'), true);
+  assert.equal(player.campChest.length > 0, true);
+  const medkitCounts = player.campChest.map(it => Number.isFinite(it?.count) ? it.count : 1);
+  const totalMedkits = medkitCounts.reduce((sum, qty) => sum + qty, 0);
+  assert.equal(totalMedkits, 10);
+  assert.equal(player.campChest.every(it => it?.id === 'medkit'), true);
+  const snapshotCounts = [...medkitCounts];
+  const snapshotIds = player.campChest.map(it => it?.id);
+  events.length = 0;
+  const repeat = unlockCampChest();
+  assert.equal(repeat, true);
+  assert.deepEqual(player.campChest.map(it => Number.isFinite(it?.count) ? it.count : 1), snapshotCounts);
+  assert.deepEqual(player.campChest.map(it => it?.id), snapshotIds);
+  assert.equal(events.length, 0);
 });
 
 test.after(() => {


### PR DESCRIPTION
## Summary
- seed the camp chest with a stack of medkits the first time it is unlocked
- add coverage ensuring the starter stash contains ten medkits and is not reseeded on subsequent unlocks

## Testing
- npm test *(fails: dustland module JSON in modules/dustland.module.js has a malformed Helix Minigun entry, causing SyntaxError during module parsing)*
- node scripts/supporting/presubmit.js


------
https://chatgpt.com/codex/tasks/task_e_68d3e4a8bcfc8328ba9cca0bcee98353