### PR TITLE
fix: ensure dustland workbench recipes persist after module load

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -16359,7 +16359,23 @@ function configureWorkbenchRecipes() {
 
 function postLoad(module, ctx = {}) {
   const phase = ctx?.phase;
+  const scheduleReconfigure = () => {
+    const scheduler = typeof globalThis.queueMicrotask === 'function'
+      ? globalThis.queueMicrotask.bind(globalThis)
+      : (fn => Promise.resolve().then(fn));
+    scheduler(() => {
+      try {
+        configureWorkbenchRecipes();
+      } catch (err) {
+        console.error('Failed to configure workbench recipes after apply:', err);
+      }
+    });
+  };
+
   if (!phase || phase === 'beforeApply') {
+    configureWorkbenchRecipes();
+    scheduleReconfigure();
+  } else if (phase === 'afterApply') {
     configureWorkbenchRecipes();
   }
 }


### PR DESCRIPTION
## Summary
- schedule a follow-up workbench recipe configuration when the dustland module postLoad runs
- reapply the configuration after module application and surface failures in the console

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3fac9ae84832887bafa16027b2507