### PR TITLE
fix: allow case-insensitive equip role checks

### DIFF
--- a/scripts/core/inventory.js
+++ b/scripts/core/inventory.js
@@ -51,19 +51,21 @@ function cloneData(obj){
 }
 
 function listRequiredRoles(it){
-  if(!it?.equip?.requires) return [];
-  const req = it.equip.requires;
   const roles = [];
-  if(typeof req.role === 'string' && req.role && !roles.includes(req.role)){
-    roles.push(req.role);
-  }
-  if(Array.isArray(req.roles)){
-    req.roles.forEach(role => {
-      if(typeof role === 'string' && role && !roles.includes(role)){
-        roles.push(role);
-      }
-    });
-  }
+  const seen = new Set();
+  const req = it?.equip?.requires;
+  if(!req) return roles;
+  const addRole = value => {
+    if(typeof value !== 'string') return;
+    const name = value.trim();
+    if(!name) return;
+    const key = name.toLowerCase();
+    if(seen.has(key)) return;
+    seen.add(key);
+    roles.push(name);
+  };
+  addRole(req.role);
+  if(Array.isArray(req.roles)) req.roles.forEach(addRole);
   return roles;
 }
 
@@ -120,7 +122,8 @@ function getEquipRestrictions(member, item){
   if(!levelMet && minLevel > 1){
     result.reasons.push(`Requires level ${minLevel}.`);
   }
-  const roleMet = !hasMember || roles.length === 0 || roles.includes(member.role);
+  const memberRole = typeof member?.role === 'string' ? member.role.trim().toLowerCase() : '';
+  const roleMet = !hasMember || roles.length === 0 || (memberRole && roles.some(role => role.toLowerCase() === memberRole));
   result.roleMet = roleMet;
   if(!roleMet && roles.length){
     const reqText = describeRequiredRoles(item);

--- a/test/inventory-highlight.test.js
+++ b/test/inventory-highlight.test.js
@@ -140,6 +140,30 @@ test('weapon suggestions respect member stats and weapon type', async () => {
   assert.ok(!slots[1].classList.contains('better'));
 });
 
+test('role requirements are case-insensitive for equip highlights', async () => {
+  const whip = () => ({ name: 'Thornlash Whip', type: 'weapon', mods: { ATK: 3, ADR: 18 } });
+  const sixShooter = () => ({
+    name: 'Dawnforge Six-Shooter',
+    type: 'weapon',
+    tags: ['ranged'],
+    mods: { ATK: 4, ADR: 20, LCK: 1 },
+    equip: { requires: { role: 'Gunslinger' } }
+  });
+  const items = [whip(), sixShooter()];
+  const eq = {
+    equip: { weapon: whip() },
+    stats: { STR: 1, AGI: 20, INT: 4, PER: 4, LCK: 4, CHA: 4 },
+    role: 'gunslinger'
+  };
+  const ctx = setup(items, eq);
+  await loadRender(ctx);
+  ctx.renderInv();
+  const slots = ctx.document.querySelectorAll('.slot');
+  assert.equal(slots.length, 2);
+  assert.ok(!slots[0].classList.contains('better'));
+  assert.ok(slots[1].classList.contains('better'));
+});
+
 test('setLeader equips missing gear and suggests a single upgrade per slot', async () => {
   const items = [
     { name: 'Axe', type: 'weapon', value: 2 },


### PR DESCRIPTION
## Summary
- deduplicate required role lists and compare member roles without case sensitivity
- add a regression test proving ranged weapons highlight correctly for lowercase gunslinger roles

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68d54bcd1068832885d4ea81438d0cc1