### PR TITLE
feat: add comfyui batch workflow for game art

### DIFF
--- a/docs/examples/comfyui-game-asset-workflow.json
+++ b/docs/examples/comfyui-game-asset-workflow.json
@@ -1,0 +1,86 @@
+{
+  "last_node_id": 4,
+  "last_link_id": 5,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CheckpointLoaderSimple",
+      "pos": [-650, -120],
+      "size": [300, 200],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "MODEL", "type": "MODEL", "links": [1], "shape": 3, "slot_index": 0},
+        {"name": "CLIP", "type": "CLIP", "links": [2], "shape": 3, "slot_index": 1},
+        {"name": "VAE", "type": "VAE", "links": [3], "shape": 3, "slot_index": 2}
+      ],
+      "widgets_values": ["sd15.safetensors"]
+    },
+    {
+      "id": 2,
+      "type": "GameAssetJSONLoader",
+      "pos": [-660, 200],
+      "size": [360, 260],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "assets", "type": "GAME_ASSET_LIST", "links": [4], "shape": 3, "slot_index": 0}
+      ],
+      "widgets_values": [
+        "game_asset_batch.json",
+        512,
+        512,
+        30,
+        7.0,
+        "euler",
+        "normal"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "GameAssetBatchRenderer",
+      "pos": [-240, 0],
+      "size": [360, 320],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {"name": "model", "type": "MODEL", "link": 1, "slot_index": 0},
+        {"name": "clip", "type": "CLIP", "link": 2, "slot_index": 1},
+        {"name": "vae", "type": "VAE", "link": 3, "slot_index": 2},
+        {"name": "assets", "type": "GAME_ASSET_LIST", "link": 4, "slot_index": 3}
+      ],
+      "outputs": [
+        {"name": "preview", "type": "IMAGE", "links": [5], "shape": 3, "slot_index": 0},
+        {"name": "filenames", "type": "STRING", "links": [], "shape": 3, "slot_index": 1}
+      ],
+      "widgets_values": ["", 4]
+    },
+    {
+      "id": 4,
+      "type": "PreviewImage",
+      "pos": [220, 20],
+      "size": [320, 280],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {"name": "images", "type": "IMAGE", "link": 5, "slot_index": 0}
+      ],
+      "outputs": [],
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [1, 1, 0, 3, 0],
+    [2, 1, 1, 3, 1],
+    [3, 1, 2, 3, 2],
+    [4, 2, 0, 3, 3],
+    [5, 3, 0, 4, 0]
+  ],
+  "groups": []
+}

--- a/docs/examples/game_asset_batch.json
+++ b/docs/examples/game_asset_batch.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "ui_button_start",
+    "prompt": "isometric pixel art start button, neon edges, retro game interface",
+    "negative_prompt": "blurry, photo, 3d render",
+    "width": 512,
+    "height": 512,
+    "steps": 28,
+    "cfg_scale": 6.5,
+    "sampler": "euler",
+    "scheduler": "normal",
+    "seed": 123456
+  },
+  {
+    "name": "enemy_drone",
+    "prompt": "top-down sprite of a hostile drone with rusted metal panels, glowing red eye",
+    "width": 640,
+    "height": 640,
+    "steps": 32,
+    "cfg_scale": 7.5,
+    "sampler": "dpmpp_2m",
+    "scheduler": "karras"
+  }
+]

--- a/docs/tutorials/comfyui-game-asset-workflow.md
+++ b/docs/tutorials/comfyui-game-asset-workflow.md
@@ -1,0 +1,83 @@
+# ComfyUI batch workflow for Dustland game art
+
+This guide explains how to install the Dustland custom nodes for ComfyUI and
+use the accompanying workflow to batch-generate in-game art directly from a
+JSON specification.
+
+## What the workflow does
+
+The workflow pairs two custom nodes:
+
+- **Dustland Game Asset JSON Loader** parses a JSON document describing each
+  asset you want to render. Every record may contain its own prompt, negative
+  prompt, output filename, sampler, scheduler, resolution, CFG scale, steps,
+  and seed. Defaults can be supplied in the node UI for any field that is not
+  specified per asset.
+- **Dustland Game Asset Batch Renderer** feeds each normalized asset into the
+  standard Stable Diffusion sampling path and saves every image using the
+  provided `name` field as the filename prefix. A preview of the first render
+  is wired to ComfyUI's `PreviewImage` node so you can confirm the batch
+  started successfully.
+
+By combining these nodes you can take the JSON exported by the Dustland
+adventure builder (or any AI planning pass) and generate all art for a module
+in one run.
+
+## Files in this repository
+
+| File | Purpose |
+| --- | --- |
+| `scripts/comfyui/game_asset_batch_nodes.py` | Custom ComfyUI nodes that power the workflow. Copy this file into your ComfyUI `custom_nodes` directory. |
+| `docs/examples/comfyui-game-asset-workflow.json` | A ready-to-import workflow that wires the custom nodes together. |
+| `docs/examples/game_asset_batch.json` | Sample asset description demonstrating the JSON schema. |
+
+## JSON schema
+
+Each asset entry may include the following fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | No | Filename prefix. Defaults to `asset_###` when omitted. |
+| `prompt` | Yes | Positive text prompt used for CLIP encoding. |
+| `negative_prompt` | No | Asset-specific negative prompt. |
+| `width` / `height` | No | Resolution in pixels. Falls back to the loader defaults. |
+| `steps` | No | Number of sampling steps. |
+| `cfg_scale` | No | CFG scale value. |
+| `sampler` | No | Name of the sampler (for example `euler`, `dpmpp_2m`). |
+| `scheduler` | No | Scheduler to use (for example `normal`, `karras`). |
+| `seed` | No | Seed value; random when omitted. |
+
+Place the JSON file inside ComfyUI's `input` directory or paste its contents
+into the loader node. The sample in [`docs/examples/game_asset_batch.json`](../examples/game_asset_batch.json)
+contains two assets you can experiment with immediately.
+
+## Installation and usage
+
+1. Copy `game_asset_batch_nodes.py` into your ComfyUI installation under
+   `custom_nodes/dustland_game_assets/` (or another folder of your choice).
+   Restart ComfyUI so it discovers the new nodes.
+2. Download `comfyui-game-asset-workflow.json` and import it through the
+   ComfyUI sidebar (`Load` → `Workflow`).
+3. Place your asset JSON file inside ComfyUI's `input` directory. Update the
+   **JSON Loader** node's `json_source` field to either the filename or paste
+   the JSON directly.
+4. Select your preferred base checkpoint on the **Checkpoint Loader** node.
+5. (Optional) Enter a base negative prompt and adjust the preview limit on the
+   **Batch Renderer** node.
+6. Queue the workflow. ComfyUI will iterate every entry, render it, and save
+   each image using the provided filename prefix. The renderer's second output
+   lists all filenames saved during the run.
+
+## Tips
+
+- Combine the base negative prompt with asset-level negatives for consistent
+  style control.
+- To create pixel-art sprites, choose checkpoints or LoRAs trained for pixel
+  aesthetics and set the resolution to multiples of your target tile size.
+- Because assets may have different dimensions, the preview only shows the
+  first image rendered. Review the saved files for the complete batch.
+- When running very large batches, use ComfyUI's queue controls to pause or
+  resume without reloading the JSON.
+
+With this workflow, any JSON-driven content plan can quickly become a full set
+of module-ready graphics.

--- a/scripts/comfyui/game_asset_batch_nodes.py
+++ b/scripts/comfyui/game_asset_batch_nodes.py
@@ -1,0 +1,261 @@
+"""Custom ComfyUI nodes for generating game art batches from JSON prompts.
+
+These nodes allow Dustland creators to feed a JSON description of assets into
+ComfyUI and automatically render each item with its own prompt, resolution,
+seed, and filename.  Copy this file into your ComfyUI installation under
+``custom_nodes`` to make the nodes available in the UI.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+import comfy.sd
+import comfy.utils
+import folder_paths
+import nodes
+import torch
+
+
+@dataclass
+class GameAssetPrompt:
+  """Description of a single asset to generate."""
+
+  name: str
+  prompt: str
+  negative_prompt: str
+  width: int
+  height: int
+  steps: int
+  cfg_scale: float
+  sampler: str
+  scheduler: str
+  seed: int
+
+
+class GameAssetJSONLoader:
+  """Parse JSON describing a batch of game asset prompts."""
+
+  @classmethod
+  def INPUT_TYPES(cls):
+    return {
+        "required": {
+            "json_source": (
+                "STRING",
+                {
+                    "multiline": True,
+                    "default": "",
+                    "placeholder": "Paste JSON or provide a relative path under input/",
+                },
+            ),
+            "fallback_width": (
+                "INT",
+                {"default": 512, "min": 64, "max": 2048, "step": 8},
+            ),
+            "fallback_height": (
+                "INT",
+                {"default": 512, "min": 64, "max": 2048, "step": 8},
+            ),
+            "fallback_steps": (
+                "INT",
+                {"default": 30, "min": 1, "max": 150},
+            ),
+            "fallback_cfg": (
+                "FLOAT",
+                {"default": 7.0, "min": 0.0, "max": 30.0, "step": 0.1},
+            ),
+            "fallback_sampler": (
+                "STRING",
+                {"default": "euler"},
+            ),
+            "fallback_scheduler": (
+                "STRING",
+                {"default": "normal"},
+            ),
+        }
+    }
+
+  RETURN_TYPES = ("GAME_ASSET_LIST",)
+  FUNCTION = "load"
+  CATEGORY = "Dustland/Game Assets"
+
+  def _read_json(self, json_source: str) -> Any:
+    text = json_source.strip()
+    if not text:
+      raise ValueError("JSON source is empty")
+    if text.startswith("{") or text.startswith("["):
+      return json.loads(text)
+    search_path = folder_paths.get_full_path("input", text)
+    if search_path is None:
+      candidate = Path(text).expanduser()
+    else:
+      candidate = Path(search_path)
+    if not candidate.exists():
+      raise FileNotFoundError(f"Could not find JSON file at {candidate}")
+    return json.loads(candidate.read_text(encoding="utf-8"))
+
+  def _normalize_asset(
+      self,
+      raw: Dict[str, Any],
+      index: int,
+      defaults: Dict[str, Any],
+  ) -> GameAssetPrompt:
+    try:
+      prompt = raw["prompt"].strip()
+    except KeyError as exc:
+      raise KeyError(f"Asset #{index + 1} is missing a 'prompt'") from exc
+    name = raw.get("name") or raw.get("filename") or f"asset_{index:03d}"
+    negative_prompt = raw.get("negative_prompt") or raw.get("negativePrompt") or ""
+    width = int(raw.get("width", defaults["width"]))
+    height = int(raw.get("height", defaults["height"]))
+    steps = int(raw.get("steps", defaults["steps"]))
+    cfg_scale = float(raw.get("cfg_scale", raw.get("cfgScale", defaults["cfg"])))
+    sampler = str(raw.get("sampler", defaults["sampler"]))
+    scheduler = str(raw.get("scheduler", defaults["scheduler"]))
+    seed_value = raw.get("seed")
+    seed = int(seed_value if seed_value is not None else comfy.utils.random_seed())
+    return GameAssetPrompt(
+        name=name,
+        prompt=prompt,
+        negative_prompt=negative_prompt,
+        width=width,
+        height=height,
+        steps=steps,
+        cfg_scale=cfg_scale,
+        sampler=sampler,
+        scheduler=scheduler,
+        seed=seed,
+    )
+
+  def load(
+      self,
+      json_source: str,
+      fallback_width: int,
+      fallback_height: int,
+      fallback_steps: int,
+      fallback_cfg: float,
+      fallback_sampler: str,
+      fallback_scheduler: str,
+  ):
+    data = self._read_json(json_source)
+    if isinstance(data, dict):
+      assets = [data]
+    elif isinstance(data, list):
+      assets = list(data)
+    else:
+      raise TypeError("JSON root must be an object or an array")
+
+    defaults = {
+        "width": fallback_width,
+        "height": fallback_height,
+        "steps": fallback_steps,
+        "cfg": fallback_cfg,
+        "sampler": fallback_sampler,
+        "scheduler": fallback_scheduler,
+    }
+
+    normalized = [self._normalize_asset(asset, idx, defaults) for idx, asset in enumerate(assets)]
+    return (normalized,)
+
+
+class GameAssetBatchRenderer:
+  """Render each JSON entry through the standard Stable Diffusion pipeline."""
+
+  @classmethod
+  def INPUT_TYPES(cls):
+    return {
+        "required": {
+            "model": ("MODEL",),
+            "clip": ("CLIP",),
+            "vae": ("VAE",),
+            "assets": ("GAME_ASSET_LIST",),
+            "base_negative_prompt": (
+                "STRING",
+                {"multiline": True, "default": ""},
+            ),
+            "batch_preview_limit": (
+                "INT",
+                {"default": 4, "min": 1, "max": 32},
+            ),
+        }
+    }
+
+  RETURN_TYPES = ("IMAGE", "STRING")
+  RETURN_NAMES = ("preview", "filenames")
+  FUNCTION = "render"
+  CATEGORY = "Dustland/Game Assets"
+
+  def _get_conditioning(self, clip: comfy.sd.CLIP, prompt: str):
+    text_encoder = nodes.CLIPTextEncode()
+    cond, = text_encoder.encode(clip, prompt)
+    return cond
+
+  def _decode_latent(self, vae, latent):
+    decoder = nodes.VAEDecode()
+    image, = decoder.decode(vae, latent)
+    return image
+
+  def _build_latent(self, width: int, height: int):
+    latent_builder = nodes.EmptyLatentImage()
+    latent, = latent_builder.generate(width, height, 1)
+    return latent
+
+  def render(
+      self,
+      model,
+      clip,
+      vae,
+      assets: Iterable[GameAssetPrompt],
+      base_negative_prompt: str,
+      batch_preview_limit: int,
+  ):
+    images: List[torch.Tensor] = []
+    filenames: List[str] = []
+    saver = nodes.SaveImage()
+
+    for index, asset in enumerate(assets):
+      positive = self._get_conditioning(clip, asset.prompt)
+      negative_prompt = "\n".join(filter(None, [base_negative_prompt.strip(), asset.negative_prompt.strip()]))
+      negative = self._get_conditioning(clip, negative_prompt) if negative_prompt else self._get_conditioning(clip, "")
+
+      latent = self._build_latent(asset.width, asset.height)
+      sampler = nodes.common_ksampler
+      latent_out = sampler(
+          model=model,
+          seed=asset.seed,
+          steps=asset.steps,
+          cfg=asset.cfg_scale,
+          sampler_name=asset.sampler,
+          scheduler=asset.scheduler,
+          positive=positive,
+          negative=negative,
+          latent=latent,
+      )[0]
+
+      image = self._decode_latent(vae, latent_out)
+      save_results = saver.save_images(image, filename_prefix=asset.name)
+      filenames.extend(result["filename"] for result in save_results)
+
+      if len(images) < batch_preview_limit:
+        images.append(image)
+
+    if not images:
+      raise RuntimeError("No images were generated from the provided JSON")
+
+    preview = images[0]
+    joined_names = "\n".join(filenames)
+    return (preview, joined_names)
+
+
+NODE_CLASS_MAPPINGS = {
+    "GameAssetJSONLoader": GameAssetJSONLoader,
+    "GameAssetBatchRenderer": GameAssetBatchRenderer,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "GameAssetJSONLoader": "Dustland Game Asset JSON Loader",
+    "GameAssetBatchRenderer": "Dustland Game Asset Batch Renderer",
+}


### PR DESCRIPTION
## Summary
- add custom ComfyUI nodes that read JSON asset specs and batch render/saves outputs
- provide importable workflow JSON plus sample asset description for quick testing
- document installation, JSON schema, and usage for the new batch renderer

## Testing
- npm test
- node scripts/supporting/presubmit.js

------
https://chatgpt.com/codex/tasks/task_e_68def44941288328b95375983eaca744