### PR TITLE
fix: pulse adrenaline effect on player icon

### DIFF
--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -389,7 +389,7 @@ function revealFog(map, x, y, radius = FOG_RADIUS){
       const gx = x + dx;
       const gy = y + dy;
       if(gx<0 || gy<0 || gx>=W || gy>=H) continue;
-      let visibility = Math.max(0, 1 - (dist / denom)) * 2;
+      let visibility = Math.max(0, 1 - (dist / denom));
       // const factor = 3;
       // visibility = Math.round(visibility * factor) / factor;
       if(visibility <= 0) continue;

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -389,9 +389,7 @@ function revealFog(map, x, y, radius = FOG_RADIUS){
       const gx = x + dx;
       const gy = y + dy;
       if(gx<0 || gy<0 || gx>=W || gy>=H) continue;
-      let visibility = Math.max(0, 1 - (dist / denom));
-      // const factor = 3;
-      // visibility = Math.round(visibility * factor) / factor;
+      let visibility = Math.max(0, 1 - (dist / denom)) * 2; // Multiply by 2 so that the center of the circle "blows out" above 1 (to be clamped below)
       if(visibility <= 0) continue;
       const key = `${gx},${gy}`;
       const storedRaw = fogIsMap ? fog.get(key) : fog[key];

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -100,29 +100,31 @@ test('adrenaline tint and grayscale filters update based on config', async () =>
   assert.ok(/grayscale/.test(filt2));
 });
 
-test('adrenaline bloom pulses with adr ratio', async () => {
+test('adrenaline pulse updates player fx with adr ratio', async () => {
   const ctx = setup(HUD_HTML);
   ctx.fxConfig.adrenalineTint = true;
   ctx.leader = () => ({ maxHp: 10, adr: 50, maxAdr: 100 });
   ctx.pulseAdrenaline(0);
-  const bloom1 = ctx.document.getElementById('game').style.getPropertyValue('--fxBloom');
-  assert.ok(/brightness/.test(bloom1));
+  assert.ok(ctx.playerAdrenalineFx.intensity > 0);
+  assert.ok(ctx.playerAdrenalineFx.scale > 1);
+  assert.ok(ctx.playerAdrenalineFx.hueShift > 0);
   ctx.leader = () => ({ maxHp: 10, adr: 0, maxAdr: 100 });
   ctx.pulseAdrenaline(0);
-  const bloom2 = ctx.document.getElementById('game').style.getPropertyValue('--fxBloom');
-  assert.equal(bloom2, '');
+  assert.equal(ctx.playerAdrenalineFx.intensity, 0);
+  assert.equal(ctx.playerAdrenalineFx.scale, 1);
+  assert.equal(ctx.playerAdrenalineFx.hueShift, 0);
 });
 
-test('adrenaline blur only activates at low health', async () => {
+test('adrenaline pulse ignores hp when active', async () => {
   const ctx = setup(HUD_HTML);
   ctx.fxConfig.adrenalineTint = true;
   ctx.leader = () => ({ maxHp: 10, hp: 10, adr: 50, maxAdr: 100 });
   ctx.pulseAdrenaline(0);
-  const healthyBloom = ctx.document.getElementById('game').style.getPropertyValue('--fxBloom');
-  assert.ok(/brightness/.test(healthyBloom));
-  assert.ok(!/blur\(/.test(healthyBloom));
+  const healthyFx = { ...ctx.playerAdrenalineFx };
   ctx.leader = () => ({ maxHp: 10, hp: 3, adr: 50, maxAdr: 100 });
   ctx.pulseAdrenaline(0);
-  const lowHpBloom = ctx.document.getElementById('game').style.getPropertyValue('--fxBloom');
-  assert.ok(/blur\(/.test(lowHpBloom));
+  assert.equal(ctx.playerAdrenalineFx.intensity, healthyFx.intensity);
+  assert.equal(ctx.playerAdrenalineFx.scale, healthyFx.scale);
+  assert.equal(ctx.playerAdrenalineFx.hueShift, healthyFx.hueShift);
+  assert.equal(ctx.playerAdrenalineFx.glow, healthyFx.glow);
 });


### PR DESCRIPTION
## Summary
- Move adrenaline pulse logic off the screen bloom and onto the player icon with a color-shifting glow
- Track adrenaline pulse state globally, reset it safely, and harden fog helpers for sandboxed contexts
- Keep fog reveal gradients below full intensity and refresh HUD tests for the new player-focused effect

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d44ea44d288328af01c59881ea6d9c