### PR TITLE
feat: give gunslinger a dawnforge six-shooter

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -794,6 +794,26 @@
         "heavy",
         "wand"
       ]
+    },
+    {
+      "id": "dawnforge_six_shooter",
+      "name": "Dawnforge Six-Shooter",
+      "type": "weapon",
+      "desc": "Hand-tuned revolver balanced for blazing draws.",
+      "rarity": "rare",
+      "mods": {
+        "ATK": 4,
+        "ADR": 20,
+        "LCK": 1
+      },
+      "tags": [
+        "ranged"
+      ],
+      "equip": {
+        "requires": {
+          "role": "Gunslinger"
+        }
+      }
     }
   ],
   "quests": [

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -825,6 +825,26 @@ const DATA = `
         "heavy",
         "wand"
       ]
+    },
+    {
+      "id": "dawnforge_six_shooter",
+      "name": "Dawnforge Six-Shooter",
+      "type": "weapon",
+      "desc": "Hand-tuned revolver balanced for blazing draws.",
+      "rarity": "rare",
+      "mods": {
+        "ATK": 4,
+        "ADR": 20,
+        "LCK": 1
+      },
+      "tags": [
+        "ranged"
+      ],
+      "equip": {
+        "requires": {
+          "role": "Gunslinger"
+        }
+      }
     }
   ],
   "quests": [

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -1574,9 +1574,9 @@ const specializations={
     gear:[{id:'crowbar',name:'Crowbar',type:'weapon',mods:{ATK:+1}}]
   },
   'Gunslinger':{
-    desc:'Gunslinger: +1 AGI, starts with a pipe rifle, and tosses a Stun Grenade that deals 1 damage and stuns for a turn (40 ADR).',
+    desc:'Gunslinger: +1 AGI, starts with the Dawnforge Six-Shooter, and tosses a Stun Grenade that deals 1 damage and stuns for a turn (40 ADR).',
     stats:{AGI:+1},
-    gear:[{id:'pipe_rifle',name:'Pipe Rifle',type:'weapon',mods:{ATK:+2}}]
+    gear:[{id:'dawnforge_six_shooter',name:'Dawnforge Six-Shooter',type:'weapon',mods:{ATK:+3,ADR:+4,LCK:+1}}]
   },
   'Snakeoil Preacher':{
     desc:'Snakeoil Preacher: +1 CHA, carries the Tin Sun trinket, and patches wounds with First Aid for 4 HP (35 ADR).',

--- a/test/creator-perks.test.js
+++ b/test/creator-perks.test.js
@@ -38,8 +38,8 @@ test('specialization and quirk bonuses apply',()=>{
   assert.strictEqual(member.stats.AGI,5);
   assert.strictEqual(member.stats.LCK,5);
   const ids=inv.map(i=>i.id);
-  assert(!ids.includes('pipe_rifle'));
+  assert(!ids.includes('dawnforge_six_shooter'));
   assert(ids.includes('lucky_coin'));
-  assert.strictEqual(context.party[0].equip.weapon.id,'pipe_rifle');
+  assert.strictEqual(context.party[0].equip.weapon.id,'dawnforge_six_shooter');
   assert.strictEqual(context.party[0].equip.trinket,null);
 });


### PR DESCRIPTION
## Summary
- add the Dawnforge Six-Shooter weapon to the Dustland module data
- update the Gunslinger specialization to start with the upgraded revolver
- refresh creator perk tests to expect the new starting loadout

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68d3edf786e083289872eedffcad0ecd