### PR TITLE
feat: add fog of war toggle

### DIFF
--- a/balance-tester.html
+++ b/balance-tester.html
@@ -39,7 +39,7 @@
           <div class="badge">Scrap: <span id="scrap">0</span></div>
           <div class="badge">Map: <span id="mapname">—</span></div>
         </div>
-        <p class="muted" style="margin-top:10px">Controls: <b>WASD/Arrows</b> move • <b>E/Space</b> interact/door & take nearby item • <b>T/G</b> take item • <b>I</b> Inventory • <b>P</b> Party • <b>Q</b> Quests • <b>O</b> audio • <b>C</b> mobile controls • <b>M</b> minimap • <b>Esc</b> close</p>
+        <p class="muted" style="margin-top:10px">Controls: <b>WASD/Arrows</b> move • <b>E/Space</b> interact/door & take nearby item • <b>T/G</b> take item • <b>I</b> Inventory • <b>P</b> Party • <b>Q</b> Quests • <b>O</b> audio • <b>C</b> mobile controls • <b>F</b> fog of war • <b>M</b> minimap • <b>Esc</b> close</p>
         <div class="tabs" role="tablist">
           <div class="tab active" id="tabInv" role="tab" tabindex="0" aria-label="Inventory" aria-selected="true">Inventory</div>
           <div class="tab" id="tabParty" role="tab" tabindex="0" aria-label="Party" aria-selected="false">Party</div>
@@ -73,6 +73,7 @@
         <button class="btn" id="musicToggle">Music: Off</button>
         <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
         <button class="btn" id="tileCharToggle">ASCII Tiles: On</button>
+        <button class="btn" id="fogToggle">Fog of War: On</button>
         <div class="field">
           <label for="fontScale">Font Scale</label>
           <input type="range" id="fontScale" min="1" max="1.75" step="0.05" value="1" />

--- a/dustland.html
+++ b/dustland.html
@@ -131,6 +131,7 @@
         <button class="btn" id="musicToggle">Music: Off</button>
         <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
         <button class="btn" id="tileCharToggle">ASCII Tiles: On</button>
+        <button class="btn" id="fogToggle">Fog of War: On</button>
         <div class="field">
           <label for="fontScale">Font Scale</label>
           <input type="range" id="fontScale" min="1" max="1.75" step="0.05" value="1" />

--- a/game.html
+++ b/game.html
@@ -494,7 +494,7 @@
               <div class="badge alt-badge">Scrap: <span id="scrap">0</span></div>
               <div class="badge alt-badge">Map: <span id="mapname">—</span></div>
             </div>
-            <p class="muted alt-muted">Controls: <b>WASD/Arrows</b> move • <b>E/Space</b> interact &amp; take • <b>T/G</b> take item • <b>I</b> Inventory • <b>P</b> Party • <b>Q</b> Quests • <b>O</b> audio • <b>C</b> mobile controls • <b>M</b> minimap • <b>Esc</b> close</p>
+            <p class="muted alt-muted">Controls: <b>WASD/Arrows</b> move • <b>E/Space</b> interact &amp; take • <b>T/G</b> take item • <b>I</b> Inventory • <b>P</b> Party • <b>Q</b> Quests • <b>O</b> audio • <b>C</b> mobile controls • <b>F</b> fog of war • <b>M</b> minimap • <b>Esc</b> close</p>
             <div class="tabs alt-tabs" role="tablist">
               <div class="tab active" id="tabInv" role="tab" tabindex="0" aria-label="Inventory" aria-selected="true">Inventory</div>
               <div class="tab" id="tabParty" role="tab" tabindex="0" aria-label="Party" aria-selected="false">Party</div>
@@ -618,6 +618,7 @@
         <button class="btn" id="musicToggle">Music: Off</button>
         <button class="btn" id="mobileToggle">Mobile Controls: Off</button>
         <button class="btn" id="tileCharToggle">ASCII Tiles: On</button>
+        <button class="btn" id="fogToggle">Fog of War: On</button>
         <div class="field">
           <label for="fontScale">Font Scale</label>
           <input type="range" id="fontScale" min="1" max="1.75" step="0.05" value="1" />

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -307,6 +307,14 @@ const playerIcons = [
 ];
 let playerIconIndex = 0;
 let tileCharsEnabled = true;
+const FOG_OF_WAR_STORAGE_KEY = 'fogOfWarEnabled';
+let fogOfWarEnabled = true;
+const savedFogSetting = globalThis.localStorage?.getItem(FOG_OF_WAR_STORAGE_KEY);
+if(savedFogSetting === '0'){
+  fogOfWarEnabled = false;
+}else if(savedFogSetting === '1'){
+  fogOfWarEnabled = true;
+}
 let retroNpcArtEnabled = false;
 const retroNpcArtCache = new Map();
 let retroPlayerSprite = null;
@@ -325,6 +333,19 @@ function setTileChars(on){
 }
 function toggleTileChars(){ setTileChars(!tileCharsEnabled); }
 globalThis.toggleTileChars = toggleTileChars;
+function setFogOfWar(on, opts = {}){
+  fogOfWarEnabled = !!on;
+  if(typeof document !== 'undefined'){
+    const btn=document.getElementById('fogToggle');
+    if(btn) btn.textContent = `Fog of War: ${fogOfWarEnabled ? 'On' : 'Off'}`;
+  }
+  if(!opts.skipStorage){
+    globalThis.localStorage?.setItem(FOG_OF_WAR_STORAGE_KEY, fogOfWarEnabled ? '1' : '0');
+  }
+  return fogOfWarEnabled;
+}
+function toggleFogOfWar(){ setFogOfWar(!fogOfWarEnabled); }
+globalThis.toggleFogOfWar = toggleFogOfWar;
 const FONT_SCALE_STORAGE_KEY = 'fontScale';
 const FONT_SCALE_MIN = 1;
 const FONT_SCALE_MAX = 1.75;
@@ -1261,6 +1282,7 @@ function centerCamera(x,y,map){
 
 function shouldRenderFog(map){
   if(!map) return false;
+  if(!fogOfWarEnabled) return false;
   if(typeof mapSupportsFog === 'function') return mapSupportsFog(map);
   return map !== 'creator';
 }
@@ -2766,6 +2788,11 @@ globalThis.Dustland.retroNpcArt = {
   getLootGlyph: () => getRetroLootSprite(),
   getItemCacheGlyph: () => getRetroItemCacheSprite()
 };
+globalThis.Dustland.fogOfWar = {
+  isEnabled: () => fogOfWarEnabled,
+  setEnabled: (value, opts) => setFogOfWar(value, opts),
+  toggle: () => toggleFogOfWar()
+};
 globalThis.Dustland.font = {
   getScale: () => fontScale,
   setScale: (value, opts) => setFontScale(value, opts)
@@ -2845,6 +2872,8 @@ function runTests(){
   if(mobileBtn) mobileBtn.onclick=()=>toggleMobileControls();
   const tileCharBtn=document.getElementById('tileCharToggle');
   if(tileCharBtn) tileCharBtn.onclick=()=>toggleTileChars();
+  const fogBtn=document.getElementById('fogToggle');
+  if(fogBtn) fogBtn.onclick=()=>toggleFogOfWar();
   const fontScaleSlider=document.getElementById('fontScale');
   if(fontScaleSlider){
     fontScaleSlider.addEventListener('input', ()=>{
@@ -2890,6 +2919,7 @@ function runTests(){
   setAudio(audioEnabled);
   setMobileControls(mobileControlsEnabled);
   setTileChars(tileCharsEnabled);
+  setFogOfWar(fogOfWarEnabled, { skipStorage: true });
   const settingsBtn=document.getElementById('settingsBtn');
   const settings=document.getElementById('settings');
   if(settingsBtn && settings){
@@ -3066,6 +3096,7 @@ function runTests(){
       case 'o': case 'O': toggleAudio(); break;
       case 'c': case 'C': toggleMobileControls(); break;
       case 'j': case 'J': toggleTileChars(); break;
+      case 'f': case 'F': toggleFogOfWar(); break;
       case 'i': case 'I': showTab('inv'); break;
       case 'p': case 'P': showTab('party'); break;
       case 'q': if(!e.ctrlKey && !e.metaKey){ showTab('quests'); e.preventDefault(); } break;

--- a/test/keyboard-shortcuts.test.js
+++ b/test/keyboard-shortcuts.test.js
@@ -9,9 +9,11 @@ test('keyboard shortcuts toggle audio, mobile controls, and pickup', async () =>
   const audioBtn = document.getElementById('audioToggle');
   const mobileBtn = document.getElementById('mobileToggle');
   const tileBtn = document.getElementById('tileCharToggle');
+  const fogBtn = document.getElementById('fogToggle');
   assert.strictEqual(audioBtn.textContent, 'Audio: On');
   assert.strictEqual(mobileBtn.textContent, 'Mobile Controls: Off');
   assert.strictEqual(tileBtn.textContent, 'ASCII Tiles: On');
+  assert.strictEqual(fogBtn.textContent, 'Fog of War: On');
 
   context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'o' }));
   assert.strictEqual(audioBtn.textContent, 'Audio: Off');
@@ -21,6 +23,9 @@ test('keyboard shortcuts toggle audio, mobile controls, and pickup', async () =>
 
   context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'j' }));
   assert.strictEqual(tileBtn.textContent, 'ASCII Tiles: Off');
+
+  context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'f' }));
+  assert.strictEqual(fogBtn.textContent, 'Fog of War: Off');
 
   context.window.dispatchEvent(new context.window.KeyboardEvent('keydown', { key:'g' }));
   assert.strictEqual(takeCalls, 1);

--- a/test/persist-llm-button.test.js
+++ b/test/persist-llm-button.test.js
@@ -31,6 +31,7 @@ test('Persist LLM button hidden until Nano is ready', async () => {
   document.body.appendChild(document.getElementById('audioToggle'));
   document.body.appendChild(document.getElementById('mobileToggle'));
   document.body.appendChild(document.getElementById('tileCharToggle'));
+  document.body.appendChild(document.getElementById('fogToggle'));
   document.body.appendChild(document.getElementById('retroNpcToggle'));
   const persistBtn = document.getElementById('persistLLM');
   document.body.appendChild(persistBtn);


### PR DESCRIPTION
## Summary
- add a fog of war toggle with persistence, keyboard support, and Dustland API exposure
- surface the new toggle in each settings menu and update the control hints
- extend automated tests to cover the fog toggle and include it in the DOM harness

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d41a3b550483288ccb4695b262764a