### PR TITLE
fix: rebalance dustland combat xp

### DIFF
--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -852,6 +852,11 @@
       "mods": {
         "encounter_guard": 10
       }
+    },
+    {
+      "id": "magnetic_tape",
+      "name": "Magnetic Tape",
+      "type": "quest"
     }
   ],
   "quests": [
@@ -1072,6 +1077,7 @@
       "name": "Strange Vortex",
       "title": "A swirling vortex of dust and sand.",
       "desc": "You feel a strange pull towards it.",
+      "prompt": "Churning vortex of dust twisting in midair",
       "portraitSheet": "assets/portraits/dustland-module/strange_vortex_4.png",
       "tree": {
         "start": {
@@ -1245,7 +1251,13 @@
             {
               "label": "(Thank him)",
               "to": "bye",
-              "reward": "XP 5"
+              "reward": "XP 5",
+              "effects": [
+                {
+                  "effect": "addItem",
+                  "id": "magnetic_tape"
+                }
+              ]
             }
           ]
         },
@@ -1282,6 +1294,7 @@
       "name": "Caretaker Kesh",
       "title": "Hall Steward",
       "desc": "Weary caretaker guarding the hall's chained exit.",
+      "prompt": "Tired steward leaning on a chained bunker door",
       "portraitSheet": "assets/portraits/kesh_4.png",
       "questId": "q_hall_key",
       "tree": {
@@ -1353,6 +1366,7 @@
       "name": "Dusty Crate",
       "title": "",
       "desc": "A dusty crate that might hide something useful.",
+      "prompt": "Splintered crate half-collapsed under dust",
       "portraitSheet": "assets/portraits/crate_4.png",
       "portraitLock": false,
       "tree": {
@@ -1392,6 +1406,7 @@
       "name": "Lone Drifter",
       "title": "Mutters",
       "desc": "A drifter muttering to themselves.",
+      "prompt": "Road-weary drifter whispering to the dust",
       "portraitSheet": "assets/portraits/drifter_4.png",
       "tree": {
         "start": {
@@ -1410,6 +1425,7 @@
       "name": "Rotwalker",
       "title": "Test Monster",
       "desc": "A shambler posted here for practice.",
+      "prompt": "Rotting training ghoul chained in the hall",
       "portraitSheet": "assets/portraits/dustland-module/rotwalker_4.png",
       "portraitLock": false,
       "tree": {
@@ -1425,7 +1441,8 @@
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 6
       },
       "symbol": "!"
     },
@@ -1438,6 +1455,7 @@
       "name": "Mira",
       "title": "Blade Dancer",
       "desc": "A lithe fighter ready to strike back.",
+      "prompt": "Scarred warrior with twin blades poised to strike",
       "portraitSheet": "assets/portraits/dustland-module/mira_4.png",
       "tree": {
         "start": {
@@ -1452,7 +1470,8 @@
         "counterBasic": {
           "dmg": 2
         },
-        "auto": true
+        "auto": true,
+        "challenge": 15
       },
       "symbol": "!",
       "overrideColor": true
@@ -1466,6 +1485,7 @@
       "name": "Nora",
       "title": "Storm Caller",
       "desc": "Crackling energy dances across her gauntlet.",
+      "prompt": "Focused stormcaster with a crackling gauntlet",
       "portraitSheet": "assets/portraits/dustland-module/nora_4.png",
       "tree": {
         "start": {
@@ -1483,7 +1503,8 @@
           "stun": 1,
           "delay": 800
         },
-        "auto": true
+        "auto": true,
+        "challenge": 14
       },
       "symbol": "!",
       "overrideColor": true
@@ -1497,6 +1518,7 @@
       "name": "Tess",
       "title": "Venom Rogue",
       "desc": "She twirls a dagger dripping with toxins.",
+      "prompt": "Dagger-wielding rogue balancing a vial of poison",
       "portraitSheet": "assets/portraits/dustland-module/tess_4.png",
       "tree": {
         "start": {
@@ -1518,7 +1540,8 @@
           "spread": true,
           "delay": 800
         },
-        "auto": true
+        "auto": true,
+        "challenge": 14
       },
       "symbol": "!"
     },
@@ -1531,6 +1554,7 @@
       "name": "Worn Sign",
       "title": "Warning",
       "desc": "Faded letters warn travelers.",
+      "prompt": "Sun-bleached warning sign rattling on a pole",
       "portraitSheet": "assets/portraits/dustland-module/worn_sign_4.png",
       "symbol": "?",
       "tree": {
@@ -1549,6 +1573,7 @@
       "name": "Nila the Pump-Keeper",
       "title": "Parched Farmer",
       "desc": "Sunburnt hands, hopeful eyes. Smells faintly of mud.",
+      "prompt": "Dust-caked farmer gripping a cracked pump handle",
       "portraitSheet": "assets/portraits/mara_4.png",
       "questId": "q_waterpump",
       "tree": {
@@ -1596,6 +1621,7 @@
       "name": "Grin",
       "title": "Scav-for-Hire",
       "desc": "Lean scav with a crowbar and half a smile.",
+      "prompt": "Lean scavenger twirling a prybar with a crooked grin",
       "portraitSheet": "assets/portraits/grin_4.png",
       "questId": "q_recruit_grin",
       "tree": {
@@ -1703,6 +1729,7 @@
       "name": "Postmaster Ivo",
       "title": "Courier of Dust",
       "desc": "Dusty courier seeking a lost parcel.",
+      "prompt": "Weathered courier clutching a bundle of worn letters",
       "portraitSheet": "assets/portraits/ivo_4.png",
       "questId": "q_postal",
       "tree": {
@@ -1760,6 +1787,7 @@
       "name": "Rella",
       "title": "Radio Tech",
       "desc": "Tower technician with grease-stained hands.",
+      "prompt": "Focused radio tech tightening wires on a battered console",
       "portraitSheet": "assets/portraits/rella_4.png",
       "questId": "q_tower",
       "tree": {
@@ -1798,6 +1826,7 @@
       "name": "The Shifting Hermit",
       "title": "Pilgrim",
       "desc": "A cloaked hermit murmuring about rusted idols.",
+      "prompt": "Hooded hermit clutching a rust-streaked idol",
       "portraitSheet": "assets/portraits/pilgrim_4.png",
       "questId": "q_idol",
       "tree": {
@@ -1845,6 +1874,7 @@
       "name": "Scrap Duchess",
       "title": "Toll-Queen",
       "desc": "A crown of bottlecaps; eyes like razors.",
+      "prompt": "Scrap-armored matriarch demanding toll at a barricade",
       "portraitSheet": "assets/portraits/scrap_4.png",
       "questId": "q_toll",
       "tree": {
@@ -1895,6 +1925,7 @@
       "name": "Hidden Hermit",
       "title": "Lurker",
       "desc": "A hermit steps out when you return.",
+      "prompt": "Weathered hermit peering from shadowed dunes",
       "portraitSheet": "assets/portraits/dustland-module/hidden_hermit_4.png",
       "tree": {
         "start": {
@@ -1967,6 +1998,7 @@
       "name": "Road Raider",
       "title": "Bandit",
       "desc": "Scarred scav looking for trouble.",
+      "prompt": "Scarred highway raider leveling a rusted rifle",
       "portraitSheet": "assets/portraits/raider_4.png",
       "portraitLock": false,
       "tree": {
@@ -1993,7 +2025,9 @@
         "scrap": {
           "min": 3,
           "max": 5
-        }
+        },
+        "HP": 16,
+        "challenge": 16
       },
       "symbol": "!"
     },
@@ -2006,6 +2040,7 @@
       "name": "Cass the Trader",
       "title": "Shopkeep",
       "desc": "A roving merchant weighing your wares.",
+      "prompt": "Nomad trader arranging scrap goods on a tarp",
       "portraitSheet": "assets/portraits/cass_4.png",
       "tree": {
         "start": {
@@ -2093,6 +2128,7 @@
       "name": "Tess the Scout",
       "title": "Water Runner",
       "desc": "She checks the pump then the far ridge.",
+      "prompt": "Desert scout balancing canteens and ridgeglass charms",
       "portraitSheet": "assets/portraits/dustland-module/tess_4.png",
       "tree": {
         "start": {
@@ -2159,6 +2195,7 @@
       "name": "Scrap Mutt",
       "title": "Mangy Hound",
       "desc": "A feral mutt snarling over junk.",
+      "prompt": "Patchwork metal hound with glowing eyes over a scrap pile",
       "portraitSheet": "assets/portraits/dustland-module/scrap_mutt_4.png",
       "portraitLock": false,
       "tree": {
@@ -2175,7 +2212,8 @@
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 10
       },
       "symbol": "!"
     },
@@ -2188,6 +2226,7 @@
       "name": "Rust Bandit",
       "title": "Scav Raider",
       "desc": "A bandit prowling for easy loot.",
+      "prompt": "Rust-scarred raider brandishing a jagged machete",
       "portraitSheet": "assets/portraits/dustland-module/rust_bandit_4.png",
       "portraitLock": false,
       "tree": {
@@ -2204,7 +2243,8 @@
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 11
       },
       "symbol": "!"
     },
@@ -2217,6 +2257,7 @@
       "name": "Feral Nomad",
       "title": "Mad Drifter",
       "desc": "A wild-eyed drifter muttering to himself.",
+      "prompt": "Wild-eyed nomad clutching scavenged charms",
       "portraitSheet": "assets/portraits/dustland-module/feral_nomad_4.png",
       "portraitLock": false,
       "tree": {
@@ -2233,7 +2274,8 @@
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 12
       },
       "symbol": "!"
     },
@@ -2246,6 +2288,7 @@
       "name": "Waste Ghoul",
       "title": "Rotwalker",
       "desc": "A decayed wanderer hungry for flesh.",
+      "prompt": "Decayed ghoul dragging chains through toxic dust",
       "portraitSheet": "assets/portraits/dustland-module/waste_ghoul_4.png",
       "portraitLock": false,
       "tree": {
@@ -2262,7 +2305,8 @@
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 13
       },
       "symbol": "!"
     },
@@ -2270,6 +2314,7 @@
       "id": "iron_brute",
       "name": "Iron Brute",
       "desc": "A hulking brute plated in scrap.",
+      "prompt": "Towering brute encased in welded scrap armor",
       "color": "#f66",
       "symbol": "!",
       "map": "world",
@@ -2317,7 +2362,8 @@
         "scrap": {
           "min": 3,
           "max": 5
-        }
+        },
+        "challenge": 18
       },
       "portraitSheet": "assets/portraits/dustland-module/iron_brute_4.png",
       "portraitLock": false
@@ -2331,6 +2377,7 @@
       "name": "Grit Stalker",
       "title": "Wasteland Hunter",
       "desc": "A ruthless drifter prowling for prey.",
+      "prompt": "Cloaked hunter stalking the dunes with a hooked spear",
       "portraitSheet": "assets/portraits/portrait_1079.png",
       "portraitLock": false,
       "tree": {
@@ -2367,7 +2414,7 @@
           "max": 5
         },
         "auto": true,
-        "challenge": 0
+        "challenge": 14
       },
       "symbol": "!"
     },
@@ -2380,6 +2427,7 @@
       "name": "Brakk",
       "title": "Power Trainer",
       "desc": "A former arena champ teaching raw strength.",
+      "prompt": "Muscular arena veteran demonstrating crushing strikes",
       "portraitSheet": "assets/portraits/dustland-module/brakk_4.png",
       "trainer": "power",
       "tree": {
@@ -2419,6 +2467,7 @@
       "name": "Rusty",
       "title": "Endurance Trainer",
       "desc": "A grizzled scavenger preaching survival.",
+      "prompt": "Weathered survivor wrapped in patched leathers",
       "portraitSheet": "assets/portraits/dustland-module/rusty_4.png",
       "trainer": "endurance",
       "tree": {
@@ -2458,6 +2507,7 @@
       "name": "Mira",
       "title": "Tricks Trainer",
       "desc": "A nimble tinkerer teaching odd moves.",
+      "prompt": "Quick-handed tinkerer juggling coins and gadgets",
       "portraitSheet": "assets/portraits/dustland-module/mira_4.png",
       "trainer": "tricks",
       "tree": {
@@ -2497,6 +2547,7 @@
       "name": "Nora",
       "title": "Worm Seller",
       "desc": "She trades memory worms for scrap.",
+      "prompt": "Mystic merchant offering jars of glowing worms",
       "portraitSheet": "assets/portraits/dustland-module/nora_4.png",
       "tree": {
         "start": {
@@ -2538,6 +2589,7 @@
       "name": "One-Armed Bandit",
       "title": "Slot Machine",
       "desc": "It wheezes, eager for scrap.",
+      "prompt": "Rusted slot machine flickering with failing bulbs",
       "portraitSheet": "assets/portraits/dustland-module/slot_machine.png",
       "symbol": "?",
       "tree": {
@@ -2632,6 +2684,7 @@
       "id": "scrap_behemoth",
       "name": "Scrap Behemoth",
       "desc": "A towering mass of twisted metal.",
+      "prompt": "Colossal golem of fused scrap towering over the dunes",
       "color": "#f66",
       "symbol": "!",
       "map": "world",
@@ -2667,7 +2720,8 @@
           "cue": "crackles with energy!",
           "dmg": 5,
           "delay": 1000
-        }
+        },
+        "challenge": 22
       },
       "portraitSheet": "assets/portraits/portrait_1084.png",
       "portraitLock": false
@@ -2866,7 +2920,8 @@
         "scrap": {
           "min": 3,
           "max": 5
-        }
+        },
+        "challenge": 9
       },
       "symbol": "!"
     },
@@ -2901,7 +2956,8 @@
         "scrap": {
           "min": 3,
           "max": 5
-        }
+        },
+        "challenge": 15
       },
       "symbol": "!"
     },
@@ -2990,7 +3046,7 @@
           "min": 6,
           "max": 9
         },
-        "xp": 60
+        "xp": 54
       }
     },
     {
@@ -3036,7 +3092,7 @@
           "min": 7,
           "max": 11
         },
-        "xp": 100
+        "xp": 96
       }
     },
     {
@@ -3136,7 +3192,7 @@
           "min": 15,
           "max": 25
         },
-        "xp": 400
+        "xp": 225
       }
     },
     {
@@ -3228,7 +3284,7 @@
           "min": 6,
           "max": 10
         },
-        "xp": 70
+        "xp": 66
       }
     },
     {
@@ -3272,7 +3328,7 @@
           "min": 8,
           "max": 12
         },
-        "xp": 120
+        "xp": 78
       }
     },
     {
@@ -3318,7 +3374,7 @@
           "min": 12,
           "max": 16
         },
-        "xp": 180
+        "xp": 90
       }
     },
     {
@@ -3330,6 +3386,7 @@
       "name": "Medic Lysa",
       "title": "Workshop Healer",
       "desc": "A weary medic sorting salvaged herbs.",
+      "prompt": "Tired field medic grinding herbs beside a jury-rigged still",
       "portraitSheet": "assets/portraits/dustland-module/mira_4.png",
       "symbol": "!",
       "questId": "q_antidote_aid",
@@ -3387,6 +3444,7 @@
       "name": "Scout Bren",
       "title": "Sandway Patrol",
       "desc": "A scout slumped against the wall, breathing shallowly.",
+      "prompt": "Dusty scout clutching ribs while propped against a workbench",
       "portraitSheet": "assets/portraits/dustland-module/nora_4.png",
       "symbol": "!",
       "questId": "q_scout_recon",
@@ -3445,6 +3503,7 @@
       "name": "Mahra",
       "title": "Hall Envoy",
       "desc": "An envoy wringing her hands over desert politics.",
+      "prompt": "Nervous envoy clutching a ledger among supply crates",
       "questId": "q_curry_favor",
       "tree": {
         "start": {
@@ -3519,6 +3578,7 @@
       "name": "Duke of the Wastes",
       "title": "Desert Sovereign",
       "desc": "The Duke lounges on a rusted throne surrounded by sand-bitten trophies.",
+      "prompt": "Regal wasteland warlord reclining on a rusted throne",
       "tree": {
         "start": {
           "text": "A throne of rust looms over dunes of sand poured inside the lair.",
@@ -4629,7 +4689,6 @@
       }
     ]
   },
-  "module": "modules/dustland.module.js",
   "encounters": {
     "world": [
       {
@@ -5347,5 +5406,6 @@
         "🪨🪨🪨🪨🪨🚪🪨🪨🪨🪨🪨"
       ]
     }
-  ]
+  ],
+  "module": "modules/dustland.module.js"
 }

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -1444,7 +1444,8 @@ const DATA = `
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 6
       },
       "symbol": "!"
     },
@@ -1472,7 +1473,8 @@ const DATA = `
         "counterBasic": {
           "dmg": 2
         },
-        "auto": true
+        "auto": true,
+        "challenge": 15
       },
       "symbol": "!",
       "overrideColor": true
@@ -1504,7 +1506,8 @@ const DATA = `
           "stun": 1,
           "delay": 800
         },
-        "auto": true
+        "auto": true,
+        "challenge": 14
       },
       "symbol": "!",
       "overrideColor": true
@@ -1540,7 +1543,8 @@ const DATA = `
           "spread": true,
           "delay": 800
         },
-        "auto": true
+        "auto": true,
+        "challenge": 14
       },
       "symbol": "!"
     },
@@ -2024,7 +2028,9 @@ const DATA = `
         "scrap": {
           "min": 3,
           "max": 5
-        }
+        },
+        "HP": 16,
+        "challenge": 16
       },
       "symbol": "!"
     },
@@ -2209,7 +2215,8 @@ const DATA = `
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 10
       },
       "symbol": "!"
     },
@@ -2239,7 +2246,8 @@ const DATA = `
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 11
       },
       "symbol": "!"
     },
@@ -2269,7 +2277,8 @@ const DATA = `
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 12
       },
       "symbol": "!"
     },
@@ -2299,7 +2308,8 @@ const DATA = `
           "min": 3,
           "max": 5
         },
-        "auto": true
+        "auto": true,
+        "challenge": 13
       },
       "symbol": "!"
     },
@@ -2355,7 +2365,8 @@ const DATA = `
         "scrap": {
           "min": 3,
           "max": 5
-        }
+        },
+        "challenge": 18
       },
       "portraitSheet": "assets/portraits/dustland-module/iron_brute_4.png",
       "portraitLock": false
@@ -2406,7 +2417,7 @@ const DATA = `
           "max": 5
         },
         "auto": true,
-        "challenge": 0
+        "challenge": 14
       },
       "symbol": "!"
     },
@@ -2712,7 +2723,8 @@ const DATA = `
           "cue": "crackles with energy!",
           "dmg": 5,
           "delay": 1000
-        }
+        },
+        "challenge": 22
       },
       "portraitSheet": "assets/portraits/portrait_1084.png",
       "portraitLock": false
@@ -2911,7 +2923,8 @@ const DATA = `
         "scrap": {
           "min": 3,
           "max": 5
-        }
+        },
+        "challenge": 9
       },
       "symbol": "!"
     },
@@ -2946,7 +2959,8 @@ const DATA = `
         "scrap": {
           "min": 3,
           "max": 5
-        }
+        },
+        "challenge": 15
       },
       "symbol": "!"
     },
@@ -3035,7 +3049,7 @@ const DATA = `
           "min": 6,
           "max": 9
         },
-        "xp": 60
+        "xp": 54
       }
     },
     {
@@ -3081,7 +3095,7 @@ const DATA = `
           "min": 7,
           "max": 11
         },
-        "xp": 100
+        "xp": 96
       }
     },
     {
@@ -3181,7 +3195,7 @@ const DATA = `
           "min": 15,
           "max": 25
         },
-        "xp": 400
+        "xp": 225
       }
     },
     {
@@ -3273,7 +3287,7 @@ const DATA = `
           "min": 6,
           "max": 10
         },
-        "xp": 70
+        "xp": 66
       }
     },
     {
@@ -3317,7 +3331,7 @@ const DATA = `
           "min": 8,
           "max": 12
         },
-        "xp": 120
+        "xp": 78
       }
     },
     {
@@ -3363,7 +3377,7 @@ const DATA = `
           "min": 12,
           "max": 16
         },
-        "xp": 180
+        "xp": 90
       }
     },
     {

--- a/test/dustland.module.test.js
+++ b/test/dustland.module.test.js
@@ -37,7 +37,7 @@ test('dustland module includes patrolling enemy', () => {
     loot: 'raider_knife',
     scrap: { min: 3, max: 5 },
     auto: true,
-    challenge: 0
+    challenge: 14
   });
 });
 


### PR DESCRIPTION
## Summary
- tune Dustland combatant challenge ratings and Road Raider stats so encounter XP mirrors fight difficulty
- rescale oc3 Ashen pack XP payouts to match their challenge ratings and finale expectations
- update the patrolling enemy regression test to match the new challenge profile

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js modules/dustland.module.js
- node scripts/supporting/balance-tester-agent.js

------
https://chatgpt.com/codex/tasks/task_e_68d54c31b7a88328be5fbcfa3a8ffc3c