### PR TITLE
fix: remove unused remote party helper

### DIFF
--- a/scripts/multiplayer.js
+++ b/scripts/multiplayer.js
@@ -45,12 +45,6 @@
     updateRemoteState();
   }
 
-  function removeRemoteParty(id){
-    if (!id) return;
-    if (!remoteParties.delete(id)) return;
-    updateRemoteState();
-  }
-
   function pruneRemoteParties(ids){
     const keep = new Set((ids || []).filter(id => typeof id === 'string'));
     let changed = false;


### PR DESCRIPTION
## Summary
- remove the unused remote party cleanup helper from the multiplayer module

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3eca9a3088328a9f8707db3f1a95e