### PR TITLE
fix: auto pickup enemy loot when inventory has room

### DIFF
--- a/scripts/core/combat.js
+++ b/scripts/core/combat.js
@@ -833,7 +833,9 @@ function handleEnemyDefeat(attacker, target, sourceLabel){
     const cache = SpoilsCache.rollDrop?.(desertProphet ? challenge + 1 : challenge);
     if (cache){
       const registered = typeof registerItem === 'function' ? registerItem(cache) : cache;
-      itemDrops?.push?.({ id: registered.id, map: party.map, x: party.x, y: party.y, dropType: 'loot' });
+      const drop = { id: registered.id, map: party.map, x: party.x, y: party.y, dropType: 'loot' };
+      itemDrops?.push?.(drop);
+      tryAutoPickup?.(drop);
       log?.(`The ground coughs up a ${registered.name}.`);
       if (desertProphet) log?.('A prophetic vision hinted at this cache.');
       globalThis.EventBus?.emit?.('spoils:drop', { cache: registered, target });
@@ -1155,7 +1157,9 @@ function enemyAttack(){
       const cache = SpoilsCache.rollDrop?.(enemy.challenge);
       if (cache){
         const registered = typeof registerItem === 'function' ? registerItem(cache) : cache;
-        itemDrops?.push?.({ id: registered.id, map: party.map, x: party.x, y: party.y, dropType: 'loot' });
+        const drop = { id: registered.id, map: party.map, x: party.x, y: party.y, dropType: 'loot' };
+        itemDrops?.push?.(drop);
+        tryAutoPickup?.(drop);
         log?.(`The ground coughs up a ${registered.name}.`);
         globalThis.EventBus?.emit?.('spoils:drop', { cache: registered, target: enemy });
       }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1514,7 +1514,8 @@ test('defeated enemies can drop spoils cache', async () => {
   SpoilsCache.rollDrop = origRoll;
   global.log = origLog;
   assert.strictEqual(res.result, 'loot');
-  assert.strictEqual(itemDrops.length, 1);
+  assert.strictEqual(itemDrops.length, 0);
+  assert.ok(player.inv.some(it => it?.id === 'cache-sealed'));
   assert.ok(logs.some(l => l.includes('Sealed Cache')));
 });
 

--- a/test/drop-cache.test.js
+++ b/test/drop-cache.test.js
@@ -43,6 +43,38 @@ test('pickupCache fails if inventory full', () => {
   assert.strictEqual(player.inv.length, getPartyInventoryCapacity());
 });
 
+test('tryAutoPickup collects loot drops when inventory has room', () => {
+  player.inv = [];
+  itemDrops.length = 0;
+  const drop = { id: 'a', map: 'world', x: 0, y: 0, dropType: 'loot' };
+  itemDrops.push(drop);
+  const ok = tryAutoPickup(drop);
+  assert.ok(ok);
+  assert.strictEqual(player.inv.length, 1);
+  assert.strictEqual(itemDrops.length, 0);
+});
+
+test('tryAutoPickup collects loot caches when capacity allows', () => {
+  player.inv = [];
+  itemDrops.length = 0;
+  const drop = { items: ['a', 'b'], map: 'world', x: 0, y: 0, dropType: 'loot' };
+  const ok = tryAutoPickup(drop);
+  assert.ok(ok);
+  assert.strictEqual(player.inv.length, 2);
+  assert.strictEqual(itemDrops.length, 0);
+});
+
+test('tryAutoPickup leaves loot on the ground when inventory is full', () => {
+  player.inv = Array.from({ length: getPartyInventoryCapacity() }, (_, i) => ({ id: 'full' + i }));
+  itemDrops.length = 0;
+  const drop = { id: 'a', map: 'world', x: 0, y: 0, dropType: 'loot' };
+  itemDrops.push(drop);
+  const ok = tryAutoPickup(drop);
+  assert.strictEqual(ok, false);
+  assert.strictEqual(itemDrops.length, 1);
+  assert.strictEqual(player.inv.length, getPartyInventoryCapacity());
+});
+
 test.after(() => {
   if(orig.EventBus === undefined) delete global.EventBus; else global.EventBus = orig.EventBus;
   if(orig.player === undefined) delete global.player; else global.player = orig.player;


### PR DESCRIPTION
## Summary
- add an inventory helper that tries to grab loot drops when the party is standing on them
- invoke the helper for spoils cache drops so caches go straight into inventory when space allows
- extend drop and combat tests to cover the new auto-pickup behavior

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3fc8d07f88328acc42ef295994a3c