### PR TITLE
feat(ack): add ACK end-sequence action (game over + credits)

### DIFF
--- a/data/modules/schema.js
+++ b/data/modules/schema.js
@@ -7,6 +7,23 @@ const ackModuleSchema = {
         "name": { "type": "string" },
         "module": { "type": "string" },
         "moduleVar": { "type": "string" },
+        "credits": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    { "type": "string" },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" },
+                            "title": { "type": "string" },
+                            "role": { "type": "string" }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            }
+        },
         "start": {
             "type": "object",
             "properties": {

--- a/docs/guides/module-cli-tools.md
+++ b/docs/guides/module-cli-tools.md
@@ -267,6 +267,7 @@ Common examples:
 { "effect": "lockNPC", "npcId": "id" }
 { "effect": "addFlag", "flag": "story_flag" }
 { "effect": "openWorldMap", "id": "dest" }
+{ "effect": "endSequence", "messages": ["The signal dies."], "credits": [{ "name": "Module Author", "title": "Writer" }] }
 ```
 
 ### TileEvent

--- a/scripts/adventure-kit.js
+++ b/scripts/adventure-kit.js
@@ -5346,7 +5346,7 @@ function addEventSubBlock(container, ev = {}) {
     div.style.cssText = 'border-left:2px solid #2b3b2b;padding-left:8px;margin-bottom:6px;';
     const effectSel = document.createElement('select');
     effectSel.className = 'eventSubEffect';
-    ['toast', 'log', 'addFlag', 'modStat'].forEach(val => {
+    ['toast', 'log', 'addFlag', 'modStat', 'endSequence'].forEach(val => {
         const opt = document.createElement('option');
         opt.value = val;
         opt.textContent = val;
@@ -5370,6 +5370,24 @@ function addEventSubBlock(container, ev = {}) {
     flagLabel.textContent = 'Flag ';
     flagLabel.appendChild(flagInput);
     flagLabel.style.display = 'none';
+    const endWrap = document.createElement('div');
+    endWrap.className = 'eventSubEndWrap';
+    endWrap.style.display = 'none';
+    const endMessages = document.createElement('textarea');
+    endMessages.className = 'eventSubEndMessages';
+    endMessages.placeholder = 'End messages, one per line';
+    endMessages.value = Array.isArray(ev.messages) ? ev.messages.join('\n') : (ev.msg || 'GAME OVER');
+    endMessages.style.cssText = 'width:100%;min-height:54px;';
+    const endCredits = document.createElement('textarea');
+    endCredits.className = 'eventSubEndCredits';
+    endCredits.placeholder = 'Module credits, one per line as Name — Title';
+    endCredits.value = Array.isArray(ev.credits) ? ev.credits.map(c => typeof c === 'string' ? c : `${c.name || ''}${c.title || c.role ? ' — ' + (c.title || c.role) : ''}`).join('\n') : '';
+    endCredits.style.cssText = 'width:100%;min-height:54px;';
+    const endHint = document.createElement('small');
+    endHint.textContent = 'Fades to black, prints THE END, then rolls module credits plus Dustland game credits.';
+    endWrap.appendChild(endMessages);
+    endWrap.appendChild(endCredits);
+    endWrap.appendChild(endHint);
     const statWrap = document.createElement('div');
     statWrap.className = 'eventSubStatWrap';
     statWrap.style.display = 'none';
@@ -5404,11 +5422,13 @@ function addEventSubBlock(container, ev = {}) {
         msgLabel.style.display = (eff === 'toast' || eff === 'log') ? 'block' : 'none';
         flagLabel.style.display = eff === 'addFlag' ? 'block' : 'none';
         statWrap.style.display = eff === 'modStat' ? 'flex' : 'none';
+        endWrap.style.display = eff === 'endSequence' ? 'block' : 'none';
     }
     effectSel.addEventListener('change', updateSubFields);
     div.appendChild(effectSel);
     div.appendChild(msgLabel);
     div.appendChild(flagLabel);
+    div.appendChild(endWrap);
     div.appendChild(statWrap);
     div.appendChild(removeBtn);
     container.appendChild(div);
@@ -5446,6 +5466,15 @@ function collectEvent() {
             ev.stat = div.querySelector('.eventSubStatSelect')?.value || '';
             ev.delta = parseInt(div.querySelector('.eventSubDeltaInput')?.value, 10) || 0;
             ev.duration = parseInt(div.querySelector('.eventSubDurInput')?.value, 10) || 0;
+        }
+        if (eff === 'endSequence') {
+            const rawMessages = div.querySelector('.eventSubEndMessages')?.value || '';
+            const rawCredits = div.querySelector('.eventSubEndCredits')?.value || '';
+            ev.messages = rawMessages.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+            ev.credits = rawCredits.split(/\r?\n/).map(line => {
+                const parts = line.split(/\s+[—-]\s+/);
+                return { name: (parts.shift() || '').trim(), title: parts.join(' — ').trim() };
+            }).filter(credit => credit.name || credit.title);
         }
         return ev;
     }) : [];

--- a/scripts/core/actions.js
+++ b/scripts/core/actions.js
@@ -1,4 +1,47 @@
 (function () {
+    const GAME_CREDITS = [
+        { name: 'Riley "Clown" Morgan', title: 'Hacker-Artist / Mod-Friendly Coding' },
+        { name: 'Alex "Echo" Johnson', title: 'World-Building / Story and Dialogue' },
+        { name: 'Priya "Gizmo" Sharma', title: 'Tools Engineering / Editor Automation' },
+        { name: 'Mateo "Wing" Alvarez', title: 'Combat Tuning / User Testing' }
+    ];
+    const sleep = (ms) => new Promise(resolve => setTimeout(resolve, Math.max(0, ms)));
+    function normalizeCredit(credit) {
+        if (typeof credit === 'string')
+            return { name: credit, title: '' };
+        if (!credit || typeof credit !== 'object')
+            return null;
+        const name = String(credit.name ?? '').trim();
+        const title = String(credit.title ?? credit.role ?? '').trim();
+        if (!name && !title)
+            return null;
+        return { name, title };
+    }
+    function activeModuleCredits() {
+        const dl = globalThis.Dustland ?? {};
+        const current = dl.currentModule;
+        const moduleData = current && dl.loadedModules ? dl.loadedModules[current] : null;
+        const credits = moduleData?.credits;
+        return Array.isArray(credits) ? credits : [];
+    }
+    function ensureEndOverlay() {
+        if (typeof document === 'undefined')
+            return null;
+        let overlay = document.getElementById('dustlandEndSequence');
+        if (overlay)
+            return overlay;
+        overlay = document.createElement('div');
+        overlay.id = 'dustlandEndSequence';
+        overlay.style.cssText = 'position:fixed;inset:0;z-index:10000;background:#000;color:#9f9;display:flex;align-items:center;justify-content:center;text-align:center;font-family:monospace;letter-spacing:.08em;opacity:0;transition:opacity 1200ms ease;pointer-events:auto;padding:32px;box-sizing:border-box;';
+        document.body.appendChild(overlay);
+        return overlay;
+    }
+    function escapeHtml(value) {
+        return value.replace(/[&<>"]/g, ch => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[ch] ?? ch));
+    }
+    function setEndOverlayText(overlay, html) {
+        overlay.innerHTML = `<div style="max-width:760px;line-height:1.7;text-shadow:0 0 12px #0f0;">${html}</div>`;
+    }
     const Actions = {
         applyQuestReward(reward) {
             if (!reward)
@@ -41,6 +84,49 @@
         startCombat(defender) {
             if (typeof globalThis.startCombat === 'function')
                 return globalThis.startCombat(defender);
+        },
+        async playEndSequence(config = {}) {
+            const overlay = ensureEndOverlay();
+            const messages = Array.isArray(config.messages) && config.messages.length
+                ? config.messages.map(String)
+                : ['GAME OVER'];
+            const fadeMs = Number.isFinite(config.fadeMs) ? Number(config.fadeMs) : 1200;
+            const messageMs = Number.isFinite(config.messageMs) ? Number(config.messageMs) : 1800;
+            const creditMs = Number.isFinite(config.creditMs) ? Number(config.creditMs) : 900;
+            if (overlay) {
+                overlay.style.transition = `opacity ${fadeMs}ms ease`;
+                setEndOverlayText(overlay, '');
+                requestAnimationFrame(() => { overlay.style.opacity = '1'; });
+            }
+            await sleep(fadeMs);
+            for (const message of messages) {
+                if (typeof globalThis.log === 'function')
+                    globalThis.log(message);
+                if (overlay)
+                    setEndOverlayText(overlay, `<p>${escapeHtml(message)}</p>`);
+                await sleep(messageMs);
+            }
+            const title = String(config.title ?? 'THE END');
+            const safeTitle = escapeHtml(title);
+            const subtitle = config.subtitle ? `<p style="font-size:.9rem;color:#6f6;">${escapeHtml(String(config.subtitle))}</p>` : '';
+            if (overlay)
+                setEndOverlayText(overlay, `<h1 style="margin:0 0 12px;">${safeTitle}</h1>${subtitle}`);
+            if (typeof globalThis.log === 'function')
+                globalThis.log(title);
+            await sleep(messageMs);
+            const includeGameCredits = config.includeGameCredits !== false;
+            const credits = [
+                ...(Array.isArray(config.credits) ? config.credits : activeModuleCredits()),
+                ...(includeGameCredits ? GAME_CREDITS : [])
+            ].map(normalizeCredit).filter(Boolean);
+            for (const credit of credits) {
+                const line = credit.title ? `${credit.name} — ${credit.title}` : credit.name;
+                if (typeof globalThis.log === 'function')
+                    globalThis.log(line);
+                if (overlay)
+                    setEndOverlayText(overlay, `<p style="font-size:1.2rem;margin:0;">${escapeHtml(credit.name)}</p>${credit.title ? `<p style="color:#6f6;margin:.4rem 0 0;">${escapeHtml(credit.title)}</p>` : ''}`);
+                await sleep(creditMs);
+            }
         }
     };
     globalThis.Dustland = globalThis.Dustland || {};

--- a/scripts/core/effects.js
+++ b/scripts/core/effects.js
@@ -146,6 +146,10 @@
                         if (typeof log === 'function')
                             log(eff.msg ?? '');
                         break;
+                    case 'endSequence':
+                    case 'gameOver':
+                        globalThis.Dustland?.actions?.playEndSequence?.(eff);
+                        break;
                     case 'openWorkbench':
                         globalThis.Dustland?.openWorkbench?.();
                         break;

--- a/scripts/dustland-engine.js
+++ b/scripts/dustland-engine.js
@@ -1,6 +1,6 @@
 /// <reference path="../types/dustland-engine-globals.d.ts" />
 // ===== Rendering & Utilities =====
-const ENGINE_VERSION = '0.261.0';
+const ENGINE_VERSION = '0.255.2';
 let cachedGlobals;
 function getEngineGlobals() {
     if (cachedGlobals)

--- a/ts-src/data/modules/schema.ts
+++ b/ts-src/data/modules/schema.ts
@@ -7,6 +7,23 @@ const ackModuleSchema = {
     "name": { "type": "string" },
     "module": { "type": "string" },
     "moduleVar": { "type": "string" },
+    "credits": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "title": { "type": "string" },
+              "role": { "type": "string" }
+            },
+            "additionalProperties": true
+          }
+        ]
+      }
+    },
     "start": {
       "type": "object",
       "properties": {

--- a/ts-src/global.d.ts
+++ b/ts-src/global.d.ts
@@ -502,6 +502,7 @@ declare global {
       context?: { phase?: string;[key: string]: unknown }
     ) => void;
     start?: { map: string; x: number; y: number } | null;
+    credits?: Array<string | { name?: string; title?: string; role?: string; [key: string]: unknown }>;
     templates?: Array<{
       id?: string;
       color?: string;
@@ -883,6 +884,7 @@ declare global {
   interface DustlandActionsApi {
     applyQuestReward?: (reward: unknown) => void;
     startCombat?: (enemy: CombatParticipant & { [key: string]: unknown }) => void;
+    playEndSequence?: (config?: { [key: string]: unknown }) => Promise<void>;
     [key: string]: unknown;
   }
 

--- a/ts-src/scripts/adventure-kit.ts
+++ b/ts-src/scripts/adventure-kit.ts
@@ -5007,7 +5007,7 @@ function addEventSubBlock(container: HTMLElement, ev: any = {}): HTMLElement {
 
   const effectSel = document.createElement('select');
   effectSel.className = 'eventSubEffect';
-  ['toast', 'log', 'addFlag', 'modStat'].forEach(val => {
+  ['toast', 'log', 'addFlag', 'modStat', 'endSequence'].forEach(val => {
     const opt = document.createElement('option');
     opt.value = val; opt.textContent = val; effectSel.appendChild(opt);
   });
@@ -5027,6 +5027,20 @@ function addEventSubBlock(container: HTMLElement, ev: any = {}): HTMLElement {
   flagInput.value = ev.flag || '';
   flagLabel.textContent = 'Flag '; flagLabel.appendChild(flagInput);
   flagLabel.style.display = 'none';
+
+  const endWrap = document.createElement('div');
+  endWrap.className = 'eventSubEndWrap'; endWrap.style.display = 'none';
+  const endMessages = document.createElement('textarea');
+  endMessages.className = 'eventSubEndMessages'; endMessages.placeholder = 'End messages, one per line';
+  endMessages.value = Array.isArray(ev.messages) ? ev.messages.join('\n') : (ev.msg || 'GAME OVER');
+  endMessages.style.cssText = 'width:100%;min-height:54px;';
+  const endCredits = document.createElement('textarea');
+  endCredits.className = 'eventSubEndCredits'; endCredits.placeholder = 'Module credits, one per line as Name — Title';
+  endCredits.value = Array.isArray(ev.credits) ? ev.credits.map(c => typeof c === 'string' ? c : `${c.name || ''}${c.title || c.role ? ' — ' + (c.title || c.role) : ''}`).join('\n') : '';
+  endCredits.style.cssText = 'width:100%;min-height:54px;';
+  const endHint = document.createElement('small');
+  endHint.textContent = 'Fades to black, prints THE END, then rolls module credits plus Dustland game credits.';
+  endWrap.appendChild(endMessages); endWrap.appendChild(endCredits); endWrap.appendChild(endHint);
 
   const statWrap = document.createElement('div');
   statWrap.className = 'eventSubStatWrap'; statWrap.style.display = 'none';
@@ -5052,11 +5066,12 @@ function addEventSubBlock(container: HTMLElement, ev: any = {}): HTMLElement {
     msgLabel.style.display = (eff === 'toast' || eff === 'log') ? 'block' : 'none';
     flagLabel.style.display = eff === 'addFlag' ? 'block' : 'none';
     statWrap.style.display = eff === 'modStat' ? 'flex' : 'none';
+    endWrap.style.display = eff === 'endSequence' ? 'block' : 'none';
   }
   effectSel.addEventListener('change', updateSubFields);
 
   div.appendChild(effectSel); div.appendChild(msgLabel);
-  div.appendChild(flagLabel); div.appendChild(statWrap); div.appendChild(removeBtn);
+  div.appendChild(flagLabel); div.appendChild(endWrap); div.appendChild(statWrap); div.appendChild(removeBtn);
   container.appendChild(div);
   updateSubFields();
   return div;
@@ -5089,6 +5104,15 @@ function collectEvent() {
       ev.stat = (div.querySelector('.eventSubStatSelect') as HTMLSelectElement)?.value || '';
       ev.delta = parseInt((div.querySelector('.eventSubDeltaInput') as HTMLInputElement)?.value, 10) || 0;
       ev.duration = parseInt((div.querySelector('.eventSubDurInput') as HTMLInputElement)?.value, 10) || 0;
+    }
+    if (eff === 'endSequence') {
+      const rawMessages = (div.querySelector('.eventSubEndMessages') as HTMLTextAreaElement)?.value || '';
+      const rawCredits = (div.querySelector('.eventSubEndCredits') as HTMLTextAreaElement)?.value || '';
+      ev.messages = rawMessages.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+      ev.credits = rawCredits.split(/\r?\n/).map(line => {
+        const parts = line.split(/\s+[—-]\s+/);
+        return { name: (parts.shift() || '').trim(), title: parts.join(' — ').trim() };
+      }).filter(credit => credit.name || credit.title);
     }
     return ev;
   }) : [];

--- a/ts-src/scripts/core/actions.ts
+++ b/ts-src/scripts/core/actions.ts
@@ -1,4 +1,62 @@
 (function () {
+  type EndCredit = string | { name?: string; title?: string; role?: string; [key: string]: unknown };
+  type EndSequenceConfig = {
+    messages?: string[];
+    credits?: EndCredit[];
+    title?: string;
+    subtitle?: string;
+    fadeMs?: number;
+    messageMs?: number;
+    creditMs?: number;
+    includeGameCredits?: boolean;
+    [key: string]: unknown;
+  };
+
+  const GAME_CREDITS: EndCredit[] = [
+    { name: 'Riley "Clown" Morgan', title: 'Hacker-Artist / Mod-Friendly Coding' },
+    { name: 'Alex "Echo" Johnson', title: 'World-Building / Story and Dialogue' },
+    { name: 'Priya "Gizmo" Sharma', title: 'Tools Engineering / Editor Automation' },
+    { name: 'Mateo "Wing" Alvarez', title: 'Combat Tuning / User Testing' }
+  ];
+
+  const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, Math.max(0, ms)));
+
+  function normalizeCredit(credit: EndCredit): { name: string; title: string } | null {
+    if (typeof credit === 'string') return { name: credit, title: '' };
+    if (!credit || typeof credit !== 'object') return null;
+    const name = String(credit.name ?? '').trim();
+    const title = String(credit.title ?? credit.role ?? '').trim();
+    if (!name && !title) return null;
+    return { name, title };
+  }
+
+  function activeModuleCredits(): EndCredit[] {
+    const dl = globalThis.Dustland ?? {};
+    const current = dl.currentModule;
+    const moduleData = current && dl.loadedModules ? dl.loadedModules[current] : null;
+    const credits = moduleData?.credits;
+    return Array.isArray(credits) ? credits : [];
+  }
+
+  function ensureEndOverlay(): HTMLElement | null {
+    if (typeof document === 'undefined') return null;
+    let overlay = document.getElementById('dustlandEndSequence');
+    if (overlay) return overlay;
+    overlay = document.createElement('div');
+    overlay.id = 'dustlandEndSequence';
+    overlay.style.cssText = 'position:fixed;inset:0;z-index:10000;background:#000;color:#9f9;display:flex;align-items:center;justify-content:center;text-align:center;font-family:monospace;letter-spacing:.08em;opacity:0;transition:opacity 1200ms ease;pointer-events:auto;padding:32px;box-sizing:border-box;';
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  function escapeHtml(value: string): string {
+    return value.replace(/[&<>"]/g, ch => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[ch] ?? ch));
+  }
+
+  function setEndOverlayText(overlay: HTMLElement, html: string): void {
+    overlay.innerHTML = `<div style="max-width:760px;line-height:1.7;text-shadow:0 0 12px #0f0;">${html}</div>`;
+  }
+
   const Actions = {
     applyQuestReward(reward) {
       if (!reward) return;
@@ -40,6 +98,43 @@
     },
     startCombat(defender) {
       if (typeof globalThis.startCombat === 'function') return globalThis.startCombat(defender);
+    },
+    async playEndSequence(config: EndSequenceConfig = {}) {
+      const overlay = ensureEndOverlay();
+      const messages = Array.isArray(config.messages) && config.messages.length
+        ? config.messages.map(String)
+        : ['GAME OVER'];
+      const fadeMs = Number.isFinite(config.fadeMs) ? Number(config.fadeMs) : 1200;
+      const messageMs = Number.isFinite(config.messageMs) ? Number(config.messageMs) : 1800;
+      const creditMs = Number.isFinite(config.creditMs) ? Number(config.creditMs) : 900;
+      if (overlay) {
+        overlay.style.transition = `opacity ${fadeMs}ms ease`;
+        setEndOverlayText(overlay, '');
+        requestAnimationFrame(() => { overlay.style.opacity = '1'; });
+      }
+      await sleep(fadeMs);
+      for (const message of messages) {
+        if (typeof globalThis.log === 'function') globalThis.log(message);
+        if (overlay) setEndOverlayText(overlay, `<p>${escapeHtml(message)}</p>`);
+        await sleep(messageMs);
+      }
+      const title = String(config.title ?? 'THE END');
+      const safeTitle = escapeHtml(title);
+      const subtitle = config.subtitle ? `<p style="font-size:.9rem;color:#6f6;">${escapeHtml(String(config.subtitle))}</p>` : '';
+      if (overlay) setEndOverlayText(overlay, `<h1 style="margin:0 0 12px;">${safeTitle}</h1>${subtitle}`);
+      if (typeof globalThis.log === 'function') globalThis.log(title);
+      await sleep(messageMs);
+      const includeGameCredits = config.includeGameCredits !== false;
+      const credits = [
+        ...(Array.isArray(config.credits) ? config.credits : activeModuleCredits()),
+        ...(includeGameCredits ? GAME_CREDITS : [])
+      ].map(normalizeCredit).filter(Boolean) as { name: string; title: string }[];
+      for (const credit of credits) {
+        const line = credit.title ? `${credit.name} — ${credit.title}` : credit.name;
+        if (typeof globalThis.log === 'function') globalThis.log(line);
+        if (overlay) setEndOverlayText(overlay, `<p style="font-size:1.2rem;margin:0;">${escapeHtml(credit.name)}</p>${credit.title ? `<p style="color:#6f6;margin:.4rem 0 0;">${escapeHtml(credit.title)}</p>` : ''}`);
+        await sleep(creditMs);
+      }
     }
   };
   globalThis.Dustland = globalThis.Dustland || {};

--- a/ts-src/scripts/core/effects.ts
+++ b/ts-src/scripts/core/effects.ts
@@ -46,6 +46,8 @@
     stat?: string;
     flag?: string;
     msg?: string;
+    messages?: string[];
+    credits?: unknown[];
     [key: string]: unknown;
   };
 
@@ -215,6 +217,10 @@
             break;
           case 'log':
             if (typeof log === 'function') log(eff.msg ?? '');
+            break;
+          case 'endSequence':
+          case 'gameOver':
+            globalThis.Dustland?.actions?.playEndSequence?.(eff);
             break;
           case 'openWorkbench':
             globalThis.Dustland?.openWorkbench?.();


### PR DESCRIPTION
### Motivation
- Provide a simple tile-event action that modules can trigger to show a game-over / ending sequence, print messages, fade to black, and roll credits baked into the module as well as the project's game credits.
- Make the ACK editor and module schema first-class citizens for authoring end sequences so module authors can author endings without editing runtime code.

### Description
- Add a runtime action `Dustland.actions.playEndSequence(config)` that fades an in-page overlay, prints configurable messages, shows a THE END title, and then displays credits (module credits followed by hard-coded Dustland credits pulled from the team bios).
- Wire the effects pipeline so tile events can use `"effect": "endSequence"` (alias `"gameOver"`) and forward the effect payload to `playEndSequence`.
- Extend the Adventure Kit event editor to offer a new `endSequence` sub-effect where authors can enter one message per line and module-credit lines as `Name — Title`.
- Add `credits` to the module JSON schema and to `DustlandModuleInstance` typing so modules can embed credit lists, and document the new effect in the module CLI guide.

### Testing
- Ran `npm run build` and the TypeScript build completed successfully.
- Ran `npm test` (which runs the lint step and Node test runner) and the suite passed (all tests green).
- Ran `node scripts/supporting/presubmit.js` and it reported no forbidden patterns.
- Ran the repository checks and style validations and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64224743ec8328bac4be73796922b7)