### PR TITLE
fix: remove fog of war inside interiors

### DIFF
--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -352,7 +352,10 @@ function registerZoneEffects(list){
 const FOG_RADIUS = 5;
 
 function mapSupportsFog(map){
-  return map && map !== 'creator';
+  if(!map || map === 'creator') return false;
+  const interiorMaps = (typeof interiors === 'object' && interiors) ? interiors : null;
+  if(interiorMaps && Object.prototype.hasOwnProperty.call(interiorMaps, map)) return false;
+  return true;
 }
 
 function ensureFogMap(map){

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -894,6 +894,28 @@ test('applyModule overwrites existing interiors', () => {
   assert.strictEqual(interiors.dup.h, 2);
 });
 
+test('mapSupportsFog disables fog inside interiors', () => {
+  const savedInteriors = {};
+  Object.entries(interiors).forEach(([id, data]) => {
+    const clone = { ...data };
+    if (Array.isArray(data?.grid)) clone.grid = data.grid.map(row => [...row]);
+    savedInteriors[id] = clone;
+  });
+  try {
+    interiors.fog_test = { w: 1, h: 1, grid: [[TILE.FLOOR]], entryX: 0, entryY: 0 };
+    assert.strictEqual(globalThis.mapSupportsFog('world'), true);
+    assert.strictEqual(globalThis.mapSupportsFog('fog_test'), false);
+    assert.strictEqual(globalThis.mapSupportsFog('creator'), false);
+  } finally {
+    Object.keys(interiors).forEach(k => delete interiors[k]);
+    Object.entries(savedInteriors).forEach(([id, data]) => {
+      const clone = { ...data };
+      if (Array.isArray(data?.grid)) clone.grid = data.grid.map(row => [...row]);
+      interiors[id] = clone;
+    });
+  }
+});
+
 test('applyModule assigns interior display names', () => {
   const interiorsRef = globalThis.interiors;
   const mapLabelsRef = globalThis.mapLabels;


### PR DESCRIPTION
## Summary
- update the fog helper to treat interior maps as fully revealed while keeping support for world maps
- cover the new behavior with a regression test that verifies fog stays disabled indoors

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d418b21090832884a5621b4486e429