### PR TITLE
fix: expand shop dialog layout

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -947,13 +947,14 @@ input[type="range"] {
     }
 
 .shop-window {
-  width: min(calc(640px + (var(--font-scale) - 1) * 420px), 96vw);
-  max-width: 1100px;
+  width: min(calc(720px + (var(--font-scale) - 1) * 480px), 96vw);
+  max-width: 1240px;
   background: #0f120f;
   border: 1px solid #2b3b2b;
   border-radius: 8px;
   box-shadow: 0 0 20px #000;
-  max-height: min(480px, 92vh);
+  height: min(620px, 92vh);
+  max-height: min(620px, 92vh);
   display: flex;
   flex-direction: column;
 }

--- a/test/shop.ui.test.js
+++ b/test/shop.ui.test.js
@@ -9,13 +9,15 @@ function extractOpenShop(code) {
   return match && match[0];
 }
 
-test('shop window height matches combat menu', async () => {
+test('shop window uses expanded height and keeps scroll bounds', async () => {
   const css = await fs.readFile(new URL('../dustland.css', import.meta.url), 'utf8');
-  const combat = css.match(/#combatOverlay \.combat-window\s*{[^}]*height:\s*([^;]+);/);
-  const shop = css.match(/\.shop-window\s*{[^}]*max-height:\s*([^;]+);/);
-  assert.ok(combat && shop);
+  const height = css.match(/\.shop-window\s*{[^}]*height:\s*([^;]+);/);
+  const maxHeight = css.match(/\.shop-window\s*{[^}]*max-height:\s*([^;]+);/);
+  assert.ok(height && maxHeight);
   const norm = s => s.replace(/\s+/g, '');
-  assert.strictEqual(norm(shop[1]), norm(combat[1]));
+  const expected = norm('min(620px, 92vh)');
+  assert.strictEqual(norm(height[1]), expected);
+  assert.strictEqual(norm(maxHeight[1]), expected);
 });
 
 test('arrow keys in shop do not move the player', async () => {


### PR DESCRIPTION
## Summary
- widen the shop dialog window and raise its viewport height to provide more room
- keep the taller shop window scrollable by capping its height and updating the UI regression test

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d49789bc888328a507257ac1a1280b