### PR TITLE
fix: improve inventory layout responsiveness

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -495,9 +495,31 @@ input[type="range"] {
 
     #inv {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-        gap: 6px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 8px;
         align-content: start;
+    }
+
+    #inv > .inventory-controls {
+        grid-column: 1 / -1;
+    }
+
+    .inventory-controls {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+        margin: 4px 0;
+    }
+
+    .inventory-filter {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .inventory-filter select {
+        min-width: 140px;
     }
 
     .tabwrap {
@@ -509,6 +531,42 @@ input[type="range"] {
         border: 1px dashed #2b382b;
         border-radius: 6px;
         background: #0c0f0c;
+    }
+
+    .inventory-slot {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        column-gap: 8px;
+        row-gap: 4px;
+        align-items: start;
+        padding-right: 4px;
+        min-width: 0;
+    }
+
+    .inventory-slot .inventory-label {
+        grid-column: 1;
+        min-width: 0;
+        overflow-wrap: anywhere;
+    }
+
+    .inventory-slot .stack-count {
+        grid-column: 1;
+        justify-self: start;
+    }
+
+    .inventory-slot .inventory-actions {
+        grid-column: 2;
+        grid-row: 1 / span 2;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        justify-content: flex-end;
+        align-content: flex-start;
+        min-width: 0;
+    }
+
+    .inventory-slot .inventory-actions .btn {
+        flex: 0 0 auto;
     }
 
     .equip-line {

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -1867,7 +1867,7 @@ function renderInv(){
   inv.innerHTML='';
   if(dropMode){
     const ctrl=document.createElement('div');
-    ctrl.style.margin='4px 0';
+    ctrl.className='inventory-controls';
     const ok=document.createElement('button');
     ok.className='btn';
     ok.textContent='Drop Selected';
@@ -1904,11 +1904,7 @@ function renderInv(){
     return;
   }
   const ctrl=document.createElement('div');
-  ctrl.style.display='flex';
-  ctrl.style.flexWrap='wrap';
-  ctrl.style.gap='8px';
-  ctrl.style.alignItems='center';
-  ctrl.style.margin='4px 0';
+  ctrl.className='inventory-controls';
   const dropBtn=document.createElement('button');
   dropBtn.className='btn';
   dropBtn.textContent='Drop';
@@ -1925,9 +1921,7 @@ function renderInv(){
   }
   const filterLabel=document.createElement('label');
   filterLabel.htmlFor='inventorySlotFilter';
-  filterLabel.style.display='flex';
-  filterLabel.style.alignItems='center';
-  filterLabel.style.gap='6px';
+  filterLabel.className='inventory-filter';
   filterLabel.textContent='Slot';
   const filterSelect=document.createElement('select');
   filterSelect.id='inventorySlotFilter';
@@ -2036,12 +2030,7 @@ function renderInv(){
   others.forEach(it => {
     const qty = Math.max(1, Number.isFinite(it?.count) ? it.count : 1);
     const row=document.createElement('div');
-    row.className='slot';
-    row.style.display='flex';
-    row.style.alignItems='center';
-    row.style.justifyContent='flex-start';
-    row.style.gap='8px';
-    row.style.paddingRight='4px';
+    row.className='slot inventory-slot';
     if(['weapon','armor','trinket'].includes(it.type) && suggestions[it.type]===it){
       row.classList.add('better');
     }
@@ -2049,15 +2038,14 @@ function renderInv(){
     const baseLabel = it.name + (['weapon','armor','trinket'].includes(it.type)?` [${it.type}]`:'');
     const label = (it.cursed && it.cursedKnown)? `${baseLabel} (cursed)` : baseLabel;
     const labelSpan=document.createElement('span');
+    labelSpan.className='inventory-label';
     labelSpan.textContent=label;
     if(restriction && !restriction.levelMet && restriction.levelRequired > 1){
       row.classList.add('level-locked');
       labelSpan.classList.add('level-locked-label');
     }
-    const btnWrap=document.createElement('span');
-    btnWrap.style.display='flex';
-    btnWrap.style.gap='6px';
-    btnWrap.style.marginLeft='auto';
+    const btnWrap=document.createElement('div');
+    btnWrap.className='inventory-actions';
     if(['weapon','armor','trinket'].includes(it.type)){
       const equipBtn=document.createElement('button');
       equipBtn.className='btn';


### PR DESCRIPTION
## Summary
- widen the inventory grid and add responsive CSS hooks so controls span the full panel and item rows wrap instead of overlapping when fonts scale
- update the inventory renderer to use the new layout classes for controls, labels, and action buttons so icons stay inside the slot and drop mode UI matches the new styling

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d4987fef48832891f37939261ae8d8