### PR TITLE
feat: ACK 1.0 Milestone 2 - dialog authoring at scale

### DIFF
--- a/adventure-kit.html
+++ b/adventure-kit.html
@@ -1120,6 +1120,29 @@
         <div><b>Dialog Tree Editor</b></div>
         <button class="btn" type="button" id="closeDialogModal">Close</button>
       </div>
+      <div id="dlgToolbar" style="display:flex;gap:4px;flex-wrap:wrap;margin-bottom:4px">
+        <input id="dlgSearch" placeholder="Search nodes &amp; choices..." aria-label="Search dialog nodes" style="flex:1 1 160px" />
+        <select id="dlgFilter" aria-label="Filter dialog nodes">
+          <option value="">All nodes</option>
+          <option value="effects">With effects</option>
+          <option value="checks">With stat checks</option>
+          <option value="conditions">With conditions</option>
+          <option value="orphans">Unreachable</option>
+        </select>
+        <select id="dlgTemplate" aria-label="Insert dialog template">
+          <option value="">Insert template…</option>
+          <option value="greeting">Greeting</option>
+          <option value="fetchQuest">Fetch quest (accept/turn-in)</option>
+          <option value="gatekeeper">Locked gatekeeper</option>
+          <option value="lore">Lore branches</option>
+        </select>
+        <button class="btn" type="button" id="pasteSubtree" style="display:none" title="Paste the copied dialog subtree into this tree">Paste Subtree</button>
+      </div>
+      <div id="dlgStatus" class="small" role="status" aria-live="polite" style="margin:2px 0;opacity:0.8"></div>
+      <details id="dlgGraphWrap" style="margin:4px 0">
+        <summary style="cursor:pointer">Graph view</summary>
+        <div id="dlgGraph" style="overflow:auto;max-height:260px;border:1px solid #2b3b2b;margin-top:4px"></div>
+      </details>
       <div id="treeEditor"></div>
       <div id="treeWarning" style="color:#fc0;font-size:0.75rem;margin-top:4px"></div>
       <button class="btn" type="button" id="addNode">Add Node</button>

--- a/docs/roadmap/ack-1.0-roadmap.md
+++ b/docs/roadmap/ack-1.0-roadmap.md
@@ -49,14 +49,15 @@ A creator who has never seen the ACK can build a small, complete, playable modul
 ## Milestone 2 — Dialog authoring at scale
 
 *The dialog editor is the richest surface and the biggest friction point. A writer with a 40-node tree currently has no way to search it, no way to see its shape, and no way to reuse work.*
+*Status: implemented 2026-07-24 (see notes per item).*
 
-- [ ] **Dialog search & filter**: text search across node text and choice labels; filters for nodes with effects, with stat checks, orphaned, unreachable from root.
-- [ ] **Copy/paste dialog subtrees** between nodes and between NPCs.
-- [ ] **Dialog templates**: one-click insert for the common patterns (greeting + shop, fetch-quest accept/turn-in, gatekeeper, lore branch) with placeholders to fill in.
-- [ ] **Conditional preview**: playtest dialog in-editor with arbitrary flags/inventory/stats set, so every branch is testable without launching the game.
-- [ ] **Visual dialog graph (stretch — cut from 1.0 if it slips)**: read-only node-graph rendering with orphan/broken-link highlighting is 1.0-worthy on its own; draggable node editing can wait for 1.x.
+- [x] **Dialog search & filter** — toolbar in the dialog modal: text search across node ids, text, choice labels, and success/failure lines; filters for nodes with effects, stat checks, conditions, and unreachable nodes (engine-entered nodes recognized). Shows "N of M nodes" while active.
+- [x] **Copy/paste dialog subtrees** — a copy button on every node card grabs the node plus everything it links to; the clipboard lives in `localStorage`, so it survives switching NPCs. Paste merges with collision-safe renaming and remaps internal links.
+- [x] **Dialog templates** — "Insert template…" dropdown: greeting, fetch quest (accept/turn-in wired to the quest engine's `q` choices and `do_turnin` node), locked gatekeeper (with `locked` node), and lore branches. Inserted templates auto-link from `start`.
+- [x] **Conditional preview** — the inline preview now honors spoofed flags (`if` conditions with all operators), required/cost items, and tags; unavailable choices render disabled with the reason in their tooltip. Stat-check choices offer explicit "pass"/"fail" buttons showing the success/failure text and branching accordingly. Spoof panel values persist across edits instead of resetting. (Spoofed in-game playback already existed.)
+- [x] **Visual dialog graph (read-only)** — collapsible "Graph view" in the dialog modal: SVG layered by BFS depth from engine entry nodes, edges for choice links, orphans outlined in orange, click any box to scroll to and flash its node card. Draggable editing remains post-1.0.
 
-**Done when:** a writer can find any line of dialog in seconds, reuse a quest-dialog pattern without rebuilding it, and verify every branch without leaving the editor.
+**Done when:** a writer can find any line of dialog in seconds, reuse a quest-dialog pattern without rebuilding it, and verify every branch without leaving the editor. ✅
 
 ## Milestone 3 — Discoverability: the editor explains itself
 

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -1688,40 +1688,124 @@ function renderDialogPreview() {
         prev.parentElement.insertBefore(ctl, prev);
         document.getElementById('playDlg').onclick = () => playInGameWithSpoof();
         document.getElementById('stopDlg').onclick = () => stopSpoofPlayback();
+        document.getElementById('spoofFlags')?.addEventListener('input', () => renderDialogPreview());
     }
-    // Render imports spoof panel (lightweight)
+    // Render imports spoof panel (lightweight); preserve typed values across rebuilds
     const importsEl = document.getElementById('spoofImports');
     if (importsEl) {
         let imports = (tree && tree.imports) || null;
         if (!imports && tree)
             imports = generateImportsShallow(tree);
         const flags = (imports && imports.flags) || [];
-        const items = (imports && imports.items) || [];
-        let html = '';
-        if (flags.length) {
-            html += '<div><b>Flags</b> ' + flags.map(f => `<label style="margin-right:6px">${f}<input type="number" data-flag="${f}" value="1" min="0" style="width:56px;margin-left:4px"/></label>`).join('') + '</div>';
+        const items = ((imports && imports.items) || []).slice();
+        Object.values(tree || {}).forEach((node) => {
+            (node?.choices || []).forEach(c => {
+                if (c?.reqTag)
+                    items.push('tag:' + c.reqTag);
+                if (c?.costTag)
+                    items.push('tag:' + c.costTag);
+            });
+        });
+        const itemKeys = [...new Set(items)];
+        const sig = JSON.stringify([flags, itemKeys]);
+        if (importsEl.dataset?.sig !== sig) {
+            const prevVals = {};
+            importsEl.querySelectorAll('input').forEach(inp => {
+                const el = inp;
+                prevVals[el.dataset.flag ? 'f:' + el.dataset.flag : 'i:' + el.dataset.item] = el.value;
+            });
+            let html = '';
+            if (flags.length) {
+                html += '<div><b>Flags</b> ' + flags.map(f => `<label style="margin-right:6px">${f}<input type="number" data-flag="${f}" value="${prevVals['f:' + f] ?? '1'}" min="0" style="width:56px;margin-left:4px"/></label>`).join('') + '</div>';
+            }
+            if (itemKeys.length) {
+                html += '<div style="margin-top:4px"><b>Items</b> ' + itemKeys.map(it => `<label style="margin-right:6px">${it}<input type="number" data-item="${it}" value="${prevVals['i:' + it] ?? '1'}" min="0" style="width:56px;margin-left:4px"/></label>`).join('') + '</div>';
+            }
+            importsEl.innerHTML = html || '<span class="muted">(no imports)</span>';
+            if (importsEl.dataset)
+                importsEl.dataset.sig = sig;
         }
-        if (items.length) {
-            html += '<div style="margin-top:4px"><b>Items</b> ' + items.map(it => `<label style="margin-right:6px">${it}<input type="number" data-item="${it}" value="1" min="0" style="width:56px;margin-left:4px"/></label>`).join('') + '</div>';
+        if (!importsEl.dataset?.wired) {
+            if (importsEl.dataset)
+                importsEl.dataset.wired = '1';
+            importsEl.addEventListener('input', () => renderDialogPreview());
         }
-        importsEl.innerHTML = html || '<span class="muted">(no imports)</span>';
     }
     if (!tree || !tree.start) {
         prev.innerHTML = '';
         return;
     }
-    function show(id) {
+    const spoofedFlags = buildSpoofFlagsFromPanel() || parseSpoofFlags(document.getElementById('spoofFlags')?.value || '');
+    const spoofedItems = buildSpoofItemsFromPanel() || {};
+    const cmp = (a, op, b) => {
+        if (op === '>')
+            return a > b;
+        if (op === '<')
+            return a < b;
+        if (op === '<=')
+            return a <= b;
+        if (op === '==')
+            return a === b;
+        if (op === '!=')
+            return a !== b;
+        return a >= b;
+    };
+    const itemCount = key => Number(spoofedItems[key] ?? 0) || 0;
+    const choiceBlockers = c => {
+        const reasons = [];
+        if (c.if?.flag && !cmp(Number(spoofedFlags[c.if.flag] ?? 0) || 0, c.if.op || '>=', c.if.value ?? 1)) {
+            reasons.push(`flag ${c.if.flag} ${c.if.op || '>='} ${c.if.value ?? 1}`);
+        }
+        if (c.reqItem && itemCount(c.reqItem) <= 0)
+            reasons.push(`needs ${c.reqItem}`);
+        if (c.costItem && itemCount(c.costItem) <= 0)
+            reasons.push(`costs ${c.costItem}`);
+        if (c.reqTag && itemCount('tag:' + c.reqTag) <= 0)
+            reasons.push(`needs tag ${c.reqTag}`);
+        if (c.costTag && itemCount('tag:' + c.costTag) <= 0)
+            reasons.push(`costs tag ${c.costTag}`);
+        return reasons;
+    };
+    function show(id, note = '') {
         const node = tree[id];
         if (!node)
             return;
-        const html = (node.choices || [])
-            .map(c => `<button class="btn" data-to="${c.to || ''}" style="margin-top:4px">${c.label}</button>`)
-            .join('');
-        prev.innerHTML = `<div>${node.text || ''}</div>` + html;
-        Array.from(prev.querySelectorAll('button')).forEach(btn => btn.onclick = () => {
-            const t = btn.dataset.to;
-            if (t)
-                show(t);
+        const parts = [];
+        const actions = [];
+        if (note)
+            parts.push(`<div class="small" style="opacity:0.8">${note}</div>`);
+        parts.push(`<div>${node.text || ''}</div>`);
+        const pushBtn = (label, title, action, faded = false) => {
+            const blocked = !action;
+            actions.push(action);
+            const style = `margin-top:4px${faded ? ';opacity:0.6' : ''}${blocked ? ';opacity:0.4' : ''}`;
+            parts.push(`<button class="btn" data-act="${actions.length - 1}" style="${style}"${title ? ` title="${title}"` : ''}${blocked ? ' disabled' : ''}>${label}</button>`);
+        };
+        (node.choices || []).forEach(c => {
+            if (!c)
+                return;
+            const blockers = choiceBlockers(c);
+            const blockedTitle = blockers.length ? 'Unavailable: ' + blockers.join(', ') + ' — adjust spoof values above to test' : '';
+            if (c.stat && c.dc != null) {
+                pushBtn(`${c.label} [${c.stat} DC ${c.dc}: pass]`, blockedTitle || 'Preview the successful check', blockers.length ? null : () => {
+                    const next = c.to && tree[c.to] ? c.to : id;
+                    show(next, c.success || '(Check passed.)');
+                });
+                pushBtn(`${c.label} [fail]`, blockedTitle || 'Preview the failed check', blockers.length ? null : () => show(id, c.failure || '(Check failed.)'), true);
+                return;
+            }
+            pushBtn(c.label || '(choice)', blockedTitle, blockers.length ? null : () => {
+                if (c.to && tree[c.to])
+                    show(c.to);
+            });
+        });
+        prev.innerHTML = parts.join('');
+        Array.from(prev.querySelectorAll('button')).forEach(btn => {
+            btn.onclick = () => {
+                const act = actions[parseInt(btn.dataset?.act ?? '-1', 10)];
+                if (act)
+                    act();
+            };
         });
     }
     show('start');
@@ -2283,13 +2367,18 @@ function renderTreeEditor() {
     const wrap = document.getElementById('treeEditor');
     if (!wrap)
         return;
+    if (!wrap.dataset?.dirtyWired) {
+        if (wrap.dataset)
+            wrap.dataset.dirtyWired = '1';
+        wrap.addEventListener('input', () => globalThis.markAckDirty?.());
+    }
     wrap.innerHTML = '';
     Object.entries(getTreeData()).forEach(([id, node]) => {
         if (id === 'imports')
             return;
         const div = document.createElement('div');
         div.className = 'node';
-        div.innerHTML = `<div class="nodeHeader"><button class="btn toggle" type="button" aria-label="Toggle node">-</button><label>Node ID<input class="nodeId" value="${id}"></label><button class="btn delNode" type="button" title="Delete node" aria-label="Delete node">&#128465;</button></div><div class="nodeBody"><label>Dialog Text<textarea class="nodeText" rows="2">${node.text || ''}</textarea></label><fieldset class="choiceGroup"><legend>Choices</legend><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button></fieldset></div>`;
+        div.innerHTML = `<div class="nodeHeader"><button class="btn toggle" type="button" aria-label="Toggle node">-</button><label>Node ID<input class="nodeId" value="${id}"></label><button class="btn copyNode" type="button" title="Copy this node and everything it links to" aria-label="Copy subtree">&#10697;</button><button class="btn delNode" type="button" title="Delete node" aria-label="Delete node">&#128465;</button></div><div class="nodeBody"><label>Dialog Text<textarea class="nodeText" rows="2">${node.text || ''}</textarea></label><fieldset class="choiceGroup"><legend>Choices</legend><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button></fieldset></div>`;
         const choicesDiv = div.querySelector('.choices');
         if (!choicesDiv)
             return;
@@ -2297,6 +2386,9 @@ function renderTreeEditor() {
         const addChoiceBtn = div.querySelector('.addChoice');
         if (addChoiceBtn)
             addChoiceBtn.onclick = () => addChoiceRow(choicesDiv);
+        const copyBtn = div.querySelector('.copyNode');
+        if (copyBtn)
+            copyBtn.onclick = () => copyDialogSubtree(div.querySelector('.nodeId')?.value.trim());
         const toggleBtn = div.querySelector('.toggle');
         toggleBtn.addEventListener('click', () => {
             div.classList.toggle('collapsed');
@@ -2316,6 +2408,8 @@ function renderTreeEditor() {
     wrap.querySelectorAll('select').forEach(el => el.addEventListener('change', updateTreeData));
     wrap.querySelectorAll('input[type=checkbox]').forEach(el => el.addEventListener('change', updateTreeData));
     refreshChoiceDropdowns();
+    if (typeof applyDialogNodeFilter === 'function')
+        applyDialogNodeFilter();
 }
 function updateTreeData() {
     const wrap = document.getElementById('treeEditor');
@@ -2521,6 +2615,8 @@ function updateTreeData() {
     // Live preview + keep "to" dropdowns in sync with current node keys
     renderDialogPreview();
     refreshChoiceDropdowns();
+    if (typeof renderDialogGraph === 'function')
+        renderDialogGraph();
     // ---- Validation: highlight bad targets & orphans ----
     // 1) Choice target validation: red border if target doesn't exist
     choiceRefs.forEach(({ to, el }) => {
@@ -2568,6 +2664,7 @@ function loadTreeEditor() {
 }
 function openDialogEditor() {
     document.getElementById('dialogModal').classList.add('shown');
+    updatePasteSubtreeButton();
     renderTreeEditor();
 }
 function closeDialogEditor() {
@@ -2594,6 +2691,311 @@ function addNode() {
     setTreeData(tree);
     renderTreeEditor();
     updateTreeData();
+}
+// === Dialog subtree clipboard, templates, and search ===
+const DIALOG_CLIPBOARD_KEY = 'ack_dialog_clipboard';
+function setDialogEditorStatus(msg, autoClear = true) {
+    const el = document.getElementById('dlgStatus');
+    if (!el)
+        return;
+    const prev = el._statusTimer;
+    if (prev)
+        clearTimeout(prev);
+    el.textContent = msg || '';
+    if (autoClear && msg) {
+        el._statusTimer = setTimeout(() => { el.textContent = ''; }, 4000);
+    }
+}
+function collectDialogSubtree(tree, rootId) {
+    const nodes = {};
+    const queue = [rootId];
+    while (queue.length) {
+        const id = queue.shift();
+        if (!id || nodes[id] || !tree[id] || id === 'imports')
+            continue;
+        nodes[id] = JSON.parse(JSON.stringify(tree[id]));
+        (tree[id].choices || []).forEach(ch => { if (ch?.to && tree[ch.to])
+            queue.push(ch.to); });
+    }
+    return nodes;
+}
+function copyDialogSubtree(rootId) {
+    if (!rootId)
+        return;
+    updateTreeData();
+    const tree = getTreeData();
+    if (!tree[rootId])
+        return;
+    const nodes = collectDialogSubtree(tree, rootId);
+    try {
+        localStorage.setItem(DIALOG_CLIPBOARD_KEY, JSON.stringify({ root: rootId, nodes }));
+    }
+    catch (e) {
+        setDialogEditorStatus('Copy failed — browser storage is full.');
+        return;
+    }
+    updatePasteSubtreeButton();
+    const linked = Object.keys(nodes).length - 1;
+    setDialogEditorStatus(`Copied "${rootId}"${linked ? ` + ${linked} linked node(s)` : ''}. Paste into any NPC's dialog.`);
+}
+function readDialogClipboard() {
+    try {
+        const raw = localStorage.getItem(DIALOG_CLIPBOARD_KEY);
+        if (!raw)
+            return null;
+        const clip = JSON.parse(raw);
+        if (!clip?.root || !clip.nodes || !clip.nodes[clip.root])
+            return null;
+        return clip;
+    }
+    catch (e) {
+        return null;
+    }
+}
+function updatePasteSubtreeButton() {
+    const btn = document.getElementById('pasteSubtree');
+    if (btn)
+        btn.style.display = readDialogClipboard() ? 'inline-block' : 'none';
+}
+// Merge nodes into tree with collision-safe renaming; internal links are remapped.
+function mergeDialogNodes(tree, nodes, rootId) {
+    const rename = {};
+    const taken = new Set(Object.keys(tree));
+    Object.keys(nodes).forEach(id => {
+        let cand = id;
+        let i = 1;
+        while (taken.has(cand))
+            cand = `${id}-${i++}`;
+        rename[id] = cand;
+        taken.add(cand);
+    });
+    Object.entries(nodes).forEach(([id, node]) => {
+        const copy = JSON.parse(JSON.stringify(node));
+        (copy.choices || []).forEach(ch => { if (ch?.to && rename[ch.to])
+            ch.to = rename[ch.to]; });
+        tree[rename[id]] = copy;
+    });
+    return rename[rootId];
+}
+function pasteDialogSubtree() {
+    const clip = readDialogClipboard();
+    if (!clip) {
+        updatePasteSubtreeButton();
+        return;
+    }
+    updateTreeData();
+    const tree = getTreeData();
+    const newRoot = mergeDialogNodes(tree, clip.nodes, clip.root);
+    setTreeData(tree);
+    renderTreeEditor();
+    updateTreeData();
+    globalThis.markAckDirty?.();
+    setDialogEditorStatus(`Pasted ${Object.keys(clip.nodes).length} node(s) as "${newRoot}". Link a choice to it.`);
+}
+const DIALOG_TEMPLATES = {
+    greeting: {
+        linkLabel: '(Talk)',
+        root: 'greet',
+        nodes: {
+            greet: { text: 'Hello, wanderer. Stay out of the dust.', choices: [{ label: '(Leave)', to: 'bye' }] }
+        }
+    },
+    fetchQuest: {
+        linkLabel: '(Ask about work)',
+        root: 'job',
+        nodes: {
+            job: {
+                text: 'I lost something out there. Bring it back and I\'ll make it worth your while.',
+                choices: [
+                    { label: '(Accept the job)', to: 'accept', q: 'accept' },
+                    { label: '(Turn in)', to: 'do_turnin', q: 'turnin' },
+                    { label: '(Leave)', to: 'bye' }
+                ]
+            },
+            accept: { text: 'Good. It should be somewhere in the waste. Don\'t come back empty-handed.', choices: [{ label: '(Leave)', to: 'bye' }] },
+            do_turnin: { text: 'You actually found it. Here\'s your cut.', choices: [{ label: '(Leave)', to: 'bye' }] }
+        }
+    },
+    gatekeeper: {
+        linkLabel: '(Approach the door)',
+        root: 'gate',
+        nodes: {
+            gate: {
+                text: 'The way is sealed. Only those with the key pass.',
+                choices: [
+                    { label: '(Use key)', to: 'gate-open', reqItem: 'key_item', once: true },
+                    { label: '(Leave)', to: 'bye' }
+                ]
+            },
+            'gate-open': { text: 'The lock grinds open. Beyond, darkness waits.', choices: [{ label: '(Continue)', to: 'bye' }] },
+            locked: { text: '(It won\'t budge.)', choices: [{ label: '(Leave)', to: 'bye' }] }
+        }
+    },
+    lore: {
+        linkLabel: '(Ask about the old world)',
+        root: 'lore',
+        nodes: {
+            lore: {
+                text: 'What do you want to know?',
+                choices: [
+                    { label: 'The Dust', to: 'lore-dust' },
+                    { label: 'Before the fall', to: 'lore-fall' },
+                    { label: '(Leave)', to: 'bye' }
+                ]
+            },
+            'lore-dust': { text: 'The dust never settles. It remembers.', choices: [{ label: '(Ask more)', to: 'lore' }] },
+            'lore-fall': { text: 'There were cities once. Now there are warnings.', choices: [{ label: '(Ask more)', to: 'lore' }] }
+        }
+    }
+};
+function insertDialogTemplate(key) {
+    const tpl = DIALOG_TEMPLATES[key];
+    if (!tpl)
+        return;
+    updateTreeData();
+    const tree = getTreeData();
+    const newRoot = mergeDialogNodes(tree, tpl.nodes, tpl.root);
+    const startNode = tree.start;
+    if (startNode && newRoot !== 'start') {
+        startNode.choices = startNode.choices || [];
+        startNode.choices.push({ label: tpl.linkLabel, to: newRoot });
+    }
+    setTreeData(tree);
+    renderTreeEditor();
+    updateTreeData();
+    globalThis.markAckDirty?.();
+    setDialogEditorStatus(tree.start && newRoot !== 'start'
+        ? `Inserted template at "${newRoot}" and linked it from "start".`
+        : `Inserted template at "${newRoot}".`);
+}
+// Read-only node graph: layered by BFS depth, orphans highlighted, click to jump.
+function renderDialogGraph() {
+    const wrapEl = document.getElementById('dlgGraphWrap');
+    const graphEl = document.getElementById('dlgGraph');
+    if (!wrapEl || !graphEl || !wrapEl.open)
+        return;
+    const tree = getTreeData();
+    const ids = Object.keys(tree).filter(k => k !== 'imports');
+    if (!ids.length) {
+        graphEl.innerHTML = '<div class="small" style="padding:4px">No nodes yet.</div>';
+        return;
+    }
+    const depth = {};
+    const queue = [];
+    ['start', 'locked', 'sell', 'accept', 'do_turnin', 'do_fight'].forEach(id => {
+        if (tree[id] && depth[id] === undefined) {
+            depth[id] = 0;
+            queue.push(id);
+        }
+    });
+    while (queue.length) {
+        const id = queue.shift();
+        (tree[id]?.choices || []).forEach(c => {
+            const to = typeof c?.to === 'string' ? c.to : '';
+            if (to && tree[to] && depth[to] === undefined) {
+                depth[to] = depth[id] + 1;
+                queue.push(to);
+            }
+        });
+    }
+    const maxDepth = Math.max(0, ...Object.values(depth));
+    const orphanCol = maxDepth + 1;
+    const cols = [];
+    ids.forEach(id => {
+        const col = depth[id] !== undefined ? depth[id] : orphanCol;
+        (cols[col] || (cols[col] = [])).push(id);
+    });
+    const BOX_W = 110, BOX_H = 24, GAP_X = 50, GAP_Y = 10, PAD = 8;
+    const pos = {};
+    cols.forEach((colIds, ci) => {
+        (colIds || []).forEach((id, ri) => {
+            pos[id] = { x: PAD + ci * (BOX_W + GAP_X), y: PAD + ri * (BOX_H + GAP_Y) };
+        });
+    });
+    const width = PAD * 2 + cols.length * (BOX_W + GAP_X);
+    const height = PAD * 2 + Math.max(...cols.map(c => (c || []).length)) * (BOX_H + GAP_Y);
+    const edges = [];
+    ids.forEach(id => {
+        (tree[id]?.choices || []).forEach(c => {
+            const to = typeof c?.to === 'string' ? c.to : '';
+            if (!to || !pos[to] || !pos[id])
+                return;
+            const a = pos[id], b = pos[to];
+            edges.push(`<line x1="${a.x + BOX_W}" y1="${a.y + BOX_H / 2}" x2="${b.x}" y2="${b.y + BOX_H / 2}" stroke="#4a6a4a" stroke-width="1"/>`);
+        });
+    });
+    const boxes = ids.map(id => {
+        const p = pos[id];
+        const orphan = depth[id] === undefined && id !== 'bye';
+        const label = id.length > 15 ? id.slice(0, 14) + '…' : id;
+        return `<g data-node="${id}" style="cursor:pointer"><rect x="${p.x}" y="${p.y}" width="${BOX_W}" height="${BOX_H}" fill="#101a10" stroke="${orphan ? '#fa0' : '#2b6b2b'}" rx="3"/><text x="${p.x + 6}" y="${p.y + 16}" fill="${orphan ? '#fc0' : '#9ef7a0'}" font-size="11" font-family="monospace">${label}</text></g>`;
+    });
+    graphEl.innerHTML = `<svg width="${width}" height="${height}" role="img" aria-label="Dialog node graph">${edges.join('')}${boxes.join('')}</svg>`;
+    graphEl.querySelectorAll('[data-node]').forEach(g => {
+        g.onclick = () => {
+            const id = g.dataset?.node || g.getAttribute('data-node');
+            const wrap = document.getElementById('treeEditor');
+            if (!wrap || !id)
+                return;
+            const target = Array.from(wrap.querySelectorAll('.node')).find(n => (n.querySelector('.nodeId')?.value.trim() === id));
+            if (target) {
+                target.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+                target.style.outline = '1px solid #9ef7a0';
+                setTimeout(() => { target.style.outline = ''; }, 1200);
+            }
+        };
+    });
+}
+function applyDialogNodeFilter() {
+    const wrap = document.getElementById('treeEditor');
+    if (!wrap)
+        return;
+    const q = (document.getElementById('dlgSearch')?.value || '').trim().toLowerCase();
+    const mode = document.getElementById('dlgFilter')?.value || '';
+    const statusEl = document.getElementById('dlgStatus');
+    const tree = getTreeData();
+    const reachable = new Set();
+    const visit = id => {
+        if (reachable.has(id) || !tree[id])
+            return;
+        reachable.add(id);
+        (tree[id].choices || []).forEach(c => { if (c.to)
+            visit(c.to); });
+    };
+    ['start', 'locked', 'sell', 'accept', 'do_turnin', 'do_fight'].forEach(id => { if (tree[id])
+        visit(id); });
+    let shown = 0;
+    let total = 0;
+    wrap.querySelectorAll('.node').forEach(nodeEl => {
+        const id = nodeEl.querySelector('.nodeId')?.value.trim() || '';
+        const node = tree[id] || { text: '', choices: [] };
+        total += 1;
+        let ok = true;
+        if (q) {
+            const hay = [id, node.text || '']
+                .concat((node.choices || []).flatMap(c => [c?.label || '', c?.to || '', c?.success || '', c?.failure || '']))
+                .join('\n').toLowerCase();
+            ok = hay.includes(q);
+        }
+        if (ok && mode) {
+            const cs = node.choices || [];
+            if (mode === 'effects')
+                ok = cs.some(c => (c?.effects?.length ?? 0) > 0 || c?.setFlag || c?.reward || c?.spawn || c?.goto || c?.join);
+            else if (mode === 'checks')
+                ok = cs.some(c => c?.stat);
+            else if (mode === 'conditions')
+                ok = cs.some(c => c?.if || c?.reqItem || c?.reqTag || c?.reqSlot || c?.costItem || c?.costTag || c?.costSlot || c?.ifOnce);
+            else if (mode === 'orphans')
+                ok = !reachable.has(id) && id !== 'bye';
+        }
+        nodeEl.style.display = ok ? '' : 'none';
+        if (ok)
+            shown += 1;
+    });
+    if (statusEl && (q || mode))
+        statusEl.textContent = `Showing ${shown} of ${total} nodes`;
+    else if (statusEl && !statusEl._statusTimer)
+        statusEl.textContent = '';
 }
 function generateQuestTree() {
     const sel = document.getElementById('npcQuests');
@@ -8166,6 +8568,16 @@ if (spawnHeatBtn)
 document.getElementById('addNode')?.addEventListener('click', addNode);
 document.getElementById('editDialog')?.addEventListener('click', openDialogEditor);
 document.getElementById('closeDialogModal')?.addEventListener('click', closeDialogEditor);
+document.getElementById('dlgSearch')?.addEventListener('input', applyDialogNodeFilter);
+document.getElementById('dlgFilter')?.addEventListener('change', applyDialogNodeFilter);
+document.getElementById('dlgTemplate')?.addEventListener('change', e => {
+    const sel = e.target;
+    if (sel.value)
+        insertDialogTemplate(sel.value);
+    sel.value = '';
+});
+document.getElementById('pasteSubtree')?.addEventListener('click', pasteDialogSubtree);
+document.getElementById('dlgGraphWrap')?.addEventListener('toggle', renderDialogGraph);
 document.getElementById('dialogModal')?.addEventListener('click', e => { if (e.target?.id === 'dialogModal')
     closeDialogEditor(); });
 // Live preview when dialog text changes

--- a/test/dialog-subtree.test.js
+++ b/test/dialog-subtree.test.js
@@ -1,0 +1,73 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const code = await fs.readFile(new URL('../scripts/adventure-kit.js', import.meta.url), 'utf8');
+const normalized = code.replace(/\r\n/g, '\n');
+const collectCode = normalized.match(/function collectDialogSubtree[\s\S]*?\n}\n/)[0];
+const mergeCode = normalized.match(/function mergeDialogNodes[\s\S]*?\n}\n/)[0];
+vm.runInThisContext(collectCode + mergeCode);
+
+test('collectDialogSubtree gathers the root and reachable descendants only', () => {
+  const tree = {
+    start: { text: 'hi', choices: [{ label: 'a', to: 'a' }, { label: 'leave', to: 'bye' }] },
+    a: { text: 'A', choices: [{ label: 'b', to: 'b' }] },
+    b: { text: 'B', choices: [] },
+    unrelated: { text: 'X', choices: [] },
+    imports: { flags: ['f'] }
+  };
+  const nodes = collectDialogSubtree(tree, 'a');
+  assert.deepStrictEqual(Object.keys(nodes).sort(), ['a', 'b']);
+  assert.strictEqual(nodes.a.text, 'A');
+});
+
+test('collectDialogSubtree handles cycles and missing targets', () => {
+  const tree = {
+    a: { text: 'A', choices: [{ label: 'b', to: 'b' }, { label: 'ghost', to: 'missing' }] },
+    b: { text: 'B', choices: [{ label: 'back', to: 'a' }] }
+  };
+  const nodes = collectDialogSubtree(tree, 'a');
+  assert.deepStrictEqual(Object.keys(nodes).sort(), ['a', 'b']);
+});
+
+test('collectDialogSubtree returns deep copies, not references', () => {
+  const tree = { a: { text: 'A', choices: [{ label: 'x', to: 'bye' }] } };
+  const nodes = collectDialogSubtree(tree, 'a');
+  nodes.a.text = 'mutated';
+  nodes.a.choices[0].label = 'mutated';
+  assert.strictEqual(tree.a.text, 'A');
+  assert.strictEqual(tree.a.choices[0].label, 'x');
+});
+
+test('mergeDialogNodes keeps ids when there is no collision', () => {
+  const tree = { start: { text: 's', choices: [] } };
+  const root = mergeDialogNodes(tree, { lore: { text: 'L', choices: [{ label: 'more', to: 'lore2' }] }, lore2: { text: 'L2', choices: [] } }, 'lore');
+  assert.strictEqual(root, 'lore');
+  assert.strictEqual(tree.lore.text, 'L');
+  assert.strictEqual(tree.lore.choices[0].to, 'lore2');
+});
+
+test('mergeDialogNodes renames on collision and remaps internal links', () => {
+  const tree = {
+    start: { text: 's', choices: [] },
+    accept: { text: 'existing accept', choices: [] }
+  };
+  const nodes = {
+    job: { text: 'J', choices: [{ label: 'yes', to: 'accept' }, { label: 'leave', to: 'bye' }] },
+    accept: { text: 'new accept', choices: [] }
+  };
+  const root = mergeDialogNodes(tree, nodes, 'job');
+  assert.strictEqual(root, 'job');
+  assert.strictEqual(tree.accept.text, 'existing accept', 'existing node untouched');
+  assert.strictEqual(tree['accept-1'].text, 'new accept');
+  assert.strictEqual(tree.job.choices[0].to, 'accept-1', 'internal link remapped to renamed node');
+  assert.strictEqual(tree.job.choices[1].to, 'bye', 'external link untouched');
+});
+
+test('mergeDialogNodes avoids chains of collisions', () => {
+  const tree = { a: {}, 'a-1': {} };
+  const root = mergeDialogNodes(tree, { a: { text: 'new', choices: [] } }, 'a');
+  assert.strictEqual(root, 'a-2');
+  assert.strictEqual(tree['a-2'].text, 'new');
+});

--- a/ts-src/scripts/adventure-kit.ts
+++ b/ts-src/scripts/adventure-kit.ts
@@ -1706,33 +1706,103 @@ function renderDialogPreview() {
     prev.parentElement.insertBefore(ctl, prev);
     document.getElementById('playDlg').onclick = () => playInGameWithSpoof();
     document.getElementById('stopDlg').onclick = () => stopSpoofPlayback();
+    document.getElementById('spoofFlags')?.addEventListener('input', () => renderDialogPreview());
   }
-  // Render imports spoof panel (lightweight)
+  // Render imports spoof panel (lightweight); preserve typed values across rebuilds
   const importsEl = document.getElementById('spoofImports');
   if (importsEl) {
     let imports = (tree && tree.imports) || null;
     if (!imports && tree) imports = generateImportsShallow(tree);
     const flags = (imports && imports.flags) || [];
-    const items = (imports && imports.items) || [];
-    let html = '';
-    if (flags.length) {
-      html += '<div><b>Flags</b> ' + flags.map(f => `<label style="margin-right:6px">${f}<input type="number" data-flag="${f}" value="1" min="0" style="width:56px;margin-left:4px"/></label>`).join('') + '</div>';
+    const items = ((imports && imports.items) || []).slice();
+    Object.values(tree || {}).forEach((node: any) => {
+      (node?.choices || []).forEach(c => {
+        if (c?.reqTag) items.push('tag:' + c.reqTag);
+        if (c?.costTag) items.push('tag:' + c.costTag);
+      });
+    });
+    const itemKeys = [...new Set(items)];
+    const sig = JSON.stringify([flags, itemKeys]);
+    if ((importsEl as any).dataset?.sig !== sig) {
+      const prevVals = {} as Record<string, string>;
+      importsEl.querySelectorAll('input').forEach(inp => {
+        const el = inp as HTMLInputElement;
+        prevVals[el.dataset.flag ? 'f:' + el.dataset.flag : 'i:' + el.dataset.item] = el.value;
+      });
+      let html = '';
+      if (flags.length) {
+        html += '<div><b>Flags</b> ' + flags.map(f => `<label style="margin-right:6px">${f}<input type="number" data-flag="${f}" value="${prevVals['f:' + f] ?? '1'}" min="0" style="width:56px;margin-left:4px"/></label>`).join('') + '</div>';
+      }
+      if (itemKeys.length) {
+        html += '<div style="margin-top:4px"><b>Items</b> ' + itemKeys.map(it => `<label style="margin-right:6px">${it}<input type="number" data-item="${it}" value="${prevVals['i:' + it] ?? '1'}" min="0" style="width:56px;margin-left:4px"/></label>`).join('') + '</div>';
+      }
+      importsEl.innerHTML = html || '<span class="muted">(no imports)</span>';
+      if ((importsEl as any).dataset) (importsEl as any).dataset.sig = sig;
     }
-    if (items.length) {
-      html += '<div style="margin-top:4px"><b>Items</b> ' + items.map(it => `<label style="margin-right:6px">${it}<input type="number" data-item="${it}" value="1" min="0" style="width:56px;margin-left:4px"/></label>`).join('') + '</div>';
+    if (!(importsEl as any).dataset?.wired) {
+      if ((importsEl as any).dataset) (importsEl as any).dataset.wired = '1';
+      importsEl.addEventListener('input', () => renderDialogPreview());
     }
-    importsEl.innerHTML = html || '<span class="muted">(no imports)</span>';
   }
   if (!tree || !tree.start) { prev.innerHTML = ''; return; }
-  function show(id) {
+  const spoofedFlags = buildSpoofFlagsFromPanel() || parseSpoofFlags((document.getElementById('spoofFlags') as HTMLInputElement)?.value || '');
+  const spoofedItems = buildSpoofItemsFromPanel() || {};
+  const cmp = (a, op, b) => {
+    if (op === '>') return a > b;
+    if (op === '<') return a < b;
+    if (op === '<=') return a <= b;
+    if (op === '==') return a === b;
+    if (op === '!=') return a !== b;
+    return a >= b;
+  };
+  const itemCount = key => Number(spoofedItems[key] ?? 0) || 0;
+  const choiceBlockers = c => {
+    const reasons = [];
+    if (c.if?.flag && !cmp(Number(spoofedFlags[c.if.flag] ?? 0) || 0, c.if.op || '>=', c.if.value ?? 1)) {
+      reasons.push(`flag ${c.if.flag} ${c.if.op || '>='} ${c.if.value ?? 1}`);
+    }
+    if (c.reqItem && itemCount(c.reqItem) <= 0) reasons.push(`needs ${c.reqItem}`);
+    if (c.costItem && itemCount(c.costItem) <= 0) reasons.push(`costs ${c.costItem}`);
+    if (c.reqTag && itemCount('tag:' + c.reqTag) <= 0) reasons.push(`needs tag ${c.reqTag}`);
+    if (c.costTag && itemCount('tag:' + c.costTag) <= 0) reasons.push(`costs tag ${c.costTag}`);
+    return reasons;
+  };
+  function show(id, note = '') {
     const node = tree[id]; if (!node) return;
-    const html = (node.choices || [])
-      .map(c => `<button class="btn" data-to="${c.to || ''}" style="margin-top:4px">${c.label}</button>`)
-      .join('');
-    prev.innerHTML = `<div>${node.text || ''}</div>` + html;
-    Array.from(prev.querySelectorAll('button')).forEach(btn => btn.onclick = () => {
-      const t = btn.dataset.to;
-      if (t) show(t);
+    const parts = [];
+    const actions = [];
+    if (note) parts.push(`<div class="small" style="opacity:0.8">${note}</div>`);
+    parts.push(`<div>${node.text || ''}</div>`);
+    const pushBtn = (label, title, action, faded = false) => {
+      const blocked = !action;
+      actions.push(action);
+      const style = `margin-top:4px${faded ? ';opacity:0.6' : ''}${blocked ? ';opacity:0.4' : ''}`;
+      parts.push(`<button class="btn" data-act="${actions.length - 1}" style="${style}"${title ? ` title="${title}"` : ''}${blocked ? ' disabled' : ''}>${label}</button>`);
+    };
+    (node.choices || []).forEach(c => {
+      if (!c) return;
+      const blockers = choiceBlockers(c);
+      const blockedTitle = blockers.length ? 'Unavailable: ' + blockers.join(', ') + ' — adjust spoof values above to test' : '';
+      if (c.stat && c.dc != null) {
+        pushBtn(`${c.label} [${c.stat} DC ${c.dc}: pass]`, blockedTitle || 'Preview the successful check',
+          blockers.length ? null : () => {
+            const next = c.to && tree[c.to] ? c.to : id;
+            show(next, c.success || '(Check passed.)');
+          });
+        pushBtn(`${c.label} [fail]`, blockedTitle || 'Preview the failed check',
+          blockers.length ? null : () => show(id, c.failure || '(Check failed.)'), true);
+        return;
+      }
+      pushBtn(c.label || '(choice)', blockedTitle, blockers.length ? null : () => {
+        if (c.to && tree[c.to]) show(c.to);
+      });
+    });
+    prev.innerHTML = parts.join('');
+    Array.from(prev.querySelectorAll('button')).forEach(btn => {
+      btn.onclick = () => {
+        const act = actions[parseInt(btn.dataset?.act ?? '-1', 10)];
+        if (act) act();
+      };
     });
   }
   show('start');
@@ -2231,17 +2301,23 @@ function refreshChoiceDropdowns() {
 function renderTreeEditor() {
   const wrap = document.getElementById('treeEditor');
   if (!wrap) return;
+  if (!(wrap as any).dataset?.dirtyWired) {
+    if ((wrap as any).dataset) (wrap as any).dataset.dirtyWired = '1';
+    wrap.addEventListener('input', () => globalThis.markAckDirty?.());
+  }
   wrap.innerHTML = '';
   Object.entries(getTreeData()).forEach(([id, node]: [string, any]) => {
     if (id === 'imports') return;
     const div = document.createElement('div');
     div.className = 'node';
-    div.innerHTML = `<div class="nodeHeader"><button class="btn toggle" type="button" aria-label="Toggle node">-</button><label>Node ID<input class="nodeId" value="${id}"></label><button class="btn delNode" type="button" title="Delete node" aria-label="Delete node">&#128465;</button></div><div class="nodeBody"><label>Dialog Text<textarea class="nodeText" rows="2">${node.text || ''}</textarea></label><fieldset class="choiceGroup"><legend>Choices</legend><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button></fieldset></div>`;
+    div.innerHTML = `<div class="nodeHeader"><button class="btn toggle" type="button" aria-label="Toggle node">-</button><label>Node ID<input class="nodeId" value="${id}"></label><button class="btn copyNode" type="button" title="Copy this node and everything it links to" aria-label="Copy subtree">&#10697;</button><button class="btn delNode" type="button" title="Delete node" aria-label="Delete node">&#128465;</button></div><div class="nodeBody"><label>Dialog Text<textarea class="nodeText" rows="2">${node.text || ''}</textarea></label><fieldset class="choiceGroup"><legend>Choices</legend><div class="choices"></div><button class="btn addChoice" type="button">Add Choice</button></fieldset></div>`;
     const choicesDiv = div.querySelector('.choices') as HTMLElement | null;
     if (!choicesDiv) return;
     (node.choices || []).forEach(ch => addChoiceRow(choicesDiv, ch));
     const addChoiceBtn = div.querySelector('.addChoice') as HTMLButtonElement | null;
     if (addChoiceBtn) addChoiceBtn.onclick = () => addChoiceRow(choicesDiv);
+    const copyBtn = div.querySelector('.copyNode') as HTMLButtonElement | null;
+    if (copyBtn) copyBtn.onclick = () => copyDialogSubtree((div.querySelector('.nodeId') as HTMLInputElement)?.value.trim());
     const toggleBtn = div.querySelector('.toggle');
     toggleBtn.addEventListener('click', () => {
       div.classList.toggle('collapsed');
@@ -2261,6 +2337,7 @@ function renderTreeEditor() {
   wrap.querySelectorAll('select').forEach(el => el.addEventListener('change', updateTreeData));
   wrap.querySelectorAll('input[type=checkbox]').forEach(el => el.addEventListener('change', updateTreeData));
   refreshChoiceDropdowns();
+  if (typeof applyDialogNodeFilter === 'function') applyDialogNodeFilter();
 }
 
 function updateTreeData() {
@@ -2436,6 +2513,7 @@ function updateTreeData() {
   // Live preview + keep "to" dropdowns in sync with current node keys
   renderDialogPreview();
   refreshChoiceDropdowns();
+  if (typeof renderDialogGraph === 'function') renderDialogGraph();
 
   // ---- Validation: highlight bad targets & orphans ----
 
@@ -2480,6 +2558,7 @@ function loadTreeEditor() {
 
 function openDialogEditor() {
   document.getElementById('dialogModal').classList.add('shown');
+  updatePasteSubtreeButton();
   renderTreeEditor();
 }
 
@@ -2507,6 +2586,284 @@ function addNode() {
   setTreeData(tree);
   renderTreeEditor();
   updateTreeData();
+}
+
+// === Dialog subtree clipboard, templates, and search ===
+const DIALOG_CLIPBOARD_KEY = 'ack_dialog_clipboard';
+
+function setDialogEditorStatus(msg, autoClear = true) {
+  const el = document.getElementById('dlgStatus');
+  if (!el) return;
+  const prev = (el as any)._statusTimer;
+  if (prev) clearTimeout(prev);
+  el.textContent = msg || '';
+  if (autoClear && msg) {
+    (el as any)._statusTimer = setTimeout(() => { el.textContent = ''; }, 4000);
+  }
+}
+
+function collectDialogSubtree(tree, rootId) {
+  const nodes = {} as AnyRecord;
+  const queue = [rootId];
+  while (queue.length) {
+    const id = queue.shift();
+    if (!id || nodes[id] || !tree[id] || id === 'imports') continue;
+    nodes[id] = JSON.parse(JSON.stringify(tree[id]));
+    (tree[id].choices || []).forEach(ch => { if (ch?.to && tree[ch.to]) queue.push(ch.to); });
+  }
+  return nodes;
+}
+
+function copyDialogSubtree(rootId) {
+  if (!rootId) return;
+  updateTreeData();
+  const tree = getTreeData();
+  if (!tree[rootId]) return;
+  const nodes = collectDialogSubtree(tree, rootId);
+  try {
+    localStorage.setItem(DIALOG_CLIPBOARD_KEY, JSON.stringify({ root: rootId, nodes }));
+  } catch (e) {
+    setDialogEditorStatus('Copy failed — browser storage is full.');
+    return;
+  }
+  updatePasteSubtreeButton();
+  const linked = Object.keys(nodes).length - 1;
+  setDialogEditorStatus(`Copied "${rootId}"${linked ? ` + ${linked} linked node(s)` : ''}. Paste into any NPC's dialog.`);
+}
+
+function readDialogClipboard() {
+  try {
+    const raw = localStorage.getItem(DIALOG_CLIPBOARD_KEY);
+    if (!raw) return null;
+    const clip = JSON.parse(raw);
+    if (!clip?.root || !clip.nodes || !clip.nodes[clip.root]) return null;
+    return clip;
+  } catch (e) {
+    return null;
+  }
+}
+
+function updatePasteSubtreeButton() {
+  const btn = document.getElementById('pasteSubtree');
+  if (btn) btn.style.display = readDialogClipboard() ? 'inline-block' : 'none';
+}
+
+// Merge nodes into tree with collision-safe renaming; internal links are remapped.
+function mergeDialogNodes(tree, nodes, rootId) {
+  const rename = {} as Record<string, string>;
+  const taken = new Set(Object.keys(tree));
+  Object.keys(nodes).forEach(id => {
+    let cand = id;
+    let i = 1;
+    while (taken.has(cand)) cand = `${id}-${i++}`;
+    rename[id] = cand;
+    taken.add(cand);
+  });
+  Object.entries(nodes).forEach(([id, node]) => {
+    const copy = JSON.parse(JSON.stringify(node));
+    (copy.choices || []).forEach(ch => { if (ch?.to && rename[ch.to]) ch.to = rename[ch.to]; });
+    tree[rename[id]] = copy;
+  });
+  return rename[rootId];
+}
+
+function pasteDialogSubtree() {
+  const clip = readDialogClipboard();
+  if (!clip) { updatePasteSubtreeButton(); return; }
+  updateTreeData();
+  const tree = getTreeData();
+  const newRoot = mergeDialogNodes(tree, clip.nodes, clip.root);
+  setTreeData(tree);
+  renderTreeEditor();
+  updateTreeData();
+  globalThis.markAckDirty?.();
+  setDialogEditorStatus(`Pasted ${Object.keys(clip.nodes).length} node(s) as "${newRoot}". Link a choice to it.`);
+}
+
+const DIALOG_TEMPLATES = {
+  greeting: {
+    linkLabel: '(Talk)',
+    root: 'greet',
+    nodes: {
+      greet: { text: 'Hello, wanderer. Stay out of the dust.', choices: [{ label: '(Leave)', to: 'bye' }] }
+    }
+  },
+  fetchQuest: {
+    linkLabel: '(Ask about work)',
+    root: 'job',
+    nodes: {
+      job: {
+        text: 'I lost something out there. Bring it back and I\'ll make it worth your while.',
+        choices: [
+          { label: '(Accept the job)', to: 'accept', q: 'accept' },
+          { label: '(Turn in)', to: 'do_turnin', q: 'turnin' },
+          { label: '(Leave)', to: 'bye' }
+        ]
+      },
+      accept: { text: 'Good. It should be somewhere in the waste. Don\'t come back empty-handed.', choices: [{ label: '(Leave)', to: 'bye' }] },
+      do_turnin: { text: 'You actually found it. Here\'s your cut.', choices: [{ label: '(Leave)', to: 'bye' }] }
+    }
+  },
+  gatekeeper: {
+    linkLabel: '(Approach the door)',
+    root: 'gate',
+    nodes: {
+      gate: {
+        text: 'The way is sealed. Only those with the key pass.',
+        choices: [
+          { label: '(Use key)', to: 'gate-open', reqItem: 'key_item', once: true },
+          { label: '(Leave)', to: 'bye' }
+        ]
+      },
+      'gate-open': { text: 'The lock grinds open. Beyond, darkness waits.', choices: [{ label: '(Continue)', to: 'bye' }] },
+      locked: { text: '(It won\'t budge.)', choices: [{ label: '(Leave)', to: 'bye' }] }
+    }
+  },
+  lore: {
+    linkLabel: '(Ask about the old world)',
+    root: 'lore',
+    nodes: {
+      lore: {
+        text: 'What do you want to know?',
+        choices: [
+          { label: 'The Dust', to: 'lore-dust' },
+          { label: 'Before the fall', to: 'lore-fall' },
+          { label: '(Leave)', to: 'bye' }
+        ]
+      },
+      'lore-dust': { text: 'The dust never settles. It remembers.', choices: [{ label: '(Ask more)', to: 'lore' }] },
+      'lore-fall': { text: 'There were cities once. Now there are warnings.', choices: [{ label: '(Ask more)', to: 'lore' }] }
+    }
+  }
+};
+
+function insertDialogTemplate(key) {
+  const tpl = DIALOG_TEMPLATES[key];
+  if (!tpl) return;
+  updateTreeData();
+  const tree = getTreeData() as AnyRecord;
+  const newRoot = mergeDialogNodes(tree, tpl.nodes, tpl.root);
+  const startNode = tree.start as any;
+  if (startNode && newRoot !== 'start') {
+    startNode.choices = startNode.choices || [];
+    startNode.choices.push({ label: tpl.linkLabel, to: newRoot });
+  }
+  setTreeData(tree);
+  renderTreeEditor();
+  updateTreeData();
+  globalThis.markAckDirty?.();
+  setDialogEditorStatus(tree.start && newRoot !== 'start'
+    ? `Inserted template at "${newRoot}" and linked it from "start".`
+    : `Inserted template at "${newRoot}".`);
+}
+
+// Read-only node graph: layered by BFS depth, orphans highlighted, click to jump.
+function renderDialogGraph() {
+  const wrapEl = document.getElementById('dlgGraphWrap') as HTMLDetailsElement | null;
+  const graphEl = document.getElementById('dlgGraph');
+  if (!wrapEl || !graphEl || !wrapEl.open) return;
+  const tree = getTreeData() as AnyRecord;
+  const ids = Object.keys(tree).filter(k => k !== 'imports');
+  if (!ids.length) { graphEl.innerHTML = '<div class="small" style="padding:4px">No nodes yet.</div>'; return; }
+  const depth = {} as Record<string, number>;
+  const queue = [];
+  ['start', 'locked', 'sell', 'accept', 'do_turnin', 'do_fight'].forEach(id => {
+    if (tree[id] && depth[id] === undefined) { depth[id] = 0; queue.push(id); }
+  });
+  while (queue.length) {
+    const id = queue.shift();
+    ((tree[id] as any)?.choices || []).forEach(c => {
+      const to = typeof c?.to === 'string' ? c.to : '';
+      if (to && tree[to] && depth[to] === undefined) { depth[to] = depth[id] + 1; queue.push(to); }
+    });
+  }
+  const maxDepth = Math.max(0, ...Object.values(depth));
+  const orphanCol = maxDepth + 1;
+  const cols = [] as string[][];
+  ids.forEach(id => {
+    const col = depth[id] !== undefined ? depth[id] : orphanCol;
+    (cols[col] ||= []).push(id);
+  });
+  const BOX_W = 110, BOX_H = 24, GAP_X = 50, GAP_Y = 10, PAD = 8;
+  const pos = {} as Record<string, { x: number; y: number }>;
+  cols.forEach((colIds, ci) => {
+    (colIds || []).forEach((id, ri) => {
+      pos[id] = { x: PAD + ci * (BOX_W + GAP_X), y: PAD + ri * (BOX_H + GAP_Y) };
+    });
+  });
+  const width = PAD * 2 + cols.length * (BOX_W + GAP_X);
+  const height = PAD * 2 + Math.max(...cols.map(c => (c || []).length)) * (BOX_H + GAP_Y);
+  const edges = [] as string[];
+  ids.forEach(id => {
+    ((tree[id] as any)?.choices || []).forEach(c => {
+      const to = typeof c?.to === 'string' ? c.to : '';
+      if (!to || !pos[to] || !pos[id]) return;
+      const a = pos[id], b = pos[to];
+      edges.push(`<line x1="${a.x + BOX_W}" y1="${a.y + BOX_H / 2}" x2="${b.x}" y2="${b.y + BOX_H / 2}" stroke="#4a6a4a" stroke-width="1"/>`);
+    });
+  });
+  const boxes = ids.map(id => {
+    const p = pos[id];
+    const orphan = depth[id] === undefined && id !== 'bye';
+    const label = id.length > 15 ? id.slice(0, 14) + '…' : id;
+    return `<g data-node="${id}" style="cursor:pointer"><rect x="${p.x}" y="${p.y}" width="${BOX_W}" height="${BOX_H}" fill="#101a10" stroke="${orphan ? '#fa0' : '#2b6b2b'}" rx="3"/><text x="${p.x + 6}" y="${p.y + 16}" fill="${orphan ? '#fc0' : '#9ef7a0'}" font-size="11" font-family="monospace">${label}</text></g>`;
+  });
+  graphEl.innerHTML = `<svg width="${width}" height="${height}" role="img" aria-label="Dialog node graph">${edges.join('')}${boxes.join('')}</svg>`;
+  graphEl.querySelectorAll('[data-node]').forEach(g => {
+    (g as any).onclick = () => {
+      const id = (g as any).dataset?.node || g.getAttribute('data-node');
+      const wrap = document.getElementById('treeEditor');
+      if (!wrap || !id) return;
+      const target = Array.from(wrap.querySelectorAll('.node')).find(n =>
+        ((n.querySelector('.nodeId') as HTMLInputElement)?.value.trim() === id));
+      if (target) {
+        (target as HTMLElement).scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+        (target as HTMLElement).style.outline = '1px solid #9ef7a0';
+        setTimeout(() => { (target as HTMLElement).style.outline = ''; }, 1200);
+      }
+    };
+  });
+}
+
+function applyDialogNodeFilter() {
+  const wrap = document.getElementById('treeEditor');
+  if (!wrap) return;
+  const q = ((document.getElementById('dlgSearch') as HTMLInputElement)?.value || '').trim().toLowerCase();
+  const mode = (document.getElementById('dlgFilter') as HTMLSelectElement)?.value || '';
+  const statusEl = document.getElementById('dlgStatus');
+  const tree = getTreeData();
+  const reachable = new Set();
+  const visit = id => {
+    if (reachable.has(id) || !tree[id]) return;
+    reachable.add(id);
+    (tree[id].choices || []).forEach(c => { if (c.to) visit(c.to); });
+  };
+  ['start', 'locked', 'sell', 'accept', 'do_turnin', 'do_fight'].forEach(id => { if (tree[id]) visit(id); });
+  let shown = 0;
+  let total = 0;
+  wrap.querySelectorAll('.node').forEach(nodeEl => {
+    const id = (nodeEl.querySelector('.nodeId') as HTMLInputElement)?.value.trim() || '';
+    const node = tree[id] || { text: '', choices: [] };
+    total += 1;
+    let ok = true;
+    if (q) {
+      const hay = [id, node.text || '']
+        .concat((node.choices || []).flatMap(c => [c?.label || '', c?.to || '', c?.success || '', c?.failure || '']))
+        .join('\n').toLowerCase();
+      ok = hay.includes(q);
+    }
+    if (ok && mode) {
+      const cs = node.choices || [];
+      if (mode === 'effects') ok = cs.some(c => (c?.effects?.length ?? 0) > 0 || c?.setFlag || c?.reward || c?.spawn || c?.goto || c?.join);
+      else if (mode === 'checks') ok = cs.some(c => c?.stat);
+      else if (mode === 'conditions') ok = cs.some(c => c?.if || c?.reqItem || c?.reqTag || c?.reqSlot || c?.costItem || c?.costTag || c?.costSlot || c?.ifOnce);
+      else if (mode === 'orphans') ok = !reachable.has(id) && id !== 'bye';
+    }
+    (nodeEl as HTMLElement).style.display = ok ? '' : 'none';
+    if (ok) shown += 1;
+  });
+  if (statusEl && (q || mode)) statusEl.textContent = `Showing ${shown} of ${total} nodes`;
+  else if (statusEl && !(statusEl as any)._statusTimer) statusEl.textContent = '';
 }
 
 function generateQuestTree() {
@@ -7557,6 +7914,15 @@ if (spawnHeatBtn) spawnHeatBtn.onclick = () => {
 document.getElementById('addNode')?.addEventListener('click', addNode);
 document.getElementById('editDialog')?.addEventListener('click', openDialogEditor);
 document.getElementById('closeDialogModal')?.addEventListener('click', closeDialogEditor);
+document.getElementById('dlgSearch')?.addEventListener('input', applyDialogNodeFilter);
+document.getElementById('dlgFilter')?.addEventListener('change', applyDialogNodeFilter);
+document.getElementById('dlgTemplate')?.addEventListener('change', e => {
+  const sel = e.target as HTMLSelectElement;
+  if (sel.value) insertDialogTemplate(sel.value);
+  sel.value = '';
+});
+document.getElementById('pasteSubtree')?.addEventListener('click', pasteDialogSubtree);
+document.getElementById('dlgGraphWrap')?.addEventListener('toggle', renderDialogGraph);
 document.getElementById('dialogModal')?.addEventListener('click', e => { if ((e.target as HTMLElement)?.id === 'dialogModal') closeDialogEditor(); });
 // Live preview when dialog text changes
 ['npcDialog', 'npcAccept', 'npcTurnin'].forEach(id => {


### PR DESCRIPTION
- Dialog search & filter in the tree editor: text search across node ids/text/choice labels/success/failure lines, plus filters for effects, stat checks, conditions, and unreachable nodes
- Copy/paste dialog subtrees: per-node copy button grabs the node and all linked descendants; clipboard persists in localStorage so subtrees can be pasted into other NPCs; collision-safe renaming with internal link remapping
- Dialog templates: one-click insert for greeting, fetch quest (accept/turn-in), locked gatekeeper, and lore branches, auto-linked from the start node
- Conditional inline preview: honors spoofed flags (all operators), req/cost items and tags; blocked choices render disabled with the reason; stat checks offer pass/fail buttons showing success/failure text; spoof panel values persist across edits
- Read-only dialog graph view: SVG layered by reachability, orphan nodes highlighted, click a node to jump to its editor card
- Dialog edits inside the tree editor now mark the module dirty
- Tests for subtree collect/merge (test/dialog-subtree.test.js)