### PR TITLE
fix: award archivist magnetic tape

### DIFF
--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -855,6 +855,11 @@ const DATA = `
       "mods": {
         "encounter_guard": 10
       }
+    },
+    {
+      "id": "magnetic_tape",
+      "name": "Magnetic Tape",
+      "type": "quest"
     }
   ],
   "quests": [
@@ -1249,7 +1254,13 @@ const DATA = `
             {
               "label": "(Thank him)",
               "to": "bye",
-              "reward": "XP 5"
+              "reward": "XP 5",
+              "effects": [
+                {
+                  "effect": "addItem",
+                  "id": "magnetic_tape"
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
## Summary
- add a magnetic tape quest item to the Dustland module data
- grant the magnetic tape when the Archivist shares his recorded story

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68d547ccf59c832886569eaf1ad09275