### PR TITLE
fix: expire loot drops outside the overworld

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -2366,7 +2366,8 @@
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 0
       },
       "symbol": "!"
     },

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -2369,7 +2369,8 @@ const DATA = `
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 0
       },
       "symbol": "!"
     },

--- a/modules/office.module.js
+++ b/modules/office.module.js
@@ -605,8 +605,8 @@ startGame = function () {
       const interior = interiors[castleId];
       const ix = Math.floor(interior.w / 2);
       const iy = Math.floor(interior.h / 2);
-      itemDrops.push({ id: charm.id, map: castleId, x: ix, y: iy });
-      itemDrops.push({ id: stim.id, map: castleId, x: ix + 1, y: iy });
+      itemDrops.push({ id: charm.id, map: castleId, x: ix, y: iy, dropType: 'world' });
+      itemDrops.push({ id: stim.id, map: castleId, x: ix + 1, y: iy, dropType: 'world' });
     }
     const s = OFFICE_MODULE.start;
     setPartyPos(s.x, s.y);

--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -236,7 +236,7 @@
                 if (dropCfg.rank && typeof SpoilsCache?.create === 'function') {
                   const cache = SpoilsCache.create(dropCfg.rank);
                   const registered = typeof registerItem === 'function' ? registerItem(cache) : cache;
-                  itemDrops?.push?.({ id: registered.id, ...dropPos });
+                  itemDrops?.push?.({ id: registered.id, ...dropPos, dropType: 'loot' });
                   globalThis.EventBus?.emit?.('spoils:drop', { cache: registered, target: npc });
                 }
               }

--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -385,7 +385,7 @@ function dropItemNearParty(item) {
     throw new Error('Unknown item');
   }
   const base = cloneItem(ITEMS[it.id] || registerItem(it));
-  itemDrops.push({ id: base.id, map: party.map, x: party.x, y: party.y });
+  itemDrops.push({ id: base.id, map: party.map, x: party.x, y: party.y, dropType: 'loot' });
   log(`Inventory full, ${base.name} was dropped.`);
   if (typeof toast === 'function') toast(`Inventory full, ${base.name} was dropped.`);
 }
@@ -538,7 +538,7 @@ function dropItems(indices) {
     removeFromInv(idx, counts.get(idx));
   }
   if (drops.length) {
-    itemDrops.push({ items: drops, map: party.map, x: party.x, y: party.y });
+    itemDrops.push({ items: drops, map: party.map, x: party.x, y: party.y, dropType: 'loot' });
   }
   return drops.length;
 }

--- a/scripts/core/movement.js
+++ b/scripts/core/movement.js
@@ -112,12 +112,20 @@ function lockInput(ms = RANDOM_COMBAT_INPUT_LOCK_MS, key){
   game.inputLockKey = typeof key === 'string' ? key.toLowerCase() : null;
 }
 
-function markWorldDropAges(beforeTurn){
+function getDropType(drop){
+  if(!drop) return null;
+  const type = typeof drop.dropType === 'string' ? drop.dropType : (drop.source === 'loot' ? 'loot' : 'world');
+  return type;
+}
+
+function isLootDrop(drop){
+  return getDropType(drop) === 'loot';
+}
+
+function markLootDropAges(beforeTurn){
   if(!Array.isArray(itemDrops) || !itemDrops.length) return;
   for(const drop of itemDrops){
-    if(!drop) continue;
-    const mapId = typeof drop.map === 'string' ? drop.map : 'world';
-    if(mapId !== 'world') continue;
+    if(!isLootDrop(drop)) continue;
     if(!Number.isFinite(drop.worldTurn)) drop.worldTurn = beforeTurn;
   }
 }
@@ -126,9 +134,7 @@ function decayWorldLoot(now){
   if(!Array.isArray(itemDrops) || !itemDrops.length) return;
   for(let i=itemDrops.length-1;i>=0;i--){
     const drop=itemDrops[i];
-    if(!drop) continue;
-    const mapId = typeof drop.map === 'string' ? drop.map : 'world';
-    if(mapId !== 'world') continue;
+    if(!isLootDrop(drop)) continue;
     const born = Number.isFinite(drop.worldTurn) ? drop.worldTurn : (now - 1);
     if(now - born >= WORLD_LOOT_DECAY_TURNS){
       itemDrops.splice(i,1);
@@ -138,7 +144,7 @@ function decayWorldLoot(now){
 
 function advanceWorldTurn(){
   const before = worldTurnCounter;
-  markWorldDropAges(before);
+  markLootDropAges(before);
   worldTurnCounter = before + 1;
   const now = worldTurnCounter;
   decayWorldLoot(now);

--- a/scripts/dustland-core.js
+++ b/scripts/dustland-core.js
@@ -657,6 +657,7 @@ function applyModule(data = {}, options = {}) {
       const registered = registerItem(def);
       if (map !== undefined && x !== undefined && y !== undefined) {
         const loc = { id: registered.id, map: map || 'world', x, y };
+        loc.dropType = 'world';
         itemDrops.push(loc);
         questItemLocations[registered.id] = { map: loc.map, x: loc.x, y: loc.y };
       }

--- a/test/world-loot-decay.test.js
+++ b/test/world-loot-decay.test.js
@@ -87,18 +87,21 @@ test('world loot decays after configured turns', async () => {
   assert.strictEqual(typeof move, 'function');
 
   const worldDrop = { id: 'loot-cache', map: 'world', x: party.x, y: party.y, dropType: 'loot' };
-  const interiorDrop = { id: 'safe-cache', map: 'bunker', x: 1, y: 1 };
-  globalThis.itemDrops.push(worldDrop, interiorDrop);
+  const interiorLoot = { id: 'safe-cache', map: 'bunker', x: 1, y: 1, dropType: 'loot' };
+  const placedDrop = { id: 'placed-cache', map: 'bunker', x: 2, y: 1, dropType: 'world' };
+  globalThis.itemDrops.push(worldDrop, interiorLoot, placedDrop);
 
   for (let i = 0; i < WORLD_LOOT_DECAY_TURNS - 1; i++) {
     await move(0, 0);
   }
   assert.ok(globalThis.itemDrops.includes(worldDrop));
-  assert.ok(globalThis.itemDrops.includes(interiorDrop));
+  assert.ok(globalThis.itemDrops.includes(interiorLoot));
+  assert.ok(globalThis.itemDrops.includes(placedDrop));
   assert.strictEqual(getWorldTurns(), WORLD_LOOT_DECAY_TURNS - 1);
 
   await move(0, 0);
   assert.ok(!globalThis.itemDrops.includes(worldDrop));
-  assert.ok(globalThis.itemDrops.includes(interiorDrop));
+  assert.ok(!globalThis.itemDrops.includes(interiorLoot));
+  assert.ok(globalThis.itemDrops.includes(placedDrop));
   assert.strictEqual(getWorldTurns(), WORLD_LOOT_DECAY_TURNS);
 });


### PR DESCRIPTION
## Summary
- update the movement loot decay helper to time out only dropType "loot" items on every map
- tag generated loot caches with dropType "loot" and mark placed items as dropType "world" in inventory, effects, and module data
- ensure the Dustland stalker patrol keeps its challenge rating and adjust the decay test to cover interior loot

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d47b4db62083289d6eab4b2fc0ad1d