### PR TITLE
fix: restock essential supplies

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -777,6 +777,34 @@
       ]
     },
     {
+      "id": "tuned_crystal",
+      "name": "Tuned Crystal",
+      "type": "quest"
+    },
+    {
+      "id": "signal_fragment_1",
+      "name": "Signal Fragment 1",
+      "type": "quest",
+      "desc": "A strange, humming piece of metal that seems to resonate with the radio waves."
+    },
+    {
+      "id": "power_cell",
+      "name": "Power Cell",
+      "type": "quest"
+    },
+    {
+      "id": "signal_fragment_2",
+      "name": "Signal Fragment 2",
+      "type": "quest",
+      "desc": "Another humming fragment. The resonance is stronger."
+    },
+    {
+      "id": "signal_fragment_3",
+      "name": "Signal Fragment 3",
+      "type": "quest",
+      "desc": "The final fragment. It hums with a powerful, clear energy."
+    },
+    {
       "id": "minigun",
       "type": "weapon",
       "baseId": "wand",
@@ -977,6 +1005,31 @@
       "title": "Patch Cass's Wagon",
       "desc": "Deliver spare parts so Cass eases her grudge.",
       "xp": 1
+    },
+    {
+      "id": "q_first_echo",
+      "title": "The First Echo",
+      "desc": "Find the Tuned Crystal for Sparks to help him focus the Ghost Signal.",
+      "item": "tuned_crystal",
+      "reward": "signal_fragment_1",
+      "xp": 10
+    },
+    {
+      "id": "q_silent_tower",
+      "title": "The Silent Tower",
+      "desc": "Find 3 Power Cells to help Echo restore power to the comms tower.",
+      "item": "power_cell",
+      "count": 3,
+      "reward": "signal_fragment_2",
+      "xp": 20
+    },
+    {
+      "id": "q_resonant_cave",
+      "title": "The Resonant Cave",
+      "desc": "Follow the Hermit's instructions to activate the Resonant Crystals in the correct order.",
+      "reward": "signal_fragment_3",
+      "xp": 30,
+      "reqFlag": "cave_puzzle_complete"
     }
   ],
   "npcs": [
@@ -1966,6 +2019,12 @@
           },
           {
             "id": "water_flask",
+            "rarity": "common",
+            "cadence": "daily",
+            "refreshHours": 24
+          },
+          {
+            "id": "medkit",
             "rarity": "common",
             "cadence": "daily",
             "refreshHours": 24
@@ -3595,6 +3654,403 @@
         }
       },
       "symbol": "✦"
+    },
+    {
+      "id": "sparks",
+      "map": "radio_shack",
+      "x": 3,
+      "y": 2,
+      "name": "Sparks",
+      "color": "#a9f59f",
+      "title": "Wasteland Listener",
+      "desc": "An old man hunched over a crackling radio, his eyes wide with a strange light.",
+      "prompt": "A wiry scavenger hunched over a battered radio",
+      "questId": "q_first_echo",
+      "tree": {
+        "start": {
+          "text": "The signal... it's so faint. A whisper in a hurricane. I need something to focus the receiver. A crystal. A tuned crystal. There's one in the ruins to the east. Bring it to me!",
+          "choices": [
+            {
+              "label": "(Accept) I'll find your crystal.",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Turn in) I have the Tuned Crystal.",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Hurry! The ghosts don't wait forever.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "Yes, yes! This is it! Let me just... *static crackles* ... there! A fragment... a piece of the song! Take it. It's the key.",
+          "choices": [
+            {
+              "label": "(Take Fragment)",
+              "to": "post_quest",
+              "reward": "signal_fragment_1"
+            }
+          ]
+        },
+        "post_quest": {
+          "text": "The signal is stronger now, but it's moving. It points through the north door toward the old comms tower. Follow it when you're ready.",
+          "choices": [
+            {
+              "label": "(Head North) I'll follow the signal.",
+              "to": "bye",
+              "effects": [
+                {
+                  "effect": "toast",
+                  "msg": "Sparks nods toward the door to the north."
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "crystal_ruin",
+      "map": "radio_shack",
+      "x": 5,
+      "y": 3,
+      "name": "Collapsed Hut",
+      "color": "#9ef7a0",
+      "desc": "A pile of rubble. Something glints within.",
+      "prompt": "Collapsed hut with a crystal glinting in the rubble",
+      "tree": {
+        "start": {
+          "text": "A collapsed hut. It looks like it was recently scavenged.",
+          "choices": [
+            {
+              "label": "(Search the rubble)",
+              "to": "search",
+              "once": true
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "search": {
+          "text": "Among the debris, you find a strange, perfectly formed crystal.",
+          "choices": [
+            {
+              "label": "(Take Tuned Crystal)",
+              "to": "empty",
+              "reward": "tuned_crystal"
+            }
+          ]
+        },
+        "empty": {
+          "text": "There's nothing else of interest here.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "echo_scavenger",
+      "map": "comms_tower_base",
+      "x": 4,
+      "y": 4,
+      "name": "Echo",
+      "color": "#a9f59f",
+      "title": "Tech Scavenger",
+      "desc": "A young woman tinkering with a rusty control panel at the base of a huge comms tower.",
+      "prompt": "Young tinkerer repairing a rusted comm tower base",
+      "questId": "q_silent_tower",
+      "tree": {
+        "start": {
+          "text": "Almost got it... this old tower wants to sing again, I know it. But the generators are dead. I need three more power cells to get it online. There are some old service depots around here, maybe you can find some?",
+          "choices": [
+            {
+              "label": "(Accept) I'll find them.",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Turn in) I have 3 Power Cells.",
+              "to": "turnin",
+              "q": "turnin",
+              "reqItem": "power_cell",
+              "reqCount": 3
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "Thanks! Be careful out there.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "You found them! Amazing! Let's plug these in... *The tower hums to life, and a clear, melodic signal plays for a moment before fading.* It's beautiful... Here, I recorded the fragment for you.",
+          "choices": [
+            {
+              "label": "(Take Fragment)",
+              "to": "post_quest",
+              "reward": "signal_fragment_2",
+              "costItem": "power_cell",
+              "costCount": 3
+            }
+          ]
+        },
+        "post_quest": {
+          "text": "That was just one piece of it. The signal is a symphony! The next part hums behind the northern door, down into a cave system. It's strange, almost like it's underground.",
+          "choices": [
+            {
+              "label": "(Head North) I'll check it out.",
+              "to": "bye",
+              "effects": [
+                {
+                  "effect": "toast",
+                  "msg": "Echo gestures toward the tower ladder leading north."
+                }
+              ]
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "depot1",
+      "map": "comms_tower_base",
+      "x": 1,
+      "y": 7,
+      "name": "Service Depot",
+      "color": "#9ef7a0",
+      "desc": "A rusty service depot.",
+      "prompt": "Rusty service depot littered with wires",
+      "tree": {
+        "start": {
+          "text": "You find a Power Cell inside.",
+          "choices": [
+            {
+              "label": "(Take Cell)",
+              "to": "bye",
+              "reward": "power_cell",
+              "once": true
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "depot2",
+      "map": "comms_tower_base",
+      "x": 7,
+      "y": 7,
+      "name": "Service Depot",
+      "color": "#9ef7a0",
+      "desc": "A rusty service depot.",
+      "prompt": "Rusty service depot littered with wires",
+      "tree": {
+        "start": {
+          "text": "You find a Power Cell inside.",
+          "choices": [
+            {
+              "label": "(Take Cell)",
+              "to": "bye",
+              "reward": "power_cell",
+              "once": true
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "depot3",
+      "map": "comms_tower_base",
+      "x": 1,
+      "y": 2,
+      "name": "Service Depot",
+      "color": "#9ef7a0",
+      "desc": "A rusty service depot.",
+      "prompt": "Rusty service depot littered with wires",
+      "tree": {
+        "start": {
+          "text": "You find a Power Cell inside.",
+          "choices": [
+            {
+              "label": "(Take Cell)",
+              "to": "bye",
+              "reward": "power_cell",
+              "once": true
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "cave_hermit",
+      "map": "resonant_cave",
+      "x": 5,
+      "y": 1,
+      "name": "The Hermit",
+      "color": "#9abf9a",
+      "title": "Cave Dweller",
+      "desc": "A man with eyes that seem to look through you, not at you.",
+      "prompt": "Gaunt hermit in a humming cavern",
+      "questId": "q_resonant_cave",
+      "tree": {
+        "start": {
+          "text": "You feel the hum, don't you? This cave sings. The stones remember the signal's song. To hear it, you must play along. Red, Blue, then Green. Touch the crystals in that order.",
+          "choices": [
+            {
+              "label": "(Accept) I will listen.",
+              "to": "accept",
+              "q": "accept"
+            },
+            {
+              "label": "(Complete) I have activated the crystals.",
+              "to": "turnin",
+              "q": "turnin"
+            },
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "accept": {
+          "text": "The cave is patient.",
+          "choices": [
+            {
+              "label": "(Leave)",
+              "to": "bye"
+            }
+          ]
+        },
+        "turnin": {
+          "text": "You hear it now! The full song! The signal is not a what, but a where. It points to the Salt Flats. To the Observatory. Go.",
+          "choices": [
+            {
+              "label": "(Take Final Fragment)",
+              "to": "bye",
+              "reward": "signal_fragment_3",
+              "applyModule": "GRAFFITI_PUZZLE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "red_crystal",
+      "map": "resonant_cave",
+      "x": 2,
+      "y": 5,
+      "name": "Red Crystal",
+      "color": "#f88",
+      "prompt": "Glowing red crystal pulsing with energy",
+      "tree": {
+        "start": {
+          "text": "A large, red crystal hums faintly.",
+          "choices": [
+            {
+              "label": "(Touch it)",
+              "to": "bye",
+              "effects": [
+                {
+                  "effect": "addFlag",
+                  "flag": "crystal_1_red"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "blue_crystal",
+      "map": "resonant_cave",
+      "x": 8,
+      "y": 5,
+      "name": "Blue Crystal",
+      "color": "#88f",
+      "prompt": "Glowing blue crystal humming softly",
+      "tree": {
+        "start": {
+          "text": "A large, blue crystal hums faintly.",
+          "choices": [
+            {
+              "label": "(Touch it)",
+              "to": "bye",
+              "if": {
+                "flag": "crystal_1_red"
+              },
+              "effects": [
+                {
+                  "effect": "addFlag",
+                  "flag": "crystal_2_blue"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "green_crystal",
+      "map": "resonant_cave",
+      "x": 5,
+      "y": 8,
+      "name": "Green Crystal",
+      "color": "#8f8",
+      "prompt": "Glowing green crystal thrumming in the dark",
+      "tree": {
+        "start": {
+          "text": "A large, green crystal hums faintly.",
+          "choices": [
+            {
+              "label": "(Touch it)",
+              "to": "bye",
+              "if": {
+                "flag": "crystal_2_blue"
+              },
+              "effects": [
+                {
+                  "effect": "addFlag",
+                  "flag": "cave_puzzle_complete"
+                }
+              ]
+            }
+          ]
+        }
+      }
     }
   ],
   "events": [
@@ -3916,6 +4372,38 @@
       "toX": 2,
       "toY": 45,
       "desc": "The vision releases you back to the wastes."
+    },
+    {
+      "map": "radio_shack",
+      "x": 3,
+      "y": 0,
+      "toMap": "comms_tower_base",
+      "toX": 4,
+      "toY": 7
+    },
+    {
+      "map": "comms_tower_base",
+      "x": 4,
+      "y": 8,
+      "toMap": "radio_shack",
+      "toX": 3,
+      "toY": 1
+    },
+    {
+      "map": "comms_tower_base",
+      "x": 4,
+      "y": 0,
+      "toMap": "resonant_cave",
+      "toX": 5,
+      "toY": 9
+    },
+    {
+      "map": "resonant_cave",
+      "x": 5,
+      "y": 10,
+      "toMap": "comms_tower_base",
+      "toX": 4,
+      "toY": 1
     }
   ],
   "zoneEffects": [
@@ -4487,6 +4975,16 @@
       "boarded": true,
       "bunker": true,
       "bunkerId": "dustland_overlook"
+    },
+    {
+      "x": 5,
+      "y": 80,
+      "w": 1,
+      "h": 1,
+      "doorX": 5,
+      "doorY": 80,
+      "interiorId": "radio_shack",
+      "boarded": false
     }
   ],
   "interiors": [
@@ -4717,6 +5215,58 @@
         "🧱⬜🪨⬜🪨⬜🧱",
         "🧱⬜⬜⬜⬜⬜🧱",
         "🧱🧱🧱🚪🧱🧱🧱"
+      ]
+    },
+    {
+      "id": "radio_shack",
+      "w": 7,
+      "h": 5,
+      "entryX": 3,
+      "entryY": 3,
+      "grid": [
+        "🏝🏝🏝🚪🏝🏝🏝",
+        "🏝⬜⬜⬜⬜⬜🏝",
+        "🏝⬜⬜⬜⬜⬜🏝",
+        "🏝⬜⬜⬜⬜⬜🏝",
+        "🏝🏝🏝🚪🏝🏝🏝"
+      ]
+    },
+    {
+      "id": "comms_tower_base",
+      "w": 9,
+      "h": 9,
+      "entryX": 4,
+      "entryY": 7,
+      "grid": [
+        "🏝🏝🏝🏝🚪🏝🏝🏝🏝",
+        "🏝⬜⬜⬜⬜⬜⬜⬜🏝",
+        "🏝⬜🪨🪨🪨🪨🪨⬜🏝",
+        "🏝⬜🪨🏠🏠🏠🪨⬜🏝",
+        "🏝⬜🪨🏠⬜🏠🪨⬜🏝",
+        "🏝⬜🪨🏠🏠🏠🪨⬜🏝",
+        "🏝⬜🪨🪨🪨🪨🪨⬜🏝",
+        "🏝⬜⬜⬜⬜⬜⬜⬜🏝",
+        "🏝🏝🏝🏝🚪🏝🏝🏝🏝"
+      ]
+    },
+    {
+      "id": "resonant_cave",
+      "w": 11,
+      "h": 11,
+      "entryX": 5,
+      "entryY": 9,
+      "grid": [
+        "🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨🪨",
+        "🪨⬜⬜⬜⬜⬜⬜⬜⬜⬜🪨",
+        "🪨⬜🪨🪨⬜⬜⬜🪨🪨⬜🪨",
+        "🪨⬜🪨⬜⬜⬜⬜⬜🪨⬜🪨",
+        "🪨⬜⬜⬜🪨⬜🪨⬜⬜⬜🪨",
+        "🪨⬜⬜🪨⬜⬜⬜🪨⬜⬜🪨",
+        "🪨⬜⬜⬜⬜🪨⬜⬜⬜⬜🪨",
+        "🪨⬜🪨⬜⬜⬜⬜⬜🪨⬜🪨",
+        "🪨⬜🪨🪨⬜⬜⬜🪨🪨⬜🪨",
+        "🪨⬜⬜⬜⬜⬜⬜⬜⬜⬜🪨",
+        "🪨🪨🪨🪨🪨🚪🪨🪨🪨🪨🪨"
       ]
     }
   ],

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -807,6 +807,7 @@ const DATA = `
       "type": "quest",
       "desc": "The final fragment. It hums with a powerful, clear energy."
     },
+    {
       "id": "minigun",
       "type": "weapon",
       "baseId": "wand",
@@ -2021,6 +2022,12 @@ const DATA = `
           },
           {
             "id": "water_flask",
+            "rarity": "common",
+            "cadence": "daily",
+            "refreshHours": 24
+          },
+          {
+            "id": "medkit",
             "rarity": "common",
             "cadence": "daily",
             "refreshHours": 24

--- a/scripts/supporting/module-json.js
+++ b/scripts/supporting/module-json.js
@@ -33,6 +33,16 @@ function gridToEmoji(grid){
   return grid.map(r=> r.map(t=> tileEmoji[t] || '').join(''));
 }
 
+function worldIsNumeric(grid){
+  if (!Array.isArray(grid) || !grid.length) return false;
+  return grid.every(row => Array.isArray(row) && row.every(cell => typeof cell === 'number'));
+}
+
+function worldIsEmoji(grid){
+  if (!Array.isArray(grid) || !grid.length) return false;
+  return grid.every(row => typeof row === 'string');
+}
+
 function extractData(str){
   const match = str.match(/const DATA = `([\s\S]*?)`;/);
   return match ? match[1] : null;
@@ -46,7 +56,7 @@ if (cmd === 'export') {
     process.exit(1);
   }
   const obj = JSON.parse(dataStr);
-  if (Array.isArray(obj.world) && Array.isArray(obj.world[0]) && typeof obj.world[0][0] === 'number') {
+  if (worldIsNumeric(obj.world)) {
     obj.world = gridToEmoji(obj.world);
   }
   obj.module = file;
@@ -57,7 +67,7 @@ if (cmd === 'export') {
 } else if (cmd === 'import') {
   const jsonText = fs.readFileSync(jsonPath, 'utf8');
   const obj = JSON.parse(jsonText);
-  if (Array.isArray(obj.world) && typeof obj.world[0] === 'string') {
+  if (worldIsEmoji(obj.world)) {
     obj.world = gridFromEmoji(obj.world);
   }
   delete obj.module;

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -193,6 +193,7 @@ test('trader patrols east-west with basic goods', () => {
     'pipe_rifle',
     'leather_jacket',
     'water_flask',
+    'medkit',
     'frag_grenade',
     'incendiary_grenade',
     'minigun'

--- a/test/shop-restock.test.js
+++ b/test/shop-restock.test.js
@@ -1,0 +1,137 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import './fast-timeouts.js';
+
+test('essential supplies restock after ten world turns', async () => {
+  const TILE = { SAND: 0, ROCK: 1, WATER: 2, BRUSH: 3, ROAD: 4, RUIN: 5, WALL: 6, FLOOR: 7, DOOR: 8, BUILDING: 9 };
+  const walkable = { 0: true, 1: true, 2: false, 3: true, 4: true, 5: true, 6: false, 7: true, 8: true, 9: false };
+  globalThis.TILE = TILE;
+  globalThis.walkable = walkable;
+  globalThis.clamp = (v, a, b) => {
+    if (a > b) [a, b] = [b, a];
+    return Math.max(a, Math.min(b, v));
+  };
+  globalThis.WORLD_W = 5;
+  globalThis.WORLD_H = 5;
+  const WORLD_W = globalThis.WORLD_W;
+  const WORLD_H = globalThis.WORLD_H;
+  const world = Array.from({ length: WORLD_H }, () => Array(WORLD_W).fill(TILE.SAND));
+  globalThis.world = world;
+  globalThis.interiors = {};
+  globalThis.portals = [];
+  globalThis.buildings = [];
+  globalThis.enemyBanks = {};
+  globalThis.enemyTurnStats = {};
+  globalThis.tileEvents = [];
+  globalThis.itemDrops = [];
+
+  const party = [{ id: 'p1', name: 'Scout', role: 'scout', hp: 10, maxHp: 10, adr: 0, stats: {}, equip: {} }];
+  party.x = 2;
+  party.y = 2;
+  party.map = 'world';
+  globalThis.party = party;
+  const state = { map: 'world', mapEntry: null };
+  globalThis.state = state;
+
+  globalThis.player = { hp: 10, inv: [], scrap: 0 };
+  globalThis.log = () => {};
+  globalThis.toast = () => {};
+  globalThis.renderParty = () => {};
+  globalThis.renderInv = () => {};
+  globalThis.renderQuests = () => {};
+  globalThis.updateHUD = () => {};
+  globalThis.centerCamera = () => {};
+  globalThis.updateZoneMsgs = () => {};
+  globalThis.applyZones = () => {};
+  globalThis.footstepBump = () => {};
+  globalThis.pickupSparkle = () => {};
+  globalThis.getPartyInventoryCapacity = () => 10;
+  globalThis.addToInv = () => {};
+  globalThis.getItem = () => null;
+  globalThis.checkFlagCondition = () => true;
+  globalThis.tickStatuses = () => {};
+  globalThis.leader = () => party[0];
+  globalThis.setPartyPos = (x, y) => { party.x = x; party.y = y; };
+  globalThis.setMap = map => { state.map = map; party.map = map; };
+
+  const handlers = new Map();
+  const bus = {
+    on(event, fn) {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event).add(fn);
+    },
+    off(event, fn) {
+      handlers.get(event)?.delete(fn);
+    },
+    emit(event, payload) {
+      handlers.get(event)?.forEach(fn => fn(payload));
+    }
+  };
+  globalThis.EventBus = bus;
+
+  const effectsStub = { tick() {}, apply() {} };
+  globalThis.Effects = effectsStub;
+
+  const trader = { id: 'trader', shop: { markup: 1, inv: [] } };
+  globalThis.NPCS = [trader];
+
+  const moduleData = {
+    npcs: [
+      {
+        id: 'trader',
+        shop: {
+          markup: 1,
+          inv: [
+            { id: 'medkit', rarity: 'common', cadence: 'daily', refreshHours: 24 },
+            { id: 'water_flask', rarity: 'common', cadence: 'daily', refreshHours: 24 }
+          ]
+        }
+      }
+    ]
+  };
+
+  globalThis.Dustland = {
+    eventBus: bus,
+    effects: effectsStub,
+    actions: { startCombat: () => ({ result: 'flee' }) },
+    path: { tickPathAI() {} },
+    zoneEffects: [],
+    fastTravel: {},
+    worldMap: {},
+    loadedModules: { 'restock-test': moduleData },
+    currentModule: 'restock-test'
+  };
+
+  const code = await fs.readFile(new URL('../scripts/core/movement.js', import.meta.url), 'utf8');
+  vm.runInThisContext(code, { filename: 'movement.js' });
+
+  const { move, getWorldTurns } = globalThis.Dustland.movement;
+  assert.strictEqual(typeof move, 'function');
+  assert.strictEqual(trader.shop.inv.length, 0);
+
+  for (let i = 0; i < 9; i++) {
+    await move(0, 0);
+  }
+  assert.strictEqual(trader.shop.inv.length, 0);
+
+  await move(0, 0);
+  const firstRestockIds = trader.shop.inv.map(entry => entry.id);
+  assert.ok(firstRestockIds.includes('medkit'));
+  assert.ok(firstRestockIds.includes('water_flask'));
+
+  trader.shop.inv.length = 0;
+  const startTurn = getWorldTurns();
+
+  for (let i = 0; i < 9; i++) {
+    await move(0, 0);
+  }
+  assert.strictEqual(trader.shop.inv.length, 0);
+
+  await move(0, 0);
+  const secondRestockIds = trader.shop.inv.map(entry => entry.id);
+  assert.ok(secondRestockIds.includes('medkit'));
+  assert.ok(secondRestockIds.includes('water_flask'));
+  assert.ok(getWorldTurns() >= startTurn + 10);
+});

--- a/test/trader-price-scan.test.js
+++ b/test/trader-price-scan.test.js
@@ -26,6 +26,7 @@ test('collectPricingData summarizes dustland traders and scrap', () => {
     'pipe_rifle',
     'leather_jacket',
     'water_flask',
+    'medkit',
     'frag_grenade',
     'incendiary_grenade',
     'minigun'


### PR DESCRIPTION
## Summary
- ensure essential supplies like medkits and water flasks restock after ten world turns via movement hooks
- add medkit to Cass the Trader's inventory in both the module script and JSON data
- update trader expectations and add a dedicated restock test to cover the new logic
- update the module-json tooling to convert numeric world grids into emoji rows and re-export dustland.json accordingly

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3e50692288328a0b6a3dbeb04e8f3