### PR TITLE
fix: desaturate world at low hp

### DIFF
--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -1687,6 +1687,16 @@ function updateHUD(){
   }
   if(disp && fx){
     const filters = [];
+    if(lead && fx?.lowHpDesaturate !== false){
+      const maxHp = lead.maxHp || 1;
+      const ratio = maxHp > 0 ? Math.max(0, Math.min(1, player.hp / maxHp)) : 0;
+      const threshold = 0.35;
+      if(ratio < threshold){
+        const normalized = Math.min(1, (threshold - ratio) / threshold);
+        const gray = Math.min(1, normalized * normalized * 1.05);
+        if(gray > 0.01) filters.push(`grayscale(${gray.toFixed(3)})`);
+      }
+    }
     if(fx.grayscale) filters.push('grayscale(1)');
     if(fx.adrenalineTint && lead){
       const ratio = Math.max(0, Math.min(1, lead.adr / (lead.maxAdr || 1)));

--- a/test/hud.test.js
+++ b/test/hud.test.js
@@ -100,6 +100,15 @@ test('adrenaline tint and grayscale filters update based on config', async () =>
   assert.ok(/grayscale/.test(filt2));
 });
 
+test('low health applies a desaturation filter', async () => {
+  const ctx = setup(HUD_HTML);
+  ctx.updateHUD();
+  ctx.player.hp = 3;
+  ctx.updateHUD();
+  const filt = ctx.document.getElementById('game').style.getPropertyValue('--fxFilter');
+  assert.ok(/grayscale\(/.test(filt));
+});
+
 test('adrenaline pulse updates player fx with adr ratio', async () => {
   const ctx = setup(HUD_HTML);
   ctx.fxConfig.adrenalineTint = true;


### PR DESCRIPTION
## Summary
- restore low-health world desaturation by scaling a grayscale filter off the leader's HP ratio
- cover the new visual effect with a HUD unit test that verifies the filter is applied

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d476bd08d083288e56168ca31feaa0