### PR TITLE
fix: let modules configure workbench recipes

### DIFF
--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -60,8 +60,18 @@
 
   function invokeWorkbench(recipe) {
     if (!recipe) return;
-    const fn = globalThis.Dustland?.workbench?.[recipe];
-    if (typeof fn === 'function') fn();
+    const workbench = globalThis.Dustland?.workbench;
+    if (!workbench) return;
+    if (typeof recipe === 'string') {
+      if (typeof workbench.craft === 'function') {
+        workbench.craft(recipe);
+      } else {
+        const fn = workbench[recipe];
+        if (typeof fn === 'function') fn();
+      }
+    } else if (typeof recipe === 'function') {
+      recipe();
+    }
   }
 
   const Effects = {
@@ -252,9 +262,11 @@
             } else if (typeof eff.log === 'string' && typeof log === 'function') {
               log(eff.log);
             } else if (!eff.silent && typeof log === 'function') {
-              if (diff > 0) log(`Cass's grudge rises to ${next}.`);
-              else if (diff < 0) log(`Cass's grudge falls to ${next}.`);
-              else log(`Cass's grudge holds at ${next}.`);
+              const name = eff.label || shop?.name || trader?.name || 'Trader';
+              const possessive = /s$/i.test(name) ? `${name}'` : `${name}'s`;
+              if (diff > 0) log(`${possessive} grudge rises to ${next}.`);
+              else if (diff < 0) log(`${possessive} grudge falls to ${next}.`);
+              else log(`${possessive} grudge holds at ${next}.`);
             }
             break; }
           case 'buyMemoryWorm': {
@@ -270,9 +282,6 @@
             if (typeof updateHUD === 'function') updateHUD();
             if (typeof log === 'function') log(eff.log || 'Purchased Memory Worm.');
             break; }
-          case 'craftSignalBeacon':
-            invokeWorkbench('craftSignalBeacon');
-            break;
           case 'workbenchCraft':
             invokeWorkbench(eff.recipe);
             break;

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -477,6 +477,10 @@ function applyModule(data = {}, options = {}) {
       if (k !== 'world' && k !== 'creator') delete mapLabels[k];
     });
 
+    if (globalThis.Dustland?.workbench?.setRecipes) {
+      globalThis.Dustland.workbench.setRecipes([]);
+    }
+
     // Generate terrain based on config
     let generated = false;
     if (moduleData.worldGen) {

--- a/scripts/workbench.js
+++ b/scripts/workbench.js
@@ -90,70 +90,64 @@
     return def;
   }
 
-  function craftSignalBeacon(){
-    const scrapCost = 5;
-    const fuelCost = 50;
-    if ((player.scrap || 0) < scrapCost){
-      log('Need 5 scrap.');
-      return;
-    }
-    if ((player.fuel || 0) < fuelCost){
-      log('Need 50 fuel.');
-      return;
-    }
-    player.scrap -= scrapCost;
-    player.fuel -= fuelCost;
-    addToInv('signal_beacon');
-    bus?.emit('craft:signal-beacon');
-    log('Crafted a signal beacon.');
+  const recipeRegistry = new Map();
+
+  function normalizeRequirement(req = {}) {
+    const key = req.key ?? req.id;
+    if (!key) return null;
+    const type = req.type === 'resource' ? 'resource' : 'item';
+    const amount = Number.isFinite(req.amount) ? req.amount : 1;
+    const label = req.label || String(key);
+    return { label, key, amount, type };
   }
 
-  function craftSolarTarp(){
-    const scrapCost = 3;
-    if ((player.scrap || 0) < scrapCost){
-      log('Need 3 scrap.');
-      return;
-    }
-    if (!hasItem('cloth')){
-      log('Need cloth.');
-      return;
-    }
-    player.scrap -= scrapCost;
-    const idx = findItemIndex('cloth');
-    if (idx >= 0) removeFromInv(idx);
-    addToInv('solar_tarp');
-    bus?.emit('craft:solar-tarp');
-    log('Crafted a solar panel tarp.');
+  function normalizeRecipe(def = {}) {
+    if (!def) return null;
+    const id = def.id ?? def.recipe ?? def.key;
+    const craft = typeof def.craft === 'function' ? def.craft : null;
+    if (!id || !craft) return null;
+    const name = def.name || def.label || String(id);
+    const requirements = Array.isArray(def.requirements)
+      ? def.requirements.map(normalizeRequirement).filter(Boolean)
+      : [];
+    return { id: String(id), name, craft, requirements };
   }
 
-  function craftBandage(){
-    if (!hasItem('plant_fiber')){
-      log('Need plant fiber.');
-      return;
-    }
-    const idx = findItemIndex('plant_fiber');
-    if (idx >= 0) removeFromInv(idx);
-    addToInv('bandage');
-    bus?.emit('craft:bandage');
-    log('Crafted a bandage.');
+  function setRecipes(list = []) {
+    recipeRegistry.clear();
+    list.forEach(def => {
+      const norm = normalizeRecipe(def);
+      if (norm) recipeRegistry.set(norm.id, norm);
+    });
+    return listRecipes();
   }
 
-  function craftAntidote(){
-    if (!hasItem('plant_fiber')){
-      log('Need plant fiber.');
-      return;
-    }
-    if (!hasItem('water_flask')){
-      log('Need a water flask.');
-      return;
-    }
-    let idx = findItemIndex('plant_fiber');
-    if (idx >= 0) removeFromInv(idx);
-    idx = findItemIndex('water_flask');
-    if (idx >= 0) removeFromInv(idx);
-    addToInv('antidote');
-    bus?.emit('craft:antidote');
-    log('Crafted an antidote.');
+  function registerRecipe(def) {
+    const norm = normalizeRecipe(def);
+    if (!norm) return null;
+    recipeRegistry.set(norm.id, norm);
+    return norm;
+  }
+
+  function unregisterRecipe(id) {
+    if (id == null) return;
+    recipeRegistry.delete(String(id));
+  }
+
+  function getRecipe(id) {
+    if (id == null) return null;
+    return recipeRegistry.get(String(id)) || null;
+  }
+
+  function listRecipes() {
+    return Array.from(recipeRegistry.values());
+  }
+
+  function craftRecipe(id) {
+    const recipe = getRecipe(id);
+    if (!recipe) return false;
+    const result = recipe.craft();
+    return result === undefined ? true : !!result;
   }
 
   function craftEnhancedItem(baseId){
@@ -240,54 +234,22 @@
     function renderRecipes(){
       list.innerHTML = '';
       focusables = [];
-      const recipes = [
-        {
-          name: 'Signal Beacon',
-          craft: craftSignalBeacon,
-          requirements: [
-            { label: 'Scrap', key: 'scrap', amount: 5, type: 'resource' },
-            { label: 'Fuel', key: 'fuel', amount: 50, type: 'resource' }
-          ]
-        },
-        {
-          name: 'Solar Panel Tarp',
-          craft: craftSolarTarp,
-          requirements: [
-            { label: 'Scrap', key: 'scrap', amount: 3, type: 'resource' },
-            { label: 'Cloth', key: 'cloth', amount: 1, type: 'item' }
-          ]
-        },
-        {
-          name: 'Bandage',
-          craft: craftBandage,
-          requirements: [
-            { label: 'Plant Fiber', key: 'plant_fiber', amount: 1, type: 'item' }
-          ]
-        },
-        {
-          name: 'Antidote',
-          craft: craftAntidote,
-          requirements: [
-            { label: 'Plant Fiber', key: 'plant_fiber', amount: 1, type: 'item' },
-            { label: 'Water Flask', key: 'water_flask', amount: 1, type: 'item' }
-          ]
-        }
-      ];
+      const baseRecipes = listRecipes();
       const enhancementRecipes = getEnhancementRecipes();
-      enhancementRecipes.forEach(r => recipes.push(r));
+      const recipes = [...baseRecipes, ...enhancementRecipes];
 
       recipes.forEach(r => {
         const row = document.createElement('div');
         row.className = 'slot';
         const info = document.createElement('div');
         const title = document.createElement('span');
-        title.textContent = r.name;
+        title.textContent = r.name || r.id || 'Recipe';
         info.appendChild(title);
         const reqList = document.createElement('ul');
         let craftable = true;
-        r.requirements.forEach(req => {
+        (Array.isArray(r.requirements) ? r.requirements : []).forEach(req => {
           const have = req.type === 'resource'
-            ? (player[req.key] || 0)
+            ? (player?.[req.key] || 0)
             : getItemCount(req.key);
           if (have < req.amount) craftable = false;
           const li = document.createElement('li');
@@ -300,7 +262,14 @@
           const btn = document.createElement('button');
           btn.className = 'btn';
           btn.textContent = 'Craft';
-          btn.onclick = () => { r.craft(); renderRecipes(); };
+          btn.onclick = () => {
+            if (r.id && typeof Dustland.workbench?.craft === 'function') {
+              Dustland.workbench.craft(r.id);
+            } else if (typeof r.craft === 'function') {
+              r.craft();
+            }
+            renderRecipes();
+          };
           row.appendChild(btn);
           focusables.push(btn);
         }
@@ -337,6 +306,14 @@
     overlay.focus();
   }
 
-  Dustland.workbench = { craftSignalBeacon, craftSolarTarp, craftBandage, craftAntidote, craftEnhancedItem };
+  Dustland.workbench = {
+    setRecipes,
+    registerRecipe,
+    unregisterRecipe,
+    getRecipe,
+    listRecipes,
+    craft: craftRecipe,
+    craftEnhancedItem
+  };
   Dustland.openWorkbench = openWorkbench;
 })();

--- a/test/workbench.ui.test.js
+++ b/test/workbench.ui.test.js
@@ -14,6 +14,99 @@ async function loadWorkbench(dom){
   vm.runInThisContext(code);
 }
 
+function registerTestRecipes(){
+  const workbench = globalThis.Dustland?.workbench;
+  if (!workbench || typeof workbench.setRecipes !== 'function') return;
+  const bus = globalThis.EventBus;
+  const log = typeof globalThis.log === 'function' ? globalThis.log : () => {};
+  const addToInv = typeof globalThis.addToInv === 'function' ? globalThis.addToInv : () => false;
+  const hasItem = typeof globalThis.hasItem === 'function' ? globalThis.hasItem : () => false;
+  const findItemIndex = typeof globalThis.findItemIndex === 'function' ? globalThis.findItemIndex : () => -1;
+  const removeFromInv = typeof globalThis.removeFromInv === 'function' ? globalThis.removeFromInv : () => {};
+
+  workbench.setRecipes([
+    {
+      id: 'signal_beacon',
+      name: 'Signal Beacon',
+      craft: () => {
+        const scrapCost = 5;
+        const fuelCost = 50;
+        const scrap = Number(globalThis.player?.scrap) || 0;
+        const fuel = Number(globalThis.player?.fuel) || 0;
+        if (scrap < scrapCost) { log('Need 5 scrap.'); return false; }
+        if (fuel < fuelCost) { log('Need 50 fuel.'); return false; }
+        globalThis.player.scrap = scrap - scrapCost;
+        globalThis.player.fuel = fuel - fuelCost;
+        addToInv('signal_beacon');
+        if (bus?.emit) bus.emit('craft:signal-beacon');
+        log('Crafted a signal beacon.');
+        return true;
+      },
+      requirements: [
+        { label: 'Scrap', key: 'scrap', amount: 5, type: 'resource' },
+        { label: 'Fuel', key: 'fuel', amount: 50, type: 'resource' }
+      ]
+    },
+    {
+      id: 'solar_tarp',
+      name: 'Solar Panel Tarp',
+      craft: () => {
+        const scrapCost = 3;
+        const scrap = Number(globalThis.player?.scrap) || 0;
+        if (scrap < scrapCost) { log('Need 3 scrap.'); return false; }
+        if (!hasItem('cloth')) { log('Need cloth.'); return false; }
+        globalThis.player.scrap = scrap - scrapCost;
+        const idx = findItemIndex('cloth');
+        if (idx >= 0) removeFromInv(idx);
+        addToInv('solar_tarp');
+        if (bus?.emit) bus.emit('craft:solar-tarp');
+        log('Crafted a solar panel tarp.');
+        return true;
+      },
+      requirements: [
+        { label: 'Scrap', key: 'scrap', amount: 3, type: 'resource' },
+        { label: 'Cloth', key: 'cloth', amount: 1, type: 'item' }
+      ]
+    },
+    {
+      id: 'bandage',
+      name: 'Bandage',
+      craft: () => {
+        if (!hasItem('plant_fiber')) { log('Need plant fiber.'); return false; }
+        const idx = findItemIndex('plant_fiber');
+        if (idx >= 0) removeFromInv(idx);
+        addToInv('bandage');
+        if (bus?.emit) bus.emit('craft:bandage');
+        log('Crafted a bandage.');
+        return true;
+      },
+      requirements: [
+        { label: 'Plant Fiber', key: 'plant_fiber', amount: 1, type: 'item' }
+      ]
+    },
+    {
+      id: 'antidote',
+      name: 'Antidote',
+      craft: () => {
+        if (!hasItem('plant_fiber')) { log('Need plant fiber.'); return false; }
+        if (!hasItem('water_flask')) { log('Need a water flask.'); return false; }
+        let idx = findItemIndex('plant_fiber');
+        if (idx >= 0) removeFromInv(idx);
+        idx = findItemIndex('water_flask');
+        if (idx >= 0) removeFromInv(idx);
+        addToInv('antidote');
+        if (bus?.emit) bus.emit('craft:antidote');
+        log('Crafted an antidote.');
+        return true;
+      },
+      requirements: [
+        { label: 'Plant Fiber', key: 'plant_fiber', amount: 1, type: 'item' },
+        { label: 'Water Flask', key: 'water_flask', amount: 1, type: 'item' }
+      ]
+    }
+  ]);
+}
+
 test('workbench shows requirement counts for recipes you lack', async () => {
   const dom = new JSDOM('<div id="workbenchOverlay"><div class="workbench-window"><header><button id="closeWorkbenchBtn"></button></header><div id="workbenchRecipes"></div></div></div>');
   await loadWorkbench(dom);
@@ -33,6 +126,7 @@ test('workbench shows requirement counts for recipes you lack', async () => {
   global.addToInv = id => { player.inv.push({ id }); return true; };
   global.countItems = id => player.inv.reduce((sum, it) => sum + (it.id === id ? Math.max(1, Number.isFinite(it?.count) ? it.count : 1) : 0), 0);
 
+  registerTestRecipes();
   Dustland.openWorkbench();
   const rows = dom.window.document.querySelectorAll('#workbenchRecipes .slot');
   assert.strictEqual(rows.length, 4);
@@ -68,6 +162,7 @@ test('arrow keys in workbench do not bubble to window', async () => {
 
   let moved = 0;
   dom.window.addEventListener('keydown', () => { moved++; });
+  registerTestRecipes();
   Dustland.openWorkbench();
   const overlay = dom.window.document.getElementById('workbenchOverlay');
   const evt = new dom.window.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
@@ -100,6 +195,7 @@ test('workbench lists enhancement recipes when you have duplicate gear', async (
     player.inv.push(global.getItem('pipe_blade'));
   }
 
+  registerTestRecipes();
   Dustland.openWorkbench();
 
   const rows = Array.from(dom.window.document.querySelectorAll('#workbenchRecipes .slot'));


### PR DESCRIPTION
## Summary
- add a workbench recipe registry so modules can register craftable items instead of relying on hard-coded Dustland data
- move Dustland crafting recipes into its postLoad hook and reset the workbench during module application
- tweak shop grudge messaging and update workbench tests for the configurable workflow

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68d3e837217883288c8c78e6f9def781