### PR TITLE
fix: keep shop lists scrollable

### DIFF
--- a/dustland.css
+++ b/dustland.css
@@ -1269,6 +1269,7 @@ input[type="range"] {
   margin-top: 8px;
   overflow-y: auto;
   flex: 1;
+  min-height: 0;
 }
 
     #creator .win {


### PR DESCRIPTION
## Summary
- allow slot-list containers to shrink within flex parents so they can scroll

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d549a7e1008328bce4d626903318d2