### PR TITLE
fix: triple quest xp rewards

### DIFF
--- a/data/modules/cli-demo.json
+++ b/data/modules/cli-demo.json
@@ -30,14 +30,14 @@
       "title": "Trail Briefing",
       "desc": "Talk to Rowan and inspect the humming stones.",
       "reward": "starter_kit",
-      "xp": 2
+      "xp": 6
     },
     {
       "id": "coded_stone",
       "title": "Decode the Stone",
       "desc": "Use the cipher wheel Rowan gave you to decode the humming stone.",
       "reward": "camp_rations",
-      "xp": 4
+      "xp": 12
     }
   ],
   "npcs": [

--- a/data/modules/dustland.json
+++ b/data/modules/dustland.json
@@ -875,7 +875,7 @@
           "LCK": 1
         }
       },
-      "xp": 4
+      "xp": 12
     },
     {
       "id": "q_recruit_grin",
@@ -896,7 +896,7 @@
           "LCK": 1
         }
       },
-      "xp": 4
+      "xp": 12
     },
     {
       "id": "q_tower",
@@ -912,7 +912,7 @@
           "PER": 1
         }
       },
-      "xp": 5
+      "xp": 15
     },
     {
       "id": "q_idol",
@@ -928,13 +928,13 @@
           "CHA": 1
         }
       },
-      "xp": 5
+      "xp": 15
     },
     {
       "id": "q_toll",
       "title": "Toll-Booth Etiquette",
       "desc": "You met the Duchess on the road.",
-      "xp": 2
+      "xp": 6
     },
     {
       "id": "q_signal",
@@ -942,7 +942,7 @@
       "desc": "Collect three signal fragments in the wastes.",
       "item": "signal_fragment",
       "count": 3,
-      "xp": 3
+      "xp": 9
     },
     {
       "id": "q_spark",
@@ -967,7 +967,7 @@
       "desc": "Deliver the Sun Charm to the Archivist in the Hall so he can decode the broadcast and chart a path to the missing fragment.",
       "item": "sun_charm",
       "reward": "sun_charm",
-      "xp": 4,
+      "xp": 12,
       "dialog": {
         "offer": "The Archivist taps a reel. 'The Sun Charm hums with a lost broadcast. Bring it so I can hear the dawn.'",
         "active": "The Archivist taps a reel. 'The Sun Charm hums with a lost broadcast. Bring it so I can hear the dawn.'",
@@ -980,7 +980,7 @@
       "desc": "Recover Signal Fragment C from the echo relay hidden in the far northeast so the Archivist can finish the broadcast and unlock the Epic Blade.",
       "item": "signal_fragment_c",
       "reward": "epic_blade",
-      "xp": 8,
+      "xp": 24,
       "dialog": {
         "offer": "The Archivist squints at the receiver. 'I traced the pattern, but Signal Fragment C will complete the chorus.'",
         "active": "The Archivist squints at the receiver. 'I traced the pattern, but Signal Fragment C will complete the chorus.'",
@@ -992,21 +992,21 @@
       "title": "Antidote Assembly",
       "desc": "Collect water flasks and plant fiber, then craft an antidote at the workshop for Medic Lysa.",
       "item": "antidote",
-      "xp": 5
+      "xp": 15
     },
     {
       "id": "q_scout_recon",
       "title": "Scout's Return",
       "desc": "Once the antidote works, bring Scout Bren a bandage so they can rejoin patrol duty.",
       "item": "bandage",
-      "xp": 4
+      "xp": 12
     },
     {
       "id": "q_curry_favor",
       "title": "Currying Favor",
       "desc": "Earn the Duke of the Wastes' respect for the Hall.",
       "count": 1,
-      "xp": 35,
+      "xp": 105,
       "progressText": "The Duke has not pledged us his favor yet.",
       "dialogNodes": [
         {
@@ -1028,13 +1028,13 @@
       "id": "task_grudge_sour_routes",
       "title": "Sour Cass's Routes",
       "desc": "Tip off rival caravans to rile Cass and raise her grudge.",
-      "xp": 1
+      "xp": 3
     },
     {
       "id": "task_grudge_patch_wagon",
       "title": "Patch Cass's Wagon",
       "desc": "Deliver spare parts so Cass eases her grudge.",
-      "xp": 1
+      "xp": 3
     },
     {
       "id": "q_first_echo",
@@ -1042,7 +1042,7 @@
       "desc": "Find the Tuned Crystal for Sparks to help him focus the Ghost Signal.",
       "item": "tuned_crystal",
       "reward": "signal_fragment_1",
-      "xp": 10
+      "xp": 30
     },
     {
       "id": "q_silent_tower",
@@ -1051,14 +1051,14 @@
       "item": "power_cell",
       "count": 3,
       "reward": "signal_fragment_2",
-      "xp": 20
+      "xp": 60
     },
     {
       "id": "q_resonant_cave",
       "title": "The Resonant Cave",
       "desc": "Follow the Hermit's instructions to activate the Resonant Crystals in the correct order.",
       "reward": "signal_fragment_3",
-      "xp": 30,
+      "xp": 90,
       "reqFlag": "cave_puzzle_complete"
     }
   ],

--- a/modules/cli-demo.module.js
+++ b/modules/cli-demo.module.js
@@ -33,14 +33,14 @@ const DATA = `
       "title": "Trail Briefing",
       "desc": "Talk to Rowan and inspect the humming stones.",
       "reward": "starter_kit",
-      "xp": 2
+      "xp": 6
     },
     {
       "id": "coded_stone",
       "title": "Decode the Stone",
       "desc": "Use the cipher wheel Rowan gave you to decode the humming stone.",
       "reward": "camp_rations",
-      "xp": 4
+      "xp": 12
     }
   ],
   "npcs": [

--- a/modules/dustland.module.js
+++ b/modules/dustland.module.js
@@ -883,7 +883,7 @@ const DATA = `
           "LCK": 1
         }
       },
-      "xp": 4
+      "xp": 12
     },
     {
       "id": "q_recruit_grin",
@@ -904,7 +904,7 @@ const DATA = `
           "LCK": 1
         }
       },
-      "xp": 4
+      "xp": 12
     },
     {
       "id": "q_tower",
@@ -920,7 +920,7 @@ const DATA = `
           "PER": 1
         }
       },
-      "xp": 5
+      "xp": 15
     },
     {
       "id": "q_idol",
@@ -936,13 +936,13 @@ const DATA = `
           "CHA": 1
         }
       },
-      "xp": 5
+      "xp": 15
     },
     {
       "id": "q_toll",
       "title": "Toll-Booth Etiquette",
       "desc": "You met the Duchess on the road.",
-      "xp": 2
+      "xp": 6
     },
     {
       "id": "q_signal",
@@ -950,7 +950,7 @@ const DATA = `
       "desc": "Collect three signal fragments in the wastes.",
       "item": "signal_fragment",
       "count": 3,
-      "xp": 3
+      "xp": 9
     },
     {
       "id": "q_spark",
@@ -975,7 +975,7 @@ const DATA = `
       "desc": "Deliver the Sun Charm to the Archivist in the Hall so he can decode the broadcast and chart a path to the missing fragment.",
       "item": "sun_charm",
       "reward": "sun_charm",
-      "xp": 4,
+      "xp": 12,
       "dialog": {
         "offer": "The Archivist taps a reel. 'The Sun Charm hums with a lost broadcast. Bring it so I can hear the dawn.'",
         "active": "The Archivist taps a reel. 'The Sun Charm hums with a lost broadcast. Bring it so I can hear the dawn.'",
@@ -988,7 +988,7 @@ const DATA = `
       "desc": "Recover Signal Fragment C from the echo relay hidden in the far northeast so the Archivist can finish the broadcast and unlock the Epic Blade.",
       "item": "signal_fragment_c",
       "reward": "epic_blade",
-      "xp": 8,
+      "xp": 24,
       "dialog": {
         "offer": "The Archivist squints at the receiver. 'I traced the pattern, but Signal Fragment C will complete the chorus.'",
         "active": "The Archivist squints at the receiver. 'I traced the pattern, but Signal Fragment C will complete the chorus.'",
@@ -1000,21 +1000,21 @@ const DATA = `
       "title": "Antidote Assembly",
       "desc": "Collect water flasks and plant fiber, then craft an antidote at the workshop for Medic Lysa.",
       "item": "antidote",
-      "xp": 5
+      "xp": 15
     },
     {
       "id": "q_scout_recon",
       "title": "Scout's Return",
       "desc": "Once the antidote works, bring Scout Bren a bandage so they can rejoin patrol duty.",
       "item": "bandage",
-      "xp": 4
+      "xp": 12
     },
     {
       "id": "q_curry_favor",
       "title": "Currying Favor",
       "desc": "Earn the Duke of the Wastes' respect for the Hall.",
       "count": 1,
-      "xp": 35,
+      "xp": 105,
       "progressText": "The Duke has not pledged us his favor yet.",
       "dialogNodes": [
         {
@@ -1036,13 +1036,13 @@ const DATA = `
       "id": "task_grudge_sour_routes",
       "title": "Sour Cass's Routes",
       "desc": "Tip off rival caravans to rile Cass and raise her grudge.",
-      "xp": 1
+      "xp": 3
     },
     {
       "id": "task_grudge_patch_wagon",
       "title": "Patch Cass's Wagon",
       "desc": "Deliver spare parts so Cass eases her grudge.",
-      "xp": 1
+      "xp": 3
     },
     {
       "id": "q_first_echo",
@@ -1050,7 +1050,7 @@ const DATA = `
       "desc": "Find the Tuned Crystal for Sparks to help him focus the Ghost Signal.",
       "item": "tuned_crystal",
       "reward": "signal_fragment_1",
-      "xp": 10
+      "xp": 30
     },
     {
       "id": "q_silent_tower",
@@ -1059,14 +1059,14 @@ const DATA = `
       "item": "power_cell",
       "count": 3,
       "reward": "signal_fragment_2",
-      "xp": 20
+      "xp": 60
     },
     {
       "id": "q_resonant_cave",
       "title": "The Resonant Cave",
       "desc": "Follow the Hermit's instructions to activate the Resonant Crystals in the correct order.",
       "reward": "signal_fragment_3",
-      "xp": 30,
+      "xp": 90,
       "reqFlag": "cave_puzzle_complete"
     }
   ],


### PR DESCRIPTION
## Summary
- triple the XP payouts for Dustland module quests to keep pace with combat gains
- update the CLI demo module to use the higher quest XP baseline

## Testing
- npm test
- node scripts/supporting/presubmit.js
- node scripts/supporting/placement-check.js data/modules/dustland.json
- node scripts/supporting/placement-check.js data/modules/cli-demo.json

------
https://chatgpt.com/codex/tasks/task_e_68d54c6d7fa4832894c7c8dd3c52b1dd