### PR TITLE
fix: scope module data constants

### DIFF
--- a/modules/world-one.module.js
+++ b/modules/world-one.module.js
@@ -1,5 +1,6 @@
 function seedWorldContent() {}
 
+(function(){
 const DATA = `
 {
   "seed": "world-one",
@@ -319,6 +320,8 @@ function postLoad(module){
   );
 }
 globalThis.WORLD_ONE_MODULE.postLoad = postLoad;
+
+})();
 
 startGame = function(){
   WORLD_ONE_MODULE.postLoad?.(WORLD_ONE_MODULE);

--- a/modules/world-two.module.js
+++ b/modules/world-two.module.js
@@ -1,5 +1,6 @@
 function seedWorldContent() {}
 
+(function(){
 const DATA = `
 {
   "seed": "world-two",
@@ -348,6 +349,8 @@ function postLoad(module){
   );
 }
 globalThis.WORLD_TWO_MODULE.postLoad = postLoad;
+
+})();
 
 startGame = function(){
   WORLD_TWO_MODULE.postLoad?.(WORLD_TWO_MODULE);


### PR DESCRIPTION
## Summary
- wrap the world-one and world-two module scripts in IIFEs so their DATA strings stay scoped
- keep module exports on globalThis after parsing so startGame continues to work

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/world-one.module.js
- node scripts/supporting/placement-check.js modules/world-two.module.js

------
https://chatgpt.com/codex/tasks/task_e_68d3f923c3408328b030b7b0e3ab12d2