### PR TITLE
fix: auto-activate beta bunker

### DIFF
--- a/modules/world-two.module.js
+++ b/modules/world-two.module.js
@@ -283,6 +283,20 @@ function postLoad(module){
     });
   });
 
+  function activateBunkerWhenReady(id, attempts){
+    if (!id || attempts <= 0) return;
+    const ft = globalThis.Dustland?.fastTravel;
+    if (ft?.activateBunker) {
+      ft.activateBunker(id);
+      return;
+    }
+    if (typeof setTimeout === 'function') {
+      setTimeout(() => activateBunkerWhenReady(id, attempts - 1), 50);
+    }
+  }
+
+  activateBunkerWhenReady('beta', 20);
+
   const timers = module._timers || (module._timers = {});
   function ensureCourier(flag, dropFactory, messageFactory, intervalMs){
     if (!flag || typeof setTimeout !== 'function') return;


### PR DESCRIPTION
## Summary
- ensure the Two Worlds module activates the Beta bunker as soon as the fast-travel API is available so it appears in the map immediately

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/world-two.module.js

------
https://chatgpt.com/codex/tasks/task_e_68d3e715040083289a14806fb3aced68