### PR TITLE
fix: keep activated bunkers when merging modules

### DIFF
--- a/scripts/ui/world-map.js
+++ b/scripts/ui/world-map.js
@@ -59,7 +59,9 @@
             ft?.upsertBunkers?.([entry]);
             const existing = result.find(r => r.id === id);
             if(existing){
+              const wasActive = existing.active === true;
               Object.assign(existing, entry);
+              if(wasActive) existing.active = true;
             } else {
               result.push({ ...entry });
             }


### PR DESCRIPTION
## Summary
- preserve previously activated bunkers when merging fast-travel data from linked modules
- ensure remote module data no longer deactivates bunkers unlocked by the player

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d41770e144832894ed4bc7aa9856f9