### PR TITLE
Alphabetize Adventure Kit item dropdowns

### DIFF
--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1654,10 +1654,17 @@ function populateTypeDropdown(sel, selected = '') {
 }
 
 function populateItemDropdown(sel, selected = '') {
-  const ids = moduleData.items.map(it => it.id);
-  if (selected && !ids.includes(selected)) ids.push(selected);
-  sel.innerHTML = '<option value=""></option>' + ids.map(id => `<option value="${id}">${id}</option>`).join('');
-  sel.value = selected;
+  const selectedId = typeof selected === 'string' ? selected.trim() : '';
+  const ids = Array.isArray(moduleData?.items)
+    ? moduleData.items
+      .map(it => typeof it?.id === 'string' ? it.id : '')
+      .filter(Boolean)
+    : [];
+  const uniqueIds = new Set(ids);
+  if (selectedId) uniqueIds.add(selectedId);
+  const sortedIds = Array.from(uniqueIds).sort((a, b) => a.localeCompare(b));
+  sel.innerHTML = '<option value=""></option>' + sortedIds.map(id => `<option value="${id}">${id}</option>`).join('');
+  sel.value = selectedId;
 }
 
 function populateNPCDropdown(sel, selected = '') {


### PR DESCRIPTION
## Summary
- sort item IDs alphabetically when populating Adventure Kit dropdowns so selectors match loot ordering
- ensure dropdown population tolerates missing item IDs when building the option list

## Testing
- npm test
- node scripts/supporting/presubmit.js adventure-kit.html

------
https://chatgpt.com/codex/tasks/task_e_68d48b7ea9588328b2dd6deefecfc0fd