### PR TITLE
fix: let Bren join after recovery

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -3408,6 +3408,20 @@
               "label": "(Hand Over Bandage)",
               "to": "turnin",
               "q": "turnin"
+            },
+            {
+              "label": "(Recruit) Patrol the dunes with me.",
+              "join": {
+                "id": "bren",
+                "name": "Bren",
+                "role": "Scout"
+              },
+              "success": "Bren falls in beside you, eyes already scanning the dunes.",
+              "if": {
+                "flag": "scout_bren_recovered",
+                "op": ">=",
+                "value": 1
+              }
             }
           ]
         },
@@ -3426,7 +3440,12 @@
                   "effect": "toast",
                   "msg": "Bren wraps the bandage around their side."
                 }
-              ]
+              ],
+              "setFlag": {
+                "flag": "scout_bren_recovered",
+                "op": "set",
+                "value": 1
+              }
             }
           ]
         },

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -3455,6 +3455,20 @@ const DATA = `
               "label": "(Hand Over Bandage)",
               "to": "turnin",
               "q": "turnin"
+            },
+            {
+              "label": "(Recruit) Patrol the dunes with me.",
+              "join": {
+                "id": "bren",
+                "name": "Bren",
+                "role": "Scout"
+              },
+              "success": "Bren falls in beside you, eyes already scanning the dunes.",
+              "if": {
+                "flag": "scout_bren_recovered",
+                "op": ">=",
+                "value": 1
+              }
             }
           ]
         },
@@ -3473,7 +3487,12 @@ const DATA = `
                   "effect": "toast",
                   "msg": "Bren wraps the bandage around their side."
                 }
-              ]
+              ],
+              "setFlag": {
+                "flag": "scout_bren_recovered",
+                "op": "set",
+                "value": 1
+              }
             }
           ]
         },


### PR DESCRIPTION
## Summary
- add a recruit choice for Scout Bren once they have recovered
- flag Bren's bandage turn-in so the recruitment option unlocks
- update the JSON copy of the module to match the dialog changes

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js

------
https://chatgpt.com/codex/tasks/task_e_68d54a3cb5f48328bb627e47e0b8b478