### PR TITLE
fix: ignore hotkeys while typing in text fields

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2879,6 +2879,12 @@ function runTests(){
       if (e.key === 'Escape') document.getElementById('closeShopBtn')?.click();
       return;
     }
+    const target=e.target || document.activeElement;
+    const isTypingTarget=target?.matches?.('input:not([type]),input[type="text"],input[type="search"],input[type="email"],input[type="password"],input[type="number"],input[type="url"],input[type="tel"],textarea');
+    const isEditable=target?.isContentEditable;
+    if(isTypingTarget || isEditable){
+      return;
+    }
     if((e.key==='b' || e.key==='B') && mobileControlsEnabled && panel?.classList?.contains('show')){
       closePanel();
       e.preventDefault();


### PR DESCRIPTION
## Summary
- stop global keyboard shortcuts from firing while focus is on text inputs or editable elements

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3ea4793fc8328a74bc37994a2353f