### PR TITLE
fix: consolidate dustland encounter loot

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -4634,15 +4634,39 @@
     "world": [
       {
         "templateId": "vine_creature",
-        "loot": "plant_fiber",
-        "lootChance": 0.25,
-        "maxDist": 20
+        "maxDist": 20,
+        "lootTable": [
+          {
+            "item": "plant_fiber",
+            "chance": 0.25
+          },
+          {
+            "item": "thornlash_whip",
+            "chance": 0.18
+          },
+          {
+            "item": "sap_poultice",
+            "chance": 0.3
+          }
+        ]
       },
       {
         "templateId": "rotwalker",
-        "loot": "water_flask",
-        "lootChance": 0.25,
-        "maxDist": 24
+        "maxDist": 24,
+        "lootTable": [
+          {
+            "item": "water_flask",
+            "chance": 0.25
+          },
+          {
+            "item": "patchwork_plate",
+            "chance": 0.2
+          },
+          {
+            "item": "corroded_hatchet",
+            "chance": 0.16
+          }
+        ]
       },
       {
         "templateId": "scavenger",
@@ -4652,9 +4676,17 @@
       },
       {
         "templateId": "sand_titan",
-        "loot": "artifact_blade",
-        "lootChance": 0.75,
-        "minDist": 30
+        "minDist": 30,
+        "lootTable": [
+          {
+            "item": "artifact_blade",
+            "chance": 0.75
+          },
+          {
+            "item": "fuel_cell",
+            "chance": 0.25
+          }
+        ]
       },
       {
         "templateId": "dune_reaper",
@@ -4681,30 +4713,6 @@
         "loot": "medkit",
         "lootChance": 1,
         "minDist": 50
-      },
-      {
-        "templateId": "vine_creature",
-        "loot": "thornlash_whip",
-        "lootChance": 0.18,
-        "maxDist": 20
-      },
-      {
-        "templateId": "vine_creature",
-        "loot": "sap_poultice",
-        "lootChance": 0.3,
-        "maxDist": 20
-      },
-      {
-        "templateId": "rotwalker",
-        "loot": "patchwork_plate",
-        "lootChance": 0.2,
-        "maxDist": 24
-      },
-      {
-        "templateId": "rotwalker",
-        "loot": "corroded_hatchet",
-        "lootChance": 0.16,
-        "maxDist": 24
       }
     ],
     "room_oc3abv": [

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -4671,15 +4671,39 @@ const DATA = `
     "world": [
       {
         "templateId": "vine_creature",
-        "loot": "plant_fiber",
-        "lootChance": 0.25,
-        "maxDist": 20
+        "maxDist": 20,
+        "lootTable": [
+          {
+            "item": "plant_fiber",
+            "chance": 0.25
+          },
+          {
+            "item": "thornlash_whip",
+            "chance": 0.18
+          },
+          {
+            "item": "sap_poultice",
+            "chance": 0.3
+          }
+        ]
       },
       {
         "templateId": "rotwalker",
-        "loot": "water_flask",
-        "lootChance": 0.25,
-        "maxDist": 24
+        "maxDist": 24,
+        "lootTable": [
+          {
+            "item": "water_flask",
+            "chance": 0.25
+          },
+          {
+            "item": "patchwork_plate",
+            "chance": 0.2
+          },
+          {
+            "item": "corroded_hatchet",
+            "chance": 0.16
+          }
+        ]
       },
       {
         "templateId": "scavenger",
@@ -4689,9 +4713,17 @@ const DATA = `
       },
       {
         "templateId": "sand_titan",
-        "loot": "artifact_blade",
-        "lootChance": 0.75,
-        "minDist": 30
+        "minDist": 30,
+        "lootTable": [
+          {
+            "item": "artifact_blade",
+            "chance": 0.75
+          },
+          {
+            "item": "fuel_cell",
+            "chance": 0.25
+          }
+        ]
       },
       {
         "templateId": "dune_reaper",
@@ -4718,30 +4750,6 @@ const DATA = `
         "loot": "medkit",
         "lootChance": 1,
         "minDist": 50
-      },
-      {
-        "templateId": "vine_creature",
-        "loot": "thornlash_whip",
-        "lootChance": 0.18,
-        "maxDist": 20
-      },
-      {
-        "templateId": "vine_creature",
-        "loot": "sap_poultice",
-        "lootChance": 0.3,
-        "maxDist": 20
-      },
-      {
-        "templateId": "rotwalker",
-        "loot": "patchwork_plate",
-        "lootChance": 0.2,
-        "maxDist": 24
-      },
-      {
-        "templateId": "rotwalker",
-        "loot": "corroded_hatchet",
-        "lootChance": 0.16,
-        "maxDist": 24
       }
     ],
     "room_oc3abv": [

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -152,24 +152,54 @@ test('bandage heals more than water flask', () => {
   assert.ok(bandage.use.amount > flask.use.amount);
 });
 
-test('vine creature drops plant fiber', () => {
+test('vine creature rolls loot table for scavenged supplies', () => {
   const data = loadModuleData();
   const template = data.templates.find(t => t.id === 'vine_creature');
   assert.ok(template);
   const encounter = data.encounters.world.find(e => e.templateId === 'vine_creature');
   assert.ok(encounter);
-  assert.strictEqual(encounter.loot, 'plant_fiber');
-  assert.strictEqual(encounter.lootChance, 0.25);
+  assert.ok(Array.isArray(encounter.lootTable));
+  const loot = Object.fromEntries(encounter.lootTable.map(entry => [entry.item, entry.chance]));
+  assert.deepStrictEqual(Object.keys(loot).sort(), [
+    'plant_fiber',
+    'sap_poultice',
+    'thornlash_whip'
+  ].sort());
+  assert.strictEqual(loot.plant_fiber, 0.25);
+  assert.strictEqual(loot.sap_poultice, 0.3);
+  assert.strictEqual(loot.thornlash_whip, 0.18);
 });
 
-test('rotwalker drops water flask', () => {
+test('rotwalker rolls loot table for salvage', () => {
   const data = loadModuleData();
   const template = data.templates.find(t => t.id === 'rotwalker');
   assert.ok(template);
   const encounter = data.encounters.world.find(e => e.templateId === 'rotwalker');
   assert.ok(encounter);
-  assert.strictEqual(encounter.loot, 'water_flask');
-  assert.strictEqual(encounter.lootChance, 0.25);
+  assert.ok(Array.isArray(encounter.lootTable));
+  const loot = Object.fromEntries(encounter.lootTable.map(entry => [entry.item, entry.chance]));
+  assert.deepStrictEqual(Object.keys(loot).sort(), [
+    'corroded_hatchet',
+    'patchwork_plate',
+    'water_flask'
+  ].sort());
+  assert.strictEqual(loot.corroded_hatchet, 0.16);
+  assert.strictEqual(loot.patchwork_plate, 0.2);
+  assert.strictEqual(loot.water_flask, 0.25);
+});
+
+test('sand titan can drop artifact blade or fuel cell', () => {
+  const data = loadModuleData();
+  const encounter = data.encounters.world.find(e => e.templateId === 'sand_titan');
+  assert.ok(encounter);
+  assert.ok(Array.isArray(encounter.lootTable));
+  const loot = Object.fromEntries(encounter.lootTable.map(entry => [entry.item, entry.chance]));
+  assert.deepStrictEqual(Object.keys(loot).sort(), [
+    'artifact_blade',
+    'fuel_cell'
+  ].sort());
+  assert.strictEqual(loot.artifact_blade, 0.75);
+  assert.strictEqual(loot.fuel_cell, 0.25);
 });
 
 test('northeast hut has portal to hall', () => {


### PR DESCRIPTION
## Summary
- consolidate duplicate vine creature and rotwalker encounters into loot tables so each spawn rolls multiple rewards
- add a fuel cell entry to the sand titan loot table while preserving the artifact blade drop
- update module tests to reflect loot tables and the sand titan's new fuel cell drop

## Testing
- node scripts/supporting/placement-check.js data/modules/dustland.json
- node scripts/supporting/placement-check.js modules/dustland.module.js
- node scripts/supporting/presubmit.js
- npm test
- node --test test/dustland.module.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d493f62a448328a5b22b7b531b167f