### PR TITLE
feat: support zone-based encounter placement

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -801,6 +801,7 @@
         <button class="btn" type="button" id="newZone">+ Zone</button>
         <div id="zoneEditor" style="display:none">
           <label>Map<select id="zoneMap"></select></label>
+          <label>Tag<input id="zoneTag" /></label>
           <div class="xy">
             <label>X<input id="zoneX" type="number" min="0" /></label>
             <label>Y<input id="zoneY" type="number" min="0" /></label>
@@ -834,9 +835,14 @@
         <button class="btn" type="button" id="newEncounter">+ Enemy</button>
         <div id="encounterEditor" style="display:none">
           <label>Map<select id="encMap"></select></label>
+          <label>Location<select id="encLocationMode">
+            <option value="distance">Distance from road</option>
+            <option value="zone">Zone tag</option>
+          </select></label>
           <label>Template<select id="encTemplate"></select></label>
           <label>Min Dist<input id="encMinDist" type="number" min="0" /></label>
           <label>Max Dist<input id="encMaxDist" type="number" min="0" /></label>
+          <label id="encZoneWrap">Zone<select id="encZone"></select></label>
           <div class="lootTableWrap">
             <div class="lootTableLabel">Loot Table</div>
             <div class="lootTableHeader"><span>Item</span><span>Chance %</span></div>

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -2636,6 +2636,32 @@ test('enemies respect max distance', () => {
   assert.ok(!started);
 });
 
+test('zone-tagged encounters trigger only inside tagged zone', () => {
+  const row = Array(6).fill(TILE.SAND);
+  applyModule({
+    world: [row],
+    zones: [{ map: 'world', x: 3, y: 0, w: 1, h: 1, tag: 'ambush' }],
+    templates: [{ id: 'zone_enemy', name: 'Stalker', combat: { HP: 2, ATK: 1, DEF: 0 } }],
+    encounters: { world: [{ templateId: 'zone_enemy', mode: 'zone', zoneTag: 'ambush' }] }
+  });
+  state.map = 'world';
+  let started = false;
+  const origStart = globalThis.Dustland.actions.startCombat;
+  const origRand = Math.random;
+  Math.random = () => 0;
+  globalThis.Dustland.actions.startCombat = () => { started = true; return Promise.resolve({ result: 'flee' }); };
+  encounterCooldown = 0;
+  setPartyPos(1, 0);
+  checkRandomEncounter();
+  assert.ok(!started);
+  encounterCooldown = 0;
+  setPartyPos(3, 0);
+  checkRandomEncounter();
+  Math.random = origRand;
+  globalThis.Dustland.actions.startCombat = origStart;
+  assert.ok(started);
+});
+
 test('enemy requires a specific weapon', () => {
   const enemy = { name: 'Shellback', hp: 10, requires: 'artifact_blade' };
   if(!getItem('artifact_blade')){

--- a/test/npc-patrol.test.js
+++ b/test/npc-patrol.test.js
@@ -224,6 +224,8 @@ test('collectEncounter reads loot chance', async () => {
   const document = makeDocument();
   mkInput(document, 'encMap', 'world');
   mkInput(document, 'encTemplate', 't');
+  mkInput(document, 'encLocationMode', 'distance');
+  mkInput(document, 'encZone', '');
   mkInput(document, 'encMinDist', '0');
   mkInput(document, 'encMaxDist', '0');
   const lootTable = document.getElementById('encLootTable');
@@ -246,6 +248,7 @@ test('collectEncounter reads loot chance', async () => {
   vm.runInContext(code.slice(start, end), context);
   const e = context.collectEncounter();
   assert.ok(Array.isArray(e.lootTable));
+  assert.strictEqual(e.mode, 'distance');
   const drops = JSON.parse(JSON.stringify(e.lootTable));
   assert.deepStrictEqual(drops, [{ item: 'rat_tail', chance: 0.3 }]);
 });


### PR DESCRIPTION
## Summary
- add zone tag editing and selectable encounter location modes in the Adventure Kit
- enable runtime encounter selection to respect zone-tagged entries and keep ACK lists in sync
- cover the new UI and behavior with updated ACK, patrol, and core tests

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d48e7a770883288f0979cd60f389ff