### PR TITLE
feat: add UI font selector

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -6,6 +6,7 @@
         --muted: #7a8a7a;
         --panelW: 440px;
         --font-scale: 1;
+        --ui-font: 'Pixelify Sans', sans-serif;
     }
 
     html {
@@ -44,7 +45,7 @@ input[type="range"] {
         background: radial-gradient(circle at top, #141614 0%, var(--bg) 70%);
         color: var(--ink);
         overscroll-behavior-y: none;
-        font-family: 'Pixelify Sans', sans-serif;
+        font-family: var(--ui-font, 'Pixelify Sans', sans-serif);
         font-size: 0.875rem;
         line-height: 1.5;
     }

--- a/dustland.html
+++ b/dustland.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
   <title>Dustland: CRT Edition</title>
-  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Oxanium:wght@400;600;700&family=Pixelify+Sans:wght@400;700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="dustland.css" />
 </head>
 <body>
@@ -135,6 +135,16 @@
           <label for="fontScale">Font Scale</label>
           <input type="range" id="fontScale" min="1" max="1.75" step="0.05" value="1" />
           <div class="small" id="fontScaleValue">100%</div>
+        </div>
+        <div class="field">
+          <label for="fontFamily">UI Font</label>
+          <select id="fontFamily">
+            <option value="pixel">Pixelify Sans (Retro)</option>
+            <option value="oxanium">Oxanium (Tech)</option>
+            <option value="atkinson">Atkinson Hyperlegible (Readable)</option>
+            <option value="roboto">Roboto (Modern)</option>
+          </select>
+          <div class="small" id="fontFamilySample">Sample: The wasteland is calling.</div>
         </div>
         <div class="field">
           <label id="playerIconLabel">Player Icon</label>

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -373,6 +373,70 @@ function setFontScale(scale, opts = {}){
     globalThis.localStorage?.setItem(FONT_SCALE_STORAGE_KEY, formatFontScale(next));
   }
 }
+
+const FONT_FAMILY_STORAGE_KEY = 'fontFamily';
+const FONT_FAMILY_SAMPLE_TEXT = 'Sample: The wasteland is calling.';
+const FONT_FAMILY_OPTIONS = [
+  { id:'pixel', css:"'Pixelify Sans', sans-serif" },
+  { id:'oxanium', css:"'Oxanium', 'Pixelify Sans', sans-serif" },
+  { id:'atkinson', css:"'Atkinson Hyperlegible', 'Source Sans Pro', 'Arial', sans-serif" },
+  { id:'roboto', css:"'Roboto', 'Helvetica Neue', 'Arial', sans-serif" }
+];
+const FONT_FAMILY_DEFAULT = FONT_FAMILY_OPTIONS[0];
+let fontFamily = FONT_FAMILY_DEFAULT;
+
+function getFontFamilyOption(id){
+  if(!id) return FONT_FAMILY_DEFAULT;
+  for(let i=0;i<FONT_FAMILY_OPTIONS.length;i++){
+    const option = FONT_FAMILY_OPTIONS[i];
+    if(option.id === id) return option;
+  }
+  return FONT_FAMILY_DEFAULT;
+}
+
+function updateFontFamilyUI(id){
+  if(typeof document === 'undefined') return;
+  const option = getFontFamilyOption(id);
+  const select = document.getElementById('fontFamily');
+  if(select){
+    select.value = option.id;
+    select.style?.setProperty?.('font-family', option.css);
+  }
+  const sample = document.getElementById('fontFamilySample');
+  if(sample){
+    sample.textContent = FONT_FAMILY_SAMPLE_TEXT;
+    sample.style?.setProperty?.('font-family', option.css);
+  }
+}
+
+function applyFontFamily(option){
+  fontFamily = option || FONT_FAMILY_DEFAULT;
+  const style = getFontScaleRootStyle();
+  const value = fontFamily.css || FONT_FAMILY_DEFAULT.css;
+  style?.setProperty('--ui-font', value);
+  if(typeof document !== 'undefined'){
+    const bodyStyle = document.body?.style;
+    if(bodyStyle && bodyStyle !== style){
+      bodyStyle.setProperty('--ui-font', value);
+    }
+  }
+  updateFontFamilyUI(fontFamily.id);
+}
+
+function setFontFamily(id, opts = {}){
+  const option = getFontFamilyOption(id);
+  applyFontFamily(option);
+  if(!opts.skipStorage){
+    globalThis.localStorage?.setItem(FONT_FAMILY_STORAGE_KEY, option.id);
+  }
+}
+
+const savedFontFamily = globalThis.localStorage?.getItem(FONT_FAMILY_STORAGE_KEY);
+if(typeof savedFontFamily === 'string' && savedFontFamily){
+  setFontFamily(savedFontFamily, { skipStorage: true });
+} else {
+  applyFontFamily(fontFamily);
+}
 const savedFontScale = Number.parseFloat(globalThis.localStorage?.getItem(FONT_SCALE_STORAGE_KEY));
 if(Number.isFinite(savedFontScale)){
   setFontScale(savedFontScale, { skipStorage: true });
@@ -2715,6 +2779,13 @@ function runTests(){
       setFontScale(raw);
     });
     updateFontScaleUI(fontScale);
+  }
+  const fontFamilySelect=document.getElementById('fontFamily');
+  if(fontFamilySelect){
+    fontFamilySelect.addEventListener('change', ()=>{
+      setFontFamily(fontFamilySelect.value);
+    });
+    updateFontFamilyUI(fontFamily.id);
   }
   const retroToggle=document.getElementById('retroNpcToggle');
   if(retroToggle){

--- a/test/font-family.test.js
+++ b/test/font-family.test.js
@@ -1,0 +1,70 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDocument } from './test-harness.js';
+
+const full = await fs.readFile(new URL('../scripts/dustland-engine.js', import.meta.url), 'utf8');
+const code = full.split('// ===== Boot =====')[0];
+
+class AudioCtx {
+  createOscillator(){ return { connect(){}, start(){}, stop(){}, frequency:{ value:0 }, type:'' }; }
+  createGain(){ return { connect(){}, gain:{ value:0, exponentialRampToValueAtTime(){} } }; }
+  get destination(){ return {}; }
+  get currentTime(){ return 0; }
+}
+
+test('font family select updates CSS variable and localStorage', async () => {
+  const document = makeDocument();
+  const localStore = new Map();
+  const localStorage = {
+    getItem: key => (localStore.has(key) ? localStore.get(key) : null),
+    setItem: (key, value) => { localStore.set(key, value); }
+  };
+  const window = {
+    document,
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    HTMLCanvasElement: class {},
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  window.HTMLCanvasElement.prototype.getContext = () => ({ });
+  const context = {
+    window,
+    document,
+    requestAnimationFrame: () => 0,
+    AudioContext: AudioCtx,
+    webkitAudioContext: AudioCtx,
+    Audio: class { constructor(){ this.addEventListener = () => {}; } cloneNode(){ return new this.constructor(); } },
+    EventBus: { on: () => {}, emit: () => {} },
+    Dustland: { eventBus: { on: () => {}, emit: () => {} } },
+    NanoDialog: { enabled: true },
+    location: { hash: '' },
+    move: () => {},
+    interact: () => {},
+    takeNearestItem: () => {},
+    save: () => {},
+    load: () => {},
+    resetAll: () => {},
+    console,
+    localStorage,
+    globalThis: null
+  };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(code, context);
+
+  const initialFont = document.body.style.getPropertyValue('--ui-font');
+  assert.strictEqual(initialFont, "'Pixelify Sans', sans-serif");
+  const select = document.getElementById('fontFamily');
+  select.value = 'atkinson';
+  select.dispatchEvent({ type: 'change' });
+  const updated = document.body.style.getPropertyValue('--ui-font');
+  assert.strictEqual(updated, "'Atkinson Hyperlegible', 'Source Sans Pro', 'Arial', sans-serif");
+  assert.strictEqual(localStore.get('fontFamily'), 'atkinson');
+  select.value = 'pixel';
+  select.dispatchEvent({ type: 'change' });
+  assert.strictEqual(document.body.style.getPropertyValue('--ui-font'), "'Pixelify Sans', sans-serif");
+});
+


### PR DESCRIPTION
## Summary
- load additional Google Fonts for the control panel and expose a UI font picker in settings
- store the selection in a CSS variable/localStorage so the interface uses the chosen typeface across sessions
- add automated coverage that the font selector updates the CSS variable and persistence layer

## Testing
- npm test *(jsdom reports network errors while fetching Google Fonts in the sandbox, but the suite passes)*
- node scripts/supporting/presubmit.js


------
https://chatgpt.com/codex/tasks/task_e_68d3e9ecf2d48328a4854b0a38de01c0