### PR TITLE
fix: target encounter input lock by key

### DIFF
--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -19,6 +19,16 @@ bus?.on?.('weather:change', w => {
   encounterBias = w?.encounterBias || null;
 });
 
+const RANDOM_COMBAT_INPUT_LOCK_MS = 333;
+
+function lockInput(ms = RANDOM_COMBAT_INPUT_LOCK_MS, key){
+  const game = globalThis.Dustland || (globalThis.Dustland = {});
+  const target = Date.now() + ms;
+  const current = typeof game.inputLockUntil === 'number' ? game.inputLockUntil : 0;
+  game.inputLockUntil = current > target ? current : target;
+  game.inputLockKey = typeof key === 'string' ? key.toLowerCase() : null;
+}
+
 function zoneAttrs(map,x,y){
   let healMult = 1;
   let noEncounters = false;
@@ -409,6 +419,7 @@ function checkRandomEncounter(){
       const min = mods.minSteps ?? 3;
       const max = mods.maxSteps ?? 5;
       encounterCooldown = min + Math.floor(Math.random() * (max - min + 1));
+      lockInput(undefined, globalThis.Dustland?.lastNonCombatKey);
       return Dustland.actions.startCombat({ ...chosen });
     }
     return;
@@ -448,6 +459,7 @@ function checkRandomEncounter(){
     const min = mods.minSteps ?? 3;
     const max = mods.maxSteps ?? 5;
     encounterCooldown = min + Math.floor(Math.random() * (max - min + 1));
+    lockInput(undefined, globalThis.Dustland?.lastNonCombatKey);
     return Dustland.actions.startCombat(def);
   }
 }

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -2727,6 +2727,20 @@ function runTests(){
   }
 
   window.addEventListener('keydown',(e)=>{
+    const game = globalThis.Dustland || (globalThis.Dustland = {});
+    const lockUntil = game.inputLockUntil;
+    if(typeof lockUntil === 'number' && lockUntil > Date.now()){
+      const lockedKey = typeof game.inputLockKey === 'string' ? game.inputLockKey : null;
+      if(!lockedKey){
+        return;
+      }
+      const incoming = typeof e.key === 'string' ? e.key.toLowerCase() : '';
+      if(incoming && incoming === lockedKey){
+        return;
+      }
+    } else if(game.inputLockKey){
+      game.inputLockKey = null;
+    }
     if(overlay?.classList.contains('shown')){
       if(e.key==='Escape') closeDialog();
       else if(handleDialogKey?.(e)) e.preventDefault();
@@ -2747,6 +2761,8 @@ function runTests(){
       e.preventDefault();
       return;
     }
+    const keyId = typeof e.key === 'string' ? e.key.toLowerCase() : '';
+    if(keyId) game.lastNonCombatKey = keyId;
     switch(e.key){
       case 'ArrowUp': case 'w': case 'W': move(0,-1); break;
       case 'ArrowDown': case 's': case 'S': move(0,1); break;


### PR DESCRIPTION
## Summary
- remember the last non-combat key press and pass it to the random encounter input lock
- skip only the locked key while the encounter transition is active so other input still works

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/balance-tester-agent.js

------
https://chatgpt.com/codex/tasks/task_e_68d3419222288328b8ec43c360d9326b