### PR TITLE
fix: allow common equipment stacks

### DIFF
--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -136,7 +136,10 @@ function canEquip(member, item){
 }
 
 function isStackable(it){
-  return !!it && !EQUIP_TYPES.includes(it.type);
+  if(!it) return false;
+  if(!EQUIP_TYPES.includes(it.type)) return true;
+  const rarity = typeof it.rarity === 'string' ? it.rarity.toLowerCase() : '';
+  return rarity === 'common';
 }
 
 function getStackCount(it){
@@ -574,10 +577,23 @@ function equipItem(memberIndex, invIndex){
       return;
     }
     setStackCount(prevEq, 1);
-    player.inv.push(prevEq);
+    if(!addExistingItemToInventory(prevEq)){
+      player.inv.push(prevEq);
+    }
   }
-  m.equip[slot]=it;
-  player.inv.splice(invIndex,1);
+  const stackable = isStackable(it);
+  const count = getStackCount(it);
+  const removeEntry = !stackable || count <= 1;
+  let equipped = it;
+  if(stackable && count > 1){
+    equipped = cloneItem(it);
+    setStackCount(equipped, 1);
+    setStackCount(it, count - 1);
+  }
+  if(removeEntry){
+    player.inv.splice(invIndex,1);
+  }
+  m.equip[slot]=equipped;
   applyEquipmentStats(m);
   const after = m._bonus || {};
   const deltas = [];
@@ -615,16 +631,19 @@ function unequipItem(memberIndex, slot){
   if(!it){ log('Nothing to unequip.'); return; }
   if(it.cursed){
     it.cursedKnown = true;
-      notifyInventoryChanged();
-      log(`${it.name} is cursed and won't come off!`);
-      return;
-    }
-    m.equip[slot]=null;
-    setStackCount(it, 1);
-    player.inv.push(it);
-    applyEquipmentStats(m);
     notifyInventoryChanged();
-    log(`${m.name} unequips ${it.name}.`);
+    log(`${it.name} is cursed and won't come off!`);
+    return;
+  }
+  m.equip[slot]=null;
+  setStackCount(it, 1);
+  const added = addExistingItemToInventory(it);
+  if(!added){
+    player.inv.push(it);
+  }
+  applyEquipmentStats(m);
+  notifyInventoryChanged();
+  log(`${m.name} unequips ${it.name}.`);
   if(typeof toast==='function') toast(`${m.name} unequips ${it.name}`);
   emit('sfx','tick');
   if(it.unequip && it.unequip.teleport){
@@ -700,7 +719,7 @@ function normalizeItem(it){
     unequip: cloneData(it.unequip),
     cursed: !!it.cursed,
     cursedKnown: !!it.cursedKnown,
-    rarity: it.rarity || 'common',
+    rarity: typeof it.rarity === 'string' ? it.rarity.toLowerCase() : 'common',
     value: val,
     scrap: typeof it.scrap === 'number' ? it.scrap : undefined,
     fuel: typeof it.fuel === 'number' ? it.fuel : undefined,

--- a/test/shop.ui.test.js
+++ b/test/shop.ui.test.js
@@ -166,24 +166,31 @@ test('shop stacks identical sell items and updates counts after selling', async 
   global.player = {
     scrap: 0,
     inv: [
-      { id: 'potion', name: 'Potion', value: 6, type: 'misc', count: 3 },
-      { id: 'sword', name: 'Sword', value: 10, type: 'weapon' },
-      { id: 'sword', name: 'Sword', value: 10, type: 'weapon' }
+      { id: 'potion', name: 'Potion', value: 6, type: 'misc', rarity: 'common', count: 3 },
+      { id: 'sword', name: 'Sword', value: 10, type: 'weapon', rarity: 'common' },
+      { id: 'sword', name: 'Sword', value: 10, type: 'weapon', rarity: 'common' }
     ]
   };
   global.getItem = id => {
-    if (id === 'potion') return { id, name: 'Potion', value: 4, type: 'misc' };
-    if (id === 'sword') return { id, name: 'Sword', value: 10, type: 'weapon' };
+    if (id === 'potion') return { id, name: 'Potion', value: 4, type: 'misc', rarity: 'common' };
+    if (id === 'sword') return { id, name: 'Sword', value: 10, type: 'weapon', rarity: 'common' };
     return null;
   };
   global.addToInv = () => true;
   global.removeFromInv = idx => {
     const entry = global.player.inv[idx];
     if (!entry) return;
-    const stackable = entry.type !== 'weapon' && entry.type !== 'armor' && entry.type !== 'trinket';
+    const rarity = typeof entry.rarity === 'string' ? entry.rarity.toLowerCase() : 'common';
+    const isEquipment = entry.type === 'weapon' || entry.type === 'armor' || entry.type === 'trinket';
+    const stackable = !isEquipment || rarity === 'common';
     const current = Math.max(1, Number.isFinite(entry.count) ? entry.count : 1);
     if (stackable && current > 1) {
-      entry.count = current - 1;
+      const next = current - 1;
+      if (next <= 1) {
+        delete entry.count;
+      } else {
+        entry.count = next;
+      }
     } else {
       global.player.inv.splice(idx, 1);
     }


### PR DESCRIPTION
## Summary
- allow common equipment to stack by basing stackability on normalized rarity
- update equip and unequip flows to consume single copies and merge inventory stacks
- expand inventory and shop tests to cover stackable equipment behavior

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d3feeb6dac8328b226d5716d9a93e3