### PR TITLE
fix: ensure font scale slider affects rem sizing

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -46,8 +46,11 @@ input[type="range"] {
         color: var(--ink);
         overscroll-behavior-y: none;
         font-family: var(--ui-font, 'Pixelify Sans', sans-serif);
-        font-size: 0.875rem;
         line-height: 1.5;
+    }
+
+    body {
+        font-size: 0.875rem;
     }
 
     .wrap {


### PR DESCRIPTION
## Summary
- ensure the html element keeps the scalable base font size while body applies the 0.875rem sizing

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3f9bb82f08328bdcb45df62fd1535